### PR TITLE
added broadcast & multicast counters to interfaces (ipdevinfo)

### DIFF
--- a/python/nav/ipdevpoll/plugins/statports.py
+++ b/python/nav/ipdevpoll/plugins/statports.py
@@ -27,11 +27,19 @@ from nav.mibs.ip_mib import IpMib
 OCTET_COUNTERS = (
     "ifInOctets",
     "ifOutOctets",
+    "ifInBroadcastPkts",
+    "ifOutBroadcastPkts",
+    "ifInMulticastPkts",
+    "ifOutMulticastPkts",
 )
 
 HC_OCTET_COUNTERS = (
     "ifHCInOctets",
     "ifHCOutOctets",
+    "ifHCInBroadcastPkts",
+    "ifHCOutBroadcastPkts",
+    "ifHCInMulticastPkts",
+    "ifHCOutMulticastPkts",
 )
 
 OTHER_COUNTERS = (

--- a/python/nav/ipdevpoll/plugins/statports.py
+++ b/python/nav/ipdevpoll/plugins/statports.py
@@ -24,7 +24,7 @@ from nav.mibs.if_mib import IfMib
 from nav.mibs.ip_mib import IpMib
 
 
-OCTET_COUNTERS = (
+NON_HC_COUNTERS = (
     "ifInOctets",
     "ifOutOctets",
     "ifInBroadcastPkts",
@@ -33,7 +33,7 @@ OCTET_COUNTERS = (
     "ifOutMulticastPkts",
 )
 
-HC_OCTET_COUNTERS = (
+HC_COUNTERS = (
     "ifHCInOctets",
     "ifHCOutOctets",
     "ifHCInBroadcastPkts",
@@ -59,7 +59,7 @@ IP_COUNTERS = (
     IF_OUT_OCTETS_IPV6,
 )
 
-USED_COUNTERS = OCTET_COUNTERS + HC_OCTET_COUNTERS + OTHER_COUNTERS
+USED_COUNTERS = NON_HC_COUNTERS + HC_COUNTERS + OTHER_COUNTERS
 LOGGED_COUNTERS = USED_COUNTERS + IP_COUNTERS
 
 
@@ -122,7 +122,7 @@ def use_hc_counters(row):
     Replaces octet counter values with high capacity counter values, if present
     """
     result = False
-    for hc, nonhc in zip(HC_OCTET_COUNTERS, OCTET_COUNTERS):
+    for hc, nonhc in zip(HC_COUNTERS, NON_HC_COUNTERS):
         if row.get(hc, None) is not None:
             result = True
             row[nonhc] = row[hc]

--- a/python/nav/web/ipdevinfo/utils.py
+++ b/python/nav/web/ipdevinfo/utils.py
@@ -425,6 +425,8 @@ def get_interface_counter_graph_url(interface, timeframe='day', kind='Octets',
     titlemap = dict(octets=u'Traffic on {shortname}:{ifname} {ifalias}',
                     errors=u'Errors on {shortname}:{ifname} {ifalias}',
                     ucastpkts=u'Unicast packets on {shortname}:{ifname}',
+                    multicastpkts=u'Multicast packets on {shortname}:{ifname}',
+                    broadcastpkts=u'Broadcast packets on {shortname}:{ifname}',
                     discards=u'Discarded packets on {shortname}:{ifname}')
     title = titlemap.get(kind.lower(), u'{ifname}').format(
         ifname=interface.ifname,

--- a/python/nav/web/ipdevinfo/views.py
+++ b/python/nav/web/ipdevinfo/views.py
@@ -44,7 +44,7 @@ from nav.web.ipdevinfo import utils
 from .host_information import get_host_info
 
 NAVPATH = [('Home', '/'), ('IP Device Info', '/ipdevinfo')]
-COUNTER_TYPES = ('Octets', 'UcastPkts', 'Errors', 'Discards')
+COUNTER_TYPES = ('Octets', 'UcastPkts', 'Errors', 'Discards', 'MulticastPkts', 'BroadcastPkts')
 
 
 _logger = logging.getLogger('nav.web.ipdevinfo')
@@ -538,7 +538,7 @@ def port_counter_graph(request, interfaceid, kind='Octets'):
 
     Redirects to the created url if successful
     """
-    if kind not in ('Octets', 'Errors', 'UcastPkts', 'Discards'):
+    if kind not in ('Octets', 'Errors', 'UcastPkts', 'Discards', 'MulticastPkts', 'BroadcastPkts'):
         raise Http404
 
     timeframe = request.GET.get('timeframe', 'day')


### PR DESCRIPTION
Hi all, I added broadcast & multicast counters to interfaces counters collection & web display (ipdevinfo), as per unicast counters these can be short or long format (OCTET_COUNTERS or HC_OCTET_COUNTERS). These kind of counters are standard defined, so are included in common MIBs. AlexDF