### PR TITLE
Fix invariant error, resolves #1414

### DIFF
--- a/python/nav/report/IPtools.py
+++ b/python/nav/report/IPtools.py
@@ -293,11 +293,13 @@ def get_next_subnet(net):
 
 def create_subnet_range(net, prefixlen):
     """Creates all subnets of the given size inside the net"""
-    assert prefixlen > net.prefixlen(), '{} <= than {}'.format(net, prefixlen)
+    assert prefixlen >= net.prefixlen(), '{} < than {}'.format(net, prefixlen)
+    # Return self as the net cannot be divided further
+    if net.prefixlen() == prefixlen:
+        return [net]
     subnet = IP("{}/{}" .format(net.net().strNormal(), prefixlen))
     subnet_range = []
     while net.overlaps(subnet):
         subnet_range.append(subnet)
         subnet = get_next_subnet(subnet)
-
     return subnet_range

--- a/python/nav/report/matrixIPv4.py
+++ b/python/nav/report/matrixIPv4.py
@@ -59,9 +59,10 @@ class MatrixIPv4(Matrix):
 
         # Initially, create the rows (subnets) we're going to display
         if self.show_unused_addresses:
-            subnets = IPtools.create_subnet_range(net, self._get_row_size())
+            row_size = self._get_row_size()
+            subnets = IPtools.create_subnet_range(net, row_size)
             large_subnets = [x for x in nets.keys()
-                             if x.prefixlen() < self._get_row_size()]
+                             if x.prefixlen() < row_size]
         else:
             subnets = IPtools.sort_nets_by_address(nets.keys())
 


### PR DESCRIPTION
This allows us to show "available addresses" for scopes with no sub-scopes. Ideally we would just return an error to the user, as this makes no sense, but the subnet matrix is sufficiently complex that we probably might risk running into edge-cases.

Signed-off-by: Emil Henry <emilhf@stud.ntnu.no>