### PR TITLE
Minor IPAM improvements

### DIFF
--- a/htdocs/sass/nav/ipam.scss
+++ b/htdocs/sass/nav/ipam.scss
@@ -27,14 +27,18 @@ with children are more and more "padded" */
         opacity: 1.0;
     }
 }
-.prefix-tree-children.has_open_nodes {
-    .prefix-tree-item.prefix-tree-item-open {
+
+.has_no_open_nodes {
+    .prefix-tree-item, .prefix-tree-item-closed {
         opacity: 1.0 !important;
-        .prefix-tree-children > .prefix-tree-item {
-            opacity: 1.0;
-        }
     }
-    .prefix-tree-item {
+}
+
+.has_open_nodes {
+    .prefix-tree-item.prefix-tree-item-open {
+        opacity: 1.0;
+    }
+    .prefix-tree-item-closed {
         opacity: 0.25;
     }
     .prefix-tree-item:hover {

--- a/htdocs/static/js/src/ipam/app.js
+++ b/htdocs/static/js/src/ipam/app.js
@@ -66,10 +66,10 @@ define(function(require, exports, module) {
   });
 
   //util.debugListen("available_subnets");
-  util.ipam_debug.listen("app");
-  util.ipam_debug.listen("models");
-  util.ipam_debug.listen("views");
-  util.ipam_debug.unlisten("models:usage");
+  //util.ipam_debug.listen("app");
+  //util.ipam_debug.listen("models");
+  //util.ipam_debug.listen("views");
+  //util.ipam_debug.unlisten("models:usage");
   //util.ipam_debug.unlisten("views:available_subnets");
   util.ipam_debug.unlisten("views:nodeview");
 

--- a/htdocs/static/js/src/ipam/models.js
+++ b/htdocs/static/js/src/ipam/models.js
@@ -140,14 +140,15 @@ define(function(require, exports, module) {
       queryParams: {
         ip: null,
         type: ["ipv4", "ipv6", "rfc1918"],
-        net_type: null,
+        net_type: ["scope"],
         search: null,
         timestart: null,
         timeend: null,
         organization: null,
         usage: null,
         vlan: null,
-        description: null
+        description: null,
+        prefix: null
       }
     }
   });

--- a/htdocs/static/js/src/ipam/views/control.js
+++ b/htdocs/static/js/src/ipam/views/control.js
@@ -69,6 +69,7 @@ define(function(require, exports, module) {
       // Set up remote fetching of prefixes for form auto-completion
       var prefixSelect = this.$el.find("#prefix-search-box");
       prefixSelect.select2({
+        minimumInputLength: 1,
         ajax: {
           url: "/api/prefix/search/",
           dataType: 'json',
@@ -93,6 +94,7 @@ define(function(require, exports, module) {
           cache: true
         }
       });
+      prefixSelect.on('change', this.forceSearch.bind(this));
     },
 
     // If the user triggers a search by hitting enter

--- a/htdocs/static/js/src/ipam/views/control.js
+++ b/htdocs/static/js/src/ipam/views/control.js
@@ -66,6 +66,33 @@ define(function(require, exports, module) {
     onRender: function() {
       // Detect select2 inputs
       this.$el.find(".select2").select2();
+      // Set up remote fetching of prefixes for form auto-completion
+      var prefixSelect = this.$el.find("#prefix-search-box");
+      prefixSelect.select2({
+        ajax: {
+          url: "/api/prefix/search/",
+          dataType: 'json',
+          type: "GET",
+          delay: 250,
+          data: function (term, page) {
+            return {
+              net_address: term, // search term
+              page: page
+            };
+          },
+          results: function (data, page) {
+            return {
+              results: $.map(data, function (item) {
+                return {
+                  text: item.net_address,
+                  id: item.net_address
+                };
+              })
+            };
+          },
+          cache: true
+        }
+      });
     },
 
     // If the user triggers a search by hitting enter

--- a/htdocs/static/js/src/ipam/views/control.js
+++ b/htdocs/static/js/src/ipam/views/control.js
@@ -70,6 +70,7 @@ define(function(require, exports, module) {
       var prefixSelect = this.$el.find("#prefix-search-box");
       prefixSelect.select2({
         minimumInputLength: 1,
+        allowClear: true,
         ajax: {
           url: "/api/prefix/search/",
           dataType: 'json',
@@ -95,6 +96,9 @@ define(function(require, exports, module) {
         }
       });
       prefixSelect.on('change', this.forceSearch.bind(this));
+      // Make sure net_type select always reflects default value. This is mostly
+      // needed for the initial rendering.
+      this.$el.find("#prefix-net-type").select2("val", this.model.get("queryParams").net_type);
     },
 
     // If the user triggers a search by hitting enter

--- a/htdocs/static/js/src/ipam/views/prefixmap.js
+++ b/htdocs/static/js/src/ipam/views/prefixmap.js
@@ -259,7 +259,7 @@ define(function(require, exports, module) {
 
   // Maps different types of nodes to different colors
   var colorMap = {
-    "used": d3.hsl(0, 0, .5),
+    "used": d3.hsl(52, 1.0, 0.5),
     "reserved": d3.hsl(210, 0.79, 0.46),
     "available": d3.hsl(0, 0, 1),
     "scope": d3.hsl(0, 0, 0.87)

--- a/htdocs/static/js/src/ipam/views/prefixmap.js
+++ b/htdocs/static/js/src/ipam/views/prefixmap.js
@@ -56,6 +56,8 @@ define(function(require, exports, module) {
           .attr("class", "matrix")
           .append("g");
 
+    var rootTmpl = _.template("<%= prefix %> <% if (description) {%>- <%= description %><% } %>");
+
     // Container for tooltip on nodes
     var div = d3.select("body").append("div")
           .attr("class", "prefix-tooltip")
@@ -74,7 +76,20 @@ define(function(require, exports, module) {
       .attr("fill", colors)
       .attr("stroke", colors(rootElem).darker(1))
       .attr("width", xScale(rootElem.x1) - xScale(rootElem.x0))
-      .attr("height", yScale(rootElem.y1) - yScale(rootElem.y0));
+      .attr("height", yScale(rootElem.y1) - yScale(rootElem.y0))
+      .on("mouseover", function(d) {
+        div.transition()
+          .duration(200)
+          .style("opacity", .9);
+        div.html(tooltipTmpl(rootElem.data))
+          .style("left", (d3.event.pageX) + "px")
+          .style("top", (d3.event.pageY - 28) + "px");
+      })
+      .on("mouseout", function(d) {
+        div.transition()
+          .duration(500)
+          .style("opacity", 0);
+      });
     rootNode
       .append("text")
       .attr("visibility", "visible")
@@ -82,7 +97,7 @@ define(function(require, exports, module) {
       .attr("y", 0.5 * (yScale(rootElem.y1) - yScale(rootElem.y0)))
       .attr("class", "matrix-subnet-root-prefix")
       .append("tspan")
-      .text(rootElem.data.prefix)
+      .text(rootTmpl(rootElem.data))
       .attr("x", 0.5 * (xScale(rootElem.x1) - xScale(rootElem.x0)))
       .attr("y", 0.5 * (yScale(rootElem.y1) - yScale(rootElem.y0)));
 

--- a/htdocs/static/js/src/ipam/views/prefixmap.js
+++ b/htdocs/static/js/src/ipam/views/prefixmap.js
@@ -21,6 +21,7 @@ define(function(require, exports, module) {
   var d3 = require("d3v4");
 
   var viewbox = _.template("0 0 <%= width %> <%= height %>");
+  var tooltipTmpl = _.template("<%= prefix %> <% if (vlan_number) { %> (vlan <%= vlan_number %>)<% } %> - <%= description %>");
 
   var PrefixMap = function(opts) {
     var width = opts.width;
@@ -103,7 +104,7 @@ define(function(require, exports, module) {
             div.transition()
               .duration(200)
               .style("opacity", .9);
-            div.html(d.data.prefix)
+            div.html(tooltipTmpl(d.data))
               .style("left", (d3.event.pageX) + "px")
               .style("top", (d3.event.pageY - 28) + "px");
           })

--- a/htdocs/static/js/src/ipam/views/subnetallocator.js
+++ b/htdocs/static/js/src/ipam/views/subnetallocator.js
@@ -17,6 +17,9 @@ define(function(require, exports, module) {
   var Models = require("src/ipam/models");
   var PrefixMap = require("src/ipam/views/prefixmap");
 
+  // Event broker
+  var globalCh = Backbone.Wreqr.radio.channel("global");
+
   // For simplicity reasons, use a state singleton
   var viewStates = {
     INIT: {
@@ -112,6 +115,9 @@ define(function(require, exports, module) {
       var treeMap = target.find(".treemap").get(0);
       var data = self.model.get("raw_data");
       var notify = function(__node) {
+        if (__node.net_type == "scope") {
+          globalCh.vent.trigger("scrollto", __node);
+        }
         self.fsm.step("FOCUS_NODE", __node);
       };
       // Signal state change, do stuff

--- a/htdocs/static/js/src/subnetmatrix.js
+++ b/htdocs/static/js/src/subnetmatrix.js
@@ -88,7 +88,6 @@ require(['libs/underscore', 'libs/jquery.sparkline'], function() {
                 // Add link and text for usage if colspan is large enough
                 $element.append(this.usageString(result));
             }
-          console.log(result);
             this.createTooltipText($element, this.tooltipTemplateV4, result);
         },
 
@@ -197,18 +196,18 @@ require(['libs/underscore', 'libs/jquery.sparkline'], function() {
 
             // Actually show the tooltip only on click.
             this.container.on('click', function(event) {
-                var $target = $(event.target);
+                var $cell = event.target.nodeName === 'TD' ? $(event.target) : $(event.target).closest('td');
 
-                if ($target.hasClass('has-loaded')) {
+                if ($cell.hasClass('has-loaded')) {
                     // if for some reason the tooltip has not been created, do it now
-                    if (!$target.data('selector')) {
+                    if (!$cell.data('selector')) {
                         self.createTooltip($target);
                     }
 
-                    if ($target.hasClass('open')) {
+                    if ($cell.hasClass('open')) {
                         self.closeAllTips();
                     } else {
-                        self.openTip($target);
+                        self.openTip($cell);
                     }
                 } else {
                     // If we click outside the cells, remove all tooltips
@@ -249,7 +248,7 @@ require(['libs/underscore', 'libs/jquery.sparkline'], function() {
                 var request = $.getJSON($target.data('url'));
                 var sparkContainer = $('<div class="usage-sparkline">&nbsp;</div>');
                 sparkContainer.appendTo($toolTip);
-                
+
                 request.done(function(response) {
                     if (response.length > 0) {
                         var data = response[0],

--- a/htdocs/static/js/src/subnetmatrix.js
+++ b/htdocs/static/js/src/subnetmatrix.js
@@ -15,7 +15,9 @@ require(['libs/underscore', 'libs/jquery.sparkline'], function() {
         this.tooltipTemplateV4 = _.template(
             '<h5><%= heading %></h5>' +
                 '<p>Active IPs: <%= active %> (of max <%= max %>)<br>' +
-                'Usage: <%= usage %>%</p>' +
+                'Usage: <%= usage %>%<br>' +
+                '<% if (vlan_id) { %>VLAN: <%= vlan_id %><br><% } %>' +
+                '<% if (net_ident) { %>netident: <%= net_ident %><br><% } %></p>' +
                 '<a href="<%= url_machinetracker %>" title="<%= title_machinetracker %>">' +
                 '<%= linktext_machinetracker %></a><br>' +
                 '<a href="<%= url_report %>" title="<%= title_report %>">' +
@@ -25,7 +27,9 @@ require(['libs/underscore', 'libs/jquery.sparkline'], function() {
         );
         this.tooltipTemplateV6 = _.template(
             '<h5><%= heading %></h5>' +
-                '<p>Active IPs: <%= active %></p>' +
+                '<p>Active IPs: <%= active %><br>' +
+                '<% if (vlan_id) { %>VLAN: <%= vlan_id %><br><% } %>' +
+                '<% if (net_ident) { %>netident: <%= net_ident %><br><% } %></p>' +
                 '<a href="<%= url_machinetracker %>" title="<%= title_machinetracker %>">' +
                 '<%= linktext_machinetracker %></a><br>' +
                 '<a href="<%= url_report %>" title="<%= title_report %>">' +
@@ -84,6 +88,7 @@ require(['libs/underscore', 'libs/jquery.sparkline'], function() {
                 // Add link and text for usage if colspan is large enough
                 $element.append(this.usageString(result));
             }
+          console.log(result);
             this.createTooltipText($element, this.tooltipTemplateV4, result);
         },
 
@@ -123,6 +128,8 @@ require(['libs/underscore', 'libs/jquery.sparkline'], function() {
                 max: data.max_hosts,
                 usage: data.usage.toFixed(1),
                 url_machinetracker: data.url_machinetracker,
+                net_ident: data.net_ident,
+                vlan_id: data.vlan_id,
                 title_machinetracker: "View active addresses in MachineTracker",
                 linktext_machinetracker: "View active addresses",
                 url_report: data.url_report,

--- a/python/nav/web/api/v1/helpers/prefix_collector.py
+++ b/python/nav/web/api/v1/helpers/prefix_collector.py
@@ -37,6 +37,8 @@ class UsageResult(object):
         self.max_hosts = self.max_addresses - 2
         self.usage = self.active_addresses / float(self.max_hosts) * 100
         self.starttime = starttime
+        self.net_ident = prefix.vlan.net_ident
+        self.vlan_id = prefix.vlan.vlan
         self.endtime = endtime if self.starttime else None
         self.url_machinetracker = reverse(
             'machinetracker-prefixid_search_active', args=[prefix.pk])

--- a/python/nav/web/api/v1/serializers.py
+++ b/python/nav/web/api/v1/serializers.py
@@ -151,6 +151,8 @@ class PrefixUsageSerializer(serializers.Serializer):
     active_addresses = serializers.IntegerField()
     max_addresses = serializers.IntegerField()
     max_hosts = serializers.IntegerField()
+    vlan_id = serializers.IntegerField()
+    net_ident = serializers.CharField()
     url_machinetracker = serializers.CharField()
     url_report = serializers.CharField()
     url_vlan = serializers.CharField()

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -27,7 +27,7 @@ import iso8601
 
 from provider.utils import long_token
 from rest_framework import status, filters, viewsets, exceptions
-from rest_framework.decorators import api_view, renderer_classes
+from rest_framework.decorators import api_view, renderer_classes, list_route
 from rest_framework.reverse import reverse_lazy
 from rest_framework.renderers import (JSONRenderer, BrowsableAPIRenderer,
                                       TemplateHTMLRenderer)
@@ -469,6 +469,20 @@ class PrefixViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.PrefixSerializer
     filter_fields = ('vlan', 'net_address', 'vlan__vlan')
 
+    @list_route()
+    def search(self, request):
+        """Do string-like prefix searching. Currently only supports net_address.
+
+        """
+        net_address = request.GET.get('net_address', None)
+        if not net_address or net_address is None:
+            return Response("Empty search", status=status.HTTP_400_BAD_REQUEST)
+        query = "SELECT * FROM prefix WHERE text(netaddr) LIKE %s"
+        # Note: We assume people always know the beginning of a prefix, and
+        # need to drill down further. Hence the wildcard ("%") at the end.
+        queryset = manage.Prefix.objects.raw(query, [net_address + "%"])
+        results = self.get_serializer(queryset, many=True)
+        return Response(results.data)
 
 class RoutedPrefixList(NAVAPIMixin, ListAPIView):
     """Lists all routed prefixes. A router has category *GSW* or *GW*

--- a/python/nav/web/ipam/prefix_tree.py
+++ b/python/nav/web/ipam/prefix_tree.py
@@ -83,9 +83,11 @@ class PrefixHeap(object):
         # first, try adding to children (recursively)
         matches = (child for child in self.children if node in child)
         for child in matches:
+            node.parent = child
             child.add(node)
             return
         # if this fails, add to self
+        node.parent = self
         self.children.append(node)
         self.children.sort()
 
@@ -159,13 +161,21 @@ class IpNodeFacade(IpNode):
         "last_octet",
         "bits",
         "empty_ranges",
-        "is_reservable"
+        "is_reservable",
+        "parent_pk"
     ]
 
     def __init__(self, ip_addr, pk, net_type, sort_fn=None):
         super(IpNodeFacade, self).__init__(ip_addr, net_type)
         self.pk = pk
         self.sort_fn = sort_fn
+
+    @property
+    def parent_pk(self):
+        "The primary key of the node's parent"
+        if self.parent is None:
+            return None
+        return self.parent.pk
 
     @property
     def is_reservable(self):

--- a/python/nav/web/ipam/prefix_tree.py
+++ b/python/nav/web/ipam/prefix_tree.py
@@ -398,7 +398,7 @@ not part of the RFC1918 ranges.
     family = {"ipv4", "ipv6", "rfc1918"} if family is None else set(family)
     init = []
 
-    if root_ip is not None:
+    if root_ip is not None and root_ip:
         scope = Prefix.objects.get(net_address=root_ip)
         if scope is not None:
             node = PrefixNode(scope)

--- a/python/nav/web/ipam/prefix_tree.py
+++ b/python/nav/web/ipam/prefix_tree.py
@@ -27,6 +27,7 @@ import json
 from django.core.urlresolvers import reverse, NoReverseMatch
 
 from nav.web.ipam.util import get_available_subnets
+from nav.models.manage import Prefix
 
 
 class PrefixHeap(object):
@@ -398,7 +399,12 @@ not part of the RFC1918 ranges.
     init = []
 
     if root_ip is not None:
-        init.append(FauxNode(root_ip, "scope", "scope"))
+        scope = Prefix.objects.get(net_address=root_ip)
+        if scope is not None:
+            node = PrefixNode(scope)
+        else:
+            node = FauxNode(root_ip, "scope", "scope")
+        init.append(node)
 
     opts = {
         "initial_children": init,

--- a/python/nav/web/ipam/util.py
+++ b/python/nav/web/ipam/util.py
@@ -86,6 +86,8 @@ class PrefixQuerysetBuilder(object):
 
     def vlan_number(self, vlan_number):
         "Return prefixes belonging to a particular VLAN"
+        if vlan_number is None and vlan:
+            return self
         return self.filter(vlan_number, vlan__vlan=vlan_number)
 
     def net_type(self, net_type_or_net_types):
@@ -114,9 +116,8 @@ class PrefixQuerysetBuilder(object):
     # Mutating methods, e.g. resets the queryset
     def within(self, prefix):
         "Sets the queryset to every Prefix within a certain prefix"
-        if prefix is None:
-            return self
-        self.queryset = self.queryset & Prefix.objects.within(prefix)
+        if prefix is not None and prefix:
+            self.queryset = self.queryset & Prefix.objects.within(prefix)
         return self
 
     def contains_ip(self, addr):

--- a/python/nav/web/ipam/util.py
+++ b/python/nav/web/ipam/util.py
@@ -86,7 +86,7 @@ class PrefixQuerysetBuilder(object):
 
     def vlan_number(self, vlan_number):
         "Return prefixes belonging to a particular VLAN"
-        if vlan_number is None and vlan:
+        if vlan_number is None and vlan_number:
             return self
         return self.filter(vlan_number, vlan__vlan=vlan_number)
 

--- a/templates/ipam/includes/allocate-subnet.html
+++ b/templates/ipam/includes/allocate-subnet.html
@@ -50,6 +50,7 @@
   </h4>
   <ul>
     <% if (!node.is_mock_node) { %>
+    <li><strong>VLAN:</strong> <%= node.vlan_number || "None" %></li>
     <li><strong>Description:</strong> <%= node.description || "Nothing" %></li>
     <li><strong>Organization:</strong> <%= node.organization %></li>
     <% } %>

--- a/templates/ipam/includes/tree-form-advanced.html
+++ b/templates/ipam/includes/tree-form-advanced.html
@@ -13,6 +13,12 @@
   </label>
 
   <label>
+    Prefix
+    <input id="prefix-search-box" type="text" class="search-param" id="prefix-prefix"
+           name="within" value="<%= queryParams.prefix %>">
+  </label>
+
+  <label>
     Organization (optional)
     <select class="select2 search-param" name="organization" multiple="multiple">
     {% for organization in organizations %}

--- a/templates/ipam/includes/tree-node.html
+++ b/templates/ipam/includes/tree-node.html
@@ -2,6 +2,9 @@
   <div class="prefix-graphs"></div>
   <h3 class="ip">
     <%= prefix %>
+    <% if (description) { %>
+    <span style="font-size: 60%">&nbsp;&ndash; <%= description %></span>
+    <% } %>
     <% if (length >= 1) { %>
     <span title="<%= length %> children" class="number-of-children label round">
     <%= length %>
@@ -39,6 +42,9 @@
     </a>
     <% } %>
     <ul class="prefix-metadata">
+      <% if (vlan_number) { %>
+      <li><strong>VLAN (number):</strong> <%= vlan_number %></li>
+      <% } %>
       <% if (organization) { %>
       <li><strong>Organization:</strong> <%= organization %></li>
       <% } %>

--- a/templates/ipam/includes/tree-node.html
+++ b/templates/ipam/includes/tree-node.html
@@ -1,25 +1,25 @@
-<a href="#prefix-<%= pk %>" class="prefix-tree-item-title">
-  <div class="prefix-graphs"></div>
-  <h3 class="ip">
-    <%= prefix %>
-    <% if (description) { %>
-    <span style="font-size: 60%">&nbsp;&ndash; <%= description %></span>
+<a id="prefix-<%= pk %>" href="#prefix-<%= pk %>" class="prefix-tree-item-title">
+    <div class="prefix-graphs"></div>
+    <h3 class="ip">
+        <%= prefix %>
+        <% if (description) { %>
+        <span style="font-size: 60%">&nbsp;&ndash; <%= description %></span>
+        <% } %>
+        <% if (length >= 1) { %>
+        <span title="<%= length %> children" class="number-of-children label round">
+            <%= length %>
+        </span>
+        <% } %>
+    </h3>
+    <% if (vlan_number) { %>
+    <span class="vlan"><strong>VLAN <%= vlan_number %>:</strong> </span>
     <% } %>
-    <% if (length >= 1) { %>
-    <span title="<%= length %> children" class="number-of-children label round">
-    <%= length %>
-    </span>
+    <% if (net_ident) { %>
+    <span class="net_ident"><%= net_ident %></span> &mdash;
     <% } %>
-  </h3>
-  <% if (vlan_number) { %>
-  <span class="vlan"><strong>VLAN <%= vlan_number %>:</strong> </span>
-  <% } %>
-  <% if (net_ident) { %>
-  <span class="net_ident"><%= net_ident %></span> &mdash;
-  <% } %>
-  <span class="net-type"><%= net_type %></span>
+    <span class="net-type"><%= net_type %></span>
 </a>
-<div id="prefix-<%= pk %>" class="content prefix-tree-item-content">
+<div class="content prefix-tree-item-content">
   <div class="prefix-tree-item-content-data">
     <a class="button small" href="<%= NAV.urls['prefix-index'] %><%= pk %>" target="_blank">
       View details

--- a/templates/report/frag_matrix_report.html
+++ b/templates/report/frag_matrix_report.html
@@ -77,7 +77,9 @@
                   {% if not cell.is_empty %} class="has-data" {% endif %}
                   {% if cell.netaddr %}data-netaddr="{{ cell.netaddr }}"{% endif %}
                   {% if cell.dataurl %}data-url="{{ cell.dataurl }}"{% endif %}
-                  >  {# cell #}
+              >
+                  <i class="fa fa-info"></i>
+                  {# cell #}
 
                 {# Cells that are too small to have text #}
                 {% if cell.colspan in hide_for %}

--- a/templates/report/frag_matrix_report.html
+++ b/templates/report/frag_matrix_report.html
@@ -78,7 +78,7 @@
                   {% if cell.netaddr %}data-netaddr="{{ cell.netaddr }}"{% endif %}
                   {% if cell.dataurl %}data-url="{{ cell.dataurl }}"{% endif %}
               >
-                  <i class="fa fa-info"></i>
+                  <i class="fa fa-info-circle"></i>
                   {# cell #}
 
                 {# Cells that are too small to have text #}


### PR DESCRIPTION
This fixes a couple of minor visual aspects of the IPAM, adding the description to the prefix listing itself (allowing for quick perusal) and providing more useful context in the tooltips (VLAN, description). This should make it more comfortable to crawl prefixes with many sub-allocations.

Also fixes a minor API bug where information about the top-level prefix is not returned when searching for available address space for delegation purposes. This allows us to draw more stuff in the prefix allocation viz, for example a tooltip displaying the VLAN id.