### PR TITLE
(portadmin) Fix confusion regarding baseport vs ifindex

### DIFF
--- a/python/nav/arnold.py
+++ b/python/nav/arnold.py
@@ -454,13 +454,13 @@ def change_port_vlan(identity, vlan):
 
     agent = SNMPFactory().get_instance(netbox)
     try:
-        fromvlan = agent.get_vlan(interface.ifindex)
+        fromvlan = agent.get_vlan(interface)
     except Exception as error:
         raise ChangePortVlanError(error)
     else:
         LOGGER.info('Setting vlan %s on interface %s', vlan, interface)
         try:
-            agent.set_vlan(interface.ifindex, vlan)
+            agent.set_vlan(interface, vlan)
             agent.restart_if(interface.ifindex)
         except Exception as error:
             raise ChangePortVlanError(error)

--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -414,9 +414,9 @@ def set_vlan(account, fac, interface, request):
                 if not is_cisco_voice_enabled(config) and voice_activated:
                     fac.set_native_vlan(interface, vlan)
                 else:
-                    fac.set_vlan(interface.ifindex, vlan)
+                    fac.set_vlan(interface, vlan)
             else:
-                fac.set_vlan(interface.ifindex, vlan)
+                fac.set_vlan(interface, vlan)
 
             interface.vlan = vlan
             LogEntry.add_log_entry(

--- a/tests/unittests/portadmin/portadmin_test.py
+++ b/tests/unittests/portadmin/portadmin_test.py
@@ -17,9 +17,11 @@ class PortadminResponseTest(unittest.TestCase):
         
         self.hpType = Mock()
         self.hpType.vendor = self.hpVendor
+        self.hpType.get_enterprise_id.return_value = VENDOR_ID_HEWLETT_PACKARD
 
         self.ciscoType = Mock()
         self.ciscoType.vendor = self.ciscoVendor
+        self.ciscoType.get_enterprise_id.return_value = VENDOR_ID_CISCOSYSTEMS
 
         self.netboxHP = Mock()
         self.netboxHP.type = self.hpType
@@ -72,8 +74,10 @@ class PortadminResponseTest(unittest.TestCase):
         # replace get-method on Snmp-object with a mock-method
         # this get-method returns a vlan-number
         self.snmpReadOnlyHandler.get = Mock(return_value=666)
-        self.assertEqual(self.handler.get_vlan(1), 666,
+        ifc = Interface(baseport=1)
+        self.assertEqual(self.handler.get_vlan(ifc), 666,
                                 "getVlan-test failed")
+        self.snmpReadOnlyHandler.get.assert_called_with('1.3.6.1.2.1.17.7.1.4.5.1.1.1')
 
     def test_get_ifaliases_hp(self):
         self.handler = SNMPFactory.get_instance(self.netboxHP)
@@ -117,6 +121,8 @@ class PortadminResponseTest(unittest.TestCase):
         self.handler = SNMPFactory.get_instance(self.netboxCisco)
         self.assertNotEqual(self.handler, None, 'Could not get handler-object')
         self.assertEquals(self.handler.__unicode__(),  u'cisco', 'Wrong handler-type')
+        self.assertEquals(type(self.handler), Cisco, 'Wrong handler-type')
+
     def test_get_ifaliases_cisco(self):
         self.handler = SNMPFactory.get_instance(self.netboxCisco)
         # get hold of the read-only Snmp-object
@@ -129,13 +135,16 @@ class PortadminResponseTest(unittest.TestCase):
 
     def test_get_vlan_cisco(self):
         self.handler = SNMPFactory.get_instance(self.netboxCisco)
+        assert type(self.handler) == Cisco
         # get hold of the read-only Snmp-object
         self.snmpReadOnlyHandler = self.handler._get_read_only_handle()
         # replace get-method on Snmp-object with a mock-method
         # this get-method returns a vlan-number
         self.snmpReadOnlyHandler.get = Mock(return_value=77)
-        self.assertEqual(self.handler.get_vlan(1), 77,
+        ifc = Interface(ifindex=1)
+        self.assertEqual(self.handler.get_vlan(ifc), 77,
                                 "getVlan-test failed")
+        self.snmpReadOnlyHandler.get.assert_called_with('1.3.6.1.4.1.9.9.68.1.2.2.1.2.1')
 
     def test_get_ifaliases_cisco(self):
         self.handler = SNMPFactory.get_instance(self.netboxCisco)


### PR DESCRIPTION
The base SNMPHandler's get_vlan and set_vlan methods accepted a baseport as argument, while the cisco subclass accepted an ifindex. Various callers called these with ifindex. Changed both versions to accept an Interface as arguments and hide the details from the caller

Fixes #1560