### PR TITLE
Fixed deleting non-required schemas in search_path

### DIFF
--- a/python/nav/pgsync.py
+++ b/python/nav/pgsync.py
@@ -321,11 +321,11 @@ class Synchronizer(object):
                        if wanted not in schemas]
 
         if add_schemas:
+            print(("Existing namespaces in %s search path: %s. Adding %s." %
+                   (self.connect_options.dbname, ", ".join(schemas), ", ".join(add_schemas))))
             schemas.extend(add_schemas)
-            print(("Adding namespaces to %s search_path: %s" %
-                   (self.connect_options.dbname, ", ".join(add_schemas))))
             sql = ('ALTER DATABASE "%s" SET search_path TO %s' %
-                   (self.connect_options.dbname, ", ".join(add_schemas)))
+                   (self.connect_options.dbname, ", ".join(schemas)))
             self.cursor.execute(sql)
         self.connection.commit()
         self.connect() # must reconnect to activate the new search path

--- a/sql/changes/sc.03.08.0000.sql
+++ b/sql/changes/sc.03.08.0000.sql
@@ -1,6 +1,6 @@
 DROP TABLE nav_schema_version;
 
-CREATE TABLE schema_change_log (
+CREATE TABLE manage.schema_change_log (
     id SERIAL PRIMARY KEY,
     major INTEGER NOT NULL,
     minor INTEGER NOT NULL,

--- a/sql/changes/sc.03.13.0001.sql
+++ b/sql/changes/sc.03.13.0001.sql
@@ -1,5 +1,5 @@
 -- Added because macwatch may use mac-address prefixes
-CREATE TABLE macwatch_match(
+CREATE TABLE manage.macwatch_match(
   id SERIAL PRIMARY KEY,
   macwatch INT NOT NULL REFERENCES macwatch(id) ON DELETE CASCADE ON UPDATE CASCADE,
   cam INT NOT NULL REFERENCES cam(camid) ON DELETE CASCADE ON UPDATE CASCADE,

--- a/sql/changes/sc.03.14.0001.sql
+++ b/sql/changes/sc.03.14.0001.sql
@@ -1,6 +1,6 @@
 -- Create table for netbios names
 
-CREATE TABLE netbios (
+CREATE TABLE manage.netbios (
   netbiosid SERIAL PRIMARY KEY,
   ip INET NOT NULL,
   mac MACADDR NOT NULL,

--- a/sql/changes/sc.03.15.0002.sql
+++ b/sql/changes/sc.03.15.0002.sql
@@ -1,6 +1,6 @@
 -- Create table for images
 
-CREATE TABLE image (
+CREATE TABLE manage.image (
   imageid SERIAL PRIMARY KEY,
   roomid VARCHAR REFERENCES room(roomid) NOT NULL,
   title VARCHAR NOT NULL,

--- a/sql/changes/sc.03.15.0070.sql
+++ b/sql/changes/sc.03.15.0070.sql
@@ -1,6 +1,6 @@
 -- Create basic token storage for api tokens
 
-CREATE TABLE apitoken (
+CREATE TABLE manage.apitoken (
   id SERIAL PRIMARY KEY,
   token VARCHAR not null,
   expires TIMESTAMP not null,

--- a/sql/changes/sc.04.03.0002.sql
+++ b/sql/changes/sc.04.03.0002.sql
@@ -1,4 +1,4 @@
-CREATE TABLE netboxentity (
+CREATE TABLE manage.netboxentity (
   netboxentityid SERIAL NOT NULL,
   netboxid INTEGER NOT NULL,
 

--- a/sql/changes/sc.04.06.0052.sql
+++ b/sql/changes/sc.04.06.0052.sql
@@ -1,5 +1,5 @@
 -- Create table for storing prefix tags
-CREATE TABLE IF NOT EXISTS prefix_usage (
+CREATE TABLE IF NOT EXISTS manage.prefix_usage (
     prefix_usage_id SERIAL PRIMARY KEY,
     prefixid        INTEGER REFERENCES prefix (prefixid)
                     ON UPDATE CASCADE ON DELETE CASCADE,

--- a/sql/changes/sc.04.07.0001.sql
+++ b/sql/changes/sc.04.07.0001.sql
@@ -1,4 +1,4 @@
-CREATE TABLE peersession (
+CREATE TABLE manage.peersession (
   peersessionid SERIAL NOT NULL,
   netboxid INTEGER NOT NULL,
   protocol INTEGER NOT NULL,

--- a/sql/changes/sc.04.07.0060.sql
+++ b/sql/changes/sc.04.07.0060.sql
@@ -1,6 +1,6 @@
 -- Definition of a rack with environment sensors
 
-CREATE TABLE IF NOT EXISTS rack (
+CREATE TABLE IF NOT EXISTS manage.rack (
   rackid SERIAL PRIMARY KEY,
   roomid VARCHAR REFERENCES room ON DELETE CASCADE,
   rackname VARCHAR,

--- a/sql/changes/sc.04.07.0100.sql
+++ b/sql/changes/sc.04.07.0100.sql
@@ -1,6 +1,6 @@
 BEGIN;
-CREATE TABLE "auditlog_logentry" ("id" serial NOT NULL PRIMARY KEY, "actor_model" varchar NOT NULL, "actor_pk" varchar NOT NULL, "object_model" varchar NULL, "object_pk" varchar NULL, "target_model" varchar NULL, "target_pk" varchar NULL, "timestamp" timestamp with time zone NOT NULL, "verb" varchar(50) NOT NULL, "summary" text NOT NULL, "subsystem" varchar NULL, "before" text NULL, "after" text NULL);
-CREATE INDEX "auditlog_logentry_b512ddf1" ON "auditlog_logentry" ("verb");
-CREATE INDEX "auditlog_logentry_verb_210dd763c4f184d9_like" ON "auditlog_logentry" ("verb" varchar_pattern_ops);
+CREATE TABLE "manage.auditlog_logentry" ("id" serial NOT NULL PRIMARY KEY, "actor_model" varchar NOT NULL, "actor_pk" varchar NOT NULL, "object_model" varchar NULL, "object_pk" varchar NULL, "target_model" varchar NULL, "target_pk" varchar NULL, "timestamp" timestamp with time zone NOT NULL, "verb" varchar(50) NOT NULL, "summary" text NOT NULL, "subsystem" varchar NULL, "before" text NULL, "after" text NULL);
+CREATE INDEX "auditlog_logentry_b512ddf1" ON "manage.auditlog_logentry" ("verb");
+CREATE INDEX "auditlog_logentry_verb_210dd763c4f184d9_like" ON "manage.auditlog_logentry" ("verb" varchar_pattern_ops);
 INSERT INTO subsystem (name) VALUES ('auditlog');
 COMMIT;


### PR DESCRIPTION
Fixes so that pgsync correctly inserts existing non-required schemas to the search_path