### PR TITLE
Sixify dunder unicode, easy pickings

### DIFF
--- a/python/nav/django/auth.py
+++ b/python/nav/django/auth.py
@@ -25,6 +25,7 @@ from django.http import (HttpResponseForbidden, HttpResponseRedirect,
                          HttpResponse)
 from django.contrib.sessions.backends.db import SessionStore
 from django.conf import settings
+from django.utils.encoding import python_2_unicode_compatible
 
 
 _logger = getLogger(__name__)
@@ -138,17 +139,19 @@ def get_sudoer(request):
         return Account.objects.get(id=request.session[SUDOER_ID_VAR])
 
 
+@python_2_unicode_compatible
 class SudoRecursionError(Exception):
     msg = u"Already posing as another user"
 
-    def __unicode__(self):
+    def __str__(self):
         return self.msg
 
 
+@python_2_unicode_compatible
 class SudoNotAdminError(Exception):
     msg = u"Not admin"
 
-    def __unicode__(self):
+    def __str__(self):
         return self.msg
 
 

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -16,13 +16,17 @@
 """Models for the NAV API"""
 
 from datetime import datetime
+
 from django.db import models
 from django.core.urlresolvers import reverse
 from django_hstore import hstore
+from django.utils.encoding import python_2_unicode_compatible
+
 from nav.models.fields import VarcharField
 from nav.models.profiles import Account
 
 
+@python_2_unicode_compatible
 class APIToken(models.Model):
     """APItokens are used for authenticating to the api
 
@@ -42,7 +46,7 @@ class APIToken(models.Model):
 
     objects = hstore.HStoreManager()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.token
 
     def is_expired(self):

--- a/python/nav/models/arnold.py
+++ b/python/nav/models/arnold.py
@@ -18,9 +18,11 @@
 
 #pylint: disable=R0903
 
+from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
+
 from nav.models.fields import VarcharField
 from nav.models.manage import Interface
-from django.db import models
 
 STATUSES = [
     ('enabled', 'Enabled'),
@@ -34,6 +36,7 @@ DETENTION_TYPE_CHOICES = [('disable', 'Block'),
 KEEP_CLOSED_CHOICES = [('n', 'Open on move'), ('y', 'All closed')]
 
 
+@python_2_unicode_compatible
 class Identity(models.Model):
     """
     The table contains a listing for each computer,interface combo Arnold
@@ -70,7 +73,7 @@ class Identity(models.Model):
     # The format is "interface.ifname at interface.netbox.sysname"
     textual_interface = VarcharField(default='')
 
-    def __unicode__(self):
+    def __str__(self):
         try:
             interface = self.interface
         except Interface.DoesNotExist:
@@ -85,6 +88,7 @@ class Identity(models.Model):
         unique_together = ('mac', 'interface')
 
 
+@python_2_unicode_compatible
 class Event(models.Model):
     """A class representing an action taken"""
     id = models.AutoField(db_column='eventid', primary_key=True)
@@ -97,7 +101,7 @@ class Event(models.Model):
     autoenablestep = models.IntegerField(null=True)
     executor = VarcharField(db_column='username')
 
-    def __unicode__(self):
+    def __str__(self):
         return "%s: %s" % (self.action, self.event_time)
 
     class Meta(object):
@@ -105,13 +109,14 @@ class Event(models.Model):
         ordering = ('event_time', )
 
 
+@python_2_unicode_compatible
 class Justification(models.Model):
     """Represents the justification for an event"""
     id = models.AutoField(db_column='blocked_reasonid', primary_key=True)
     name = VarcharField()
     description = VarcharField(db_column='comment', blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     class Meta(object):
@@ -119,13 +124,14 @@ class Justification(models.Model):
         ordering = ('name', )
 
 
+@python_2_unicode_compatible
 class QuarantineVlan(models.Model):
     """A quarantine vlan is a vlan where offenders are placed"""
     id = models.AutoField(db_column='quarantineid', primary_key=True)
     vlan = models.IntegerField(unique=True)
     description = VarcharField(blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return "%s - %s" % (self.vlan, self.description)
 
     class Meta(object):
@@ -133,6 +139,7 @@ class QuarantineVlan(models.Model):
         ordering = ('vlan',)
 
 
+@python_2_unicode_compatible
 class DetentionProfile(models.Model):
     """A detention profile is a configuration used by an automatic detention"""
     id = models.AutoField(db_column='blockid', primary_key=True)
@@ -155,7 +162,7 @@ class DetentionProfile(models.Model):
     quarantine_vlan = models.ForeignKey('QuarantineVlan',
                                         db_column='quarantineid', null=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     class Meta(object):

--- a/python/nav/models/cabling.py
+++ b/python/nav/models/cabling.py
@@ -17,11 +17,13 @@
 """Django ORM wrapper for the NAV manage database"""
 
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 
 from nav.models.manage import Room, Interface
 from nav.models.fields import VarcharField
 
 
+@python_2_unicode_compatible
 class Cabling(models.Model):
     """From NAV Wiki: The cabling table documents the cabling from the wiring
     closet's jack number to the end user's room number."""
@@ -38,7 +40,7 @@ class Cabling(models.Model):
         db_table = 'cabling'
         unique_together = (('room', 'jack'),)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'jack %s, in room %s' % (self.jack, self.room.id)
 
     def verbose(self):
@@ -48,6 +50,7 @@ class Cabling(models.Model):
                          self.description] if x]))
 
 
+@python_2_unicode_compatible
 class Patch(models.Model):
     """From NAV Wiki: The patch table documents the cross connect from switch
     port to jack."""
@@ -62,5 +65,5 @@ class Patch(models.Model):
         db_table = 'patch'
         unique_together = (('interface', 'cabling'),)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s, patched to %s' % (self.interface, self.cabling)

--- a/python/nav/models/event.py
+++ b/python/nav/models/event.py
@@ -24,6 +24,7 @@ import datetime as dt
 
 from django.db import models
 from django.db.models import Q
+from django.utils.encoding import python_2_unicode_compatible
 
 from nav.models.fields import VarcharField, DateTimeInfinityField, UNRESOLVED
 
@@ -40,6 +41,7 @@ STATE_CHOICES = (
 )
 
 
+@python_2_unicode_compatible
 class Subsystem(models.Model):
     """From NAV Wiki: Defines the subsystems that post or receives an event."""
 
@@ -49,7 +51,7 @@ class Subsystem(models.Model):
     class Meta(object):
         db_table = 'subsystem'
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 #######################################################################
@@ -182,6 +184,7 @@ class StateVariableMap(VariableMapBase):
                     variable.save()
 
 
+@python_2_unicode_compatible
 class UnknownEventSubject(object):
     """Representation of unknown alert/event subjects"""
     def __init__(self, alert):
@@ -194,7 +197,7 @@ class UnknownEventSubject(object):
         if self.netbox:
             return self.netbox.get_absolute_url()
 
-    def __unicode__(self):
+    def __str__(self):
         descr = self._get_description_from_message()
         if descr:
             return descr
@@ -272,6 +275,7 @@ class EventMixIn(object):
         return self.netbox or u"N/A"
 
 
+@python_2_unicode_compatible
 class ThresholdEvent(object):
     """
     Magic class to act as a threshold event subject that produces useful
@@ -289,7 +293,7 @@ class ThresholdEvent(object):
         from nav.metrics.lookup import lookup
         self.subject = lookup(self.metric)
 
-    def __unicode__(self):
+    def __str__(self):
         subject = self.subject or self.metric
         if self.rule:
             descr = self.rule.description or self.rule.alert
@@ -312,6 +316,7 @@ class ThresholdEvent(object):
                 return self.subject.netbox.get_absolute_url()
 
 
+@python_2_unicode_compatible
 class EventQueue(models.Model, EventMixIn):
     """From NAV Wiki: The event queue. Additional data in eventqvar. Different
     subsystem (specified in source) post events on the event queue. Normally
@@ -349,7 +354,7 @@ class EventQueue(models.Model, EventMixIn):
             for attr in ('id', 'event_type_id', 'source_id', 'target_id',
                          'netbox', 'subid', 'state', 'time'))
 
-    def __unicode__(self):
+    def __str__(self):
         string = ("{self.event_type} {state} event for {self.netbox} "
                   "(subid={self.subid}) from {self.source} to {self.target} "
                   "at {self.time}")
@@ -364,6 +369,7 @@ class EventQueue(models.Model, EventMixIn):
             self.varmap = self.varmap
 
 
+@python_2_unicode_compatible
 class EventType(models.Model):
     """From NAV Wiki: Defines event types."""
 
@@ -382,10 +388,11 @@ class EventType(models.Model):
     class Meta(object):
         db_table = 'eventtype'
 
-    def __unicode__(self):
+    def __str__(self):
         return self.id
 
 
+@python_2_unicode_compatible
 class EventQueueVar(models.Model):
     """From NAV Wiki: Defines additional (key,value) tuples that follow
     events."""
@@ -399,13 +406,14 @@ class EventQueueVar(models.Model):
         db_table = 'eventqvar'
         unique_together = (('event_queue', 'variable'),)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s=%s' % (self.variable, self.value)
 
 #######################################################################
 ### Alert system
 
 
+@python_2_unicode_compatible
 class AlertQueue(models.Model, EventMixIn):
     """From NAV Wiki: The alert queue. Additional data in alertqvar and
     alertmsg. Event engine posts alerts on the alert queue (and in addition on
@@ -441,7 +449,7 @@ class AlertQueue(models.Model, EventMixIn):
     class Meta(object):
         db_table = 'alertq'
 
-    def __unicode__(self):
+    def __str__(self):
         return u'Source %s, state %s, severity %d' % (
             self.source, self.get_state_display(), self.severity)
 
@@ -453,6 +461,7 @@ class AlertQueue(models.Model, EventMixIn):
             self.varmap = self.varmap
 
 
+@python_2_unicode_compatible
 class AlertType(models.Model):
     """From NAV Wiki: Defines the alert types. An event type may have many alert
     types."""
@@ -466,10 +475,11 @@ class AlertType(models.Model):
         db_table = 'alerttype'
         unique_together = (('event_type', 'name'),)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s, of event type %s' % (self.name, self.event_type)
 
 
+@python_2_unicode_compatible
 class AlertQueueMessage(models.Model):
     """From NAV Wiki: Event engine will, based on alertmsg.conf, preformat the
     alarm messages, one message for each configured alert channel (email, sms),
@@ -487,10 +497,11 @@ class AlertQueueMessage(models.Model):
         db_table = 'alertqmsg'
         unique_together = (('alert_queue', 'type', 'language'),)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s message in language %s' % (self.type, self.language)
 
 
+@python_2_unicode_compatible
 class AlertQueueVariable(models.Model):
     """From NAV Wiki: Defines additional (key,value) tuples that follow alert.
     Note: the eventqvar tuples are passed along to the alertqvar table so that
@@ -506,7 +517,7 @@ class AlertQueueVariable(models.Model):
         db_table = 'alertqvar'
         unique_together = (('alert_queue', 'variable'),)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s=%s' % (self.variable, self.value)
 
 
@@ -527,6 +538,7 @@ class AlertHistoryManager(models.Manager):
         return self.filter(filtr)
 
 
+@python_2_unicode_compatible
 class AlertHistory(models.Model, EventMixIn):
     """From NAV Wiki: The alert history. Simular to the alert queue with one
     important distinction; alert history stores stateful events as one row,
@@ -551,7 +563,7 @@ class AlertHistory(models.Model, EventMixIn):
     class Meta(object):
         db_table = 'alerthist'
 
-    def __unicode__(self):
+    def __str__(self):
         return u'Source %s, severity %d' % (self.source, self.severity)
 
     def is_stateful(self):
@@ -615,6 +627,7 @@ class AlertHistory(models.Model, EventMixIn):
             self.varmap = self.varmap
 
 
+@python_2_unicode_compatible
 class AlertHistoryMessage(models.Model):
     """From NAV Wiki: To have a history of the formatted messages too, they are
     stored in alerthistmsg."""
@@ -637,10 +650,11 @@ class AlertHistoryMessage(models.Model):
         db_table = 'alerthistmsg'
         unique_together = (('alert_history', 'state', 'type', 'language'),)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s message in language %s' % (self.type, self.language)
 
 
+@python_2_unicode_compatible
 class AlertHistoryVariable(models.Model):
     """From NAV Wiki: Defines additional (key,value) tuples that follow the
     alerthist record."""
@@ -662,10 +676,11 @@ class AlertHistoryVariable(models.Model):
         db_table = 'alerthistvar'
         unique_together = (('alert_history', 'state', 'variable'),)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s=%s' % (self.variable, self.value)
 
 
+@python_2_unicode_compatible
 class Acknowledgement(models.Model):
     """Alert acknowledgements"""
     alert = models.OneToOneField('AlertHistory', null=False, blank=False,
@@ -677,6 +692,6 @@ class Acknowledgement(models.Model):
     class Meta(object):
         db_table = 'alerthist_ack'
 
-    def __unicode__(self):
+    def __str__(self):
         return u"%r acknowledged by %s at %s" % (self.alert, self.account,
                                                  self.date)

--- a/python/nav/models/logger.py
+++ b/python/nav/models/logger.py
@@ -19,22 +19,26 @@ Django ORM wrapper for the NAV logger database
 
 
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
+
 from nav.models.fields import VarcharField
 
 
+@python_2_unicode_compatible
 class LoggerCategory(models.Model):
     """
     Model for the logger.category-table
     """
     category = VarcharField(db_column='category', unique=True, primary_key=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.category
 
     class Meta(object):
         db_table = '"logger"."category"'
 
 
+@python_2_unicode_compatible
 class Origin(models.Model):
     """
     Model for the logger.origin-table
@@ -43,13 +47,14 @@ class Origin(models.Model):
     name = VarcharField(db_column='name')
     category = models.ForeignKey(LoggerCategory, db_column='category')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     class Meta(object):
         db_table = '"logger"."origin"'
 
 
+@python_2_unicode_compatible
 class Priority(models.Model):
     """
     Model for the logger.priority-table
@@ -58,13 +63,14 @@ class Priority(models.Model):
     keyword = VarcharField(db_column='keyword', unique=True)
     description = VarcharField(db_column='description')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.keyword
 
     class Meta(object):
         db_table = '"logger"."priority"'
 
 
+@python_2_unicode_compatible
 class LogMessageType(models.Model):
     """
     Model for the logger.log_message_type-table
@@ -74,7 +80,7 @@ class LogMessageType(models.Model):
     facility = VarcharField(db_column='facility')
     mnemonic = VarcharField(db_column='mnemonic')
 
-    def __unicode__(self):
+    def __str__(self):
         return u"{0}-{1}-{2}".format(
             self.facility,
             self.priority,

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -29,6 +29,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models import Q
+from django.utils.encoding import python_2_unicode_compatible
 from functools import partial
 from itertools import count, groupby
 
@@ -66,6 +67,7 @@ class UpsManager(models.Manager):
             sensor__internal_name__startswith='ups').distinct()
 
 
+@python_2_unicode_compatible
 class Netbox(models.Model):
     """From NAV Wiki: The netbox table is the heart of the heart so to speak,
     the most central table of them all. The netbox tables contains information
@@ -114,7 +116,7 @@ class Netbox(models.Model):
         verbose_name_plural = 'ip devices'
         ordering = ('sysname',)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.get_short_sysname()
 
     @property
@@ -372,6 +374,7 @@ class Netbox(models.Model):
             Q(unit_of_measurement__icontains='percent'))
 
 
+@python_2_unicode_compatible
 class NetboxInfo(models.Model):
     """From NAV Wiki: The netboxinfo table is the place
     to store additional info on a netbox."""
@@ -387,10 +390,11 @@ class NetboxInfo(models.Model):
         db_table = 'netboxinfo'
         unique_together = (('netbox', 'key', 'variable', 'value'),)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s="%s"' % (self.variable, self.value)
 
 
+@python_2_unicode_compatible
 class NetboxEntity(models.Model):
     """
     Represents a physical Entity within a Netbox. Largely modeled after
@@ -464,7 +468,7 @@ class NetboxEntity(models.Model):
         db_table = 'netboxentity'
         unique_together = (('netbox', 'index'),)
 
-    def __unicode__(self):
+    def __str__(self):
         klass = (self.get_physical_class_display() or '').capitalize()
         title = self.name or '(Unnamed entity)'
         if klass and not title.strip().lower().startswith(klass.lower()):
@@ -535,6 +539,7 @@ class NetboxEntity(models.Model):
         return parents
 
 
+@python_2_unicode_compatible
 class NetboxPrefix(models.Model):
     """Which prefix a netbox is connected to.
 
@@ -550,7 +555,7 @@ class NetboxPrefix(models.Model):
         db_table = 'netboxprefix'
         unique_together = (('netbox', 'prefix'),)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s at %s' % (self.netbox.sysname, self.prefix.net_address)
 
     def save(self, *_args, **_kwargs):
@@ -558,6 +563,7 @@ class NetboxPrefix(models.Model):
         raise Exception("Cannot save to a view.")
 
 
+@python_2_unicode_compatible
 class Device(models.Model):
     """From NAV Wiki: The device table contains all physical devices in the
     network. As opposed to the netbox table, the device table focuses on the
@@ -574,10 +580,11 @@ class Device(models.Model):
     class Meta(object):
         db_table = 'device'
 
-    def __unicode__(self):
+    def __str__(self):
         return self.serial or ''
 
 
+@python_2_unicode_compatible
 class Module(models.Model):
     """From NAV Wiki: The module table defines modules. A module is a part of a
     netbox of category GW, SW and GSW. A module has ports; i.e router ports
@@ -607,7 +614,7 @@ class Module(models.Model):
         ordering = ('netbox', 'module_number', 'name')
         unique_together = (('netbox', 'name'),)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'{name} at {netbox}'.format(
             name=self.name or self.module_number, netbox=self.netbox)
 
@@ -692,6 +699,7 @@ class Module(models.Model):
         return current
 
 
+@python_2_unicode_compatible
 class Memory(models.Model):
     """From NAV Wiki: The mem table describes the memory
     (memory and nvram) of a netbox."""
@@ -707,13 +715,14 @@ class Memory(models.Model):
         db_table = 'mem'
         unique_together = (('netbox', 'type', 'device'),)
 
-    def __unicode__(self):
+    def __str__(self):
         if self.used is not None and self.size is not None and self.size != 0:
             return u'%s, %d%% used' % (self.type, self.used * 100 // self.size)
         else:
             return self.type
 
 
+@python_2_unicode_compatible
 class Room(models.Model):
     """From NAV Wiki: The room table defines a wiring closes / network room /
     server room."""
@@ -732,7 +741,7 @@ class Room(models.Model):
         verbose_name = 'room'
         ordering = ('id',)
 
-    def __unicode__(self):
+    def __str__(self):
         if self.description:
             return u'%s (%s)' % (self.id, self.description)
         else:
@@ -768,6 +777,7 @@ class TreeMixin(object):
         return descendants
 
 
+@python_2_unicode_compatible
 class Location(models.Model, TreeMixin):
     """The location table defines a group of rooms; i.e. a campus."""
 
@@ -783,7 +793,7 @@ class Location(models.Model, TreeMixin):
         db_table = 'location'
         verbose_name = 'location'
 
-    def __unicode__(self):
+    def __str__(self):
         if self.description:
             return u'{} ({})'.format(self.id, self.description)
         else:
@@ -796,6 +806,7 @@ class Location(models.Model, TreeMixin):
         return Room.objects.filter(location__in=locations)
 
 
+@python_2_unicode_compatible
 class Organization(models.Model, TreeMixin):
     """From NAV Wiki: The org table defines an organization which is in charge
     of a given netbox and is the user of a given prefix."""
@@ -814,7 +825,7 @@ class Organization(models.Model, TreeMixin):
         verbose_name = 'organization'
         ordering = ['id']
 
-    def __unicode__(self):
+    def __str__(self):
         if self.description:
             return u'{o.id} ({o.description})'.format(o=self)
         else:
@@ -826,6 +837,7 @@ class Organization(models.Model, TreeMixin):
         return re.findall(r'(\b[\w.]+@[\w.]+\b)', contact)
 
 
+@python_2_unicode_compatible
 class Category(models.Model):
     """From NAV Wiki: The cat table defines the categories of a netbox
     (GW,GSW,SW,EDGE,WLAN,SRV,OTHER)."""
@@ -839,7 +851,7 @@ class Category(models.Model):
         verbose_name = 'category'
         verbose_name_plural = 'categories'
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s (%s)' % (self.id, self.description)
 
     def is_gw(self):
@@ -867,6 +879,7 @@ class Category(models.Model):
         return self.id == 'OTHER'
 
 
+@python_2_unicode_compatible
 class NetboxGroup(models.Model):
     """A group that one or more netboxes belong to
 
@@ -886,13 +899,14 @@ class NetboxGroup(models.Model):
         ordering = ('id',)
         verbose_name = 'device group'
 
-    def __unicode__(self):
+    def __str__(self):
         return self.id
 
     def get_absolute_url(self):
         return reverse('netbox-group-detail', kwargs={'groupid': self.pk})
 
 
+@python_2_unicode_compatible
 class NetboxCategory(models.Model):
     """Store the relation between a netbox and its groups"""
 
@@ -907,10 +921,11 @@ class NetboxCategory(models.Model):
         db_table = 'netboxcategory'
         unique_together = (('netbox', 'category'),)  # Primary key
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s in category %s' % (self.netbox, self.category)
 
 
+@python_2_unicode_compatible
 class NetboxType(models.Model):
     """From NAV Wiki: The type table defines the type of a netbox, the
     sysobjectid being the unique identifier."""
@@ -925,7 +940,7 @@ class NetboxType(models.Model):
         db_table = 'type'
         unique_together = (('vendor', 'name'),)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s (%s from %s)' % (self.name, self.description, self.vendor)
 
     def get_enterprise_id(self):
@@ -947,6 +962,7 @@ class NetboxType(models.Model):
 ### Device management
 
 
+@python_2_unicode_compatible
 class Vendor(models.Model):
     """From NAV Wiki: The vendor table defines vendors. A
     type is of a vendor. A product is of a vendor."""
@@ -958,13 +974,14 @@ class Vendor(models.Model):
         db_table = 'vendor'
         ordering = ('id', )
 
-    def __unicode__(self):
+    def __str__(self):
         return self.id
 
 #######################################################################
 ### Router/topology
 
 
+@python_2_unicode_compatible
 class GwPortPrefix(models.Model):
     """Defines IP addresses assigned to Interfaces, with a relation to the
     associated Prefix.
@@ -978,7 +995,7 @@ class GwPortPrefix(models.Model):
     class Meta(object):
         db_table = 'gwportprefix'
 
-    def __unicode__(self):
+    def __str__(self):
         return self.gw_ip
 
 
@@ -1012,6 +1029,7 @@ class PrefixManager(models.Manager):
         ).select_related('vlan')
 
 
+@python_2_unicode_compatible
 class Prefix(models.Model):
     """From NAV Wiki: The prefix table stores IP prefixes."""
 
@@ -1026,7 +1044,7 @@ class Prefix(models.Model):
     class Meta(object):
         db_table = 'prefix'
 
-    def __unicode__(self):
+    def __str__(self):
         if self.vlan:
             return u'%s (vlan %s)' % (self.net_address, self.vlan)
         else:
@@ -1064,6 +1082,7 @@ class Prefix(models.Model):
         return reverse('prefix-details', args=[self.pk])
 
 
+@python_2_unicode_compatible
 class Vlan(models.Model):
     """From NAV Wiki: The vlan table defines the IP broadcast domain / vlan. A
     broadcast domain often has a vlan value, it may consist of many IP
@@ -1083,7 +1102,7 @@ class Vlan(models.Model):
     class Meta(object):
         db_table = 'vlan'
 
-    def __unicode__(self):
+    def __str__(self):
         result = u''
         if self.vlan:
             result += u'%d' % self.vlan
@@ -1121,6 +1140,7 @@ class Vlan(models.Model):
                 format='json')
 
 
+@python_2_unicode_compatible
 class NetType(models.Model):
     """From NAV Wiki: The nettype table defines network type;lan, core, link,
     elink, loopback, closed, static, reserved, scope. The network types are
@@ -1133,10 +1153,11 @@ class NetType(models.Model):
     class Meta(object):
         db_table = 'nettype'
 
-    def __unicode__(self):
+    def __str__(self):
         return self.id
 
 
+@python_2_unicode_compatible
 class PrefixUsage(models.Model):
     """Combines prefixes and usages for tagging of prefixes"""
     id = models.AutoField(db_column='prefix_usage_id', primary_key=True)
@@ -1146,10 +1167,11 @@ class PrefixUsage(models.Model):
     class Meta(object):
         db_table = 'prefix_usage'
 
-    def __unicode__(self):
+    def __str__(self):
         return u"{}:{}".format(self.prefix.net_address, self.usage.id)
 
 
+@python_2_unicode_compatible
 class Usage(models.Model):
     """From NAV Wiki: The usage table defines the user group (student, staff
     etc). Usage categories are maintained in the edit database tool."""
@@ -1162,10 +1184,11 @@ class Usage(models.Model):
         verbose_name = 'usage'
         ordering = ['id']
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s (%s)' % (self.id, self.description)
 
 
+@python_2_unicode_compatible
 class Arp(models.Model):
     """From NAV Wiki: The arp table contains (ip, mac, time
     start, time end)."""
@@ -1183,13 +1206,14 @@ class Arp(models.Model):
     class Meta(object):
         db_table = 'arp'
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s to %s' % (self.ip, self.mac)
 
 #######################################################################
 ### Switch/topology
 
 
+@python_2_unicode_compatible
 class SwPortVlan(models.Model):
     """From NAV Wiki: The swportvlan table defines the
     vlan values on all switch ports. dot1q trunk ports
@@ -1216,10 +1240,11 @@ class SwPortVlan(models.Model):
         db_table = 'swportvlan'
         unique_together = (('interface', 'vlan'),)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s, on vlan %s' % (self.interface, self.vlan)
 
 
+@python_2_unicode_compatible
 class SwPortAllowedVlan(models.Model):
     """Stores a hexstring that encodes the list of VLANs that are allowed to
     traverse a trunk port.
@@ -1273,10 +1298,11 @@ class SwPortAllowedVlan(models.Model):
         bits = BitVector(string)
         return set(bits.get_set_bits())
 
-    def __unicode__(self):
+    def __str__(self):
         return u'Allowed vlans for swport %s' % self.interface
 
 
+@python_2_unicode_compatible
 class SwPortBlocked(models.Model):
     """This table defines the spanning tree blocked ports for a given vlan for
     a given switch port."""
@@ -1289,10 +1315,11 @@ class SwPortBlocked(models.Model):
         db_table = 'swportblocked'
         unique_together = (('interface', 'vlan'),)  # Primary key
 
-    def __unicode__(self):
+    def __str__(self):
         return '%d, at %s' % (self.vlan, self.interface)
 
 
+@python_2_unicode_compatible
 class AdjacencyCandidate(models.Model):
     """A candidate for netbox/interface adjacency.
 
@@ -1316,13 +1343,14 @@ class AdjacencyCandidate(models.Model):
         db_table = 'adjacency_candidate'
         unique_together = (('netbox', 'interface', 'to_netbox', 'source'),)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s:%s %s candidate %s:%s' % (self.netbox, self.interface,
                                               self.source,
                                               self.to_netbox,
                                               self.to_interface)
 
 
+@python_2_unicode_compatible
 class NetboxVtpVlan(models.Model):
     """From NAV Wiki: A help table that contains the vtp vlan database of a
     switch. For certain cisco switches cam information is gathered using a
@@ -1338,10 +1366,11 @@ class NetboxVtpVlan(models.Model):
         db_table = 'netbox_vtpvlan'
         unique_together = (('netbox', 'vtp_vlan'),)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%d, at %s' % (self.vtp_vlan, self.netbox)
 
 
+@python_2_unicode_compatible
 class Cam(models.Model):
     """From NAV Wiki: The cam table defines (swport, mac, time start, time
     end)"""
@@ -1363,13 +1392,14 @@ class Cam(models.Model):
         unique_together = (('netbox', 'sysname', 'module', 'port',
                             'mac', 'start_time'),)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s, %s' % (self.mac, self.netbox)
 
 
 #######################################################################
 ### Interfaces and related attributes
 
+@python_2_unicode_compatible
 class Interface(models.Model):
     """The network interfaces, both physical and virtual, of a Netbox."""
 
@@ -1447,7 +1477,7 @@ class Interface(models.Model):
         # FIXME: Replace with real Django caching
         self.time_since_activity_cache = {}
 
-    def __unicode__(self):
+    def __str__(self):
         return u'{ifname} at {netbox}'.format(
             ifname=self.ifname, netbox=self.netbox)
 
@@ -1735,6 +1765,7 @@ class GatewayPeerSession(models.Model):
                            peer=self.get_peer_display())
 
 
+@python_2_unicode_compatible
 class Sensor(models.Model):
     """
     This table contains meta-data about available sensors in
@@ -1878,7 +1909,7 @@ class Sensor(models.Model):
         db_table = 'sensor'
         ordering = ('name',)
 
-    def __unicode__(self):
+    def __str__(self):
         return u"Sensor '{}' on {}".format(
             self.human_readable or self.internal_name,
             self.netbox)
@@ -1922,6 +1953,7 @@ class Sensor(models.Model):
         return self.unit_of_measurement
 
 
+@python_2_unicode_compatible
 class PowerSupplyOrFan(models.Model):
     STATE_UP = u'y'
     STATE_DOWN = u'n'
@@ -1959,7 +1991,7 @@ class PowerSupplyOrFan(models.Model):
         """Returns True if the owning Netbox is on maintenance"""
         return self.netbox.is_on_maintenance()
 
-    def __unicode__(self):
+    def __str__(self):
         return "{name} at {netbox}".format(
             name=self.name or self.descr,
             netbox=self.netbox
@@ -1971,6 +2003,7 @@ class PowerSupplyOrFan(models.Model):
         return base + "#!sensors"
 
 
+@python_2_unicode_compatible
 class UnrecognizedNeighbor(models.Model):
     id = models.AutoField(primary_key=True)
     netbox = models.ForeignKey(Netbox, db_column='netboxid')
@@ -1985,13 +2018,14 @@ class UnrecognizedNeighbor(models.Model):
         db_table = 'unrecognized_neighbor'
         ordering = ('remote_id',)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s:%s %s neighbor %s (%s)' % (
             self.netbox.sysname, self.interface.ifname,
             self.source,
             self.remote_id, self.remote_name)
 
 
+@python_2_unicode_compatible
 class IpdevpollJobLog(models.Model):
     id = models.AutoField(primary_key=True)
     netbox = models.ForeignKey(Netbox, db_column='netboxid', null=False,
@@ -2005,7 +2039,7 @@ class IpdevpollJobLog(models.Model):
     class Meta(object):
         db_table = 'ipdevpoll_job_log'
 
-    def __unicode__(self):
+    def __str__(self):
         return u"Job %s for %s ended in %s at %s, after %s seconds" % (
             self.job_name, self.netbox.sysname,
             'success' if self.success else 'failure',

--- a/python/nav/models/msgmaint.py
+++ b/python/nav/models/msgmaint.py
@@ -17,12 +17,15 @@
 """Django ORM wrapper for the NAV manage database"""
 
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
+
 from datetime import datetime, timedelta
 from nav.models.fields import (VarcharField, LegacyGenericForeignKey,
                                DateTimeInfinityField, INFINITY)
 from nav.models import manage, service
 
 
+@python_2_unicode_compatible
 class Message(models.Model):
     """From NAV Wiki: The table contains the messages registered
     in the messages tool. Each message has a timeframe for when
@@ -47,7 +50,7 @@ class Message(models.Model):
     class Meta(object):
         db_table = 'message'
 
-    def __unicode__(self):
+    def __str__(self):
         return u'"%s" by %s' % (self.title, self.author)
 
 
@@ -79,6 +82,7 @@ class MaintenanceTaskManager(models.Manager):
         return self.get_queryset().filter(end_time__gte=INFINITY)
 
 
+@python_2_unicode_compatible
 class MaintenanceTask(models.Model):
     """From NAV Wiki: The maintenance task created in the maintenance task
     tool."""
@@ -105,7 +109,7 @@ class MaintenanceTask(models.Model):
     class Meta(object):
         db_table = 'maint_task'
 
-    def __unicode__(self):
+    def __str__(self):
         return u'"%s" by %s' % (self.description, self.author)
 
     def full_representation(self):
@@ -146,6 +150,7 @@ class MaintenanceTask(models.Model):
         return self.end_time >= INFINITY
 
 
+@python_2_unicode_compatible
 class MaintenanceComponent(models.Model):
     """From NAV Wiki: The components that are put on maintenance in the
     maintenance tool."""
@@ -161,10 +166,11 @@ class MaintenanceComponent(models.Model):
         db_table = 'maint_component'
         unique_together = (('maint_task', 'key', 'value'),)  # Primary key
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s=%s' % (self.key, self.value)
 
 
+@python_2_unicode_compatible
 class MessageToMaintenanceTask(models.Model):
     """From NAV Wiki: The connection between messages and related maintenance
     tasks."""
@@ -179,6 +185,6 @@ class MessageToMaintenanceTask(models.Model):
         db_table = 'message_to_maint_task'
         unique_together = (('message', 'maintenance_task'),)  # Primary key
 
-    def __unicode__(self):
+    def __str__(self):
         return u'Message %s, connected to task %s' % (
             self.message, self.maintenance_task)

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -30,6 +30,7 @@ from django.views.decorators.debug import sensitive_variables
 from hashlib import md5
 
 from django.db import models, transaction
+from django.utils.encoding import python_2_unicode_compatible
 from django_hstore import hstore
 
 import nav.path
@@ -66,6 +67,7 @@ _ = lambda a: a
 ### Account models
 
 
+@python_2_unicode_compatible
 class Account(models.Model):
     """ NAV's basic account model"""
 
@@ -97,7 +99,7 @@ class Account(models.Model):
         db_table = u'account'
         ordering = ('login',)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.login
 
     def get_active_profile(self):
@@ -230,6 +232,7 @@ class Account(models.Model):
             self.password = '!' + self.password
 
 
+@python_2_unicode_compatible
 class AccountGroup(models.Model):
     """NAV account groups"""
 
@@ -248,7 +251,7 @@ class AccountGroup(models.Model):
         db_table = u'accountgroup'
         ordering = ('name',)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def is_system_group(self):
@@ -268,6 +271,7 @@ class AccountGroup(models.Model):
         return self.id == self.ADMIN_GROUP
 
 
+@python_2_unicode_compatible
 class NavbarLink(models.Model):
     """A hyperlink on a user's navigation bar."""
     account = models.ForeignKey('Account', db_column='accountid')
@@ -278,10 +282,11 @@ class NavbarLink(models.Model):
         db_table = u'navbarlink'
         ordering = ('id', )
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s=%s' % (self.name, self.uri)
 
 
+@python_2_unicode_compatible
 class Privilege(models.Model):
     """A privilege granted to an AccountGroup."""
     group = models.ForeignKey('AccountGroup', db_column='accountgroupid')
@@ -291,10 +296,11 @@ class Privilege(models.Model):
     class Meta(object):
         db_table = u'accountgroupprivilege'
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s for %s' % (self.type, self.target)
 
 
+@python_2_unicode_compatible
 class PrivilegeType(models.Model):
     """A registered privilege type."""
     id = models.AutoField(db_column='privilegeid', primary_key=True)
@@ -303,10 +309,11 @@ class PrivilegeType(models.Model):
     class Meta(object):
         db_table = u'privilege'
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
+@python_2_unicode_compatible
 class AlertAddress(models.Model):
     """Accounts alert addresses, valid types are retrived from
     alertengine.conf
@@ -321,7 +328,7 @@ class AlertAddress(models.Model):
     class Meta(object):
         db_table = u'alertaddress'
 
-    def __unicode__(self):
+    def __str__(self):
         return self.type.scheme() + self.address
 
     @transaction.atomic
@@ -383,6 +390,7 @@ class AlertAddress(models.Model):
         return True
 
 
+@python_2_unicode_compatible
 class AlertSender(models.Model):
     """A registered alert sender/medium."""
     name = models.CharField(max_length=100)
@@ -403,7 +411,7 @@ class AlertSender(models.Model):
         SLACK: u'slack:'
     }
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     @transaction.atomic
@@ -454,6 +462,7 @@ class AlertSender(models.Model):
         db_table = 'alertsender'
 
 
+@python_2_unicode_compatible
 class AlertPreference(models.Model):
     """AlertProfile account preferences"""
 
@@ -467,13 +476,14 @@ class AlertPreference(models.Model):
     class Meta(object):
         db_table = u'alertpreference'
 
-    def __unicode__(self):
+    def __str__(self):
         return 'preferences for %s' % self.account
 
 
 #######################################################################
 ### Profile models
 
+@python_2_unicode_compatible
 class AlertProfile(models.Model):
     """Account AlertProfiles"""
 
@@ -506,7 +516,7 @@ class AlertProfile(models.Model):
     class Meta(object):
         db_table = u'alertprofile'
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def get_active_timeperiod(self):
@@ -548,6 +558,7 @@ class AlertProfile(models.Model):
         return active_timeperiod
 
 
+@python_2_unicode_compatible
 class TimePeriod(models.Model):
     """Defines TimerPeriods and which part of the week they are valid"""
 
@@ -569,11 +580,12 @@ class TimePeriod(models.Model):
     class Meta(object):
         db_table = u'timeperiod'
 
-    def __unicode__(self):
+    def __str__(self):
         return u'from %s for %s profile on %s' % (
             self.start, self.profile, self.get_valid_during_display())
 
 
+@python_2_unicode_compatible
 class AlertSubscription(models.Model):
     """Links an address and timeperiod to a filtergroup with a given
     subscription type.
@@ -601,7 +613,7 @@ class AlertSubscription(models.Model):
     class Meta(object):
         db_table = u'alertsubscription'
 
-    def __unicode__(self):
+    def __str__(self):
         return 'alerts received %s should be sent %s to %s' % (
             self.time_period, self.get_type_display(), self.alert_address)
 
@@ -609,6 +621,7 @@ class AlertSubscription(models.Model):
 ### Equipment models
 
 
+@python_2_unicode_compatible
 class FilterGroupContent(models.Model):
     """Defines how a given filter should be used in a filtergroup"""
 
@@ -639,7 +652,7 @@ class FilterGroupContent(models.Model):
         db_table = u'filtergroupcontent'
         ordering = ['priority']
 
-    def __unicode__(self):
+    def __str__(self):
         if self.include:
             type_ = 'inclusive'
         else:
@@ -651,6 +664,7 @@ class FilterGroupContent(models.Model):
         return '%s filter on %s' % (type_, self.filter)
 
 
+@python_2_unicode_compatible
 class Operator(models.Model):
     """Defines valid operators for a given matchfield."""
 
@@ -727,7 +741,7 @@ class Operator(models.Model):
         db_table = u'operator'
         unique_together = (('type', 'match_field'),)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s match on %s' % (self.get_type_display(), self.match_field)
 
     def get_operator_mapping(self):
@@ -739,6 +753,7 @@ class Operator(models.Model):
         return self.IP_OPERATOR_MAPPING[self.type]
 
 
+@python_2_unicode_compatible
 class Expression(models.Model):
     """Combines filer, operator, matchfield and value into an expression that
     can be evaluated.
@@ -752,7 +767,7 @@ class Expression(models.Model):
     class Meta(object):
         db_table = u'expression'
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s match on %s against %s' % (self.get_operator_display(),
                                               self.match_field, self.value)
 
@@ -761,6 +776,7 @@ class Expression(models.Model):
         return Operator(type=self.operator).get_operator_mapping()
 
 
+@python_2_unicode_compatible
 class Filter(models.Model):
     """One or more expressions that are combined with an and operation.
 
@@ -773,7 +789,7 @@ class Filter(models.Model):
     class Meta(object):
         db_table = u'filter'
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def check(self, alert):
@@ -881,6 +897,7 @@ class Filter(models.Model):
         return False
 
 
+@python_2_unicode_compatible
 class FilterGroup(models.Model):
     """A set of filters group contents that an account can subscribe to or be
     given permission to.
@@ -896,10 +913,11 @@ class FilterGroup(models.Model):
     class Meta(object):
         db_table = u'filtergroup'
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
+@python_2_unicode_compatible
 class MatchField(models.Model):
     """Defines which fields can be matched upon and how"""
 
@@ -1064,7 +1082,7 @@ class MatchField(models.Model):
     class Meta(object):
         db_table = u'matchfield'
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def get_lookup_mapping(self):
@@ -1090,6 +1108,7 @@ class MatchField(models.Model):
 #######################################################################
 ### AlertEngine models
 
+@python_2_unicode_compatible
 class SMSQueue(models.Model):
     """Queue of messages that should be sent or have been sent by SMSd"""
 
@@ -1116,7 +1135,7 @@ class SMSQueue(models.Model):
     class Meta(object):
         db_table = u'smsq'
 
-    def __unicode__(self):
+    def __str__(self):
         return '"%s" to %s, sent: %s' % (self.message, self.phone, self.sent)
 
     def save(self, *args, **kwargs):
@@ -1197,6 +1216,7 @@ class AccountAlertQueue(models.Model):
 LINK_TYPES = (2, 'Layer 2'), (3, 'Layer 3')
 
 
+@python_2_unicode_compatible
 class NetmapView(models.Model):
     """Properties for a specific view in Netmap"""
     viewid = models.AutoField(primary_key=True)
@@ -1212,7 +1232,7 @@ class NetmapView(models.Model):
     display_orphans = models.BooleanField(default=False)
     location_room_filter = models.CharField(max_length=255, blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s (%s)' % (self.viewid, self.title)
 
     def topology_unicode(self):
@@ -1270,6 +1290,7 @@ class NetmapViewDefaultView(models.Model):
         db_table = u'netmap_view_defaultview'
 
 
+@python_2_unicode_compatible
 class NetmapViewCategories(models.Model):
     """Saved categories for a selected view in Netmap"""
     id = models.AutoField(primary_key=True)  # Serial for faking a primary key
@@ -1278,7 +1299,7 @@ class NetmapViewCategories(models.Model):
     category = models.ForeignKey(
         Category, db_column='catid', related_name='netmapview_set')
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s in category %s' % (self.view, self.category)
 
     class Meta(object):
@@ -1300,6 +1321,7 @@ class NetmapViewNodePosition(models.Model):
         db_table = u'netmap_view_nodeposition'
 
 
+@python_2_unicode_compatible
 class AccountTool(models.Model):
     """Link between tool and account"""
     id = models.AutoField(primary_key=True, db_column='account_tool_id')
@@ -1308,13 +1330,14 @@ class AccountTool(models.Model):
     display = models.BooleanField(default=True)
     priority = models.IntegerField(default=0)
 
-    def __unicode__(self):
+    def __str__(self):
         return "%s - %s" % (self.toolname, self.account)
 
     class Meta(object):
         db_table = u'accounttool'
 
 
+@python_2_unicode_compatible
 class AccountDashboard(models.Model):
     """Stores dashboards for each user"""
     name = VarcharField()
@@ -1322,7 +1345,7 @@ class AccountDashboard(models.Model):
     num_columns = models.IntegerField(default=3)
     account = models.ForeignKey(Account)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def get_absolute_url(self):
@@ -1345,6 +1368,7 @@ class AccountDashboard(models.Model):
         ordering = ('name',)
 
 
+@python_2_unicode_compatible
 class AccountNavlet(models.Model):
     """Store information about a users navlets"""
     navlet = VarcharField()
@@ -1354,7 +1378,7 @@ class AccountNavlet(models.Model):
     column = models.IntegerField(db_column='col')
     dashboard = models.ForeignKey(AccountDashboard, related_name='widgets')
 
-    def __unicode__(self):
+    def __str__(self):
         return "%s - %s" % (self.navlet, self.account)
 
     def to_json_dict(self):

--- a/python/nav/models/rack.py
+++ b/python/nav/models/rack.py
@@ -19,6 +19,7 @@ import json
 from itertools import chain
 
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 
 from nav.models.fields import VarcharField
 from nav.models.manage import Room, Sensor
@@ -39,6 +40,7 @@ class RackManager(models.Manager):
         return set(chain(*sensor_pks))
 
 
+@python_2_unicode_compatible
 class Rack(models.Model):
     """A physical rack placed in a room."""
 
@@ -56,7 +58,7 @@ class Rack(models.Model):
     class Meta(object):
         db_table = 'rack'
 
-    def __unicode__(self):
+    def __str__(self):
         return "'{}' in {}".format(self.rackname or self.id, self.room.pk)
 
     @property

--- a/python/nav/models/service.py
+++ b/python/nav/models/service.py
@@ -17,6 +17,8 @@
 """Django ORM wrapper for the NAV manage database"""
 
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
+
 from nav.metrics.data import get_metric_average
 from nav.metrics.templates import (
     metric_path_for_service_availability,
@@ -27,6 +29,7 @@ from nav.models.manage import Netbox
 from nav.models.fields import VarcharField
 
 
+@python_2_unicode_compatible
 class Service(models.Model):
     """From NAV Wiki: The service table defines the services on a netbox that
     serviceMon monitors."""
@@ -52,7 +55,7 @@ class Service(models.Model):
         db_table = 'service'
         ordering = ('handler',)
 
-    def __unicode__(self):
+    def __str__(self):
         return u"{handler} at {netbox}".format(
             handler=self.handler, netbox=self.netbox)
 
@@ -127,6 +130,7 @@ class Service(models.Model):
     description = property(get_handler_description)
 
 
+@python_2_unicode_compatible
 class ServiceProperty(models.Model):
     """From NAV Wiki: Each service may have an additional set of attributes.
     They are defined here."""
@@ -140,5 +144,5 @@ class ServiceProperty(models.Model):
         db_table = 'serviceproperty'
         unique_together = (('service', 'property'),) # Primary key
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s=%s, for %s' % (self.property, self.value, self.service)

--- a/python/nav/portadmin/snmputils.py
+++ b/python/nav/portadmin/snmputils.py
@@ -19,6 +19,8 @@ import time
 import logging
 from operator import attrgetter
 
+from django.utils.encoding import python_2_unicode_compatible
+
 from nav import Snmp
 from nav.errors import NoNetboxTypeError
 from nav.Snmp.errors import (SnmpError, UnsupportedSnmpVersionError,
@@ -36,6 +38,7 @@ CHARS_IN_1024_BITS = 128
 # TODO: Fix get_vlans as it does not return all vlans, see get_available_vlans
 
 
+@python_2_unicode_compatible
 class FantasyVlan(object):
     """A container object for storing vlans for a netbox
 
@@ -50,7 +53,7 @@ class FantasyVlan(object):
         self.net_ident = netident
         self.descr = descr
 
-    def __unicode__(self):
+    def __str__(self):
         if self.net_ident:
             return "%s (%s)" % (self.vlan, self.net_ident)
         else:
@@ -63,6 +66,7 @@ class FantasyVlan(object):
         return cmp(self.vlan, other.vlan)
 
 
+@python_2_unicode_compatible
 class SNMPHandler(object):
     """A basic class for SNMP-read and -write to switches."""
 
@@ -102,7 +106,7 @@ class SNMPHandler(object):
         self.timeout = kwargs.get('timeout', 3)
         self.retries = kwargs.get('retries', 3)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.netbox.type.vendor.id
 
     def _bulkwalk(self, oid):

--- a/python/nav/watchdog/tests.py
+++ b/python/nav/watchdog/tests.py
@@ -21,6 +21,7 @@ import logging
 from datetime import datetime, timedelta
 from django.utils.timesince import timesince
 from django.db.models import Count
+from django.utils.encoding import python_2_unicode_compatible
 
 from nav.asyncdns import reverse_lookup
 from nav.models.manage import IpdevpollJobLog, Netbox, Arp, Cam
@@ -34,6 +35,7 @@ STATUS_NOT_OK = 'not_ok'
 STATUS_UNKNOWN = 'unknown'
 
 
+@python_2_unicode_compatible
 class TestResult(object):
     """Result for test errors"""
 
@@ -41,7 +43,7 @@ class TestResult(object):
         self.description = description  # The human readable description
         self.obj = obj  # An optional object representing the test
 
-    def __unicode__(self):
+    def __str__(self):
         return unicode(self.description)
 
     def __str__(self):

--- a/python/nav/web/macwatch/models.py
+++ b/python/nav/web/macwatch/models.py
@@ -18,11 +18,14 @@
 import re
 
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
+
 from nav.models.fields import VarcharField
 from nav.models.manage import Cam
 from nav.models.profiles import Account
 
 
+@python_2_unicode_compatible
 class MacWatch(models.Model):
     """Data-model for mac-address that should get watched
     by bin/macwatch.py"""
@@ -42,7 +45,7 @@ class MacWatch(models.Model):
         db_table = u'macwatch'
         ordering = ('created',)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s' % self.mac
 
     def _filtered_mac_addr(self):
@@ -80,6 +83,7 @@ class MacWatch(models.Model):
             return self.mac
 
 
+@python_2_unicode_compatible
 class MacWatchMatch(models.Model):
     """Extra model (helper-model) for mac-watch when macwatch
     only has a mac-adress prefix"""
@@ -91,6 +95,6 @@ class MacWatchMatch(models.Model):
     class Meta(object):
         db_table = u'macwatch_match'
 
-    def __unicode__(self):
+    def __str__(self):
         return (u'id=%d; macwatch = %d; cam = %d; posted = %s' %
                 (self.id, self.macwatch, self.cam, str(self.posted)))

--- a/python/nav/web/webfront/utils.py
+++ b/python/nav/web/webfront/utils.py
@@ -20,6 +20,7 @@ from datetime import datetime
 import logging
 
 from django.db.models import Q
+from django.utils.encoding import python_2_unicode_compatible
 
 from nav.web import webfrontConfig
 from nav.models.msgmaint import Message
@@ -30,6 +31,7 @@ from nav.models.profiles import AccountTool
 _logger = logging.getLogger('nav.web.tools.utils')
 
 
+@python_2_unicode_compatible
 class Tool(object):
     """Class representing a tool"""
     def __init__(self, name, uri, icon, description, priority=0, display=True,
@@ -42,7 +44,7 @@ class Tool(object):
         self.display = display
         self.doclink = doclink
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def __eq__(self, other):


### PR DESCRIPTION
All places where it was easy to convert `__unicode__` to work on python3.

There's still usage of `__unicode__` in:

```
nav/netmap/stubs/__init__.py
nav/macaddress.py
tests/unittests/netmap/metaclass_testcase.py
tests/unittests/portadmin/portadmin_test.py
```

These will take slightly more effort.