### PR TITLE
Update template settings to work on Django 1.8+

### DIFF
--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -37,7 +37,8 @@ except IOError:
     webfront_config = {}
 
 DEBUG = nav_config.get('DJANGO_DEBUG', 'False').upper() in ('TRUE', 'YES', 'ON')
-TEMPLATE_DEBUG = DEBUG
+
+TEMPLATE_DEBUG = DEBUG # XXX Pre Django 1.8
 
 # Admins
 ADMINS = (
@@ -80,21 +81,34 @@ STATICFILES_FINDERS = (
 
 
 # Templates
-TEMPLATE_DIRS = (
-    os.path.join(nav.path.sysconfdir, 'templates'),
-    nav.path.djangotmpldir
-)
 
-# Context processors
-TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.core.context_processors.request',
-    'django.contrib.messages.context_processors.messages',
-    'nav.django.context_processors.debug',
-    'nav.django.context_processors.account_processor',
-    'nav.django.context_processors.nav_version',
-    'nav.django.context_processors.graphite_base',
-    'nav.django.context_processors.footer_info',
-    'django.core.context_processors.static',
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            os.path.join(nav.path.sysconfdir, 'templates'),
+            nav.path.djangotmpldir,
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.core.context_processors.request',
+                'django.contrib.messages.context_processors.messages',
+                'nav.django.context_processors.debug',
+                'nav.django.context_processors.account_processor',
+                'nav.django.context_processors.nav_version',
+                'nav.django.context_processors.graphite_base',
+                'nav.django.context_processors.footer_info',
+                'django.core.context_processors.static',
+            ],
+            'debug': DEBUG,
+        },
+    }
+]
+
+TEMPLATE_DIRS = tuple(TEMPLATES[0]['DIRS']) # XXX Pre Django 1.8
+TEMPLATE_CONTEXT_PROCESSORS = tuple(        # XXX Pre Django 1.8
+    TEMPLATES[0]['OPTIONS']['context_processors']
 )
 
 # Middleware


### PR DESCRIPTION
The following should work on both 1.7 and 1.8, and should be easy to clean up after moving to 1.8+.