### PR TITLE
Split Jenkinsfile into Python 2 and Python 3 testing environments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+/**
+ * -*- indent-tabs-mode: nil -*-
+ * -*- tab-width: 4 -*-
+ * Work in tandem with tests/docker/Dockerfile & Co to run a full CI run in
+ * Jenkins.
+*/
+node {
+    stage("Checkout") {
+        checkout scm
+    }
+    withEnv(["PYTHON_VERSION=2"]) {
+        load 'Jenkinsfile-common'
+    }
+}

--- a/Jenkinsfile-common
+++ b/Jenkinsfile-common
@@ -10,11 +10,11 @@
 
 try {
     def dockerfile = 'tests/docker/Dockerfile'
-    if (env.PYTHON_VERSOIN == '3') {
+    if (env.PYTHON_VERSION == '3') {
         dockerfile = 'tests/docker/Dockerfile3'
     }
 
-    docker.build("nav/testfjas:${env.BUILD_NUMBER}", "-f tests/docker/Dockerfile .").inside() {
+    docker.build("nav/testfjas:${env.BUILD_NUMBER}", "-f ${dockerfile} .").inside() {
         env.WORKSPACE = "${WORKSPACE}"
         env.BUILDDIR = "/opt/nav"
         env.TARGETURL = "http://localhost:8000/"

--- a/Jenkinsfile-common
+++ b/Jenkinsfile-common
@@ -10,8 +10,9 @@
 
 node {
     try {
-        stage("Checkout") {
-            checkout scm
+        def dockerfile = 'tests/docker/Dockerfile'
+        if (env.PYTHON_VERSOIN == '3') {
+            dockerfile = 'tests/docker/Dockerfile3'
         }
 
         docker.build("nav/testfjas:${env.BUILD_NUMBER}", "-f tests/docker/Dockerfile .").inside() {

--- a/Jenkinsfile-common
+++ b/Jenkinsfile-common
@@ -8,110 +8,106 @@
  * TODO: Publish coverage data
 */
 
-node {
-    try {
-        def dockerfile = 'tests/docker/Dockerfile'
-        if (env.PYTHON_VERSOIN == '3') {
-            dockerfile = 'tests/docker/Dockerfile3'
-        }
-
-        docker.build("nav/testfjas:${env.BUILD_NUMBER}", "-f tests/docker/Dockerfile .").inside() {
-            env.WORKSPACE = "${WORKSPACE}"
-            env.BUILDDIR = "/opt/nav"
-            env.TARGETURL = "http://localhost:8000/"
-
-            stage("Build NAV") {
-                sh "git fetch --tags" // seems tags arent't cloned by Jenkins :P
-                sh "/build.sh"
-            }
-
-            parallel(
-                "analyze": {
-                    stage("Analyze") {
-                        parallel (
-                            "PyLint": {
-                                env.PYLINTHOME = "${WORKSPACE}"
-                                sh """/pylint.sh > "${WORKSPACE}/pylint.txt" """
-                                //sh 'cat pylint.txt'
-                                step([
-                                    $class                     : 'WarningsPublisher',
-                                    parserConfigurations       : [[
-                                                                  parserName: 'PYLint',
-                                                                    pattern   : 'pylint.txt'
-                                                                ]],
-                                    unstableTotalAll           : '1400',
-                                    failedTotalAll             : '1450',
-                                    usePreviousBuildAsReference: true
-                                ])
-
-                            },
-                            "Lines of code": {
-                                sh "/count-lines-of-code.sh"
-                            }
-                        )
-                    }
-                },
-                "test": {
-                    try {
-                        stage("Run Python unit tests") {
-                            sh "/python-unit-tests.sh"
-                        }
-
-                        stage("Create database and start services") {
-                            sh "/create-db.sh"
-                            sh "/start-services.sh"
-                        }
-
-                        stage("Run integration tests") {
-                            sh "/integration-tests.sh"
-                        }
-
-                        stage("Run Selenium tests") {
-                            sh "/functional-tests.sh"
-                        }
-
-                        stage("Run JavaScript tests") {
-                            sh "/javascript-tests.sh"
-                        }
-                    } finally {
-                        junit "**/*-results.xml"
-                        step([$class: 'CoberturaPublisher', coberturaReportFile: 'tests/coverage.xml'])
-                    }
-                }
-            )
-
-        }
-
-        stage("Publish documentation") {
-            echo "This job is ${JOB_BASE_NAME}"
-            // publish dev docs and stable branch docs, but nothing else
-            if (env.JOB_BASE_NAME == 'master' || env.JOB_BASE_NAME.endsWith('.x')) {
-                VERSION = sh (
-                    script: 'cd ${WORKSPACE}/doc; python -c "import conf; print conf.version"',
-                    returnStdout: true
-                ).trim()
-                if (VERSION == '') {
-                    echo "VERSION is empty, not publishing docs"
-                }
-                else {
-                    echo "Publishing docs for ${VERSION}"
-                    sh "rsync -av --delete --no-perms --chmod=Dog+rx,Fog+r '${WORKSPACE}/doc/html/' 'doc@nav.uninett.no:/var/www/doc/${VERSION}/'"
-                }
-            }
-        }
-
-        archiveArtifacts artifacts: 'tests/*-report.html'
-
-    } catch (e) {
-        currentBuild.result = "FAILED"
-        echo "Build FAILED set status ${currentBuild.result}"
-        throw e
-    } finally {
-        notifyBuild(currentBuild.result)
+try {
+    def dockerfile = 'tests/docker/Dockerfile'
+    if (env.PYTHON_VERSOIN == '3') {
+        dockerfile = 'tests/docker/Dockerfile3'
     }
 
-}
+    docker.build("nav/testfjas:${env.BUILD_NUMBER}", "-f tests/docker/Dockerfile .").inside() {
+        env.WORKSPACE = "${WORKSPACE}"
+        env.BUILDDIR = "/opt/nav"
+        env.TARGETURL = "http://localhost:8000/"
 
+        stage("Build NAV") {
+            sh "git fetch --tags" // seems tags arent't cloned by Jenkins :P
+            sh "/build.sh"
+        }
+
+        parallel(
+            "analyze": {
+                stage("Analyze") {
+                    parallel (
+                        "PyLint": {
+                            env.PYLINTHOME = "${WORKSPACE}"
+                            sh """/pylint.sh > "${WORKSPACE}/pylint.txt" """
+                            //sh 'cat pylint.txt'
+                            step([
+                                $class                     : 'WarningsPublisher',
+                                parserConfigurations       : [[
+                                                              parserName: 'PYLint',
+                                                                pattern   : 'pylint.txt'
+                                                            ]],
+                                unstableTotalAll           : '1400',
+                                failedTotalAll             : '1450',
+                                usePreviousBuildAsReference: true
+                            ])
+
+                        },
+                        "Lines of code": {
+                            sh "/count-lines-of-code.sh"
+                        }
+                    )
+                }
+            },
+            "test": {
+                try {
+                    stage("Run Python unit tests") {
+                        sh "/python-unit-tests.sh"
+                    }
+
+                    stage("Create database and start services") {
+                        sh "/create-db.sh"
+                        sh "/start-services.sh"
+                    }
+
+                    stage("Run integration tests") {
+                        sh "/integration-tests.sh"
+                    }
+
+                    stage("Run Selenium tests") {
+                        sh "/functional-tests.sh"
+                    }
+
+                    stage("Run JavaScript tests") {
+                        sh "/javascript-tests.sh"
+                    }
+                } finally {
+                    junit "**/*-results.xml"
+                    step([$class: 'CoberturaPublisher', coberturaReportFile: 'tests/coverage.xml'])
+                }
+            }
+        )
+
+    }
+
+    stage("Publish documentation") {
+        echo "This job is ${JOB_BASE_NAME}"
+        // publish dev docs and stable branch docs, but nothing else
+        if (env.JOB_BASE_NAME == 'master' || env.JOB_BASE_NAME.endsWith('.x')) {
+            VERSION = sh (
+                script: 'cd ${WORKSPACE}/doc; python -c "import conf; print conf.version"',
+                returnStdout: true
+            ).trim()
+            if (VERSION == '') {
+                echo "VERSION is empty, not publishing docs"
+            }
+            else {
+                echo "Publishing docs for ${VERSION}"
+                sh "rsync -av --delete --no-perms --chmod=Dog+rx,Fog+r '${WORKSPACE}/doc/html/' 'doc@nav.uninett.no:/var/www/doc/${VERSION}/'"
+            }
+        }
+    }
+
+    archiveArtifacts artifacts: 'tests/*-report.html'
+
+} catch (e) {
+    currentBuild.result = "FAILED"
+    echo "Build FAILED set status ${currentBuild.result}"
+    throw e
+} finally {
+    notifyBuild(currentBuild.result)
+}
 
 
 

--- a/Jenkinsfile3
+++ b/Jenkinsfile3
@@ -1,0 +1,15 @@
+#!groovy
+/**
+ * -*- indent-tabs-mode: nil -*-
+ * -*- tab-width: 4 -*-
+ * Work in tandem with tests/docker/Dockerfile & Co to run a full CI run in
+ * Jenkins.
+*/
+node {
+    stage("Checkout") {
+        checkout scm
+    }
+    withEnv(["PYTHON_VERSION=3"]) {
+        load 'Jenkinsfile-common'
+    }
+}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ networkx>=1.7,<1.8
 xmpppy==0.5.0rc1  # optional, for alerting via Jabber
 Pillow==3.0.0
 pyrad==1.2
-python-ldap==2.4.10  # optional for LDAP authentication, requires libldap (OpenLDAP) to build
+python-ldap==2.4.10 ; python_version < '3' # optional for LDAP authentication, requires libldap (OpenLDAP) to build
 sphinx>=1.0
 django-crispy-forms==1.3.2
 crispy-forms-foundation==0.2.3

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -91,7 +91,6 @@ COPY requirements.txt /runtime-requirements.txt
 COPY requirements/ /requirements
 COPY tests/requirements.txt /test-requirements.txt
 RUN pip install -r /runtime-requirements.txt -r /test-requirements.txt
-RUN pip install whisper carbon==0.9.14 graphite-web==0.9.14 django-tagging
 
 
 ENV WORKSPACE /source

--- a/tests/docker/Dockerfile3
+++ b/tests/docker/Dockerfile3
@@ -1,9 +1,9 @@
 # Full integration test image for NAV
 #
-# A more or less identical image exists for Python >= 3.6, don't forget to
+# A more or less identical image exists for Python 2, don't forget to
 # update also that one.
 #
-FROM python:2.7
+FROM python:3.6
 
 ENV DISTRO jessie
 ENV DISPLAY :99

--- a/tests/docker/Makefile
+++ b/tests/docker/Makefile
@@ -5,13 +5,19 @@ uname := $(shell uname)
 uid := $(shell id -u)
 gid := $(shell id -g)
 
+ifeq ($(PYTHON_VERSION),3)
+  dockerfile := Dockerfile3
+else
+  dockerfile := Dockerfile
+endif
+
 .PHONY: build check
 
 build:
-	docker build -t $(name) -f Dockerfile $(top_srcdir)
+	docker build -t $(name) -f $(dockerfile) $(top_srcdir)
 
 buildnocache:
-	docker build --no-cache -t $(name) -f Dockerfile $(top_srcdir)
+	docker build --no-cache -t $(name) -f $(dockerfile) $(top_srcdir)
 
 check: build
 	/usr/bin/env

--- a/tests/docker/scripts/build.sh
+++ b/tests/docker/scripts/build.sh
@@ -11,7 +11,7 @@ gosu root:root make install
 gosu root:root chown -R $uid "${BUILDDIR}/var" "${BUILDDIR}/etc"
 
 # Make Python libraries available for everyone
-gosu root:root ln -fs "${BUILDDIR}/lib/python/nav" /usr/local/lib/python2.7/
+gosu root:root ln -fs "${BUILDDIR}/lib/python/nav" $(python -c 'import site;print(site.getsitepackages()[0])')
 
 # Since we're testing, let's debug log everything we can
 cat > "${BUILDDIR}/etc/logging.conf" <<EOF


### PR DESCRIPTION
A separate multibranch pipelinejob has been established in Jenkins, to look for branches with their pipeline defined in `Jenkinsfile3`. This file should script whatever is necessary to run the pipeline in a Python 3 environment.

Would like some feedback before merging.