### PR TITLE
Netmap cache unicode fix

### DIFF
--- a/python/nav/web/netmap/cache.py
+++ b/python/nav/web/netmap/cache.py
@@ -103,5 +103,10 @@ def _cache_key(*args):
     => netmap:topology:layer3
 
     """
-    args = (str(a).replace(' ', '-') for a in args)
-    return 'netmap:' + ':'.join(args)
+    def stringify(thing):
+        if type(thing) is str:
+            return thing.decode('utf-8')
+        else:
+            return unicode(thing)
+    args = (stringify(a).replace(' ', '-') for a in args)
+    return u'netmap:' + u':'.join(args)


### PR DESCRIPTION
This fixes #1583 by attempting to keep everything in unicode. It's not particularly portable to Python 3 as it stands, though. Some feedback would be appreciated :)
