### PR TITLE
Remove django-oauth2-provider library dependency

### DIFF
--- a/NOTES.rst
+++ b/NOTES.rst
@@ -18,11 +18,17 @@ Dependency changes
 NAV 4.8 introduces a new dependency on dnspython *1.15.0* for the DNS
 service checker.
 
+Removed dependencies
+~~~~~~~~~~~~~~~~~~~~
+
 The support for the old PySNMP v2 and PySNMP-SE libraries (and consequently,
 the pure-Python TwistedSNMP library) has been removed, since they are outdated
 and do not provide the full feature set used by NAV and provided by our
 preferred library: :mod:`pynetsnmp`.
 
+There is no longer a dependency to the Python module
+:mod:`django-oauth2-provider`, as NAV's usage of this non-maintained module
+was severely limited.
 
 
 NAV 4.7

--- a/python/nav/util.py
+++ b/python/nav/util.py
@@ -21,6 +21,8 @@ import re
 import stat
 import socket
 import datetime
+import uuid
+import hashlib
 from functools import wraps
 from itertools import chain, tee
 try:
@@ -29,6 +31,7 @@ except ImportError:
     ifilter = filter
 
 from django.utils import six
+from django.conf import settings
 
 import IPy
 
@@ -451,3 +454,10 @@ def address_to_string(ip, port):
     ip = IPy.IP(ip)
     ip = str(ip) if ip.version() == 4 else "[%s]" % ip
     return "%s:%s" % (ip, port)
+
+
+def oauth_token():
+    """Generates a hash that can be used as an OAuth API token"""
+    _hash = hashlib.sha1(six.text_type(uuid.uuid4()).encode('utf-8'))
+    _hash.update(settings.SECRET_KEY.encode('utf-8'))
+    return _hash.hexdigest()

--- a/python/nav/util.py
+++ b/python/nav/util.py
@@ -456,7 +456,7 @@ def address_to_string(ip, port):
     return "%s:%s" % (ip, port)
 
 
-def oauth_token():
+def auth_token():
     """Generates a hash that can be used as an OAuth API token"""
     _hash = hashlib.sha1(six.text_type(uuid.uuid4()).encode('utf-8'))
     _hash.update(settings.SECRET_KEY.encode('utf-8'))

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -29,7 +29,6 @@ from django.db.models.fields import FieldDoesNotExist
 from datetime import datetime, timedelta
 import iso8601
 
-from provider.utils import long_token
 from rest_framework import status, filters, viewsets, exceptions
 from rest_framework.decorators import api_view, renderer_classes, list_route
 from rest_framework.reverse import reverse_lazy
@@ -43,6 +42,7 @@ from nav.models.api import APIToken
 from nav.models import manage, event, cabling, rack
 from nav.models.fields import INFINITY, UNRESOLVED
 from nav.web.servicecheckers import load_checker_classes
+from nav.util import oauth_token
 
 from nav.web.api.v1 import serializers, alert_serializers
 from .auth import APIPermission, APIAuthentication, NavBaseAuthentication
@@ -783,7 +783,7 @@ def get_or_create_token(request):
     if request.account.is_admin():
         token, _ = APIToken.objects.get_or_create(
             client=request.account, expires__gte=datetime.now(),
-            defaults={'token': long_token(),
+            defaults={'token': oauth_token(),
                       'expires': datetime.now() + EXPIRE_DELTA})
         return HttpResponse(str(token))
     else:

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -42,7 +42,7 @@ from nav.models.api import APIToken
 from nav.models import manage, event, cabling, rack
 from nav.models.fields import INFINITY, UNRESOLVED
 from nav.web.servicecheckers import load_checker_classes
-from nav.util import oauth_token
+from nav.util import auth_token
 
 from nav.web.api.v1 import serializers, alert_serializers
 from .auth import APIPermission, APIAuthentication, NavBaseAuthentication
@@ -783,7 +783,7 @@ def get_or_create_token(request):
     if request.account.is_admin():
         token, _ = APIToken.objects.get_or_create(
             client=request.account, expires__gte=datetime.now(),
-            defaults={'token': oauth_token(),
+            defaults={'token': auth_token(),
                       'expires': datetime.now() + EXPIRE_DELTA})
         return HttpResponse(str(token))
     else:

--- a/python/nav/web/useradmin/forms.py
+++ b/python/nav/web/useradmin/forms.py
@@ -23,7 +23,7 @@ from nav.models.profiles import Account, AccountGroup, PrivilegeType
 from nav.models.manage import Organization
 from nav.models.api import APIToken
 from nav.web.api.v1.views import get_endpoints as get_api_endpoints
-from nav.util import oauth_token
+from nav.util import auth_token
 
 from crispy_forms.helper import FormHelper
 from crispy_forms_foundation.layout import (Layout, Fieldset, Submit, Row,
@@ -224,7 +224,7 @@ class ReadonlyField(forms.CharField):
 class TokenForm(forms.ModelForm):
     """Form for creating a new token"""
 
-    token = ReadonlyField(initial=oauth_token)
+    token = ReadonlyField(initial=auth_token)
     available_endpoints = get_api_endpoints()
     endpoints = forms.MultipleChoiceField(
         required=False,

--- a/python/nav/web/useradmin/forms.py
+++ b/python/nav/web/useradmin/forms.py
@@ -16,7 +16,6 @@
 # pylint: disable=R0903
 """Forms for the user admin system"""
 from datetime import date, timedelta
-from provider.utils import long_token
 
 from django import forms
 
@@ -24,6 +23,7 @@ from nav.models.profiles import Account, AccountGroup, PrivilegeType
 from nav.models.manage import Organization
 from nav.models.api import APIToken
 from nav.web.api.v1.views import get_endpoints as get_api_endpoints
+from nav.util import oauth_token
 
 from crispy_forms.helper import FormHelper
 from crispy_forms_foundation.layout import (Layout, Fieldset, Submit, Row,
@@ -224,7 +224,7 @@ class ReadonlyField(forms.CharField):
 class TokenForm(forms.ModelForm):
     """Form for creating a new token"""
 
-    token = ReadonlyField(initial=long_token)
+    token = ReadonlyField(initial=oauth_token)
     available_endpoints = get_api_endpoints()
     endpoints = forms.MultipleChoiceField(
         required=False,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,6 @@ markdown==2.5.1
 dnspython==1.15.0
 
 # REST framework
-django-oauth2-provider>=0.2.6
 djangorestframework==2.4.4
 django-filter>=0.7,<0.8
 iso8601


### PR DESCRIPTION
This removes the dependency to the external library, which is now non-maintained for several years.

The function may ideally be replaced in the future by something using the `secrets` module to generate the token.