### PR TITLE
SQL baseline cleanup

### DIFF
--- a/sql/baseline/arnold.sql
+++ b/sql/baseline/arnold.sql
@@ -22,6 +22,8 @@ orgid VARCHAR,
 determined CHAR(1), -- set to y if this is mac/port combo is blocked with the -d option.
 fromvlan INT, -- original vlan on port before change (only on vlanchange)
 tovlan INT, -- vlan on port after change (only on vlanchange)
+textual_interface VARCHAR DEFAULT '', -- for storing textual representation of the interface when detaining
+
 UNIQUE (mac,swportid)
 );
 
@@ -41,7 +43,9 @@ username VARCHAR NOT NULL
 CREATE TABLE quarantine_vlans (
 quarantineid SERIAL PRIMARY KEY,
 vlan INT,
-description VARCHAR
+description VARCHAR,
+
+CONSTRAINT quarantine_vlan_unique UNIQUE (vlan)
 );
 
 -- A block, of lack of better name, is a run where we do automatic blocking 
@@ -64,10 +68,6 @@ detainmenttype VARCHAR CHECK (detainmenttype='disable' OR detainmenttype='quaran
 quarantineid INT REFERENCES quarantine_vlans ON UPDATE CASCADE ON DELETE CASCADE
 );
 
--- Create field for storing textual representation of the interface when detaining
-
-ALTER table arnold.identity ADD textual_interface VARCHAR DEFAULT '';
-
 
 -- Fix uniqueness on quarantine vlans
 
@@ -77,5 +77,3 @@ DELETE FROM quarantine_vlans WHERE quarantineid in (
   JOIN quarantine_vlans q2
     ON (q1.vlan = q2.vlan AND q1.quarantineid < q2.quarantineid)
     ORDER BY q1.quarantineid);
-
-ALTER TABLE quarantine_vlans ADD CONSTRAINT quarantine_vlan_unique UNIQUE (vlan);

--- a/sql/baseline/arnold.sql
+++ b/sql/baseline/arnold.sql
@@ -67,13 +67,3 @@ activeonvlans VARCHAR, -- a string with comma-separated vlan-numbers
 detainmenttype VARCHAR CHECK (detainmenttype='disable' OR detainmenttype='quarantine'), -- type of detainment to try
 quarantineid INT REFERENCES quarantine_vlans ON UPDATE CASCADE ON DELETE CASCADE
 );
-
-
--- Fix uniqueness on quarantine vlans
-
-DELETE FROM quarantine_vlans WHERE quarantineid in (
-  SELECT q2.quarantineid
-  FROM quarantine_vlans q1
-  JOIN quarantine_vlans q2
-    ON (q1.vlan = q2.vlan AND q1.quarantineid < q2.quarantineid)
-    ORDER BY q1.quarantineid);

--- a/sql/baseline/manage.sql
+++ b/sql/baseline/manage.sql
@@ -581,6 +581,7 @@ INSERT INTO subsystem (name) VALUES ('maintenance');
 INSERT INTO subsystem (name) VALUES ('snmptrapd');
 INSERT INTO subsystem (name) VALUES ('powersupplywatch');
 INSERT INTO subsystem (name) VALUES ('ipdevpoll');
+INSERT INTO subsystem (name) VALUES ('macwatch');
 
 
 

--- a/sql/baseline/manage.sql
+++ b/sql/baseline/manage.sql
@@ -1163,11 +1163,6 @@ CREATE TABLE manage.interface_stack (
 );
 
 
-INSERT INTO vendor (
-  SELECT 'unknown' AS vendorid
-  WHERE NOT EXISTS (
-    SELECT vendorid FROM vendor WHERE vendorid='unknown'));
-
 CREATE OR REPLACE VIEW manage.netboxmac AS
 
 SELECT DISTINCT ON (mac) netboxid, mac FROM (

--- a/sql/baseline/manage.sql
+++ b/sql/baseline/manage.sql
@@ -1314,7 +1314,7 @@ CREATE TABLE manage.interface_aggregate (
 
 
 -- Create table for storing prefix tags
-CREATE TABLE IF NOT EXISTS prefix_usage (
+CREATE TABLE prefix_usage (
     prefix_usage_id SERIAL PRIMARY KEY,
     prefixid        INTEGER REFERENCES prefix (prefixid)
                     ON UPDATE CASCADE ON DELETE CASCADE,

--- a/sql/baseline/manage.sql
+++ b/sql/baseline/manage.sql
@@ -168,33 +168,32 @@ CREATE TABLE netbox_vtpvlan (
   UNIQUE(netboxid, vtpvlan)
 );
 
-CREATE TABLE subcat (
-    subcatid VARCHAR,
+CREATE TABLE netboxgroup (
+    netboxgroupid VARCHAR,
     descr VARCHAR NOT NULL,
-    catid VARCHAR(8) NOT NULL REFERENCES cat(catid),
-    PRIMARY KEY (subcatid)
+
+    PRIMARY KEY (netboxgroupid)
 );
-INSERT INTO subcat (subcatid,descr,catid) VALUES ('AD','Description','SRV');
-INSERT INTO subcat (subcatid,descr,catid) VALUES ('ADC','Description','SRV');
-INSERT INTO subcat (subcatid,descr,catid) VALUES ('BACKUP','Description','SRV');
-INSERT INTO subcat (subcatid,descr,catid) VALUES ('DNS','Description','SRV');
-INSERT INTO subcat (subcatid,descr,catid) VALUES ('FS','Description','SRV');
-INSERT INTO subcat (subcatid,descr,catid) VALUES ('LDAP','Description','SRV');
-INSERT INTO subcat (subcatid,descr,catid) VALUES ('MAIL','Description','SRV');
-INSERT INTO subcat (subcatid,descr,catid) VALUES ('NOTES','Description','SRV');
-INSERT INTO subcat (subcatid,descr,catid) VALUES ('STORE','Description','SRV');
-INSERT INTO subcat (subcatid,descr,catid) VALUES ('TEST','Description','SRV');
-INSERT INTO subcat (subcatid,descr,catid) VALUES ('UNIX','Description','SRV');
-INSERT INTO subcat (subcatid,descr,catid) VALUES ('UNIX-STUD','Description','SRV');
-INSERT INTO subcat (subcatid,descr,catid) VALUES ('WEB','Description','SRV');
-INSERT INTO subcat (subcatid,descr,catid) VALUES ('WIN','Description','SRV');
-INSERT INTO subcat (subcatid,descr,catid) VALUES ('WIN-STUD','Description','SRV'
-);
+INSERT INTO netboxgroup (netboxgroupid,descr) VALUES ('AD','Description');
+INSERT INTO netboxgroup (netboxgroupid,descr) VALUES ('ADC','Description');
+INSERT INTO netboxgroup (netboxgroupid,descr) VALUES ('BACKUP','Description');
+INSERT INTO netboxgroup (netboxgroupid,descr) VALUES ('DNS','Description');
+INSERT INTO netboxgroup (netboxgroupid,descr) VALUES ('FS','Description');
+INSERT INTO netboxgroup (netboxgroupid,descr) VALUES ('LDAP','Description');
+INSERT INTO netboxgroup (netboxgroupid,descr) VALUES ('MAIL','Description');
+INSERT INTO netboxgroup (netboxgroupid,descr) VALUES ('NOTES','Description');
+INSERT INTO netboxgroup (netboxgroupid,descr) VALUES ('STORE','Description');
+INSERT INTO netboxgroup (netboxgroupid,descr) VALUES ('TEST','Description');
+INSERT INTO netboxgroup (netboxgroupid,descr) VALUES ('UNIX','Description');
+INSERT INTO netboxgroup (netboxgroupid,descr) VALUES ('UNIX-STUD','Description');
+INSERT INTO netboxgroup (netboxgroupid,descr) VALUES ('WEB','Description');
+INSERT INTO netboxgroup (netboxgroupid,descr) VALUES ('WIN','Description');
+INSERT INTO netboxgroup (netboxgroupid,descr) VALUES ('WIN-STUD','Description');
 
 CREATE TABLE netboxcategory (
   id SERIAL,
   netboxid INT4 NOT NULL REFERENCES netbox ON UPDATE CASCADE ON DELETE CASCADE,
-  category VARCHAR NOT NULL REFERENCES subcat ON UPDATE CASCADE ON DELETE CASCADE,
+  category VARCHAR NOT NULL REFERENCES netboxgroup ON UPDATE CASCADE ON DELETE CASCADE,
   PRIMARY KEY(netboxid, category)
 );
 
@@ -1159,11 +1158,6 @@ CREATE TABLE manage.interface_stack (
   lower INTEGER REFERENCES interface(interfaceid),
   UNIQUE (higher, lower)
 );
-
-ALTER TABLE subcat DROP catid;
-ALTER TABLE subcat RENAME TO netboxgroup;
-ALTER TABLE netboxgroup RENAME subcatid TO netboxgroupid;
-
 
 -- Fix cascading deletes in interface_stack foreign keys (LP#1246226)
 

--- a/sql/baseline/manage.sql
+++ b/sql/baseline/manage.sql
@@ -580,6 +580,9 @@ INSERT INTO subsystem (name) VALUES ('getDeviceData');
 INSERT INTO subsystem (name) VALUES ('devBrowse');
 INSERT INTO subsystem (name) VALUES ('maintenance');
 INSERT INTO subsystem (name) VALUES ('snmptrapd');
+INSERT INTO subsystem (name) VALUES ('powersupplywatch');
+INSERT INTO subsystem (name) VALUES ('ipdevpoll');
+
 
 
 ------------------------------------------------------------------------------------------
@@ -978,9 +981,6 @@ INSERT INTO alerttype (eventtypeid, alerttype, alerttypedesc) VALUES
 INSERT INTO alerttype (eventtypeid, alerttype, alerttypedesc) VALUES
   ('snmpAgentState', 'snmpAgentUp', 'SNMP agent is up.');
 
-INSERT INTO subsystem (name) VALUES ('ipdevpoll');
-
-
 -- Ensure any associated service alerts are closed when a service is deleted
 CREATE RULE close_alerthist_services
   AS ON DELETE TO service DO
@@ -1073,8 +1073,6 @@ WHERE eventtypeid='snmpAgentState'
   AND end_time >= 'infinity'
   AND alerthist.netboxid = netbox.netboxid
   AND COALESCE(netbox.ro, '') = '';
-
-INSERT INTO subsystem VALUES ('powersupplywatch');
 
 -- create new event and alert types for fan and psu alerts
 

--- a/sql/baseline/manage.sql
+++ b/sql/baseline/manage.sql
@@ -627,6 +627,10 @@ INSERT INTO eventtype (eventtypeid, eventtypedesc, stateful) VALUES
   ('chassisState', 'The state of this chassis has changed', 'y');
 INSERT INTO eventtype (eventtypeid, eventtypedesc, stateful) VALUES
   ('aggregateLinkState', 'The state of this aggregated link changed', 'y');
+INSERT INTO eventtype (eventtypeid, eventtypedesc, stateful) VALUES
+  ('psuState', 'Reports state changes in power supply units', 'y');
+INSERT INTO eventtype (eventtypeid, eventtypedesc, stateful) VALUES
+  ('fanState', 'Reports state changes in fan units', 'y');
 
 
 
@@ -733,6 +737,16 @@ INSERT INTO alerttype (eventtypeid, alerttype, alerttypedesc) VALUES
   ('aggregateLinkState', 'linkDegraded', 'This aggregate link has been degraded');
 INSERT INTO alerttype (eventtypeid, alerttype, alerttypedesc) VALUES
   ('aggregateLinkState', 'linkRestored', 'This aggregate link has been restored');
+INSERT INTO alerttype (eventtypeid, alerttype, alerttypedesc) VALUES
+  ('info','macWarning','Mac appeared on port');
+INSERT INTO alerttype (eventtypeid, alerttype, alerttypedesc) VALUES
+  ('psuState', 'psuNotOK', 'A PSU has entered a non-OK state');
+INSERT INTO alerttype (eventtypeid, alerttype, alerttypedesc) VALUES
+  ('psuState', 'psuOK', 'A PSU has returned to an OK state');
+INSERT INTO alerttype (eventtypeid, alerttype, alerttypedesc) VALUES
+  ('fanState', 'fanNotOK', 'A fan unit has entered a non-OK state');
+INSERT INTO alerttype (eventtypeid, alerttype, alerttypedesc) VALUES
+  ('fanState', 'fanOK', 'A fan unit has returned to an OK state');
 
 
 
@@ -957,10 +971,6 @@ CREATE TABLE schema_change_log (
     date_applied TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
-INSERT INTO alerttype (eventtypeid, alerttype, alerttypedesc) VALUES
-  ('info','macWarning','Mac appeared on port');
-
-
 
 CREATE OR REPLACE RULE netbox_status_close_arp AS ON UPDATE TO netbox
    WHERE NEW.up='n'
@@ -1079,28 +1089,6 @@ CREATE TRIGGER trig_close_snmpagentstates_on_community_clear
     AFTER UPDATE ON netbox
     FOR EACH ROW
     EXECUTE PROCEDURE close_snmpagentstates_on_community_clear();
-
--- create new event and alert types for fan and psu alerts
-
-INSERT INTO eventtype (eventtypeid, eventtypedesc, stateful) VALUES
-  ('psuState', 'Reports state changes in power supply units', 'y');
-
-INSERT INTO alerttype (eventtypeid, alerttype, alerttypedesc) VALUES
-  ('psuState', 'psuNotOK', 'A PSU has entered a non-OK state');
-
-INSERT INTO alerttype (eventtypeid, alerttype, alerttypedesc) VALUES
-  ('psuState', 'psuOK', 'A PSU has returned to an OK state');
-
-
-INSERT INTO eventtype (eventtypeid, eventtypedesc, stateful) VALUES
-  ('fanState', 'Reports state changes in fan units', 'y');
-
-INSERT INTO alerttype (eventtypeid, alerttype, alerttypedesc) VALUES
-  ('fanState', 'fanNotOK', 'A fan unit has entered a non-OK state');
-
-INSERT INTO alerttype (eventtypeid, alerttype, alerttypedesc) VALUES
-  ('fanState', 'fanOK', 'A fan unit has returned to an OK state');
-
 
 
 -- Notify the eventEngine immediately as new events are inserted in the queue

--- a/sql/baseline/manage.sql
+++ b/sql/baseline/manage.sql
@@ -333,9 +333,11 @@ CREATE TABLE swportallowedvlan (
 
 
 CREATE TABLE swportblocked (
+  swportblockedid SERIAL PRIMARY KEY,
   interfaceid INT4 NOT NULL REFERENCES interface ON UPDATE CASCADE ON DELETE CASCADE,
   vlan INT4 NOT NULL,
-  PRIMARY KEY(interfaceid, vlan)
+
+  CONSTRAINT swportblocked_uniq UNIQUE (interfaceid, vlan)
 );
 
 -- View to mimic old swport table
@@ -1433,16 +1435,6 @@ CREATE TABLE IF NOT EXISTS prefix_usage (
                     ON UPDATE CASCADE ON DELETE CASCADE,
     UNIQUE (prefixid, usageid)
 );
-
-ALTER TABLE swportblocked
-  DROP CONSTRAINT swportblocked_pkey;
-
-ALTER TABLE swportblocked
-  ADD CONSTRAINT swportblocked_uniq UNIQUE (interfaceid, vlan);
-
-ALTER TABLE swportblocked
-  ADD COLUMN swportblockedid SERIAL PRIMARY KEY;
-
 
 INSERT INTO schema_change_log (major, minor, point, script_name)
     VALUES (4, 6, 56, 'initial install');

--- a/sql/baseline/manage.sql
+++ b/sql/baseline/manage.sql
@@ -217,8 +217,8 @@ CREATE TABLE module (
   descr VARCHAR,
   up CHAR(1) NOT NULL DEFAULT 'y' CHECK (up='y' OR up='n'), -- y=up, n=down
   downsince TIMESTAMP,
-  CONSTRAINT module_netboxid_key UNIQUE (netboxid, name),
-  UNIQUE(deviceid)
+
+  CONSTRAINT module_netboxid_key UNIQUE (netboxid, name)
 );
 
 CREATE TABLE mem (
@@ -1375,10 +1375,6 @@ CREATE OR REPLACE RULE close_alerthist_interface AS ON DELETE TO interface
 -- Add field to unrecognized_neighbor indicating ignored state
 ---
 ALTER TABLE unrecognized_neighbor ADD ignored_since TIMESTAMP DEFAULT NULL;
-
---- Remove unique constraints for devices in module table
-
-ALTER TABLE module DROP CONSTRAINT IF EXISTS module_deviceid_key;
 
 -- Fix data type of netboxentity.index, which, for mysterious reasons, was
 -- defined as varchar in 4.3.0

--- a/sql/baseline/manage.sql
+++ b/sql/baseline/manage.sql
@@ -105,6 +105,9 @@ INSERT INTO cat values ('EDGE','Edge switch without vlans (layer 2)','t');
 INSERT INTO cat values ('WLAN','Wireless equipment','t');
 INSERT INTO cat values ('SRV','Server','f');
 INSERT INTO cat values ('OTHER','Other equipment','f');
+INSERT INTO cat VALUES ('ENV', 'Environmental probes', true);
+INSERT INTO cat VALUES ('POWER', 'Power distribution equipment', true);
+
 
 CREATE TABLE device (
   deviceid SERIAL PRIMARY KEY,
@@ -1236,9 +1239,6 @@ UPDATE sensor
 SET precision=2, data_scale=NULL
 WHERE mib = 'PowerNet-MIB'
       AND data_scale = 'centi';
-
-INSERT INTO manage.cat (catid, descr, req_snmp) VALUES ('ENV', 'Environmental probes', true);
-INSERT INTO manage.cat (catid, descr, req_snmp) VALUES ('POWER', 'Power distribution equipment', true);
 
 -- clean up some alert- and event-type descriptions
 UPDATE alerttype SET alerttypedesc = 'The IP device has coldstarted'

--- a/sql/baseline/manage.sql
+++ b/sql/baseline/manage.sql
@@ -503,8 +503,7 @@ CREATE TABLE cam (
   mac MACADDR NOT NULL,
   start_time TIMESTAMP NOT NULL,
   end_time TIMESTAMP NOT NULL DEFAULT 'infinity',
-  misscnt INT4 DEFAULT '0',
-  UNIQUE(netboxid,sysname,module,port,mac,start_time)
+  misscnt INT4 DEFAULT '0'
 );
 
 
@@ -1093,32 +1092,6 @@ CREATE TRIGGER trig_close_snmpagentstates_on_community_clear
 
 -- Notify the eventEngine immediately as new events are inserted in the queue
 CREATE OR REPLACE RULE eventq_notify AS ON INSERT TO eventq DO ALSO NOTIFY new_event;
-
--- remove useless cam constraints/indexes to prevent index bloat
--- On some installs, the index may already have been manually removed. "DROP
--- CONSTRAINT IF EXISTS" wasn't introduced until PostgreSQL 9,
--- so we make a conditional drop function to accomplish this without errors
--- here:
-
-CREATE OR REPLACE FUNCTION manage.drop_constraint(tbl_schema VARCHAR, tbl_name VARCHAR, const_name VARCHAR) RETURNS void AS $$
-DECLARE
-    exec_string TEXT;
-BEGIN
-    exec_string := 'ALTER TABLE ';
-    IF tbl_schema != NULL THEN
-        exec_string := exec_string || quote_ident(tbl_schema) || '.';
-    END IF;
-    exec_string := exec_string || quote_ident(tb_name)
-        || ' DROP CONSTRAINT '
-        || quote_ident(const_name);
-    EXECUTE exec_string;
-EXCEPTION
-    WHEN OTHERS THEN
-        NULL;
-END;
-$$ LANGUAGE plpgsql;
-
-SELECT drop_constraint('manage', 'cam', 'cam_netboxid_key');
 
 
 -- Create table for netbios names

--- a/sql/baseline/manage2.sql
+++ b/sql/baseline/manage2.sql
@@ -36,12 +36,6 @@ CREATE TABLE image (
   priority INT
 );
 
-
-INSERT INTO subsystem (
-  SELECT 'macwatch' AS name
-  WHERE NOT EXISTS (
-    SELECT name FROM subsystem WHERE name='macwatch'));
-
 -- Added because macwatch may use mac-address prefixes
 CREATE TABLE macwatch_match(
   id SERIAL PRIMARY KEY,

--- a/sql/baseline/navprofiles.sql
+++ b/sql/baseline/navprofiles.sql
@@ -1075,6 +1075,7 @@ CREATE TABLE profiles.netmap_view (
   display_elinks BOOLEAN NOT NULL DEFAULT false,
   display_orphans BOOLEAN NOT NULL DEFAULT false,
   description TEXT DEFAULT null,
+  location_room_filter varchar NOT NULL DEFAULT '',
 
   PRIMARY KEY (viewid)
 );
@@ -1208,9 +1209,6 @@ SELECT insert_default_navlets_for_existing_users();
 ---
 DELETE FROM account_navlet WHERE account=0 AND navlet='nav.web.navlets.gettingstarted.GettingStartedWidget';
 
-
-
-ALTER TABLE netmap_view ADD COLUMN location_room_filter varchar NOT NULL DEFAULT '';
 
 ---
 -- Replace old status widget with new one.

--- a/sql/baseline/navprofiles.sql
+++ b/sql/baseline/navprofiles.sql
@@ -1058,6 +1058,10 @@ INSERT INTO statuspreference (id, name, position, type, accountid, states) VALUE
 INSERT INTO statuspreference (id, name, position, type, accountid, states) VALUES (3, 'IP devices on maintenance', 3, 'netbox_maintenance', 0, 'y,n,s');
 INSERT INTO statuspreference (id, name, position, type, accountid, states) VALUES (4, 'Modules down/in shadow', 4, 'module', 0, 'n,s');
 INSERT INTO statuspreference (id, name, position, type, accountid, states) VALUES (5, 'Services down', 5, 'service', 0, 'n,s');
+INSERT INTO statuspreference (id, name, position, type, accountid) VALUES (6, 'Thresholds exceeded', 6, 'threshold', 0);
+INSERT INTO statuspreference (id, name, position, type, accountid) VALUES (7, 'SNMP agents down', 7, 'snmpagent', 0);
+INSERT INTO statuspreference (id, name, position, type, accountid) VALUES (8, 'Links down', 8, 'linkstate', 0);
+
 
 -- netmap_view
 CREATE TABLE profiles.netmap_view (
@@ -1275,10 +1279,6 @@ $$ LANGUAGE plpgsql;
 CREATE TRIGGER add_default_dashboard_on_account_create AFTER INSERT ON account
   FOR EACH ROW
   EXECUTE PROCEDURE create_new_dashboard();
-
-INSERT INTO statuspreference (id, name, position, type, accountid) VALUES (6, 'Thresholds exceeded', 6, 'threshold', 0);
-INSERT INTO statuspreference (id, name, position, type, accountid) VALUES (7, 'SNMP agents down', 7, 'snmpagent', 0);
-INSERT INTO statuspreference (id, name, position, type, accountid) VALUES (8, 'Links down', 8, 'linkstate', 0);
 
 
 /*

--- a/sql/baseline/navprofiles.sql
+++ b/sql/baseline/navprofiles.sql
@@ -1256,6 +1256,11 @@ BEGIN
   END LOOP;
 END$$;
 
+--
+-- Function and trigger to ensure the default account's dashboard setup is
+-- copied to every new account that is created
+--
+
 -- Create a new dashboard and copy all the widgets from the default user to
 -- the dashboard
 CREATE OR REPLACE FUNCTION create_new_dashboard() RETURNS trigger AS $$

--- a/sql/baseline/navprofiles.sql
+++ b/sql/baseline/navprofiles.sql
@@ -839,7 +839,7 @@ INSERT INTO Operator (operator_id, match_field_id) VALUES (0, 10);
 INSERT INTO Operator (operator_id, match_field_id) VALUES (11, 10);
 
 INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES
-(11, 0, 'Alert type', 'alerttype.alerttype', 'alerttype.alerttypedesc', 'alerttype.alerttypeid', true,
+(11, 0, 'Alert type', 'alerttype.alerttype', 'alerttype.alerttypedesc', 'alerttype.alerttype', true,
 'Alert type: An alert type describes the various values an event type may take.');
 INSERT INTO Operator (operator_id, match_field_id) VALUES (0, 11);
 INSERT INTO Operator (operator_id, match_field_id) VALUES (11, 11);
@@ -864,8 +864,8 @@ INSERT INTO Operator (operator_id, match_field_id) VALUES (0, 13);
 INSERT INTO Operator (operator_id, match_field_id) VALUES (11, 13);
 
 INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES
-(14, 0, 'Sub category', 'subcat.subcatid', 'subcat.descr', 'subcat.descr', true,
-'Sub category: Within a catogory user-defined subcategories may exist.');
+(14, 0, 'Group', 'netboxgroup.netboxgroupid', 'netboxgroup.descr', 'netboxgroup.descr', true,
+'Group: netboxes may belong to a group that is independent of type and category');
 INSERT INTO Operator (operator_id, match_field_id) VALUES (0, 14);
 INSERT INTO Operator (operator_id, match_field_id) VALUES (11, 14);
 
@@ -1276,23 +1276,11 @@ CREATE TRIGGER add_default_dashboard_on_account_create AFTER INSERT ON account
   FOR EACH ROW
   EXECUTE PROCEDURE create_new_dashboard();
 
----
--- Sort Alert Types when modifying Alert Profiles
----
-UPDATE MatchField SET value_sort='alerttype.alerttype' WHERE id=11 AND value_sort='alerttype.alerttypeid';
-
 INSERT INTO statuspreference (id, name, position, type, accountid) VALUES (6, 'Thresholds exceeded', 6, 'threshold', 0);
 INSERT INTO statuspreference (id, name, position, type, accountid) VALUES (7, 'SNMP agents down', 7, 'snmpagent', 0);
 INSERT INTO statuspreference (id, name, position, type, accountid) VALUES (8, 'Links down', 8, 'linkstate', 0);
 
 
-UPDATE matchfield SET
-  name='Group',
-  value_id='netboxgroup.netboxgroupid',
-  value_name='netboxgroup.descr',
-  value_sort='netboxgroup.descr',
-  description='Group: netboxes may belong to a group that is independent of type and category'
-  WHERE id=14;
 /*
 ------------------------------------------------------
  EOF

--- a/sql/baseline/navprofiles.sql
+++ b/sql/baseline/navprofiles.sql
@@ -57,6 +57,7 @@ CREATE TABLE Account (
     name varchar DEFAULT 'Noname',
     password varchar,
     ext_sync varchar,
+    preferences manage.hstore DEFAULT manage.hstore(''),
 
     CONSTRAINT account_pkey PRIMARY KEY(id),
     CONSTRAINT account_login_key UNIQUE(login)
@@ -1253,18 +1254,6 @@ UPDATE account_navlet
   WHERE navlet='nav.web.navlets.status.StatusNavlet';
 
 INSERT INTO alertsender (id, name, handler) VALUES (4, 'Slack', 'slack');
-
-ALTER TABLE account ADD COLUMN preferences manage.hstore DEFAULT manage.hstore('');
-
--- Save all properties from accountproperty as preferences in account table.
-DO $$DECLARE accountproperty RECORD;
-BEGIN
-  FOR accountproperty IN SELECT * FROM accountproperty LOOP
-    UPDATE account
-      SET preferences = preferences || manage.hstore(accountproperty.property, accountproperty.value)
-      WHERE account.id = accountproperty.accountid;
-  END LOOP;
-END$$;
 
 -- Set refresh interval on existing message widgets
 UPDATE account_navlet

--- a/sql/baseline/navprofiles.sql
+++ b/sql/baseline/navprofiles.sql
@@ -176,11 +176,11 @@ CREATE TABLE alertaddress (
 		  FOREIGN KEY(accountid) REFERENCES Account(id)
 		  ON DELETE CASCADE
 		  ON UPDATE CASCADE,
-       CONSTRAINT alertaddress_type_fkey 
+       CONSTRAINT alertaddress_type_fkey
                   FOREIGN KEY(type) REFERENCES alertsender(id)
                   ON DELETE CASCADE
                   ON UPDATE CASCADE
-         
+
 );
 ALTER SEQUENCE alertaddress_id_seq OWNED BY alertaddress.id;
 
@@ -193,7 +193,7 @@ A table for alertprofile. Only one profile can be active simultanously. It is po
 name		The name of the profile
 daily_dispatch_time		Related to queueing. When daily queueing is selected, this attrubute specify when on a day
             enqueued alerts will be sent.
-weekly_dispatch_day		Related to queueing. When weekly queueing is selected, this attribute specify which 
+weekly_dispatch_day		Related to queueing. When weekly queueing is selected, this attribute specify which
             weekday enqueued alerts will be sent on. 0 is monday, 6 is sunday.
 weekly_dispatch_time		Related to queueing. When weekly queueing is selected, this attribute specify which time
             on the day enqueued alerts will be sent.
@@ -249,7 +249,7 @@ CREATE TABLE alertpreference (
 
 A table specifying a time period. This could be though of as an element in a timetable. A time period is related to a set of relation between equipmentgroups and alertaddresses.
 
-start_time	this attribute speficies the start time of this time period. The time period end time is 
+start_time	this attribute speficies the start time of this time period. The time period end time is
             implicit given by the start time by the next time period.
 
 valid_during		Speficies wether this time period is for weekdays or weekend or both.
@@ -275,7 +275,7 @@ ALTER SEQUENCE timeperiod_id_seq OWNED BY timeperiod.id;
 /*
 -- 9 FILTERGROUP
 
-Equipment group. An equipment is a composite of equipment filters. Equipment group is specified by a 
+Equipment group. An equipment is a composite of equipment filters. Equipment group is specified by a
 ennumerated (by priority) list of equipment filters. An equipment group could either be owned by an user, or shared among administrators.
 
 name	The name of the equipment group
@@ -343,8 +343,8 @@ ALTER SEQUENCE alertsubscription_id_seq OWNED BY alertsubscription.id;
 
 Permissions.
 
-This table contatins a relation from a user group to an equipment group. It gives all members of the 
-actual user group permission to set up notofication for alerts matching this filter. The relation 
+This table contatins a relation from a user group to an equipment group. It gives all members of the
+actual user group permission to set up notofication for alerts matching this filter. The relation
 usergroup <-> equipment group is many to many.
 */
 CREATE SEQUENCE filtergroup_group_permission_id_seq;
@@ -400,7 +400,7 @@ means that each row has a priority.
 include.    If true the related filter is included in the group.
 positive.   If this is false, the filter is inverted, which implies that true is false, and
             false is true.
-priority.   The list will be traversed in ascending priority order. Which means that the higher 
+priority.   The list will be traversed in ascending priority order. Which means that the higher
             number, the higher priority.
 */
 CREATE SEQUENCE filtergroupcontent_id_seq;
@@ -805,37 +805,37 @@ INSERT INTO AccountGroupPrivilege (accountgroupid, privilegeid, target) VALUES (
 INSERT INTO AccountGroupPrivilege (accountgroupid, privilegeid, target) VALUES (3, 2, '^/(report|status|alertprofiles|machinetracker|browse|preferences|cricket|stats|ipinfo|l2trace|logger|ipdevinfo|geomap)/?');
 
 -- Give alert_by privilege to SMS group
-INSERT INTO AccountGroupPrivilege (accountgroupid, privilegeid, target) 
+INSERT INTO AccountGroupPrivilege (accountgroupid, privilegeid, target)
        VALUES ((SELECT id FROM AccountGroup WHERE name='SMS'), 3, 'sms');
 
 -- Alert senders
 INSERT INTO alertsender VALUES (1, 'Email', 'email');
 INSERT INTO alertsender VALUES (2, 'SMS', 'sms');
-INSERT INTO alertsender VALUES (3, 'Jabber', 'jabber'); 
+INSERT INTO alertsender VALUES (3, 'Jabber', 'jabber');
 
 
 -- Matchfields
-/* 
+/*
 Matchfield.Datatype
 	string:  0
 	integer: 1
 	ip adr:  2
 */
 
-INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES 
-(10, 0, 'Event type', 'eventtype.eventtypeid', 'eventtype.eventtypedesc', 'eventtype.eventtypeid', true, 
+INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES
+(10, 0, 'Event type', 'eventtype.eventtypeid', 'eventtype.eventtypedesc', 'eventtype.eventtypeid', true,
 'Event type: An event type describes a category of alarms. (Please note that alarm type is a more refined attribute. There are a set of alarm types within an event type.)');
 INSERT INTO Operator (operator_id, match_field_id) VALUES (0, 10);
 INSERT INTO Operator (operator_id, match_field_id) VALUES (11, 10);
 
-INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES 
-(11, 0, 'Alert type', 'alerttype.alerttype', 'alerttype.alerttypedesc', 'alerttype.alerttypeid', true, 
+INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES
+(11, 0, 'Alert type', 'alerttype.alerttype', 'alerttype.alerttypedesc', 'alerttype.alerttypeid', true,
 'Alert type: An alert type describes the various values an event type may take.');
 INSERT INTO Operator (operator_id, match_field_id) VALUES (0, 11);
 INSERT INTO Operator (operator_id, match_field_id) VALUES (11, 11);
 
 
-INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description, value_help) VALUES 
+INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description, value_help) VALUES
 (12, 1, 'Severity', 'alertq.severity', null, null, false,
 'Severity: Limit your alarms based on severity.',
 'Range: Severities are in the range 0-100, where 100 is most severe.');
@@ -847,19 +847,19 @@ INSERT INTO Operator (operator_id, match_field_id) VALUES (4, 12);
 INSERT INTO Operator (operator_id, match_field_id) VALUES (5, 12);
 
 
-INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES 
+INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES
 (13, 0, 'Category', 'cat.catid', 'cat.descr', 'cat.catid', true,
 'Category: All equipment is categorized in 7 main categories.');
 INSERT INTO Operator (operator_id, match_field_id) VALUES (0, 13);
 INSERT INTO Operator (operator_id, match_field_id) VALUES (11, 13);
 
-INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES 
+INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES
 (14, 0, 'Sub category', 'subcat.subcatid', 'subcat.descr', 'subcat.descr', true,
 'Sub category: Within a catogory user-defined subcategories may exist.');
 INSERT INTO Operator (operator_id, match_field_id) VALUES (0, 14);
 INSERT INTO Operator (operator_id, match_field_id) VALUES (11, 14);
 
-INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description, value_help) VALUES 
+INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description, value_help) VALUES
 (15, 0, 'Sysname', 'netbox.sysname', null, null, false,
 'Sysname: Limit your alarms based on sysname.',
 E'Sysname examples:<blockquote>
@@ -875,7 +875,7 @@ INSERT INTO Operator (operator_id, match_field_id) VALUES (8, 15);
 INSERT INTO Operator (operator_id, match_field_id) VALUES (9, 15);
 
 
-INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description, value_help) VALUES 
+INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description, value_help) VALUES
 (16, 2, 'IP address', 'netbox.ip', null, null, false,
 'Limit your alarms based on an IP address/range (prefix)',
 'examples:<blockquote>
@@ -886,42 +886,42 @@ INSERT INTO Operator (operator_id, match_field_id) VALUES (0, 16);
 INSERT INTO Operator (operator_id, match_field_id) VALUES (11, 16);
 
 
-INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES 
+INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES
 (17, 0, 'Room', 'room.roomid', 'room.descr', 'room.roomid', true,
 'Room: Limit your alarms based on room.');
 INSERT INTO Operator (operator_id, match_field_id) VALUES (0, 17);
 INSERT INTO Operator (operator_id, match_field_id) VALUES (11, 17);
 
 
-INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES 
-(18, 0, 'Location', 'location.locationid', 'location.descr', 'location.descr', true, 
+INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES
+(18, 0, 'Location', 'location.locationid', 'location.descr', 'location.descr', true,
 'Location: Limit your alarms based on location (a location contains a set of rooms) ');
 INSERT INTO Operator (operator_id, match_field_id) VALUES (0, 18);
 INSERT INTO Operator (operator_id, match_field_id) VALUES (11, 18);
 
 
-INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES 
+INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES
 (19, 0, 'Organization', 'org.orgid', 'org.descr', 'org.descr', true,
 'Organization: Limit your alarms based on the organization ownership of the alarm in question.');
 INSERT INTO Operator (operator_id, match_field_id) VALUES (0, 19);
 INSERT INTO Operator (operator_id, match_field_id) VALUES (11, 19);
 
 
-INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES 
+INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES
 (20, 0, 'Usage', 'usage.usageid', 'usage.descr', 'usage.descr', true,
 'Usage: Different network prefixes are mapped to usage areas.');
 INSERT INTO Operator (operator_id, match_field_id) VALUES (0, 20);
 INSERT INTO Operator (operator_id, match_field_id) VALUES (11, 20);
 
 
-INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES 
+INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES
 (21, 0, 'Type', 'type.typename', 'type.descr', 'type.descr', true,
 'Type: Limit your alarms equipment type');
 INSERT INTO Operator (operator_id, match_field_id) VALUES (0, 21);
 INSERT INTO Operator (operator_id, match_field_id) VALUES (11, 21);
 
 
-INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES 
+INSERT INTO MatchField (id, data_type, name, value_id, value_name, value_sort, show_list, description) VALUES
 (22, 0, 'Equipment vendor', 'vendor.vendorid', 'vendor.vendorid', 'vendor.vendorid', true,
 'Equipment vendor: Limit alert by the vendor of the netbox.');
 INSERT INTO Operator (operator_id, match_field_id) VALUES (0, 22);

--- a/sql/baseline/navprofiles.sql
+++ b/sql/baseline/navprofiles.sql
@@ -821,6 +821,7 @@ INSERT INTO AccountGroupPrivilege (accountgroupid, privilegeid, target)
 INSERT INTO alertsender VALUES (1, 'Email', 'email');
 INSERT INTO alertsender VALUES (2, 'SMS', 'sms');
 INSERT INTO alertsender VALUES (3, 'Jabber', 'jabber');
+INSERT INTO alertsender VALUES (4, 'Slack', 'slack');
 
 
 -- Matchfields
@@ -1214,8 +1215,6 @@ UPDATE account_navlet
   SET navlet='nav.web.navlets.status2.Status2Widget',
       preferences = '{"status_filter": "event_type=boxState&stateless_threshold=24", "refresh_interval": 60000}'
   WHERE navlet='nav.web.navlets.status.StatusNavlet';
-
-INSERT INTO alertsender (id, name, handler) VALUES (4, 'Slack', 'slack');
 
 -- Set refresh interval on existing message widgets
 UPDATE account_navlet

--- a/sql/baseline/navprofiles.sql
+++ b/sql/baseline/navprofiles.sql
@@ -1123,9 +1123,6 @@ CREATE TABLE profiles.django_session (
     "expire_date" timestamp with time zone NOT NULL
 );
 
--- Map topology id to match OSI layer number
-UPDATE profiles.netmap_view SET topology = 3 where topology = 2;
-UPDATE profiles.netmap_view SET topology = 2 where topology = 1;
 
 -- Create table for storing navlet information for a user
 

--- a/sql/baseline/navprofiles.sql
+++ b/sql/baseline/navprofiles.sql
@@ -450,7 +450,7 @@ CREATE TABLE MatchField (
     value_id varchar,
     value_name varchar,
     value_sort varchar,
-    list_limit integer DEFAULT 300,
+    list_limit integer DEFAULT 1000,
     data_type integer NOT NULL DEFAULT 0,
     show_list boolean,
 
@@ -1332,7 +1332,6 @@ INSERT INTO statuspreference (id, name, position, type, accountid) VALUES (6, 'T
 INSERT INTO statuspreference (id, name, position, type, accountid) VALUES (7, 'SNMP agents down', 7, 'snmpagent', 0);
 INSERT INTO statuspreference (id, name, position, type, accountid) VALUES (8, 'Links down', 8, 'linkstate', 0);
 
-UPDATE matchfield SET list_limit=1000 WHERE list_limit < 1000;
 
 UPDATE matchfield SET
   name='Group',

--- a/sql/baseline/navprofiles.sql
+++ b/sql/baseline/navprofiles.sql
@@ -1078,7 +1078,6 @@ CREATE TABLE profiles.netmap_view_nodeposition (
   PRIMARY KEY (viewid, netboxid)
 );
 
-TRUNCATE TABLE netmap_view CASCADE;
 ALTER TABLE netmap_view ADD COLUMN topology INT4 NOT NULL;
 ALTER TABLE netmap_view DROP COLUMN link_types;
 ALTER TABLE netmap_view ADD COLUMN display_elinks BOOLEAN NOT NULL DEFAULT false;

--- a/sql/baseline/types.sql
+++ b/sql/baseline/types.sql
@@ -7,6 +7,7 @@
 
 
 -- First, vendors
+INSERT INTO vendor (vendorid) VALUES ('unknown');
 INSERT INTO vendor (vendorid) VALUES ('alcatel');
 INSERT INTO vendor (vendorid) VALUES ('allied');
 INSERT INTO vendor (vendorid) VALUES ('avaya');

--- a/sql/changes/sc.04.07.0110.sql
+++ b/sql/changes/sc.04.07.0110.sql
@@ -1,3 +1,1 @@
-BEGIN;
 INSERT INTO subsystem (name) VALUES ('portadmin');
-COMMIT;

--- a/sql/changes/sc.04.08.0001.sql
+++ b/sql/changes/sc.04.08.0001.sql
@@ -6,9 +6,9 @@ DROP FUNCTION IF EXISTS close_thresholdstate_on_threshold_delete();
 -- Since bootstrapping from a new baseline already puts it in the correct
 -- schema, and moving it to the schema it already is in raises an error, we
 -- move it around a bit first :-D
-ALTER FUNCTION create_new_dashboard() SET SCHEMA public;
-ALTER FUNCTION public.create_new_dashboard() SET SCHEMA profiles;
+ALTER FUNCTION create_new_dashboard() SET SCHEMA arnold;
+ALTER FUNCTION arnold.create_new_dashboard() SET SCHEMA profiles;
 
-ALTER FUNCTION insert_default_navlets_for_existing_users() SET SCHEMA public;
-ALTER FUNCTION public.insert_default_navlets_for_existing_users() SET SCHEMA profiles;
+ALTER FUNCTION insert_default_navlets_for_existing_users() SET SCHEMA arnold;
+ALTER FUNCTION arnold.insert_default_navlets_for_existing_users() SET SCHEMA profiles;
 

--- a/sql/changes/sc.04.08.0020.sql
+++ b/sql/changes/sc.04.08.0020.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE VIEW netboxmac as
+CREATE OR REPLACE VIEW manage.netboxmac as
  SELECT DISTINCT ON (foo.mac) foo.netboxid,
     foo.mac
    FROM ( SELECT DISTINCT netbox.netboxid,

--- a/sql/changes/sc.04.08.0050.sql
+++ b/sql/changes/sc.04.08.0050.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS report_subscription (
+CREATE TABLE IF NOT EXISTS profiles.report_subscription (
     id SERIAL PRIMARY KEY,
     account_id INT REFERENCES account ON DELETE CASCADE ON UPDATE CASCADE,
     address_id INT REFERENCES alertaddress ON DELETE CASCADE ON UPDATE CASCADE,

--- a/sql/changes/sc.04.08.0410.sql
+++ b/sql/changes/sc.04.08.0410.sql
@@ -1,4 +1,4 @@
-CREATE TABLE poegroup (
+CREATE TABLE manage.poegroup (
        poegroupid SERIAL PRIMARY KEY,
        netboxid INTEGER NOT NULL REFERENCES netbox ON DELETE CASCADE,
        moduleid INTEGER REFERENCES module ON DELETE CASCADE,
@@ -8,7 +8,7 @@ CREATE TABLE poegroup (
        UNIQUE (netboxid, index)
 );
 
-CREATE TABLE poeport (
+CREATE TABLE manage.poeport (
        poeportid SERIAL PRIMARY KEY,
        netboxid INTEGER NOT NULL REFERENCES netbox ON DELETE CASCADE,
        poegroupid INTEGER NOT NULL REFERENCES poegroup ON DELETE CASCADE,

--- a/sql/changes/sc.04.08.1000.sql
+++ b/sql/changes/sc.04.08.1000.sql
@@ -1,0 +1,35 @@
+-- Some objects may have been installed in the wrong schema over time, due to
+-- changes in how navsyncdb handles changes to the PostgreSQL search path.
+--
+-- We attempt to move potentially affected objects to the correct schema here.
+-- However, it is a PostgreSQL error move an object to a schema it is already
+-- in, so we move objects back and forth to ensure this changescript works no
+-- matter whether the object had been installed originally in the correct
+-- schema.
+
+ALTER VIEW enterprise_number SET SCHEMA arnold;
+ALTER VIEW arnold.enterprise_number SET SCHEMA manage;
+
+ALTER VIEW netboxmac SET SCHEMA arnold;
+ALTER VIEW arnold.netboxmac SET SCHEMA manage;
+
+ALTER TABLE poeport SET SCHEMA arnold;
+ALTER TABLE arnold.poeport SET SCHEMA manage;
+
+ALTER TABLE poegroup SET SCHEMA arnold;
+ALTER TABLE arnold.poegroup SET SCHEMA manage;
+
+ALTER TABLE report_subscription SET SCHEMA arnold;
+ALTER TABLE arnold.report_subscription SET SCHEMA profiles;
+
+ALTER FUNCTION close_snmpagentstates_on_community_clear() SET SCHEMA arnold;
+ALTER FUNCTION arnold.close_snmpagentstates_on_community_clear() SET SCHEMA manage;
+
+ALTER FUNCTION close_thresholdstate_on_thresholdrule_delete() SET SCHEMA arnold;
+ALTER FUNCTION arnold.close_thresholdstate_on_thresholdrule_delete() SET SCHEMA manage;
+
+ALTER FUNCTION never_use_null_subid() SET SCHEMA arnold;
+ALTER FUNCTION arnold.never_use_null_subid() SET SCHEMA manage;
+
+ALTER FUNCTION peersession_update_timestamp() SET SCHEMA arnold;
+ALTER FUNCTION arnold.peersession_update_timestamp() SET SCHEMA manage;

--- a/sql/changes/sc.04.08.1001.sql
+++ b/sql/changes/sc.04.08.1001.sql
@@ -1,0 +1,12 @@
+-- remove obsolete things that seem to hang around on some, but not all,
+-- upgraded installations (i.e. these things are just fine in the baseline,
+-- but may have become issues for those who have been upgrading NAV versions
+-- repeatedly for a long time).
+
+DROP FUNCTION IF EXISTS drop_constraint();
+
+ALTER TABLE cam
+  DROP CONSTRAINT IF EXISTS cam_netboxid_sysname_module_port_mac_start_time_key,
+  DROP CONSTRAINT IF EXISTS cam_netboxid_key;
+
+ALTER INDEX IF EXISTS subcat_pkey RENAME TO netboxgroup_pkey;


### PR DESCRIPTION
I did a bad job of reviewing #1544 - as it turns out, even though the new baseline passes the "diff test", the actual implementation is quite messy - altering table definitions after the fact, and trying to clean up data that just isn't there, since the baseline always represents a clean install. 

It seems all the mess stems from uncritically copy+pasting change scripts into the baseline, without actually consolidating the changes they represent with the existing definitions.

So, this is basically a work-in-progress to clean up the results of #1544, so we can have a proper implementation of #1510.