### PR TITLE
Fix broken auditlog browsing and auditlog more things

### DIFF
--- a/etc/toolbox/auditlog.tool
+++ b/etc/toolbox/auditlog.tool
@@ -1,4 +1,4 @@
-name=Auditlog
+name=Audit Log
 uri=/auditlog/
 icon=/static/images/toolbox/auditlog.png
-description=See who/what changed what where when
+description=See who changed what when

--- a/htdocs/static/js/src/porttable.js
+++ b/htdocs/static/js/src/porttable.js
@@ -316,13 +316,13 @@ define(function(require) {
      * done typing.
      */
     function fixSearchDelay(dataTable) {
-        $('div.dataTables_filter input').off('keyup.DT input.DT');
+        $('#ports div.dataTables_filter input').off('keyup.DT input.DT');
 
         var searchDelay = null,
             prevSearch = null;
 
-        $('div.dataTables_filter input').on('keyup', function() {
-            var search = $('div.dataTables_filter input').val();
+        $('#ports div.dataTables_filter input').on('keyup', function() {
+            var search = $('#ports div.dataTables_filter input').val();
 
             clearTimeout(searchDelay);
 

--- a/python/nav/auditlog/api.py
+++ b/python/nav/auditlog/api.py
@@ -73,4 +73,4 @@ class LogEntryViewSet(NAVDefaultsMixin, viewsets.ReadOnlyModelViewSet):
     filter_backends = NAVDefaultsMixin.filter_backends + (MultipleFilter, )
     queryset = LogEntry.objects.all()
     serializer_class = LogEntrySerializer
-    filter_fields = ('subsystem', 'object_pk', 'object_model')
+    filter_fields = ('subsystem', 'object_pk', 'object_model', 'verb')

--- a/python/nav/auditlog/api.py
+++ b/python/nav/auditlog/api.py
@@ -52,8 +52,8 @@ class LogEntrySerializer(serializers.ModelSerializer):
 
 class MultipleFilter(filters.BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
-        if 'object_pk[]' in request.QUERY_PARAMS:
-            ids = request.QUERY_PARAMS.getlist('object_pk[]')
+        if 'object_pks' in request.QUERY_PARAMS:
+            ids = request.QUERY_PARAMS.get('object_pks').split(',')
             queryset = queryset.filter(object_pk__in=ids)
         return queryset
 

--- a/python/nav/auditlog/api.py
+++ b/python/nav/auditlog/api.py
@@ -74,3 +74,4 @@ class LogEntryViewSet(NAVDefaultsMixin, viewsets.ReadOnlyModelViewSet):
     queryset = LogEntry.objects.all()
     serializer_class = LogEntrySerializer
     filter_fields = ('subsystem', 'object_pk', 'object_model', 'verb')
+    search_fields = ('summary', )

--- a/python/nav/auditlog/models.py
+++ b/python/nav/auditlog/models.py
@@ -87,7 +87,7 @@ class LogEntry(models.Model):
 
     @staticmethod
     def add_create_entry(actor, obj):
-        """Create log entry for created objects
+        """Add log entry for created objects
 
         :type actor: nav.models.profiles.Account
         """
@@ -102,7 +102,7 @@ class LogEntry(models.Model):
 
     @staticmethod
     def add_delete_entry(actor, obj, template=None):
-        """Create log entry for deleted objects"""
+        """Add log entry for deleted objects"""
         model = obj.__class__.__name__.lower()
         template = template or u'{actor} deleted {object}'
         LogEntry.add_log_entry(
@@ -113,18 +113,38 @@ class LogEntry(models.Model):
             object=obj
         )
 
+    @staticmethod
+    def add_edit_entry(actor, old, new, attribute):
+        """Add log entry for edited objects
+
+        :type attribute: str
+        """
+        model = new.__class__.__name__.lower()
+        prefix = u'{actor} edited {object}'
+        old_value = getattr(old, attribute)
+        new_value = getattr(new, attribute)
+        summary = "{} changed from '{}' to '{}'".format(
+            attribute, old_value, new_value)
+
+        LogEntry.add_log_entry(
+            actor,
+            u'edit-{}-{}'.format(model, attribute),
+            u'{}: {}'.format(prefix, summary),
+            before=old,
+            after=new,
+            object=new
+        )
 
     @staticmethod
-    def add_edit_entry(actor, old, new, attribute_list):
+    def compare_objects(actor, old, new, attribute_list):
         """Checks for differences in two objects given an attribute-list
 
         :type actor: nav.models.profiles.Account
         :type old: models.Model
         :type new: models.Model
         :type attribute_list: list[str]
-        :type verb_prefix: str
 
-        Adds a log entry for each attribute the two objects differ.
+        Adds a log entry for each attribute where the two objects differ.
         """
         model = new.__class__.__name__.lower()
         prefix = u'{actor} edited {object}'
@@ -132,17 +152,8 @@ class LogEntry(models.Model):
             old_value = getattr(old, attribute)
             new_value = getattr(new, attribute)
             if old_value != new_value:
-                change_text = "{} changed from '{}' to '{}'".format(
-                    attribute, old_value, new_value)
+                LogEntry.add_edit_entry(actor, old, new, attribute)
 
-                LogEntry.add_log_entry(
-                    actor,
-                    u'edit-{}-{}'.format(model, attribute),
-                    u'{}: {}'.format(prefix, change_text),
-                    before=old,
-                    after=new,
-                    object=new
-                )
 
     def __str__(self):
         return self.summary

--- a/python/nav/auditlog/models.py
+++ b/python/nav/auditlog/models.py
@@ -96,17 +96,20 @@ class LogEntry(models.Model):
             actor,
             u'create-{}'.format(model),
             u'{actor} created {object}',
+            after=obj,
             object=obj
         )
 
     @staticmethod
-    def add_delete_entry(actor, obj):
+    def add_delete_entry(actor, obj, template=None):
         """Create log entry for deleted objects"""
         model = obj.__class__.__name__.lower()
+        template = template or u'{actor} deleted {object}'
         LogEntry.add_log_entry(
             actor,
             u'delete-{}'.format(model),
-            u'{actor} deleted {object}',
+            template,
+            before=obj,
             object=obj
         )
 
@@ -136,10 +139,10 @@ class LogEntry(models.Model):
                     actor,
                     u'edit-{}-{}'.format(model, attribute),
                     u'{}: {}'.format(prefix, change_text),
+                    before=old,
+                    after=new,
                     object=new
                 )
-
-
 
     def __str__(self):
         return self.summary

--- a/python/nav/auditlog/models.py
+++ b/python/nav/auditlog/models.py
@@ -85,5 +85,61 @@ class LogEntry(models.Model):
         self.save()
         return self
 
+    @staticmethod
+    def add_create_entry(actor, obj):
+        """Create log entry for created objects
+
+        :type actor: nav.models.profiles.Account
+        """
+        model = obj.__class__.__name__.lower()
+        LogEntry.add_log_entry(
+            actor,
+            u'create-{}'.format(model),
+            u'{actor} created {object}',
+            object=obj
+        )
+
+    @staticmethod
+    def add_delete_entry(actor, obj):
+        """Create log entry for deleted objects"""
+        model = obj.__class__.__name__.lower()
+        LogEntry.add_log_entry(
+            actor,
+            u'delete-{}'.format(model),
+            u'{actor} deleted {object}',
+            object=obj
+        )
+
+
+    @staticmethod
+    def add_edit_entry(actor, old, new, attribute_list):
+        """Checks for differences in two objects given an attribute-list
+
+        :type actor: nav.models.profiles.Account
+        :type old: models.Model
+        :type new: models.Model
+        :type attribute_list: list[str]
+        :type verb_prefix: str
+
+        Adds a log entry for each attribute the two objects differ.
+        """
+        model = new.__class__.__name__.lower()
+        prefix = u'{actor} edited {object}'
+        for attribute in attribute_list:
+            old_value = getattr(old, attribute)
+            new_value = getattr(new, attribute)
+            if old_value != new_value:
+                change_text = "{} changed from '{}' to '{}'".format(
+                    attribute, old_value, new_value)
+
+                LogEntry.add_log_entry(
+                    actor,
+                    u'edit-{}-{}'.format(model, attribute),
+                    u'{}: {}'.format(prefix, change_text),
+                    object=new
+                )
+
+
+
     def __str__(self):
         return self.summary

--- a/python/nav/auditlog/models.py
+++ b/python/nav/auditlog/models.py
@@ -28,6 +28,18 @@ from . import find_modelname
 
 @python_2_unicode_compatible
 class LogEntry(models.Model):
+    """
+    Logs mostly user actions in NAV
+
+    Example logentry:
+    LogEntry.add_log_entry(
+        account,           # actor
+        u'set-ifalias',    # verb
+        u'{actor}: {object} - ifalias set to "%s"' % ifalias,  # template
+        subsystem=u'portadmin',                                # optional
+        object=interface,                                      # optional
+    )
+    """
     actor_model = VarcharField()
     actor_pk = VarcharField()
     actor = LegacyGenericForeignKey('actor_model', 'actor_pk')

--- a/python/nav/auditlog/urls.py
+++ b/python/nav/auditlog/urls.py
@@ -14,26 +14,11 @@
 
 from __future__ import unicode_literals, absolute_import
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-from .views import (AuditlogOverview, AuditlogObjectListView,
-                    AuditlogActorListView, AuditlogTargetListView)
+from .views import AuditlogOverview
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', AuditlogOverview.as_view(), name='auditlog-home'),
-
-    url(r'^object/*/$', AuditlogObjectListView.as_view(),
-        name='auditlog-object-list-all'),
-    url(r'^object/(?P<auditmodel>[-\w]+)/$', AuditlogObjectListView.as_view(),
-        name='auditlog-object-list'),
-    url(r'^actor/*/$', AuditlogActorListView.as_view(),
-        name='auditlog-actor-list-all'),
-    url(r'^actor/(?P<auditmodel>[-\w]+)/$', AuditlogActorListView.as_view(),
-        name='auditlog-actor-list'),
-    url(r'^target/*/$', AuditlogTargetListView.as_view(),
-        name='auditlog-target-list-all'),
-    url(r'^target/(?P<auditmodel>[-\w]+)/$', AuditlogTargetListView.as_view(),
-        name='auditlog-target-list'),
-)
+]

--- a/python/nav/auditlog/utils.py
+++ b/python/nav/auditlog/utils.py
@@ -9,16 +9,15 @@ from .models import LogEntry
 LATEST_N_AUDITLOG_ENTRIES = 15
 
 
-def get_auditlog_entries(iterable, limit=LATEST_N_AUDITLOG_ENTRIES):
+def get_auditlog_entries(iterable, limit=LATEST_N_AUDITLOG_ENTRIES, subsystem=None):
     modelname = find_modelname(list(iterable)[0])
     pks = [force_text(i.pk) for i in iterable]
     object_query = Q(object_pk__in=pks, object_model=modelname)
     target_query = Q(target_pk__in=pks, object_model=modelname)
     actor_query = Q(actor_pk__in=pks, object_model=modelname)
     filter_query = object_query | target_query | actor_query
-    entries = (LogEntry.objects
-               .filter(filter_query)
-               .distinct()
-               .order_by('-timestamp')[:limit]
-    )
+    qs = LogEntry.objects.filter(filter_query)
+    if subsystem:
+        qs = qs.filter(subsystem=subsystem)
+    entries = qs.distinct().order_by('-timestamp')[:limit]
     return entries

--- a/python/nav/auditlog/views.py
+++ b/python/nav/auditlog/views.py
@@ -38,19 +38,10 @@ class AuditlogOverview(AuditlogViewMixin, TemplateView):
     template_name = 'auditlog/overview.html'
 
     def get_context_data(self, **kwargs):
-        qs = self.model.objects.values('actor_model', 'object_model',
-                                       'target_model')
-        actors, objects, targets = set(), set(), set()
-        for row in qs:
-            actors.add(row['actor_model'])
-            objects.add(row['object_model'])
-            targets.add(row['target_model'])
-        objects.discard(None)
-        targets.discard(None)
+        verbs = list(LogEntry.objects.order_by().values_list('verb', flat=True).distinct())
+        verbs.sort()
         context = {
-            'actors': actors,
-            'objects': objects,
-            'targets': targets,
+            'auditlog_verbs': verbs
         }
         context.update(**kwargs)
         return super(AuditlogOverview, self).get_context_data(**context)

--- a/python/nav/auditlog/views.py
+++ b/python/nav/auditlog/views.py
@@ -16,24 +16,12 @@
 
 from __future__ import unicode_literals, absolute_import
 
-from django.views.generic import ListView, TemplateView
+from django.views.generic import TemplateView
 
 from .models import LogEntry
 
 
-class AuditlogViewMixin(object):
-
-    def get_context_data(self, **kwargs):
-        tool = {
-            'name': 'Auditlog',
-            'description': 'Look up who/what did what with what',
-        }
-        context = {'tool': tool}
-        context.update(**kwargs)
-        return super(AuditlogViewMixin, self).get_context_data(**context)
-
-
-class AuditlogOverview(AuditlogViewMixin, TemplateView):
+class AuditlogOverview(TemplateView):
     model = LogEntry
     template_name = 'auditlog/overview.html'
 

--- a/python/nav/auditlog/views.py
+++ b/python/nav/auditlog/views.py
@@ -45,36 +45,3 @@ class AuditlogOverview(AuditlogViewMixin, TemplateView):
         }
         context.update(**kwargs)
         return super(AuditlogOverview, self).get_context_data(**context)
-
-
-class AbstractAuditlogListView(AuditlogViewMixin, ListView):
-    slug_url_kwarg = 'auditmodel'
-    model = LogEntry
-    template_name = 'auditlog/logentry_list.html'
-    limit_to = None
-
-    def get_context_data(self, **kwargs):
-        context = {'auditmodel': self.kwargs.get(self.slug_url_kwarg, None)}
-        context.update(**kwargs)
-        return super(AbstractAuditlogListView, self).get_context_data(**context)
-
-    def get_queryset(self):
-        # Show only logs for specific object type
-        qs = super(AbstractAuditlogListView, self).get_queryset()
-        auditmodel = self.kwargs.get(self.slug_url_kwarg, None)
-        if auditmodel and self.limit_to:
-            kwargs = {self.limit_to: auditmodel}
-            qs = qs.filter(**kwargs)
-        return qs
-
-
-class AuditlogObjectListView(AbstractAuditlogListView):
-    limit_to = 'object_model'
-
-
-class AuditlogActorListView(AbstractAuditlogListView):
-    limit_to = 'actor_model'
-
-
-class AuditlogTargetListView(AbstractAuditlogListView):
-    limit_to = 'target_model'

--- a/python/nav/web/auth.py
+++ b/python/nav/web/auth.py
@@ -19,7 +19,6 @@ Contains web authentication functionality for NAV.
 """
 import logging
 
-from nav.auditlog.models import LogEntry
 from nav.web import ldapauth
 from nav.models.profiles import Account
 
@@ -77,8 +76,6 @@ def authenticate(username, password):
         auth = account.check_password(password)
 
     if auth and account:
-        LogEntry.add_log_entry(account, 'log-in', '{actor} logged in',
-                               before=account)
         return account
     else:
         return None

--- a/python/nav/web/auth.py
+++ b/python/nav/web/auth.py
@@ -19,6 +19,7 @@ Contains web authentication functionality for NAV.
 """
 import logging
 
+from nav.auditlog.models import LogEntry
 from nav.web import ldapauth
 from nav.models.profiles import Account
 
@@ -76,6 +77,8 @@ def authenticate(username, password):
         auth = account.check_password(password)
 
     if auth and account:
+        LogEntry.add_log_entry(account, 'log-in', '{actor} logged in',
+                               before=account)
         return account
     else:
         return None

--- a/python/nav/web/ipdevinfo/urls.py
+++ b/python/nav/web/ipdevinfo/urls.py
@@ -24,7 +24,7 @@ from nav.web.ipdevinfo.views import (search, service_list, service_matrix,
                                      port_details, get_port_view,
                                      render_affected, render_host_info,
                                      port_counter_graph, sensor_details,
-                                     save_port_layout_pref,
+                                     save_port_layout_pref, auditlog,
                                      unrecognized_neighbors)
 
 # The patterns are relative to the base URL of the subsystem
@@ -87,6 +87,9 @@ urlpatterns = patterns(
     # Sensors
     url(r'sensor/(?P<identifier>.+)', sensor_details,
         name="sensor-details"),
+
+    # Auditlog
+    url(r'auditlog/(?P<netboxid>.+)', auditlog, name="ipdevinfo-auditlog"),
 
     url(r'^(?P<netboxid>\d+)/unrecognized_neighbors', unrecognized_neighbors,
         name='ipdevinfo-unrecognized_neighbors')

--- a/python/nav/web/ipdevinfo/views.py
+++ b/python/nav/web/ipdevinfo/views.py
@@ -323,8 +323,9 @@ def ipdev_details(request, name=None, addr=None, netbox_id=None):
         interface.combined_data_urls = create_combined_urls(
             interface, COUNTER_TYPES)
 
+
     auditlog_api_parameters = json.dumps(
-        {'object_model': 'netbox', 'object_pk': netbox.pk})
+        {'object_model': 'netbox', 'object_pk': netbox.pk}) if netbox else {}
 
     return render_to_response(
         'ipdevinfo/ipdev-details.html',

--- a/python/nav/web/ipdevinfo/views.py
+++ b/python/nav/web/ipdevinfo/views.py
@@ -323,14 +323,9 @@ def ipdev_details(request, name=None, addr=None, netbox_id=None):
         interface.combined_data_urls = create_combined_urls(
             interface, COUNTER_TYPES)
 
-
-    auditlog_api_parameters = json.dumps(
-        {'object_model': 'netbox', 'object_pk': netbox.pk}) if netbox else {}
-
     return render_to_response(
         'ipdevinfo/ipdev-details.html',
         {
-            'auditlog_api_parameters': auditlog_api_parameters,
             'host_info': host_info,
             'netbox': netbox,
             'interfaces': interfaces,
@@ -715,6 +710,15 @@ def render_host_info(request, identifier):
     """Controller for getting host info"""
     return render(request, 'ipdevinfo/frag-hostinfo.html', {
         'host_info': get_host_info(identifier)
+    })
+
+
+def auditlog(request, netboxid):
+    netbox = get_object_or_404(Netbox, pk=netboxid)
+    auditlog_api_parameters = json.dumps(
+        {'object_model': 'netbox', 'object_pk': netbox.pk})
+    return render(request, 'ipdevinfo/frag-auditlog.html', {
+        'auditlog_api_parameters': auditlog_api_parameters
     })
 
 

--- a/python/nav/web/ipdevinfo/views.py
+++ b/python/nav/web/ipdevinfo/views.py
@@ -14,6 +14,7 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Views for ipdevinfo"""
+import json
 import re
 import logging
 import datetime as dt
@@ -322,9 +323,13 @@ def ipdev_details(request, name=None, addr=None, netbox_id=None):
         interface.combined_data_urls = create_combined_urls(
             interface, COUNTER_TYPES)
 
+    auditlog_api_parameters = json.dumps(
+        {'object_model': 'netbox', 'object_pk': netbox.pk})
+
     return render_to_response(
         'ipdevinfo/ipdev-details.html',
         {
+            'auditlog_api_parameters': auditlog_api_parameters,
             'host_info': host_info,
             'netbox': netbox,
             'interfaces': interfaces,

--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -30,7 +30,6 @@ from django.db.models import Q
 from django.views.decorators.http import require_POST
 
 from nav.auditlog.models import LogEntry
-from nav.auditlog.utils import get_auditlog_entries
 
 from nav.django.utils import get_account
 from nav.web.utils import create_title
@@ -147,10 +146,8 @@ def search_by_kwargs(request, **kwargs):
         if len(interfaces) == 0:
             messages.error(request, 'IP device has no ports (yet)')
             return default_render(request)
-        auditlog_entries = get_auditlog_entries(interfaces)
         return render(request, 'portadmin/netbox.html',
-                      populate_infodict(request, netbox, interfaces,
-                                        auditlog_entries))
+                      populate_infodict(request, netbox, interfaces))
 
 
 def search_by_interfaceid(request, interfaceid):
@@ -171,19 +168,16 @@ def search_by_interfaceid(request, interfaceid):
             return default_render(request)
 
         interfaces = [interface]
-        auditlog_entries = get_auditlog_entries(interfaces)
         return render(request, 'portadmin/netbox.html',
-                      populate_infodict(request, netbox, interfaces,
-                                        auditlog_entries))
+                      populate_infodict(request, netbox, interfaces))
 
 
-def populate_infodict(request, netbox, interfaces, auditlog_entries=None):
+def populate_infodict(request, netbox, interfaces):
     """Populate a dictionary used in every http response"""
     allowed_vlans = []
     voice_vlan = None
     readonly = False
     config = read_config()
-    auditlog_entries = {} if auditlog_entries is None else auditlog_entries
 
     try:
         fac = get_and_populate_livedata(netbox, interfaces)
@@ -224,14 +218,14 @@ def populate_infodict(request, netbox, interfaces, auditlog_entries=None):
     info_dict.update(
         {
             'interfaces': interfaces,
-            'auditmodel': netbox.sysname,
             'netbox': netbox,
             'voice_vlan': voice_vlan,
             'allowed_vlans': allowed_vlans,
             'readonly': readonly,
             'aliastemplate': aliastemplate,
-            'auditlog_api_parameters': json.dumps({'subsystem': 'portadmin'}),
-            'auditlog_entries': auditlog_entries,
+            'auditlog_api_parameters': json.dumps(
+                {'object_model': 'interface', 'object_pk': [i.pk for i in interfaces],
+                 'subsystem': 'portadmin'})
         }
     )
     return info_dict

--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -491,8 +491,8 @@ def set_admin_status(fac, interface, request):
             if adminstatus == status_up:
                 LogEntry.add_log_entry(
                     account,
-                    u'change status to up',
-                    u'change status to up',
+                    u'change-status-to-up',
+                    u'change-status-to-up',
                     subsystem=u'portadmin',
                     object=interface,
                 )
@@ -502,8 +502,8 @@ def set_admin_status(fac, interface, request):
             elif adminstatus == status_down:
                 LogEntry.add_log_entry(
                     account,
-                    u'change status to down',
-                    u'change status to down',
+                    u'change-status-to-down',
+                    u'change-status-to-down',
                     subsystem=u'portadmin',
                     object=interface,
                 )

--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -492,7 +492,7 @@ def set_admin_status(fac, interface, request):
                 LogEntry.add_log_entry(
                     account,
                     u'change-status-to-up',
-                    u'change-status-to-up',
+                    u'change status to up',
                     subsystem=u'portadmin',
                     object=interface,
                 )
@@ -503,7 +503,7 @@ def set_admin_status(fac, interface, request):
                 LogEntry.add_log_entry(
                     account,
                     u'change-status-to-down',
-                    u'change-status-to-down',
+                    u'change status to down',
                     subsystem=u'portadmin',
                     object=interface,
                 )

--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -214,6 +214,12 @@ def populate_infodict(request, netbox, interfaces):
 
     save_to_database(interfaces)
 
+    auditlog_api_parameters = {
+        'object_model': 'interface',
+        'object_pks': ','.join([str(i.pk) for i in interfaces]),
+        'subsystem': 'portadmin'
+    }
+
     info_dict = get_base_context([(netbox.sysname, )], form=get_form(request))
     info_dict.update(
         {
@@ -223,9 +229,7 @@ def populate_infodict(request, netbox, interfaces):
             'allowed_vlans': allowed_vlans,
             'readonly': readonly,
             'aliastemplate': aliastemplate,
-            'auditlog_api_parameters': json.dumps(
-                {'object_model': 'interface', 'object_pk': [i.pk for i in interfaces],
-                 'subsystem': 'portadmin'})
+            'auditlog_api_parameters': json.dumps(auditlog_api_parameters)
         }
     )
     return info_dict

--- a/python/nav/web/seeddb/page/netbox/edit.py
+++ b/python/nav/web/seeddb/page/netbox/edit.py
@@ -52,7 +52,7 @@ def log_netbox_change(account, old, new):
     # Compare changes from old to new
     attribute_list = ['read_only', 'read_write', 'category', 'ip',
                       'room', 'organization', 'snmp_version']
-    LogEntry.add_edit_entry(account, old, new, attribute_list)
+    LogEntry.compare_objects(account, old, new, attribute_list)
 
 
 def netbox_edit(request, netbox_id=None):

--- a/python/nav/web/seeddb/page/netbox/edit.py
+++ b/python/nav/web/seeddb/page/netbox/edit.py
@@ -52,7 +52,8 @@ def log_netbox_change(account, old, new):
     # Compare changes from old to new
     attribute_list = ['read_only', 'read_write', 'category', 'ip',
                       'room', 'organization', 'snmp_version']
-    LogEntry.compare_objects(account, old, new, attribute_list)
+    LogEntry.compare_objects(account, old, new, attribute_list,
+                             censored_attributes=['read_only', 'read_write'])
 
 
 def netbox_edit(request, netbox_id=None):

--- a/python/nav/web/seeddb/page/netbox/edit.py
+++ b/python/nav/web/seeddb/page/netbox/edit.py
@@ -18,6 +18,7 @@
 
 # pylint: disable=F0401
 
+import copy
 import json
 import socket
 from socket import error as SocketError
@@ -28,6 +29,7 @@ from django.shortcuts import redirect, render, get_object_or_404
 from django.db import transaction
 from django.contrib import messages
 
+from nav.auditlog.models import LogEntry
 from nav.models.manage import Netbox, NetboxCategory, NetboxType
 from nav.models.manage import NetboxInfo
 from nav.Snmp import Snmp
@@ -39,17 +41,52 @@ from nav.web.seeddb.page.netbox import NetboxInfo as NI
 from nav.web.seeddb.page.netbox.forms import NetboxModelForm
 
 
+def log_netbox_change(account, old, new):
+    """Log specific user initiated changes to netboxes"""
+
+    # If this is a new netbox
+    if not old:
+        LogEntry.add_log_entry(
+            account,
+            u'create-netbox',
+            u'{actor} created {object}',
+            object=new
+        )
+        return
+
+    # Compare changes from old to new
+    attribute_list = ['read_only', 'read_write', 'category', 'ip',
+                      'room', 'organization', 'snmp_version']
+    for attribute in attribute_list:
+        old_value = getattr(old, attribute)
+        new_value = getattr(new, attribute)
+        if old_value != new_value:
+            change_text = "{} changed from '{}' to '{}'".format(
+                attribute, old_value, new_value)
+
+            # create one logentry for each changed attribute
+            prefix = u'{actor} changed {object}: '
+            LogEntry.add_log_entry(
+                account,
+                u'edit-netbox-{}'.format(attribute),
+                u'{}{}'.format(prefix, change_text),
+                object=new)
+
+
 def netbox_edit(request, netbox_id=None):
     """Controller for edit or create of netbox"""
     netbox = None
     if netbox_id:
         netbox = get_object_or_404(Netbox, pk=netbox_id)
 
+    old_netbox = copy.deepcopy(netbox)
+
     if request.method == 'POST':
         form = NetboxModelForm(request.POST, instance=netbox)
         if form.is_valid():
             netbox = netbox_do_save(form)
             messages.add_message(request, messages.SUCCESS, 'IP Device saved')
+            log_netbox_change(request.account, old_netbox, netbox)
             return redirect(reverse('seeddb-netbox-edit', args=[netbox.pk]))
         else:
             messages.add_message(request, messages.ERROR, 'Form was not valid')

--- a/python/nav/web/seeddb/page/netbox/edit.py
+++ b/python/nav/web/seeddb/page/netbox/edit.py
@@ -46,31 +46,13 @@ def log_netbox_change(account, old, new):
 
     # If this is a new netbox
     if not old:
-        LogEntry.add_log_entry(
-            account,
-            u'create-netbox',
-            u'{actor} created {object}',
-            object=new
-        )
+        LogEntry.add_create_entry(account, new)
         return
 
     # Compare changes from old to new
     attribute_list = ['read_only', 'read_write', 'category', 'ip',
                       'room', 'organization', 'snmp_version']
-    for attribute in attribute_list:
-        old_value = getattr(old, attribute)
-        new_value = getattr(new, attribute)
-        if old_value != new_value:
-            change_text = "{} changed from '{}' to '{}'".format(
-                attribute, old_value, new_value)
-
-            # create one logentry for each changed attribute
-            prefix = u'{actor} changed {object}: '
-            LogEntry.add_log_entry(
-                account,
-                u'edit-netbox-{}'.format(attribute),
-                u'{}{}'.format(prefix, change_text),
-                object=new)
+    LogEntry.add_edit_entry(account, old, new, attribute_list)
 
 
 def netbox_edit(request, netbox_id=None):

--- a/python/nav/web/seeddb/utils/delete.py
+++ b/python/nav/web/seeddb/utils/delete.py
@@ -121,12 +121,7 @@ def render_delete(request, model, redirect, whitelist=None, extra_context=None,
 def log_deleted(account, objects, template):
     """Log the deletion of each object"""
     for obj in objects:
-        LogEntry.add_log_entry(
-            account,
-            u'delete-{}'.format(obj.__class__.__name__.lower()),
-            template,
-            object=obj
-        )
+        LogEntry.add_delete_entry(account, obj, template=template)
 
 
 def dependencies(queryset, whitelist):

--- a/python/nav/web/seeddb/utils/delete.py
+++ b/python/nav/web/seeddb/utils/delete.py
@@ -25,6 +25,7 @@ from django.template import RequestContext
 from django.http import HttpResponseRedirect
 
 from nav.web.message import new_message, Messages
+from nav.auditlog.models import LogEntry
 
 LOGGER = logging.getLogger(__name__)
 
@@ -101,9 +102,11 @@ def render_delete(request, model, redirect, whitelist=None, extra_context=None,
             if delete_operation:
                 new_message(request,
                             "Deleted %i rows" % len(objects), Messages.SUCCESS)
+                log_deleted(request.account, objects, template='{actor} deleted {object}')
             else:
                 new_message(request,
                             "Scheduled %i rows for deletion" % len(objects), Messages.SUCCESS)
+                log_deleted(request.account, objects, template='{actor} scheduled {object} for deletion')
             return HttpResponseRedirect(reverse(redirect))
 
     info_dict = {
@@ -113,6 +116,17 @@ def render_delete(request, model, redirect, whitelist=None, extra_context=None,
     extra_context.update(info_dict)
     return render_to_response('seeddb/delete.html',
         extra_context, RequestContext(request))
+
+
+def log_deleted(account, objects, template):
+    """Log the deletion of each object"""
+    for obj in objects:
+        LogEntry.add_log_entry(
+            account,
+            u'delete-{}'.format(obj.__class__.__name__.lower()),
+            template,
+            object=obj
+        )
 
 
 def dependencies(queryset, whitelist):

--- a/python/nav/web/useradmin/views.py
+++ b/python/nav/web/useradmin/views.py
@@ -142,13 +142,7 @@ def save_account_org(request, account, org_form):
             'Organization was not added as it has already been added.')
     except Organization.DoesNotExist:
         account.organizations.add(organization)
-
-        LogEntry.add_log_entry(
-            request.account,
-            u'edit-account-add-org',
-            u'{actor} added organization {target} to {object}',
-            target=organization,
-            object=account)
+        log_add_account_to_org(request, organization, account)
         messages.success(request, 'Added organization "%s" to account "%s"' %
                          (organization, account))
 
@@ -176,13 +170,7 @@ def save_account_group(request, account, group_form):
             account.accountgroup_set.add(group)
             messages.success(
                 request, 'Added "%s" to group "%s"' % (account, group))
-
-            LogEntry.add_log_entry(
-                request.account,
-                u'edit-account-add-group',
-                u'{actor} added group {target} to {object}',
-                target=group,
-                object=account)
+            log_add_account_to_group(request, group, account)
 
     return HttpResponseRedirect(reverse('useradmin-account_detail',
                                         args=[account.id]))
@@ -258,7 +246,7 @@ def account_organization_remove(request, account_id, org_id):
         LogEntry.add_log_entry(
             request.account,
             u'edit-account-remove-org',
-            u'{actor} removed org {target} from {object}',
+            u'{actor} removed user {object} from organization {target}',
             target=organization,
             object=account)
 
@@ -323,7 +311,7 @@ def account_group_remove(request, account_id, group_id, caller='account'):
         LogEntry.add_log_entry(
             request.account,
             u'edit-account-remove-group',
-            u'{actor} removed group {target} from {object}',
+            u'{actor} removed user {object} from group {target}',
             target=group,
             object=account)
 
@@ -399,6 +387,7 @@ def group_detail(request, group_id=None):
                         'a member of the group.' % account)
                 except Account.DoesNotExist:
                     group.accounts.add(account)
+                    log_add_account_to_group(request, group, account)
                     messages.success(request,
                                      'Account %s has been added.' % account)
 
@@ -564,3 +553,21 @@ def log_account_change(actor, old, new):
 
     attribute_list = ['login', 'name', 'password', 'ext_sync']
     LogEntry.compare_objects(actor, old, new, attribute_list)
+
+
+def log_add_account_to_group(request, group, account):
+    LogEntry.add_log_entry(
+        request.account,
+        u'edit-account-add-group',
+        u'{actor} added user {object} to group {target}',
+        target=group,
+        object=account)
+
+
+def log_add_account_to_org(request, organization, account):
+    LogEntry.add_log_entry(
+        request.account,
+        u'edit-account-add-org',
+        u'{actor} added user {object} to organization {target}',
+        target=organization,
+        object=account)

--- a/python/nav/web/useradmin/views.py
+++ b/python/nav/web/useradmin/views.py
@@ -53,10 +53,14 @@ def custom_processor(_request):
 def account_list(request):
     """Controller for displaying the account list"""
     accounts = Account.objects.all()
-    return render_to_response('useradmin/account_list.html',
-                              {'active': {'account_list': 1},
-                               'accounts': accounts},
-                              UserAdminContext(request))
+    return render_to_response(
+        'useradmin/account_list.html',
+        {
+            'active': {'account_list': 1},
+            'accounts': accounts,
+            'auditlog_api_parameters': {'object_model': 'account'}
+        },
+        UserAdminContext(request))
 
 
 @sensitive_post_parameters('password1', 'password2')
@@ -92,9 +96,14 @@ def account_detail(request, account_id=None):
             return sudo_to_user(request)
 
     active = {'account_detail': True} if account else {'account_new': True}
+    auditlog_api_parameters = {
+        'object_model': 'account',
+        'object_pk': account.pk
+    } if account else {}
 
     return render_to_response('useradmin/account_detail.html',
                   {
+                      'auditlog_api_parameters': auditlog_api_parameters,
                       'active': active,
                       'account': account,
                       'account_form': account_form,

--- a/python/nav/web/useradmin/views.py
+++ b/python/nav/web/useradmin/views.py
@@ -554,4 +554,4 @@ def log_account_change(actor, old, new):
         return
 
     attribute_list = ['login', 'name', 'password', 'ext_sync']
-    LogEntry.add_edit_entry(actor, old, new, attribute_list)
+    LogEntry.compare_objects(actor, old, new, attribute_list)

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -34,6 +34,7 @@ from django.utils.http import urlquote
 
 from django.utils import six
 
+from nav.auditlog.models import LogEntry
 from nav.django.auth import ACCOUNT_ID_VAR, desudo
 from nav.buildconf import sysconfdir
 from nav.django.utils import get_account
@@ -251,10 +252,13 @@ def logout(request):
         desudo(request)
         return HttpResponseRedirect(reverse('webfront-index'))
     else:
+        account = request.account
         del request.session[ACCOUNT_ID_VAR]
         del request.account
         request.session.set_expiry(datetime.now())
         request.session.save()
+        LogEntry.add_log_entry(account, 'log-out', '{actor} logged out',
+                               before=account)
     return HttpResponseRedirect('/')
 
 

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -219,6 +219,9 @@ def do_login(request):
             errors.append('Error while talking to LDAP:\n%s' % error)
         else:
             if account:
+                LogEntry.add_log_entry(
+                    account, 'log-in', '{actor} logged in', before=account)
+
                 try:
                     request.session[ACCOUNT_ID_VAR] = account.id
                     request.account = account

--- a/sql/changes/sc.04.08.0085.sql
+++ b/sql/changes/sc.04.08.0085.sql
@@ -1,0 +1,2 @@
+UPDATE auditlog_logentry SET verb='change-status-to-up' WHERE verb='change status to up';
+UPDATE auditlog_logentry SET verb='change-status-to-down' WHERE verb='change status to down';

--- a/templates/auditlog/_logentry_list.html
+++ b/templates/auditlog/_logentry_list.html
@@ -73,9 +73,18 @@
              },
              { data: columns[1] },
              { data: columns[2] },
-             { data: columns[3] },
-             { data: columns[4] },
-             { data: columns[5] }
+             {
+                 data: columns[3],
+                 orderable: false
+             },
+             {
+                 data: columns[4],
+                 orderable: false
+             },
+             {
+                 data: columns[5],
+                 orderable: false
+             }
          ],
          autowidth: false,
          info: false,

--- a/templates/auditlog/_logentry_list.html
+++ b/templates/auditlog/_logentry_list.html
@@ -1,3 +1,13 @@
+<label id="filter-verb-label" style="display:none">
+  Filter by verb
+  <select id="filter-verb">
+    <option value="">------------</option>
+    {% for verb in auditlog_verbs %}
+      <option value="{{ verb }}">{{ verb }}</option>
+    {% endfor %}
+  </select>
+</label>
+
 <table id="auditlog" class="listtable full-width">
   <thead>
     <tr>
@@ -10,8 +20,15 @@
     </tr>
   </thead>
 </table>
+
+<style>
+ #auditlog-top > div { display: inline-block; margin-right: 1em; }
+ #auditlog-top label { display: inline-block; }
+ #auditlog-top input, #auditlog-top select { display: block; max-width: 15em; }
+</style>
+
 <script type="text/javascript">
- require(['libs/datatables.min'], function(){
+ require(['libs/urijs/URI', 'libs/datatables.min'], function(Uri) {
      var api_parameters = {{ auditlog_api_parameters|safe|default:'{}' }};
      var columns = {
          0: 'timestamp',
@@ -22,13 +39,14 @@
          5: 'summary'
      };
      var dt_config = {
-         serverSide: true,
+         serverSide: true,  // Everything is done serverside - sorting, filtering, etc.
          ajax: {
              url: '/api/1/auditlog/',
              data: function(d) {
                  // Override the original parameters that we get when using serverSide rendering
                  var parameters = {
                      page: d.start / d.length + 1,
+                     search: d.search.value,
                      page_size: d.length,
                      ordering: d.order.map(function(order) {
                          var direction = order.dir === 'asc' ? '' : '-';
@@ -55,9 +73,10 @@
              { 'data': columns[5] }
          ],
          bAutoWidth: false,
-         bFilter: false,
          bInfo: false,
+         searching: true,
          bSort: true,
+         dom: '<"#auditlog-top"l<"#dataTables_verbs">f>t<p>',
          order: [[0, 'desc']],
          paging: true,
          pagingType: 'full_numbers',
@@ -66,10 +85,26 @@
              [10, 25, 50, -1],   // Choices for number of rows to display
              [10, 25, 50, "All"] // Text for the choices
          ],
+         language: {
+             lengthMenu: "Rows _MENU_",
+             search: "Search in summary"
+         },
          drawCallback: drawCallback,
      };
 
-     $('table#auditlog').DataTable(dt_config);
+     var dataTable = $('table#auditlog').DataTable(dt_config);
+
+
+     {% if auditlog_verbs %}
+     // Add form for filtering on verbs
+     $('#filter-verb-label').appendTo('#dataTables_verbs').show();
+     $('#filter-verb').on('change', function(e) {
+         var url = Uri(dataTable.ajax.url()).setQuery('verb', e.target.value);
+         dataTable.ajax.url(url).load()
+     });
+     {% endif %}
+
+
      function drawCallback(oSettings) {
          $('.paginate_button').removeClass('secondary').addClass('button tiny');
          $('.paginate_button.current').addClass('secondary');

--- a/templates/auditlog/_logentry_list.html
+++ b/templates/auditlog/_logentry_list.html
@@ -12,19 +12,47 @@
 </table>
 <script type="text/javascript">
  require(['libs/datatables.min'], function(){
+     var api_parameters = {{ auditlog_api_parameters|safe|default:'{}' }};
+     var columns = {
+         0: 'timestamp',
+         1: 'actor',
+         2: 'verb',
+         3: 'object',
+         4: 'target',
+         5: 'summary'
+     };
      var dt_config = {
+         serverSide: true,
          ajax: {
              url: '/api/1/auditlog/',
-             dataSrc: 'results',
-             {% if auditlog_api_parameters %}data: {{ auditlog_api_parameters|safe }}{% endif %}
+             data: function(d) {
+                 // Override the original parameters that we get when using serverSide rendering
+                 var parameters = {
+                     page: d.start / d.length + 1,
+                     page_size: d.length,
+                     ordering: d.order.map(function(order) {
+                         var direction = order.dir === 'asc' ? '' : '-';
+                         return direction + columns[order.column];
+                     }).join(',')
+                 }
+                 return Object.assign({}, parameters, api_parameters);
+             },
+             dataFilter: function(data) {
+                 // Map the response to something datatables understands
+                 var json = jQuery.parseJSON( data );
+                 json.recordsTotal = json.count;
+                 json.recordsFiltered = json.count;
+                 json.data = json.results;
+                 return JSON.stringify( json );
+             }
          },
          columns: [
-             { 'data': 'timestamp' },
-             { 'data': 'actor' },
-             { 'data': 'verb' },
-             { 'data': 'object' },
-             { 'data': 'target' },
-             { 'data': 'summary' }
+             { 'data': columns[0] },
+             { 'data': columns[1] },
+             { 'data': columns[2] },
+             { 'data': columns[3] },
+             { 'data': columns[4] },
+             { 'data': columns[5] }
          ],
          bAutoWidth: false,
          bFilter: false,

--- a/templates/auditlog/_logentry_list.html
+++ b/templates/auditlog/_logentry_list.html
@@ -75,6 +75,7 @@
          autowidth: false,
          info: false,
          searching: true,
+         searchDelay: 350,
          ordering: true,
          dom: '<"#auditlog-top"l<"#dataTables_verbs">f>t<p>',
          order: [[0, 'desc']],
@@ -94,6 +95,10 @@
 
      var dataTable = $('table#auditlog').DataTable(dt_config);
 
+     // Listen to an event for reloading of data
+     $(document).on('nav-portadmin-ajax-success', function(){
+         dataTable.ajax.reload();
+     });
 
      {% if auditlog_verbs %}
      // Add form for filtering on verbs

--- a/templates/auditlog/_logentry_list.html
+++ b/templates/auditlog/_logentry_list.html
@@ -1,56 +1,52 @@
-{% if object_list.exists %}
 <table id="auditlog" class="listtable full-width">
-<thead>
-<tr>
-    <th>Timestamp</th>
-    <th>Actor</th>
-    <th>Verb</th>
-    <th>Object</th>
-    <th>Target</th>
-    <th>Summary</th>
-</tr>
-</thead>
+  <thead>
+    <tr>
+      <th>Timestamp</th>
+      <th>Actor</th>
+      <th>Verb</th>
+      <th>Object</th>
+      <th>Target</th>
+      <th>Summary</th>
+    </tr>
+  </thead>
 </table>
-{% else %}
-No auditlog for {{ auditmodel }}.
-{% endif %}
 <script type="text/javascript">
-    require(['libs/datatables.min'], function(){
-        var dt_config = {
-            ajax: {
-                url: '/api/1/auditlog/',
-                dataSrc: 'results',
-                {% if auditlog_api_parameters %}data: {{ auditlog_api_parameters|safe }}{% endif %}
-            },
-            columns: [
-                { 'data': 'timestamp' },
-                { 'data': 'actor' },
-                { 'data': 'verb' },
-                { 'data': 'object' },
-                { 'data': 'target' },
-                { 'data': 'summary' }
-            ],
-            bAutoWidth: false,
-            bFilter: false,
-            bInfo: false,
-            bSort: true,
-            order: [[0, 'desc']],
-            paging: true,
-            pagingType: 'full_numbers',
-            lengthChange: true,  // Change number of visible rows
-            lengthMenu: [
-                [10, 25, 50, -1],   // Choices for number of rows to display
-                [10, 25, 50, "All"] // Text for the choices
-            ],
-            drawCallback: drawCallback,
-        };
+ require(['libs/datatables.min'], function(){
+     var dt_config = {
+         ajax: {
+             url: '/api/1/auditlog/',
+             dataSrc: 'results',
+             {% if auditlog_api_parameters %}data: {{ auditlog_api_parameters|safe }}{% endif %}
+         },
+         columns: [
+             { 'data': 'timestamp' },
+             { 'data': 'actor' },
+             { 'data': 'verb' },
+             { 'data': 'object' },
+             { 'data': 'target' },
+             { 'data': 'summary' }
+         ],
+         bAutoWidth: false,
+         bFilter: false,
+         bInfo: false,
+         bSort: true,
+         order: [[0, 'desc']],
+         paging: true,
+         pagingType: 'full_numbers',
+         lengthChange: true,  // Change number of visible rows
+         lengthMenu: [
+             [10, 25, 50, -1],   // Choices for number of rows to display
+             [10, 25, 50, "All"] // Text for the choices
+         ],
+         drawCallback: drawCallback,
+     };
 
-        $('table#auditlog').DataTable(dt_config);
-        function drawCallback(oSettings) {
-            $('.paginate_button').removeClass('secondary').addClass('button tiny');
-            $('.paginate_button.current').addClass('secondary');
-            $('.ellipsis').addClass('button tiny secondary disabled paginate_button');
-        }
+     $('table#auditlog').DataTable(dt_config);
+     function drawCallback(oSettings) {
+         $('.paginate_button').removeClass('secondary').addClass('button tiny');
+         $('.paginate_button.current').addClass('secondary');
+         $('.ellipsis').addClass('button tiny secondary disabled paginate_button');
+     }
 
-    });
+ });
 </script>

--- a/templates/auditlog/_logentry_list.html
+++ b/templates/auditlog/_logentry_list.html
@@ -28,7 +28,7 @@
 </style>
 
 <script type="text/javascript">
- require(['libs/urijs/URI', 'libs/datatables.min'], function(Uri) {
+ require(['libs/urijs/URI', 'moment', 'libs/datatables.min'], function(Uri, moment) {
      var api_parameters = {{ auditlog_api_parameters|safe|default:'{}' }};
      var columns = {
          0: 'timestamp',
@@ -65,12 +65,17 @@
              }
          },
          columns: [
-             { 'data': columns[0] },
-             { 'data': columns[1] },
-             { 'data': columns[2] },
-             { 'data': columns[3] },
-             { 'data': columns[4] },
-             { 'data': columns[5] }
+             {
+                 data: columns[0],
+                 render: function(data, type, row, meta) {
+                     return moment(data).format('YYYY-MM-DD HH:mm:ss');
+                 }
+             },
+             { data: columns[1] },
+             { data: columns[2] },
+             { data: columns[3] },
+             { data: columns[4] },
+             { data: columns[5] }
          ],
          autowidth: false,
          info: false,

--- a/templates/auditlog/_logentry_list.html
+++ b/templates/auditlog/_logentry_list.html
@@ -72,10 +72,10 @@
              { 'data': columns[4] },
              { 'data': columns[5] }
          ],
-         bAutoWidth: false,
-         bInfo: false,
+         autowidth: false,
+         info: false,
          searching: true,
-         bSort: true,
+         ordering: true,
          dom: '<"#auditlog-top"l<"#dataTables_verbs">f>t<p>',
          order: [[0, 'desc']],
          paging: true,

--- a/templates/auditlog/base.html
+++ b/templates/auditlog/base.html
@@ -8,7 +8,9 @@
 
 {% block base_content %}
 
-  {% include 'nav_header.html' %}
+  {% with tool=current_user_data.tools|get_tool:"Audit Log" %}
+    {% include 'nav_header.html' %}
+  {% endwith %}
 
   {% if messages %}
     {% for message in messages %}

--- a/templates/auditlog/logentry_list.html
+++ b/templates/auditlog/logentry_list.html
@@ -1,5 +1,0 @@
-{% extends "auditlog/base.html" %}
-
-{% block content %}
-{% include "auditlog/_logentry_list.html" %}
-{% endblock content %}

--- a/templates/auditlog/overview.html
+++ b/templates/auditlog/overview.html
@@ -1,28 +1,5 @@
 {% extends "auditlog/base.html" %}
 
 {% block content %}
-  {% if actors %}
-    <h3>Who/what did something</h3>
-    <ul>
-      {% for actor in actors %}
-        <li><a href="{% url 'auditlog-actor-list' auditmodel=actor %}">{{ actor }}</a></li>
-      {% endfor %}
-    </ul>
-  {% endif %}
-  {% if objects %}
-    <h3>What was done to what</h3>
-    <ul>
-      {% for object in objects %}
-        <li><a href="{% url 'auditlog-object-list' auditmodel=object %}">{{ object }}</a></li>
-      {% endfor %}
-    </ul>
-  {% endif %}
-  {% if targets %}
-    <h3>What was affected by what</h3>
-    <ul>
-      {% for target in targets %}
-        <li><a href="{% url 'auditlog-target-list' auditmodel=target %}">{{ target }}</a></li>
-      {% endfor %}
-    </ul>
-  {% endif %}
+  {% include "auditlog/_logentry_list.html" %}
 {% endblock content %}

--- a/templates/auditlog/overview.html
+++ b/templates/auditlog/overview.html
@@ -1,28 +1,28 @@
 {% extends "auditlog/base.html" %}
 
 {% block content %}
-{% if actors %}
-<h3>Who/what did something</h3>
-<ul>
-{% for actor in actors %}
-<li><a href="{% url 'auditlog-actor-list' auditmodel=actor %}">{{ actor }}</a></li>
-{% endfor %}
-</ul>
-{% endif %}
-{% if objects %}
-<h3>What was done to what</h3>
-<ul>
-{% for object in objects %}
-<li><a href="{% url 'auditlog-object-list' auditmodel=object %}">{{ object }}</a></li>
-{% endfor %}
-</ul>
-{% endif %}
-{% if targets %}
-<h3>What was affected by what</h3>
-<ul>
-{% for target in targets %}
-<li><a href="{% url 'auditlog-target-list' auditmodel=target %}">{{ target }}</a></li>
-{% endfor %}
-</ul>
-{% endif %}
+  {% if actors %}
+    <h3>Who/what did something</h3>
+    <ul>
+      {% for actor in actors %}
+        <li><a href="{% url 'auditlog-actor-list' auditmodel=actor %}">{{ actor }}</a></li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+  {% if objects %}
+    <h3>What was done to what</h3>
+    <ul>
+      {% for object in objects %}
+        <li><a href="{% url 'auditlog-object-list' auditmodel=object %}">{{ object }}</a></li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+  {% if targets %}
+    <h3>What was affected by what</h3>
+    <ul>
+      {% for target in targets %}
+        <li><a href="{% url 'auditlog-target-list' auditmodel=target %}">{{ target }}</a></li>
+      {% endfor %}
+    </ul>
+  {% endif %}
 {% endblock content %}

--- a/templates/ipdevinfo/frag-alerts.html
+++ b/templates/ipdevinfo/frag-alerts.html
@@ -1,6 +1,11 @@
-
 <div id="alerts">
   {% if netbox %}
+    {# Table for listing auditlog for this netbox #}
+    {% with object_list=auditlog_entries %}
+      {% include "auditlog/_logentry_list.html" %}
+    {% endwith %}
+
+    {# Table for listing recent alerts #}
     <table class="listtable">
       <caption>
         Alerts last {{ alert_info.days_back }}
@@ -69,5 +74,6 @@
         {% endif %}
       </tbody>
     </table>
+
   {% endif %}
 </div>

--- a/templates/ipdevinfo/frag-alerts.html
+++ b/templates/ipdevinfo/frag-alerts.html
@@ -1,8 +1,5 @@
 <div id="alerts">
   {% if netbox %}
-    {# Table for listing auditlog for this netbox #}
-    <h4>AuditLog</h4>
-    {% include "auditlog/_logentry_list.html" %}
 
     {# Table for listing recent alerts #}
     <h4>

--- a/templates/ipdevinfo/frag-alerts.html
+++ b/templates/ipdevinfo/frag-alerts.html
@@ -1,72 +1,73 @@
+
 <div id="alerts">
-    {% if netbox %}
-        <table class="listtable">
-            <caption>
-                Alerts last {{ alert_info.days_back }}
-                day{{ alert_info.days_back|pluralize }}
-            </caption>
+  {% if netbox %}
+    <table class="listtable">
+      <caption>
+        Alerts last {{ alert_info.days_back }}
+        day{{ alert_info.days_back|pluralize }}
+      </caption>
 
-            <thead>
-            <tr>
-                <th>Event</th>
-                <th>Message</th>
-                <th>Start</th>
-                <th>End</th>
-                <th>Downtime</th>
-            </tr>
-            </thead>
+      <thead>
+        <tr>
+          <th>Event</th>
+          <th>Message</th>
+          <th>Start</th>
+          <th>End</th>
+          <th>Downtime</th>
+        </tr>
+      </thead>
 
-            <tfoot>
-            <tr>
-                <th colspan="5">
-                    {% if alert_info.is_more_alerts %}
-                        Showing {{ alert_info.alerts|length }} of
-                        {{ alert_info.count }} alerts, see
-                        <a href="{% url 'devicehistory-view-netbox' netbox.id %}">
-                            Device History</a> for all
-                    {% else %}
-                        {{ alert_info.alerts|length }}
-                        alert{{ alert_info.alerts|length|pluralize }}
-                        found,
-                        see
-                        <a href="{% url 'devicehistory-view-netbox' netbox.id %}">Device
-                            History</a> for details
-                    {% endif %}
-                </th>
-            </tr>
-            </tfoot>
-
-            <tbody>
-            {% if alert_info.count %}
-                {% for a in alert_info.alerts %}
-                    <tr>
-                        <td>{{ a.type }}</td>
-                        <td>{{ a.message|default:"" }}</td>
-                        <td>{{ a.alert.start_time|date|default:"N/A" }}
-                            {{ a.alert.start_time|time }}</td>
-                        {% if a.alert.is_open %}
-                            <td class="status_down">Unresolved</td>
-                        {% else %}
-                            <td>{{ a.alert.end_time|date|default:"N/A" }}
-                                {{ a.alert.end_time|time }}</td>
-                        {% endif %}
-                        <td>
-                            {% if a.alert.is_stateful %}
-                                {% if a.alert.is_open %}
-                                    {{ a.alert.start_time|timesince }}
-                                {% else %}
-                                    {{ a.alert.start_time|timesince:a.alert.end_time }}
-                                {% endif %}
-                            {% endif %}
-                        </td>
-                    </tr>
-                {% endfor %}
+      <tfoot>
+        <tr>
+          <th colspan="5">
+            {% if alert_info.is_more_alerts %}
+              Showing {{ alert_info.alerts|length }} of
+              {{ alert_info.count }} alerts, see
+              <a href="{% url 'devicehistory-view-netbox' netbox.id %}">
+                Device History</a> for all
             {% else %}
-                <tr>
-                    <td>No matching alerts found.</td>
-                </tr>
+              {{ alert_info.alerts|length }}
+              alert{{ alert_info.alerts|length|pluralize }}
+              found,
+              see
+              <a href="{% url 'devicehistory-view-netbox' netbox.id %}">Device
+                History</a> for details
             {% endif %}
-            </tbody>
-        </table>
-    {% endif %}
+          </th>
+        </tr>
+      </tfoot>
+
+      <tbody>
+        {% if alert_info.count %}
+          {% for a in alert_info.alerts %}
+            <tr>
+              <td>{{ a.type }}</td>
+              <td>{{ a.message|default:"" }}</td>
+              <td>{{ a.alert.start_time|date|default:"N/A" }}
+                {{ a.alert.start_time|time }}</td>
+              {% if a.alert.is_open %}
+                <td class="status_down">Unresolved</td>
+              {% else %}
+                <td>{{ a.alert.end_time|date|default:"N/A" }}
+                  {{ a.alert.end_time|time }}</td>
+              {% endif %}
+              <td>
+                {% if a.alert.is_stateful %}
+                  {% if a.alert.is_open %}
+                    {{ a.alert.start_time|timesince }}
+                  {% else %}
+                    {{ a.alert.start_time|timesince:a.alert.end_time }}
+                  {% endif %}
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+        {% else %}
+          <tr>
+            <td>No matching alerts found.</td>
+          </tr>
+        {% endif %}
+      </tbody>
+    </table>
+  {% endif %}
 </div>

--- a/templates/ipdevinfo/frag-alerts.html
+++ b/templates/ipdevinfo/frag-alerts.html
@@ -1,17 +1,15 @@
 <div id="alerts">
   {% if netbox %}
     {# Table for listing auditlog for this netbox #}
-    {% with object_list=auditlog_entries %}
-      {% include "auditlog/_logentry_list.html" %}
-    {% endwith %}
+    <h4>AuditLog</h4>
+    {% include "auditlog/_logentry_list.html" %}
 
     {# Table for listing recent alerts #}
+    <h4>
+      Alerts last {{ alert_info.days_back }}
+      day{{ alert_info.days_back|pluralize }}
+    </h4>
     <table class="listtable">
-      <caption>
-        Alerts last {{ alert_info.days_back }}
-        day{{ alert_info.days_back|pluralize }}
-      </caption>
-
       <thead>
         <tr>
           <th>Event</th>

--- a/templates/ipdevinfo/frag-auditlog.html
+++ b/templates/ipdevinfo/frag-auditlog.html
@@ -1,0 +1,4 @@
+<div>
+  <h4>AuditLog</h4>
+  {% include 'auditlog/_logentry_list.html' %}
+</div>

--- a/templates/ipdevinfo/ipdev-details.html
+++ b/templates/ipdevinfo/ipdev-details.html
@@ -54,9 +54,6 @@
           <a href="#alerts">Recent alerts</a>
         </li>
         <li><a href="#sensors">Sensors</a></li>
-        <li aria-controls="auditlog">
-          <a href="{% url 'ipdevinfo-auditlog' netbox.id %}">AuditLog</a>
-        </li>
         <li><a href="#services">Services</a></li>
         <li><a href="#poe">PoE</a></li>
         <li aria-controls="dns">
@@ -77,7 +74,6 @@
       {% include "ipdevinfo/frag-sysmetrics.html" %}
       {% include "ipdevinfo/frag-alerts.html" %}
       {% include "ipdevinfo/frag-sensors.html" %}
-      <div id="auditlog"></div>
       {% include "ipdevinfo/frag-services.html" %}
       {% include "ipdevinfo/frag-poe.html" %}
       <div id="dns"></div>

--- a/templates/ipdevinfo/ipdev-details.html
+++ b/templates/ipdevinfo/ipdev-details.html
@@ -54,6 +54,9 @@
           <a href="#alerts">Recent alerts</a>
         </li>
         <li><a href="#sensors">Sensors</a></li>
+        <li aria-controls="auditlog">
+          <a href="{% url 'ipdevinfo-auditlog' netbox.id %}">AuditLog</a>
+        </li>
         <li><a href="#services">Services</a></li>
         <li><a href="#poe">PoE</a></li>
         <li aria-controls="dns">
@@ -74,6 +77,7 @@
       {% include "ipdevinfo/frag-sysmetrics.html" %}
       {% include "ipdevinfo/frag-alerts.html" %}
       {% include "ipdevinfo/frag-sensors.html" %}
+      <div id="auditlog"></div>
       {% include "ipdevinfo/frag-services.html" %}
       {% include "ipdevinfo/frag-poe.html" %}
       <div id="dns"></div>

--- a/templates/portadmin/netbox.html
+++ b/templates/portadmin/netbox.html
@@ -13,11 +13,6 @@
     </div>
     <script>
      require(['libs/datatables.min'], function(){
-         var table = $('table#auditlog').DataTable();
-         $(document).on('nav-portadmin-ajax-success', function(){
-             table.ajax.reload();
-         });
-
          $('.latest-changes-heading').click(function(){
              $('.latest-changes-content').slideToggle();
              $('.latest-changes-heading i').toggleClass('fa-caret-square-o-right fa-caret-square-o-down');

--- a/templates/portadmin/netbox.html
+++ b/templates/portadmin/netbox.html
@@ -8,9 +8,8 @@
     </h4>
     <div class="latest-changes-content row" style="display: none">
       <div class="small-12 column">
-        {% with object_list=auditlog_entries %}
-          {% include "auditlog/_logentry_list.html" %}
-        {% endwith %}
+        <h3>AuditLog</h3>
+        {% include "auditlog/_logentry_list.html" %}
       </div>
     </div>
     <script>

--- a/templates/portadmin/netbox.html
+++ b/templates/portadmin/netbox.html
@@ -8,7 +8,6 @@
     </h4>
     <div class="latest-changes-content row" style="display: none">
       <div class="small-12 column">
-        <h3>AuditLog</h3>
         {% include "auditlog/_logentry_list.html" %}
       </div>
     </div>

--- a/templates/useradmin/account_detail.html
+++ b/templates/useradmin/account_detail.html
@@ -25,7 +25,7 @@
       {% comment %} ACTION BUTTONS {% endcomment %}
       <div class="column large-6">
 
-        <ul class="inline-list">
+        <ul class="inline-list action-list">
           {% if account and current_user_data.is_admin and not current_user_data.sudoer %}
             {% ifnotequal current_user_data.account.id account.id %}
               <li>
@@ -52,6 +52,11 @@
 
     </div> {# row #}
 
+
+    {# AUDITLOG #}
+    {% if account %}
+      {% include 'useradmin/frag-auditlog.html' %}
+    {% endif %}
 
     <div class="row">
 

--- a/templates/useradmin/account_list.html
+++ b/templates/useradmin/account_list.html
@@ -12,6 +12,10 @@
         Create new account
       </a>
 
+      <div>
+        {% include 'useradmin/frag-auditlog.html' %}
+      </div>
+
       <table class="listtable">
         <caption>
           Account List

--- a/templates/useradmin/base.html
+++ b/templates/useradmin/base.html
@@ -16,6 +16,9 @@
        border: none;
        margin-bottom: 0;
    }
+   .action-list .button {
+       margin-bottom: 0;
+   }
 
   </style>
 {% endblock %}

--- a/templates/useradmin/frag-auditlog.html
+++ b/templates/useradmin/frag-auditlog.html
@@ -1,0 +1,16 @@
+<h5 class="latest-changes-heading" style="display: inline-block; cursor: pointer">
+  AuditLog <i class="fa fa-caret-square-o-right"></i>
+</h5>
+<div class="latest-changes-content row" style="display: none">
+  <div class="small-12 column">
+    {% include "auditlog/_logentry_list.html" %}
+  </div>
+</div>
+<script>
+ $(function(){
+     $('.latest-changes-heading').click(function(){
+         $('.latest-changes-content').slideToggle();
+         $('.latest-changes-heading i').toggleClass('fa-caret-square-o-right fa-caret-square-o-down');
+     });
+ });
+</script>


### PR DESCRIPTION
Auditlog did not display log entries properly. There were inconsitencies between getting data from context or api.

Changes done:
- Add log entries on crud of profiles
- Add log entries on crud of devices
- Add log entries when logging in and out

DataTable
- Use api only for data
- Add filters, sorting and searching
- Add DataTable to ipdevinfo (new tab)
- Fix DataTable for portadmin
- Fix DataTable main tool
- Add DataTable to user info (list and details)
