### PR TITLE
Avoid "magic" Django bootstrapping in nav.models

### DIFF
--- a/bin/alertengine.py
+++ b/bin/alertengine.py
@@ -37,6 +37,9 @@ import sys
 import time
 from psycopg2 import InterfaceError
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 import nav.buildconf
 import nav.config
 import nav.daemon

--- a/bin/autoenable.py
+++ b/bin/autoenable.py
@@ -32,6 +32,9 @@ import logging
 import sys
 from datetime import datetime
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 import nav.buildconf
 from nav.logs import init_generic_logging
 from nav.arnold import (open_port, GeneralException)

--- a/bin/collect_active_ip.py
+++ b/bin/collect_active_ip.py
@@ -25,6 +25,9 @@ import time
 import sys
 from os.path import join
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 import nav.daemon
 from nav.activeipcollector import manager
 from nav.buildconf import localstatedir

--- a/bin/emailreports.py
+++ b/bin/emailreports.py
@@ -21,6 +21,9 @@ import argparse
 import logging
 import os
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 from nav.web.business.reportengine import send_reports
 from nav.models.profiles import ReportSubscription
 from nav.buildconf import localstatedir

--- a/bin/eventengine
+++ b/bin/eventengine
@@ -10,6 +10,9 @@ The NAV eventengine deamon
 import logging
 logging.raiseExceptions = False
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 from nav.eventengine.daemon import main
 
 if __name__ == '__main__':

--- a/bin/ipdevpolld
+++ b/bin/ipdevpolld
@@ -10,6 +10,9 @@ Start the ipdevpoll daemon
 import logging
 logging.raiseExceptions = False
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 from nav.ipdevpoll.daemon import main
 
 if __name__ == '__main__':

--- a/bin/macwatch.py
+++ b/bin/macwatch.py
@@ -25,6 +25,9 @@ import re
 import time
 import logging
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 # import NAV libraries
 import nav.logs
 

--- a/bin/mailin.py
+++ b/bin/mailin.py
@@ -25,6 +25,9 @@ import configparser
 
 import argparse
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 import nav
 import nav.mailin
 from nav import logs

--- a/bin/maintengine.py
+++ b/bin/maintengine.py
@@ -26,6 +26,9 @@ import os.path
 import time
 import logging
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 import nav.buildconf
 from nav.logs import init_generic_logging
 from nav.maintengine import check_devices_on_maintenance

--- a/bin/navclean
+++ b/bin/navclean
@@ -21,7 +21,9 @@ from __future__ import print_function
 
 import sys
 import argparse
-from nav.models import manage as _manage  # Just to init Django stuff
+
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
 
 import psycopg2
 from django.db.transaction import atomic

--- a/bin/navdf
+++ b/bin/navdf
@@ -21,8 +21,13 @@ A command line interface to list and filter IP devices monitored by NAV
 from __future__ import print_function
 
 import argparse
-from nav.models.manage import Netbox
+
 import django
+
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
+from nav.models.manage import Netbox
 
 
 def main():

--- a/bin/navdump
+++ b/bin/navdump
@@ -24,10 +24,15 @@ from __future__ import print_function
 
 import sys
 import argparse
+
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
+import django_hstore.apps  # pylint: disable=W0611
+
 from nav.models import manage
 import nav.models.service
 # required to register the hstore extension outside webapp environment
-import django_hstore.apps  # pylint: disable=W0611
 
 
 SEPARATOR = ":"

--- a/bin/naventity
+++ b/bin/naventity
@@ -28,6 +28,10 @@ import argparse
 import networkx
 
 from asciitree import draw_tree
+
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 from nav.util import is_valid_ip
 from nav.ipdevpoll.snmp.common import snmp_parameter_factory, SnmpError
 from nav.ipdevpoll.snmp import AgentProxy, snmpprotocol

--- a/bin/navoidverify
+++ b/bin/navoidverify
@@ -26,19 +26,20 @@ import sys
 from itertools import cycle
 from argparse import ArgumentParser
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 from nav.ipdevpoll.snmp.common import snmp_parameter_factory, SnmpError
 from nav.models.manage import Netbox
 from nav.ipdevpoll.snmp import snmpprotocol, AgentProxy
 from nav.oids import OID
 
 from twisted.internet import reactor, defer, task
-import django
 
 
 def main():
     """Main program"""
     options = parse_args()
-    django.setup()
 
     sysnames = [n.strip() for n in sys.stdin.readlines()]
     if sysnames:

--- a/bin/navsnmp
+++ b/bin/navsnmp
@@ -17,15 +17,17 @@
 from __future__ import print_function
 import argparse
 import sys
+
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 from nav.models.manage import Netbox
-import django
 from IPy import IP
 
 
 def main():
     """Main program"""
     args = parse_args()
-    django.setup()
     if args.sysname:
         boxes = get_matching_boxes([args.sysname])
     else:

--- a/bin/navstats
+++ b/bin/navstats
@@ -24,6 +24,9 @@ import configparser
 
 from django.db import connection, DatabaseError
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 import nav.models
 from nav.buildconf import localstatedir
 from nav.config import NAVConfigParser

--- a/bin/navtopology
+++ b/bin/navtopology
@@ -1,3 +1,6 @@
 #!/usr/bin/env python
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 from nav.topology.detector import main
 main()

--- a/bin/navuser
+++ b/bin/navuser
@@ -23,14 +23,15 @@ import sys
 import argparse
 from getpass import getpass
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 from nav.models.profiles import Account, AccountGroup
-import django
 
 
 def main():
     """Main program"""
     args = parse_args()
-    django.setup()
 
     args.func(args)
 

--- a/bin/netbiostracker.py
+++ b/bin/netbiostracker.py
@@ -19,11 +19,16 @@
 import logging
 import time
 from os.path import join
+
+import django
+
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 from nav.netbiostracker import tracker
 from nav.netbiostracker.config import NetbiosTrackerConfig
 from nav.buildconf import localstatedir
 from nav.logs import init_generic_logging
-import django
 
 _logger = logging.getLogger('netbiostracker')
 LOGFILE = 'netbiostracker.log'
@@ -33,7 +38,6 @@ def main():
     """Main controller"""
     init_generic_logging(logfile=join(localstatedir, 'log', LOGFILE),
                          stderr=False)
-    django.setup()
     config = NetbiosTrackerConfig()
 
     start = time.time()

--- a/bin/powersupplywatch.py
+++ b/bin/powersupplywatch.py
@@ -28,6 +28,9 @@ from os.path import join
 from datetime import datetime
 import argparse
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 # import NAV libraries
 from nav import buildconf
 from nav.event import Event

--- a/bin/start_arnold.py
+++ b/bin/start_arnold.py
@@ -43,6 +43,9 @@ from operator import methodcaller
 import argparse
 from os.path import join
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 import nav.buildconf
 from nav.logs import init_generic_logging
 from nav.arnold import (find_computer_info, is_inside_vlans,

--- a/bin/t1000.py
+++ b/bin/t1000.py
@@ -32,6 +32,9 @@ import logging
 import getpass
 from datetime import datetime, timedelta
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 import nav.buildconf
 from nav.logs import init_generic_logging
 from nav.arnold import (find_computer_info, disable, quarantine,

--- a/bin/thresholdmon
+++ b/bin/thresholdmon
@@ -10,6 +10,9 @@ The NAV treshold monitor.
 import logging
 logging.raiseExceptions = False
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 from nav.thresholdmon import main
 
 if __name__ == '__main__':

--- a/python/nav/bootstrap.py
+++ b/python/nav/bootstrap.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import, print_function
+
+from os.path import dirname, realpath
+import os
+import sys
+
+import django
+from django.apps import apps
+from django.utils.timezone import now
+
+
+__all__ = ['bootstrap_django']
+
+RUN = False
+
+
+def bootstrap_django(caller=None):
+    global RUN
+
+    if 'DJANGO_SETTINGS_MODULE' not in os.environ:
+        os.environ['DJANGO_SETTINGS_MODULE'] = 'nav.django.settings'
+
+    mydir = dirname(dirname(realpath(__file__)))
+    sys.path.append(mydir)
+    logmsg = 'Bootstrapped at {}'.format(now())
+    if caller:
+        logmsg = logmsg + ', called by: ' + caller
+    print(logmsg)
+
+    if not RUN and not apps.ready:
+        django.setup()
+        RUN = True

--- a/python/nav/bootstrap.py
+++ b/python/nav/bootstrap.py
@@ -1,3 +1,18 @@
+# Copyright (C) 2018 UNINETT AS
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License version 2 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.  You should have received a copy of the GNU General Public
+# License along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+
 from __future__ import absolute_import, print_function
 
 from os.path import dirname, realpath

--- a/python/nav/django/manage.py
+++ b/python/nav/django/manage.py
@@ -3,11 +3,11 @@ import os
 import sys
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                 "../.."))
-import nav.models  # This MUST be here to avoid a strange deadlock in Django
+from nav.bootstrap import bootstrap_django
+
+bootstrap_django(__file__)
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "nav.django.settings")
 
     from django.core.management import execute_from_command_line
-
     execute_from_command_line(sys.argv)

--- a/python/nav/models/__init__.py
+++ b/python/nav/models/__init__.py
@@ -25,6 +25,3 @@ from django.apps import apps as _apps
 # module while having no interest in Django voodoo.
 if 'DJANGO_SETTINGS_MODULE' not in os.environ:
     os.environ['DJANGO_SETTINGS_MODULE'] = 'nav.django.settings'
-
-if not _apps.ready:
-    django.setup()

--- a/python/nav/models/__init__.py
+++ b/python/nav/models/__init__.py
@@ -17,11 +17,6 @@
 
 default_app_config = 'nav.models.apps.NavModelsConfig'
 
-import os
-import django
-from django.apps import apps as _apps
-
-# This is here to ensure NAV's models can be used by anyone importing this
-# module while having no interest in Django voodoo.
-if 'DJANGO_SETTINGS_MODULE' not in os.environ:
-    os.environ['DJANGO_SETTINGS_MODULE'] = 'nav.django.settings'
+# from nav.bootstrap import bootstrap_django
+# 
+# bootstrap_django(__file__)

--- a/python/nav/wsgi.py
+++ b/python/nav/wsgi.py
@@ -18,8 +18,10 @@ from __future__ import absolute_import
 import os
 import sys
 import logging
+
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
 import nav.logs
-import nav.models  # This MUST be here to avoid a strange deadlock in Django
 
 
 def loginit():

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -6,6 +6,9 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 USERNAME = 'admin'
 gunicorn = None
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -6,9 +6,6 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
-from nav.bootstrap import bootstrap_django
-bootstrap_django(__file__)
-
 USERNAME = 'admin'
 gunicorn = None
 
@@ -62,6 +59,9 @@ def selenium(selenium, base_url):
     in as the admin user.
 
     """
+    from nav.bootstrap import bootstrap_django
+    bootstrap_django(__file__)
+
     from nav.django.auth import create_session_cookie
 
     selenium.implicitly_wait(10)

--- a/tests/integration/alertengine_test.py
+++ b/tests/integration/alertengine_test.py
@@ -1,3 +1,6 @@
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 from nav.models.profiles import AlertSender
 from nav.alertengine.dispatchers import Dispatcher
 

--- a/tests/integration/auditlog_test.py
+++ b/tests/integration/auditlog_test.py
@@ -1,5 +1,8 @@
 from django.test import TestCase
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 from nav.models.arnold import Justification
 
 from nav.auditlog import find_modelname

--- a/tests/integration/ipdevpoll/pool_test.py
+++ b/tests/integration/ipdevpoll/pool_test.py
@@ -4,6 +4,9 @@ import pytest
 
 from mock import patch
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 from nav.buildconf import bindir, sysconfdir
 from nav.ipdevpoll import config, jobs, plugins
 from nav.ipdevpoll.pool import InlinePool, WorkerPool

--- a/tests/integration/models/model_test.py
+++ b/tests/integration/models/model_test.py
@@ -19,11 +19,15 @@ themselves.
 """
 import os
 
-import nav.models
-
 from django.db import connection
 from django.db.models import get_models
+
 import pytest
+
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
+import nav.models
 
 # Ensure that all modules are loaded
 for file_name in os.listdir(os.path.dirname(nav.models.__file__)):

--- a/tests/integration/widget_test.py
+++ b/tests/integration/widget_test.py
@@ -1,5 +1,8 @@
 from datetime import datetime, timedelta
 
+from nav.bootstrap import bootstrap_django
+bootstrap_django(__file__)
+
 from nav.web.navlets.roomstatus import RoomStatus
 from nav.models.event import AlertHistory, AlertHistoryMessage
 from nav.models.fields import INFINITY

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -1,1 +1,4 @@
 # nothing to see here, move along
+import django
+import nav.models
+django.setup()

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -1,4 +1,4 @@
 # nothing to see here, move along
-import django
-import nav.models
-django.setup()
+from nav.bootstrap import bootstrap_django
+
+bootstrap_django(__file__)


### PR DESCRIPTION
Move django magic out of `nav.models`, in preparation for running on django 1.9.