### PR TITLE
Do not consider CAM data from aggregator ports when there is LLDP/CDP topology available from its aggregated ports

### DIFF
--- a/python/nav/topology/analyze.py
+++ b/python/nav/topology/analyze.py
@@ -266,16 +266,12 @@ def build_candidate_graph_from_db():
         if not cand.interface.is_admin_up():
             continue  # ignore data from disabled interfaces
         if cand.to_interface:
-            dest_node = Port((cand.to_netbox.id,
-                              cand.to_interface.id))
-            dest_node.name = "%s (%s)" % (cand.to_netbox.sysname,
-                                          cand.to_interface.ifname)
+            dest_node = interface_to_port(cand.to_interface)
         else:
             dest_node = Box(cand.to_netbox.id)
             dest_node.name = cand.to_netbox.sysname
 
-        port = Port((cand.netbox.id, cand.interface.id))
-        port.name = "%s (%s)" % (cand.netbox.sysname, cand.interface.ifname)
+        port = interface_to_port(cand.interface)
         netbox = Box(cand.netbox.id)
         netbox.name = cand.netbox.sysname
 
@@ -283,3 +279,9 @@ def build_candidate_graph_from_db():
         graph.add_edge(netbox, port)
 
     return graph
+
+
+def interface_to_port(interface):
+    port = Port((interface.netbox.id, interface.id))
+    port.name = "{ifc.netbox.sysname} ({ifc.ifname})".format(ifc=interface)
+    return port

--- a/python/nav/topology/detector.py
+++ b/python/nav/topology/detector.py
@@ -30,7 +30,8 @@ from nav import daemon
 from nav.debug import log_stacktrace, log_last_django_query
 from nav.logs import init_generic_logging
 from nav.topology.layer2 import update_layer2_topology
-from nav.topology.analyze import AdjacencyReducer, build_candidate_graph_from_db
+from nav.topology.analyze import (AdjacencyReducer, build_candidate_graph_from_db,
+                                  get_aggregate_mapping)
 from nav.topology.vlan import VlanGraphAnalyzer, VlanTopologyUpdater
 
 from nav.models.manage import Vlan, Prefix
@@ -114,7 +115,9 @@ def with_exception_logging(func):
 @with_exception_logging
 def do_layer2_detection():
     """Detect and update layer 2 topology"""
-    reducer = AdjacencyReducer(build_candidate_graph_from_db())
+    candidates = build_candidate_graph_from_db()
+    aggregates = get_aggregate_mapping(include_stacks=True)
+    reducer = AdjacencyReducer(candidates, aggregates)
     reducer.reduce()
     links = reducer.get_single_edges_from_ports()
     update_layer2_topology(links)

--- a/python/nav/topology/diff.py
+++ b/python/nav/topology/diff.py
@@ -18,7 +18,8 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
-from .analyze import AdjacencyReducer, build_candidate_graph_from_db
+from .analyze import (AdjacencyReducer, build_candidate_graph_from_db,
+                      get_aggregate_mapping)
 from .analyze import Box, Port
 
 from nav.models.manage import Interface
@@ -29,7 +30,9 @@ def printdiffs():
     and the currently detected one.
 
     """
-    reducer = AdjacencyReducer(build_candidate_graph_from_db())
+    cand = build_candidate_graph_from_db()
+    aggregates = get_aggregate_mapping(include_stacks=True)
+    reducer = AdjacencyReducer(cand, aggregates)
     reducer.reduce()
 
     connections = reducer.get_single_edges_from_ports()


### PR DESCRIPTION
Proposition to fix #1669 

There is, however, a further problematic issue: In most cases of link-aggregation, the L2 topology will appear disjunct from the VLAN topology, since L2 is discovered for the physical ports, while the VLAN layer is on the logical ports. Further changes to VLAN discovery are needed.