### PR TITLE
Python3 fixes

### DIFF
--- a/bin/navoidverify
+++ b/bin/navoidverify
@@ -103,7 +103,7 @@ def parallel(iterable, count, func, *args, **kwargs):
     """Limits the number of parallel requests to count"""
     coop = task.Cooperator()
     work = (func(elem, *args, **kwargs) for elem in iterable)
-    return defer.DeferredList([coop.coiterate(work) for _ in xrange(count)],
+    return defer.DeferredList([coop.coiterate(work) for _ in range(count)],
                               consumeErrors=True)
 
 

--- a/python/nav/activeipcollector/manager.py
+++ b/python/nav/activeipcollector/manager.py
@@ -20,6 +20,8 @@ import logging
 import time
 from IPy import IP
 
+from django.utils.six.moves import range
+
 import nav.activeipcollector.collector as collector
 from nav.metrics.carbon import send_metrics
 from nav.metrics.templates import metric_path_for_prefix
@@ -34,7 +36,7 @@ def run(days=None):
 
 
 def store(data):
-    """Store data in rrd-files and update rrd-database
+    """Sends data to carbon for storage in Graphite.
 
     :param data: a cursor.fetchall object containing all database rows we
     are to store
@@ -43,7 +45,7 @@ def store(data):
 
     # Suspecting package drop - dividing into chunks and giving some
     # breathing room for each batch of updates.
-    chunks = [data[x:x+100] for x in xrange(0, len(data), 100)]
+    chunks = [data[x:x+100] for x in range(0, len(data), 100)]
     for chunk in chunks:
         for db_tuple in chunk:
             store_tuple(db_tuple)

--- a/python/nav/event.py
+++ b/python/nav/event.py
@@ -18,16 +18,12 @@
 from __future__ import absolute_import
 import nav.db
 from nav.errors import GeneralException
-try:
-    from collections import UserDict
-except:
-    from UserDict import UserDict
 
 from nav.models.event import EventType, AlertType
 from django.db import transaction
 
 
-class Event(UserDict):
+class Event(dict):
     """Represents a single event on or off the queue.
 
     Use like a dictionary to manipulate event variables (in eventqvar).
@@ -37,7 +33,7 @@ class Event(UserDict):
     def __init__(self, source=None, target=None, deviceid=None, netboxid=None,
                  subid=None, time=None, eventtypeid=None, state=None,
                  value=None, severity=None):
-        UserDict.__init__(self)
+        super(Event, self).__init__()
         self.eventqid = None
 
         self.source = source
@@ -58,7 +54,7 @@ class Event(UserDict):
                                   'state', 'value', 'severity')
                      if getattr(self, attr)]
         attr_list = ", ".join(attr_list)
-        return "<Event %s / %s>" % (attr_list, UserDict.__repr__(self))
+        return "<Event %s / %s>" % (attr_list, super(Event, self).__repr__())
 
     def post(self):
         """Post this event to the eventq"""

--- a/python/nav/ip.py
+++ b/python/nav/ip.py
@@ -29,6 +29,9 @@ class IP(IPy.IP):
     # and such nigh-on impossible. Here we make some workarounds for this.
 
     def __cmp__(self, other):
+        """Overrides IPy.IP's __cmp__, which us used by all its rich comparison
+        operators, even though Python no longer consults __cmp__ directly.
+        """
         try:
             return super(IP, self).__cmp__(other)
         except TypeError:

--- a/python/nav/ip.py
+++ b/python/nav/ip.py
@@ -32,7 +32,7 @@ class IP(IPy.IP):
         try:
             return super(IP, self).__cmp__(other)
         except TypeError:
-            return cmp(self.ip, other)
+            return (self.ip > other) - (self.ip < other)
 
     def __eq__(self, other):
         try:

--- a/python/nav/ipdevpoll/neighbor.py
+++ b/python/nav/ipdevpoll/neighbor.py
@@ -336,7 +336,7 @@ class LLDPNeighbor(Neighbor):
         return self._interface_query(Q(ifphysaddress=mac))
 
     def _interfaces_from_ip(self, ip):
-        ip = unicode(ip)
+        ip = six.text_type(ip)
         assert ip
         if ip in self._invalid_neighbor_ips:
             return

--- a/python/nav/ipdevpoll/plugins/cdp.py
+++ b/python/nav/ipdevpoll/plugins/cdp.py
@@ -14,6 +14,7 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 "ipdevpoll plugin to collect CDP (Cisco Discovery Protocol) information"
+from django.utils import six
 from twisted.internet import defer
 
 from nav.models import manage
@@ -137,6 +138,6 @@ class CDP(Plugin):
             key, shadows.UnrecognizedNeighbor)
         neighbor.netbox = self.netbox
         neighbor.interface = ifc
-        neighbor.remote_id = unicode(record.ip)
+        neighbor.remote_id = six.text_type(record.ip)
         neighbor.remote_name = record.deviceid
         neighbor.source = SOURCE

--- a/python/nav/ipdevpoll/plugins/entity.py
+++ b/python/nav/ipdevpoll/plugins/entity.py
@@ -17,6 +17,7 @@
 ipdevpoll plugin to collect information about physical entities, if any,
 within a Netbox, from the ENTITY-MIB::entPhysicalTable (RFC 4133 and RFC 6933)
 """
+from django.utils import six
 from twisted.internet import defer
 from nav.ipdevpoll.shadows.entity import NetboxEntity
 
@@ -72,7 +73,7 @@ class Entity(Plugin):
         ghosts = set()
         for container in containers:
             if container.contained_in:
-                parent_id = unicode(container.contained_in)
+                parent_id = six.text_type(container.contained_in)
                 parent = by_index.get(parent_id)
                 if parent:
                     container.contained_in = parent

--- a/python/nav/ipdevpoll/plugins/uptime.py
+++ b/python/nav/ipdevpoll/plugins/uptime.py
@@ -65,6 +65,6 @@ def get_upsince(timestamp, ticks):
     :returns: A datetime object representing the timestamp minus the ticks.
 
     """
-    delta = timedelta(seconds=long(ticks / 100))
+    delta = timedelta(seconds=int(ticks / 100))
     sometime = datetime.fromtimestamp(timestamp)
     return sometime - delta

--- a/python/nav/ipdevpoll/shadows/__init__.py
+++ b/python/nav/ipdevpoll/shadows/__init__.py
@@ -70,7 +70,7 @@ class NetboxType(Shadow):
         if self.sysobjectid.startswith(prefix):
             specific = self.sysobjectid[len(prefix):]
             enterprise = specific.split('.')[0]
-            return long(enterprise)
+            return int(enterprise)
 
 
 class NetboxInfo(Shadow):

--- a/python/nav/ipdevpoll/shadows/entity.py
+++ b/python/nav/ipdevpoll/shadows/entity.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 from collections import defaultdict
 from datetime import datetime
 
+from django.utils import six
 from django.utils.six import iteritems, itervalues
 
 from nav.toposort import build_graph, topological_sort
@@ -191,7 +192,7 @@ class NetboxEntity(Shadow):
 
     def __setattr__(self, key, value):
         if key == 'index' and value is not None:
-            value = unicode(value)
+            value = six.text_type(value)
         if key == 'contained_in' and value == 0:
             value = None
         super(NetboxEntity, self).__setattr__(key, value)

--- a/python/nav/macaddress.py
+++ b/python/nav/macaddress.py
@@ -114,17 +114,6 @@ class MacAddress(object):
         >>> ma.__str__()
         'e4:2f:3d:5'
         """
-        return self.__unicode__()
-
-    def __unicode__(self):
-        """Return the unicode representation of this Object.
-
-        >>> ma = MacAddress('e42f3d5')
-        >>> unicode(ma)
-        u'e4:2f:3d:5'
-        >>> ma.__unicode__()
-        u'e4:2f:3d:5'
-        """
         return _int_to_delimited_hexstring(self._addr, self.DEFAULT_DELIM,
                                            DELIMS_AND_STEPS[self.DEFAULT_DELIM])
 

--- a/python/nav/metrics/templates.py
+++ b/python/nav/metrics/templates.py
@@ -17,6 +17,8 @@
 Metric naming templates for various things that NAV sends/retrieves from
 Graphite.
 """
+from django.utils import six
+
 from nav.metrics.names import escape_metric_name
 
 # pylint: disable=C0111
@@ -158,7 +160,7 @@ def metric_prefix_for_system(sysname):
 
 def metric_prefix_for_multicast_group(group):
     tmpl = "nav.multicast.groups.{group}"
-    return tmpl.format(group=escape_metric_name(unicode(group)))
+    return tmpl.format(group=escape_metric_name(six.text_type(group)))
 
 
 def metric_path_for_multicast_usage(group, sysname):

--- a/python/nav/mibs/entity_mib.py
+++ b/python/nav/mibs/entity_mib.py
@@ -319,7 +319,7 @@ class EntityTable(dict):
                     try:
                         new_value = value.decode(encoding)
                     except UnicodeDecodeError:
-                        new_value = unicode(repr(value))
+                        new_value = six.text_type(repr(value))
                         _logger.debug(
                             "cannot decode %s value as %s, using python "
                             "string repr instead: %s",

--- a/python/nav/mibs/mibretriever.py
+++ b/python/nav/mibs/mibretriever.py
@@ -122,12 +122,19 @@ class MIBObject(object):
             value = self.enum[value]
         return value
 
-    def __cmp__(self, other):
-        """Compare to others based on OID."""
+    def __lt__(self, other):
+        """Compare to other based on OID."""
         if isinstance(other, self.__class__):
-            return cmp(self.oid, other.oid)
+            return self.oid < other.oid
         else:
-            return cmp(self.oid, other)
+            return self.oid < other
+
+    def __eq__(self, other):
+        """Compare to other based on OID."""
+        if isinstance(other, self.__class__):
+            return self.oid == other.oid
+        else:
+            return self.oid == other
 
     def __repr__(self):
         return '<MibObject %r: %r from %r)' % \

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -971,7 +971,7 @@ class NetboxType(models.Model):
         if self.sysobjectid.startswith(prefix):
             specific = self.sysobjectid[len(prefix):]
             enterprise = specific.split('.')[0]
-            return long(enterprise)
+            return int(enterprise)
 
 #######################################################################
 ### Device management

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -26,6 +26,7 @@ from datetime import datetime
 import re
 import json
 
+from django.utils import six
 from django.views.decorators.debug import sensitive_variables
 from django.core.urlresolvers import reverse
 from django.db import models, transaction
@@ -1251,7 +1252,7 @@ class NetmapView(models.Model):
 
     def to_json_dict(self):
         """Presents a NetmapView as JSON"""
-        categories = [{'name': unicode(x.category.id), 'is_selected': True}
+        categories = [{'name': six.text_type(x.category.id), 'is_selected': True}
                       for x in self.categories_set.all()]
         if self.display_elinks:
             categories.append({'name': 'ELINK', 'is_selected': True})
@@ -1263,7 +1264,7 @@ class NetmapView(models.Model):
             'description': self.description,
             'topology': self.topology,
             'zoom': self.zoom,
-            'last_modified': unicode(self.last_modified),
+            'last_modified': six.text_type(self.last_modified),
             'is_public': self.is_public,
             'categories': categories,
             'display_orphans': self.display_orphans,

--- a/python/nav/natsort.py
+++ b/python/nav/natsort.py
@@ -33,7 +33,7 @@ def split(string):
     """Split a string into digit- and non-digit components."""
     def intcast(n):
         if n.isdigit():
-            return long(n)
+            return int(n)
         else:
             return n
 

--- a/python/nav/portadmin/snmputils.py
+++ b/python/nav/portadmin/snmputils.py
@@ -70,9 +70,6 @@ class FantasyVlan(object):
     def __eq__(self, other):
         return self.vlan == other.vlan
 
-    def __cmp__(self, other):
-        return cmp(self.vlan, other.vlan)
-
 
 @python_2_unicode_compatible
 class SNMPHandler(object):

--- a/python/nav/pwhash.py
+++ b/python/nav/pwhash.py
@@ -84,8 +84,8 @@ class Hash(object):
         if password is not None:
             self.update(password)
 
-    def __cmp__(self, other):
-        return cmp(str(self), str(other))
+    def __lt__(self, other):
+        return str(self) < str(other)
 
     def __eq__(self, other):
         return str(self) == str(other)

--- a/python/nav/statemon/abstractchecker.py
+++ b/python/nav/statemon/abstractchecker.py
@@ -231,8 +231,8 @@ class AbstractChecker(object):
         return (self.serviceid == getattr(obj, 'serviceid', None)
                 and self.args == getattr(obj, 'args', None))
 
-    def __cmp__(self, obj):
-        return cmp(self.timestamp, getattr(obj, 'timestamp'), None)
+    def __lt__(self, obj):
+        return self.timestamp < getattr(obj, 'timestamp', None)
 
     def __hash__(self):
         tup = (self.serviceid, unicode(self.args), self.get_address())

--- a/python/nav/statemon/abstractchecker.py
+++ b/python/nav/statemon/abstractchecker.py
@@ -18,6 +18,8 @@
 import time
 import logging
 
+from django.utils import six
+
 from nav.statemon import config, RunQueue, db, statistics, event
 
 
@@ -235,7 +237,7 @@ class AbstractChecker(object):
         return self.timestamp < getattr(obj, 'timestamp', None)
 
     def __hash__(self):
-        tup = (self.serviceid, unicode(self.args), self.get_address())
+        tup = (self.serviceid, six.text_type(self.args), self.get_address())
         return hash(tup)
 
     def __repr__(self):

--- a/python/nav/statemon/checker/HttpChecker.py
+++ b/python/nav/statemon/checker/HttpChecker.py
@@ -18,15 +18,15 @@ from nav import buildconf
 
 from nav.statemon.event import Event
 from nav.statemon.abstractchecker import AbstractChecker
-from urlparse import urlsplit
-import httplib
+from django.utils.six.moves.urllib.parse import urlsplit
+from django.utils.six.moves import http_client
 import socket
 
 
-class HTTPConnection(httplib.HTTPConnection):
+class HTTPConnection(http_client.HTTPConnection):
     """Customized HTTP protocol interface"""
     def __init__(self, timeout, host, port=80):
-        httplib.HTTPConnection.__init__(self, host, port)
+        http_client.HTTPConnection.__init__(self, host, port)
         self.timeout = timeout
         self.connect()
 

--- a/python/nav/statemon/checker/HttpsChecker.py
+++ b/python/nav/statemon/checker/HttpsChecker.py
@@ -15,7 +15,7 @@
 #
 """HTTPS Service checker"""
 
-import httplib
+from django.utils.six.moves import http_client
 import socket
 
 from ssl import wrap_socket
@@ -23,10 +23,10 @@ from ssl import wrap_socket
 from nav.statemon.checker.HttpChecker import HttpChecker
 
 
-class HTTPSConnection(httplib.HTTPSConnection):
+class HTTPSConnection(http_client.HTTPSConnection):
     """Customized HTTPS protocol interface"""
     def __init__(self, timeout, host, port=443):
-        httplib.HTTPSConnection.__init__(self, host, port)
+        http_client.HTTPSConnection.__init__(self, host, port)
         self.timeout = timeout
         self.connect()
 

--- a/python/nav/topology/vlan.py
+++ b/python/nav/topology/vlan.py
@@ -18,6 +18,7 @@
 import logging
 import networkx as nx
 from IPy import IP
+from django.utils import six
 
 from nav.models.manage import (GwPortPrefix, Interface, SwPortVlan,
                                SwPortBlocked, Prefix, Vlan)
@@ -524,7 +525,7 @@ def build_layer3_graph(related_extra=None):
                         _LOGGER.warning(
                             "Topology error? %s classified as elink, "
                             "we know %s GwPortPrefixes ...",
-                            unicode(prefix), len(gwportprefixes))
+                            six.text_type(prefix), len(gwportprefixes))
                         _add_edge(gwportprefixes)
                 else:
 
@@ -532,10 +533,10 @@ def build_layer3_graph(related_extra=None):
                     fictive_netbox = stubs.Netbox()
                     if gwportprefixes[0].prefix.vlan.net_ident:
 
-                        fictive_netbox.sysname = unicode(
+                        fictive_netbox.sysname = six.text_type(
                             gwportprefixes[0].prefix.vlan.net_ident)
                     else:
-                        fictive_netbox.sysname = unicode(
+                        fictive_netbox.sysname = six.text_type(
                             gwportprefixes[0].interface.ifalias)
                     fictive_netbox.category_id = 'elink'
                     fictive_netbox.id = fictive_netbox.sysname

--- a/python/nav/util.py
+++ b/python/nav/util.py
@@ -33,6 +33,7 @@ except ImportError:
     ifilter = filter
 
 from django.utils import six
+from django.utils.six.moves import range
 from django.conf import settings
 
 import IPy
@@ -266,7 +267,7 @@ class IPRange(object):
 
     def __iter__(self):
         count = self.len()
-        for offset in xrange(0, count):
+        for offset in range(0, count):
             yield IPy.IP(self._min.int()+offset)
 
     def __getitem__(self, index):

--- a/python/nav/watchdog/tests.py
+++ b/python/nav/watchdog/tests.py
@@ -19,6 +19,8 @@ import collections
 import itertools
 import logging
 from datetime import datetime, timedelta
+
+from django.utils import six
 from django.utils.timesince import timesince
 from django.db.models import Count
 from django.utils.encoding import python_2_unicode_compatible
@@ -44,7 +46,7 @@ class TestResult(object):
         self.obj = obj  # An optional object representing the test
 
     def __str__(self):
-        return unicode(self.description)
+        return six.text_type(self.description)
 
 
 class Test(object):

--- a/python/nav/web/alertprofiles/utils.py
+++ b/python/nav/web/alertprofiles/utils.py
@@ -20,6 +20,7 @@ import hashlib
 import os
 
 from django.db import transaction
+from django.utils import six
 
 import nav.config
 import nav.buildconf
@@ -140,7 +141,7 @@ def alert_subscriptions_table(periods):
         # This little snippet magically assigns a class to shared time periods
         # so they appear with the same highlight color.
         if valid_during == TimePeriod.ALL_WEEK:
-            p.css_class = 'shared' + unicode(shared_class_id)
+            p.css_class = 'shared' + six.text_type(shared_class_id)
             shared_class_id += 1
             if shared_class_id > 7:
                 shared_class_id = 0

--- a/python/nav/web/alertprofiles/views.py
+++ b/python/nav/web/alertprofiles/views.py
@@ -30,6 +30,8 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.db.models import Q
 from django.shortcuts import render_to_response
+from django.utils import six
+
 from nav.web.utils import SubListView
 
 from nav.models.profiles import (
@@ -701,7 +703,7 @@ def profile_time_period_setup(request, time_period_id=None):
             ('Profiles', reverse('alertprofiles-profile')),
             (profile.name, reverse('alertprofiles-profile-detail',
                                    args=(profile.id,))),
-            (unicode(time_period.start) + u', ' +
+            (six.text_type(time_period.start) + u', ' +
              time_period.get_valid_during_display(), None),
         ],
         'title': 'NAV - Alert profiles',
@@ -792,7 +794,7 @@ def profile_time_period_subscription_edit(request, subscription_id=None):
             (profile.name, reverse('alertprofiles-profile-detail',
                                    args=(profile.id,))),
             (
-                unicode(subscription.time_period.start) + u', ' +
+                six.text_type(subscription.time_period.start) + u', ' +
                 subscription.time_period.get_valid_during_display(),
                 reverse('alertprofiles-profile-timeperiod-setup',
                         args=(subscription.time_period.id,))
@@ -900,7 +902,7 @@ def profile_time_period_subscription_remove(request):
                  reverse('alertprofiles-profile-detail',
                          args=(period.profile.id,))),
                 (
-                    unicode(period.start) + u', ' +
+                    six.text_type(period.start) + u', ' +
                     period.get_valid_during_display(),
                     reverse('alertprofiles-profile-timeperiod-setup',
                             args=(period.id,))

--- a/python/nav/web/devicehistory/utils/history.py
+++ b/python/nav/web/devicehistory/utils/history.py
@@ -13,6 +13,7 @@
 # details.  You should have received a copy of the GNU General Public License
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
+from functools import reduce
 
 from django.core.paginator import InvalidPage
 

--- a/python/nav/web/devicehistory/utils/history.py
+++ b/python/nav/web/devicehistory/utils/history.py
@@ -208,7 +208,7 @@ def _get_data_to_search_terms(selection, key_string, model):
     """
     selected_objects = len(selection[key_string])
     if selected_objects == model.objects.all().count():
-        return ["All %s selected." % unicode(model._meta.verbose_name_plural)]
+        return ["All {} selected.".format(model._meta.verbose_name_plural)]
     else:
         return model.objects.filter(id__in=selection[key_string])
 

--- a/python/nav/web/geomap/utils.py
+++ b/python/nav/web/geomap/utils.py
@@ -22,6 +22,7 @@ library.
 """
 import math
 from itertools import groupby
+from functools import reduce
 
 from django.utils.six import iteritems
 from django.utils.six.moves import range

--- a/python/nav/web/geomap/utils.py
+++ b/python/nav/web/geomap/utils.py
@@ -24,6 +24,7 @@ import math
 from itertools import groupby
 
 from django.utils.six import iteritems
+from django.utils.six.moves import range
 
 
 def identity(obj):
@@ -427,5 +428,5 @@ def chunks(lst, size):
     """
     Yields successive `size`-sized chunks from lst.
     """
-    for i in xrange(0, len(lst), size):
+    for i in range(0, len(lst), size):
         yield lst[i:i+size]

--- a/python/nav/web/ipdevinfo/views.py
+++ b/python/nav/web/ipdevinfo/views.py
@@ -26,6 +26,7 @@ from django.db.models import Q
 from django.shortcuts import (render_to_response, get_object_or_404, redirect,
                               render)
 from django.template import RequestContext
+from django.utils import six
 
 from nav.django.templatetags.thresholds import find_rules
 from nav.metrics.errors import GraphiteUnreachableError
@@ -550,7 +551,7 @@ def port_details(request, netbox_sysname, port_type=None, port_id=None,
         (netbox_sysname,
          reverse('ipdevinfo-details-by-name',
                  kwargs={'name': netbox_sysname})), ('Port Details',)]
-    heading = title = 'Port details: ' + unicode(port)
+    heading = title = 'Port details: ' + six.text_type(port)
 
     try:
         port_metrics = port.get_port_metrics()
@@ -746,7 +747,7 @@ def sensor_details(request, identifier):
         (netbox_sysname,
          reverse('ipdevinfo-details-by-name',
                  kwargs={'name': netbox_sysname})), ('Sensor Details',)]
-    heading = title = 'Sensor details: ' + unicode(sensor)
+    heading = title = 'Sensor details: ' + six.text_type(sensor)
 
     metric = dict(id=sensor.get_metric_name())
     find_rules([metric])

--- a/python/nav/web/machinetracker/utils.py
+++ b/python/nav/web/machinetracker/utils.py
@@ -20,6 +20,8 @@ from socket import gethostbyaddr, herror
 from IPy import IP
 from collections import namedtuple
 
+from django.utils import six
+
 from nav import asyncdns
 from nav.models.manage import Prefix, Netbox, Interface
 
@@ -38,7 +40,7 @@ def hostname(ip):
     :returns: A hostname string or a False value if the lookup failed.
 
     """
-    addr = unicode(ip)
+    addr = six.text_type(ip)
     if addr in _cached_hostname:
         return _cached_hostname[addr]
 
@@ -140,7 +142,7 @@ def min_max_mac(prefix):
     :returns: A tuple of (min_mac_string, max_mac_string)
 
     """
-    return unicode(prefix[0]), unicode(prefix[-1])
+    return six.text_type(prefix[0]), six.text_type(prefix[-1])
 
 
 def track_mac(keys, resultset, dns):

--- a/python/nav/web/machinetracker/views.py
+++ b/python/nav/web/machinetracker/views.py
@@ -21,6 +21,7 @@ from datetime import date, timedelta
 from django.db.models import Q
 from django.template import RequestContext
 from django.shortcuts import render_to_response
+from django.utils import six
 from django.utils.datastructures import SortedDict
 
 from nav.models.manage import Arp, Cam, Netbios
@@ -100,8 +101,8 @@ def ip_do_search(request):
         'form_data': form_data,
         'ip_tracker': tracker,
         'ip_tracker_count': row_count,
-        'subnet_start': unicode(from_ip),
-        'subnet_end': unicode(to_ip),
+        'subnet_start': six.text_type(from_ip),
+        'subnet_end': six.text_type(to_ip),
         'colspan': find_colspan('ip', form)
     }
     info_dict.update(IP_DEFAULTS)
@@ -126,7 +127,7 @@ def get_arp_records(days, from_ip, to_ip, get_netbios=False):
     from_time = date.today() - timedelta(days=days)
     extra_args = {
         'where': ['ip BETWEEN %s and %s'],
-        'params': [unicode(from_ip), unicode(to_ip)]
+        'params': [six.text_type(from_ip), six.text_type(to_ip)]
     }
     if get_netbios:
         extra_args['select'] = {'netbiosname': get_netbios_query()}
@@ -173,7 +174,7 @@ def create_tracker(active, dns, inactive, ip_range, ip_result):
 
 def create_active_row(tracker, dns, dns_lookups, ip_key, ip_result):
     """Creates a tracker tuple where the result is active"""
-    ip = unicode(ip_key)
+    ip = six.text_type(ip_key)
     rows = ip_result[ip_key]
     for row in rows:
         row = process_ip_row(row, dns=False)
@@ -191,7 +192,7 @@ def create_active_row(tracker, dns, dns_lookups, ip_key, ip_result):
 
 def create_inactive_row(tracker, dns, dns_lookups, ip_key):
     """Creates a tracker tuple where the result is inactive"""
-    ip = unicode(ip_key)
+    ip = six.text_type(ip_key)
     row = {'ip': ip, 'ip_int_value': normalize_ip_to_string(ip)}
     if dns:
         if (dns_lookups[ip] and not

--- a/python/nav/web/maintenance/utils.py
+++ b/python/nav/web/maintenance/utils.py
@@ -20,6 +20,7 @@ from time import strftime
 
 from django.core.urlresolvers import reverse
 from django.utils.html import conditional_escape
+from django.utils.six.moves import range
 
 from nav.models.manage import Netbox, Room, Location, NetboxGroup
 from nav.models.service import Service
@@ -346,12 +347,12 @@ class MaintenanceCalendar(HTMLCalendar):
                     grouped[day] = {}
                 if task.pk in task_index:
                     index = task_index[task.pk]
-                    for ii in xrange(index):
+                    for ii in range(index):
                         if ii not in grouped[day]:
                             grouped[day][ii] = None
                 else:
                     index = len(grouped[day])
-                    for ii in xrange(index):
+                    for ii in range(index):
                         if ii not in grouped[day] or not grouped[day][ii]:
                             index = ii
                             break

--- a/python/nav/web/modpython.py
+++ b/python/nav/web/modpython.py
@@ -34,7 +34,7 @@ with a suggested WSGI-based configuration.
 """
 import warnings
 import logging
-import Cookie
+from django.utils.six.moves import http_cookies
 
 from django.contrib.sessions.middleware import SessionMiddleware
 from nav.django.auth import AuthenticationMiddleware, AuthorizationMiddleware
@@ -76,7 +76,7 @@ def headerparserhandler(req):
 
 def _get_cookie_dict(req):
     if 'Cookie' in req.headers_in:
-        cookie = Cookie.SimpleCookie()
+        cookie = http_cookies.SimpleCookie()
         cookie.load(str(req.headers_in['Cookie']))
         return dict((key, c.value) for key, c in cookie.items())
     else:

--- a/python/nav/web/navlets/graph.py
+++ b/python/nav/web/navlets/graph.py
@@ -15,7 +15,7 @@
 #
 """Widget for displaying a chart"""
 
-import urlparse
+from django.utils.six.moves.urllib.parse import urlparse, parse_qs
 from django import forms
 from . import Navlet, REFRESH_INTERVAL
 
@@ -88,7 +88,7 @@ class GraphWidget(Navlet):
         """Get title from url"""
         if not url:
             return
-        parsed_url = urlparse.urlparse(url)
-        query = urlparse.parse_qs(parsed_url.query)
+        parsed_url = urlparse(url)
+        query = parse_qs(parsed_url.query)
         if 'title' in query:
             return query['title'][0]

--- a/python/nav/web/navlets/ups.py
+++ b/python/nav/web/navlets/ups.py
@@ -17,7 +17,7 @@
 
 from django import forms
 from django.db.models import Q
-from urlparse import urlparse
+from django.utils.six.moves.urllib.parse import urlparse
 
 from nav.models.manage import Netbox
 from . import Navlet

--- a/python/nav/web/netmap/cache.py
+++ b/python/nav/web/netmap/cache.py
@@ -23,6 +23,8 @@ from django.core.cache import cache
 # TODO: This cache should be invalidated only when the topology is
 # changed, which is somewhat rare, so set to a reasonable long time
 # for now
+from django.utils import six
+
 CACHE_TIMEOUT = 60*60
 # Data is collected every 5 minutes by NAV
 TRAFFIC_CACHE_TIMEOUT = 5*60
@@ -114,6 +116,6 @@ def _cache_key(*args):
         if type(thing) is str:
             return thing.decode('utf-8')
         else:
-            return unicode(thing)
+            return six.text_type(thing)
     args = (stringify(a).replace(' ', '-') for a in args)
     return u'netmap:' + u':'.join(args)

--- a/python/nav/web/networkexplorer/mixins.py
+++ b/python/nav/web/networkexplorer/mixins.py
@@ -6,6 +6,7 @@ from django.core import serializers
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse
 from django.forms.models import model_to_dict
+from django.utils import six
 
 from nav import natsort
 from nav.models.manage import Cam, Arp, GwPortPrefix, Netbox, SwPortVlan
@@ -183,8 +184,8 @@ class ExpandGWPortMixin(object):
                         'module_netbox_sysname':
                         interface.module.netbox.sysname
                         if interface.module else '',
-                        'subheader_vlan': unicode(vlan.vlan.vlan),
-                        'subheader_netbox': unicode(interface.netbox),
+                        'subheader_vlan': six.text_type(vlan.vlan.vlan),
+                        'subheader_netbox': six.text_type(interface.netbox),
                     }
                     # Check for children, services and connection
                     # to switches
@@ -270,7 +271,7 @@ class ExpandSwitchContextMixin(object):
                 'interface': model_to_dict(interface),
                 'interface_netbox_sysname': interface.netbox.sysname,
                 'interface_netbox_sysname_short':
-                unicode(interface.netbox.sysname),
+                six.text_type(interface.netbox.sysname),
             }
             c.update(_get_connected_sysname(interface))
             if interface.to_interface and switch_has_services:
@@ -334,14 +335,14 @@ def _get_connected_sysname(interface):
         return {
             'connected_to': {
                 'sysname': interface.to_netbox.sysname,
-                'short': unicode(interface.to_netbox)
+                'short': six.text_type(interface.to_netbox)
             }
         }
     elif interface.to_interface:
         return {
             'connected_to': {
                 'sysname': interface.to_interface.netbox.sysname,
-                'short': unicode(interface.to_interface.netbox)
+                'short': six.text_type(interface.to_interface.netbox)
             }
         }
     else:

--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -20,6 +20,7 @@ import logging
 import json
 
 from operator import or_ as OR
+from functools import reduce
 
 from django.http import HttpResponse, JsonResponse
 from django.template import RequestContext, Context

--- a/python/nav/web/seeddb/page/netbox/forms.py
+++ b/python/nav/web/seeddb/page/netbox/forms.py
@@ -22,6 +22,7 @@ from django.db.models import Q
 from crispy_forms.helper import FormHelper
 from crispy_forms_foundation.layout import (Layout, Row, Column, Submit,
                                             Fieldset, Field, Div, HTML)
+from django.utils import six
 
 from nav.django.forms import HStoreField
 from nav.web.crispyforms import LabelSubmit, NavButton
@@ -173,7 +174,7 @@ class NetboxModelForm(forms.ModelForm):
             ip, _ = resolve_ip_and_sysname(name)
         except SocketError:
             raise forms.ValidationError("Could not resolve name %s" % name)
-        return unicode(ip)
+        return six.text_type(ip)
 
     def clean_sysname(self):
         """Resolve sysname if not set"""

--- a/python/nav/web/seeddb/utils/edit.py
+++ b/python/nav/web/seeddb/utils/edit.py
@@ -29,6 +29,7 @@ from django.shortcuts import render_to_response, get_object_or_404
 from django.template import RequestContext
 from django.http import HttpResponseRedirect, Http404
 from django.db.models import Q
+from django.utils import six
 
 from nav.web.message import new_message, Messages
 from nav.models.manage import Netbox, NetboxCategory, NetboxGroup
@@ -116,9 +117,9 @@ def resolve_ip_and_sysname(name):
     except ValueError:
         ip_addr = IP(gethostbyname(name))
     try:
-        sysname = gethostbyaddr(unicode(ip_addr))[0]
+        sysname = gethostbyaddr(six.text_type(ip_addr))[0]
     except SocketError:
-        sysname = unicode(ip_addr)
+        sysname = six.text_type(ip_addr)
     return (ip_addr, sysname)
 
 
@@ -136,9 +137,10 @@ def does_ip_exist(ip_addr, netbox_id=None):
      - False if not.
     """
     if netbox_id:
-        ip_qs = Netbox.objects.filter(Q(ip=unicode(ip_addr)), ~Q(id=netbox_id))
+        ip_qs = Netbox.objects.filter(Q(ip=six.text_type(ip_addr)),
+                                      ~Q(id=netbox_id))
     else:
-        ip_qs = Netbox.objects.filter(ip=unicode(ip_addr))
+        ip_qs = Netbox.objects.filter(ip=six.text_type(ip_addr))
     return ip_qs.count() > 0
 
 

--- a/python/nav/web/sortedstats/statmodules.py
+++ b/python/nav/web/sortedstats/statmodules.py
@@ -18,11 +18,8 @@
 
 import logging
 from operator import itemgetter
-try:
-    from urllib.parse import urlencode
-except:
-    from urllib import urlencode
 
+from django.utils.six.moves.urllib.parse import urlencode
 from django.core.urlresolvers import reverse
 
 from nav.metrics.data import (get_metric_average, get_metric_max,

--- a/python/nav/web/threshold/views.py
+++ b/python/nav/web/threshold/views.py
@@ -20,6 +20,7 @@ import json
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 from django.shortcuts import render, redirect, get_object_or_404
+from django.utils import six
 
 from nav.metrics.names import raw_metric_query
 from nav.metrics.graphs import get_simple_graph_url, Graph
@@ -197,7 +198,7 @@ def get_graph_url(request):
         metric = request.GET['metric']
         if 'raw' in request.GET:
             graph = Graph(targets=[metric], **graph_args)
-            return redirect(unicode(graph))
+            return redirect(six.text_type(graph))
         else:
             return redirect(get_simple_graph_url([metric], **graph_args))
 

--- a/tools/iana-enterprise.py
+++ b/tools/iana-enterprise.py
@@ -22,10 +22,7 @@ from __future__ import print_function
 import sys
 import os
 from collections import namedtuple, Counter
-try:
-    from urllib.request import urlopen
-except ImportError:
-    from urllib2 import urlopen
+from django.utils.six.moves.urllib.request import urlopen
 import re
 import string
 from datetime import datetime


### PR DESCRIPTION
Raided the codebase using PyCharm code compatibility inspections for Python 3.6 as my guide to finding potential issues.

The only remaining warnings are concerned about the `configparser` module not being available under Python 2.7, which is ridiculous, since we import that as a backported module in all cases.