### PR TITLE
More python3

### DIFF
--- a/Dockerfile3
+++ b/Dockerfile3
@@ -1,0 +1,83 @@
+# NAV web development container
+#
+# This container aims at providing all the build- and runtime dependencies of
+# NAV in a single container, and allowing for running them all directly off
+# the code in your source code checkout.
+#
+# Run the container with your checked out NAV source code directory mounted on
+# the '/source' volume to build and run all the necessary components inside
+# the container. Changes to you SASS source files will be automatically
+# detected and compiled, and any changes to files in the python directory will
+# be immediately live in the web interface.
+#
+# The NAV web interface is exposed through Apache/WSGI on port 80.
+#
+# REQUIREMENT: For the users inside the container to be able to access the
+# source code mounted at /source, the directory and its files on the host must
+# be world-readable!
+#
+#
+FROM debian:stretch
+
+#### Install various build and runtime requirements as Debian packages ####
+
+RUN echo "\
+deb http://deb.debian.org/debian stretch main contrib non-free\n\
+deb-src http://deb.debian.org/debian stretch main contrib non-free\n\
+\n\
+deb http://deb.debian.org/debian stretch-updates main contrib non-free\n\
+deb-src http://deb.debian.org/debian stretch-updates main contrib non-free\n\
+\n\
+deb http://security.debian.org stretch/updates main contrib non-free\n\
+deb-src http://security.debian.org stretch/updates main contrib non-free\n\
+" > /etc/apt/sources.list
+
+RUN apt-get update && apt-get -y install --no-install-recommends \
+    curl gnupg dirmngr sudo cron inotify-tools supervisor \
+    git \
+    vim less \
+    python python-dev python-pip build-essential \
+    python3 python3-dev python3-pip \
+    apache2 \
+    libapache2-mod-wsgi-py3 \
+    libsnmp30 \
+    rubygems ruby-dev \
+    python-cairo \
+    postgresql-client \
+    libxml2-dev libxslt1-dev \
+    libwww-perl \
+    nbtscan \
+    python3-gammu
+
+RUN apt-get update && apt-get -y --no-install-recommends build-dep \
+    python3-psycopg2 python-lxml python3-pil python-ldap
+
+RUN gem install --version '3.3.9' sass ;\
+    gem install --version '~> 0.9' rb-inotify
+
+RUN adduser --system --group --no-create-home --home=/source --shell=/bin/bash nav
+
+# Ensure Python 3 is the default interpreter for Python, and fix broken
+# supervisor that required Python 2, but doesn't specify it:
+RUN echo "import sys\nsys.path.append('/source/python')" > /etc/python3.5/sitecustomize.py
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1 && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3.5 2 && \
+    dpkg -L supervisor | grep /usr/bin/ | xargs -r sed -i 's,#!/usr/bin/python,#!/usr/bin/python2,g'
+
+COPY tools/docker/supervisord.conf /etc/supervisor/conf.d/nav.conf
+
+COPY requirements/ /requirements
+COPY tests/requirements.txt /test-requirements.txt
+RUN pip3 install --upgrade pip && hash -r && pip install -r /requirements/base.txt -r /requirements/django18.txt && pip install -r /test-requirements.txt
+
+COPY tools/docker/nav-apache-site.conf /etc/apache2/sites-available/nav-site.conf
+RUN a2dissite 000-default; a2ensite nav-site
+
+COPY tools/docker/full-nav-restore.sh /usr/local/sbin/full-nav-restore.sh
+
+VOLUME ["/source"]
+ENV    PYTHONPATH /source/python
+ENV    PATH /source/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+RUN    echo "PATH=$PATH" > /etc/profile.d/navpath.sh
+EXPOSE 80
+CMD    ["/source/tools/docker/run.sh"]

--- a/bin/servicemon.py
+++ b/bin/servicemon.py
@@ -107,12 +107,10 @@ class Controller:
                 sleep(pause)
 
             # extensive debugging
-            dbgthreads = []
-            for i in gc.get_objects():
-                if isinstance(i, threading.Thread):
-                    dbgthreads.append(i)
+            objects = gc.get_objects()
+            dbgthreads = [i for i in objects if isinstance(i, threading.Thread)]
             LOGGER.debug("Garbage: %s Objects: %i Threads: %i", gc.garbage,
-                         len(gc.get_objects()), len(dbgthreads))
+                         len(objects), len(dbgthreads))
 
             wait = self._looptime - (time.time() - start)
             LOGGER.debug("Waiting %i seconds.", wait)

--- a/bin/snmptrapd.py
+++ b/bin/snmptrapd.py
@@ -36,6 +36,7 @@ import nav.buildconf
 from nav.snmptrapd.plugin import load_handler_modules, ModuleLoadError
 from nav.util import is_valid_ip, address_to_string
 from nav.db import getConnection
+from nav.bootstrap import bootstrap_django
 import nav.logs
 
 from nav.snmptrapd import agent
@@ -66,6 +67,7 @@ if socket.has_ipv6 and agent.BACKEND == 'pynetsnmp':
 
 
 def main():
+    bootstrap_django('snmptrapd')
 
     # Verify that subsystem exists, if not insert it into database
     verify_subsystem()

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,6 +19,8 @@ import sys, os
 sys.path.insert(0, os.path.join(os.path.abspath('..'), 'python'))
 
 from nav import buildconf
+from nav import bootstrap
+bootstrap.bootstrap_django('doc')
 
 # -- General configuration -----------------------------------------------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,14 @@
+# This sets up a live NAV development environment in Docker containers.
+#
+# Defaults NAV to a container with Python 2. If you want to work with NAV in a
+# Python 3 environment, add a `docker-compose.override.yml` that sets the
+# dockerfile to Dockerfile3, like so:
+#
+# version: '2'
+# services:
+#   nav:
+#     build:
+#       dockerfile: Dockerfile3
 version: '2'
 services:
   nav:

--- a/python/nav/logs.py
+++ b/python/nav/logs.py
@@ -19,6 +19,8 @@
 import sys
 import os
 import logging
+from itertools import chain
+
 import configparser
 import nav.buildconf
 
@@ -135,7 +137,7 @@ def reopen_log_files():
     root = logging.getLogger()
     manager = root.manager
     mylog = logging.getLogger('nav.logs')
-    for logger in [root] + manager.loggerDict.values():
+    for logger in chain([root], manager.loggerDict.values()):
         try:
             for hdl in logger.handlers:
                 if isinstance(hdl, logging.FileHandler):

--- a/python/nav/startstop.py
+++ b/python/nav/startstop.py
@@ -250,7 +250,7 @@ class Crontab(object):
         """Loads the currently active crontab"""
         try:
             output = subprocess.check_output(["crontab", "-u", self.user, "-l"])
-            self.content = output.splitlines()
+            self.content = output.decode('utf-8').splitlines()
         except subprocess.CalledProcessError:
             # crontab doesn't have very helpful exit codes. if we get here, it
             # may simply be because the user has no defined crontab yet
@@ -274,7 +274,7 @@ class Crontab(object):
         self.update_init()
         proc = subprocess.Popen(["crontab", "-u", self.user, "-"],
                                 stdin=subprocess.PIPE)
-        proc.stdin.write(str(self))
+        proc.stdin.write(str(self).encode('utf-8'))
         proc.stdin.close()
 
         exit_code = proc.wait()

--- a/python/nav/util.py
+++ b/python/nav/util.py
@@ -34,7 +34,6 @@ except ImportError:
 
 from django.utils import six
 from django.utils.six.moves import range
-from django.conf import settings
 
 import IPy
 
@@ -461,6 +460,7 @@ def address_to_string(ip, port):
 
 def auth_token():
     """Generates a hash that can be used as an OAuth API token"""
+    from django.conf import settings
     _hash = hashlib.sha1(six.text_type(uuid.uuid4()).encode('utf-8'))
     _hash.update(settings.SECRET_KEY.encode('utf-8'))
     return _hash.hexdigest()

--- a/tests/integration/logs_test.py
+++ b/tests/integration/logs_test.py
@@ -1,0 +1,6 @@
+from nav.logs import reopen_log_files
+
+
+def test_reopen_log_files_runs_without_error():
+    """tests syntax regressions, not actual functionality"""
+    assert reopen_log_files() is None


### PR DESCRIPTION
Added a Docker environment for running the NAV development container under Python 3 and Django 1.8.

More importantly, offers a way to switch between the environments using `docker-compose` builtin mechanisms.

Fixed various Py3-related bugs found while trying to deploy NAV inside the new container.