### PR TITLE
Support "operating as" in audit logs

### DIFF
--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -392,6 +392,7 @@ def set_ifalias(account, fac, interface, request):
                     u'{actor}: {object} - ifalias set to "%s"' % ifalias,
                     subsystem=u'portadmin',
                     object=interface,
+                    request=request,
                 )
                 _logger.info('%s: %s:%s - ifalias set to "%s"', account.login,
                              interface.netbox.get_short_sysname(),
@@ -428,6 +429,7 @@ def set_vlan(account, fac, interface, request):
                 u'{actor}: {object} - vlan set to "%s"' % vlan,
                 subsystem=u'portadmin',
                 object=interface,
+                request=request,
             )
             _logger.info('%s: %s:%s - vlan set to %s', account.login,
                          interface.netbox.get_short_sysname(),
@@ -496,6 +498,7 @@ def set_admin_status(fac, interface, request):
                     u'change status to up',
                     subsystem=u'portadmin',
                     object=interface,
+                    request=request,
                 )
                 _logger.info('%s: Setting ifadminstatus for %s to %s',
                              account.login, interface, 'up')
@@ -507,6 +510,7 @@ def set_admin_status(fac, interface, request):
                     u'change status to down',
                     subsystem=u'portadmin',
                     object=interface,
+                    request=request,
                 )
                 _logger.info('%s: Setting ifadminstatus for %s to %s',
                              account.login, interface, 'down')
@@ -598,6 +602,7 @@ def handle_trunk_edit(request, agent, interface):
         u'{actor}: {object} - native vlan: "%s", trunk vlans: "%s"' % (native_vlan, trunked_vlans),
         subsystem=u'portadmin',
         object=interface,
+        request=request,
     )
 
     if trunked_vlans:

--- a/python/nav/web/seeddb/page/netbox/edit.py
+++ b/python/nav/web/seeddb/page/netbox/edit.py
@@ -41,19 +41,20 @@ from nav.web.seeddb.page.netbox import NetboxInfo as NI
 from nav.web.seeddb.page.netbox.forms import NetboxModelForm
 
 
-def log_netbox_change(account, old, new):
+def log_netbox_change(request, old, new):
     """Log specific user initiated changes to netboxes"""
 
     # If this is a new netbox
     if not old:
-        LogEntry.add_create_entry(account, new)
+        LogEntry.add_create_entry(request.account, new, request=request)
         return
 
     # Compare changes from old to new
     attribute_list = ['read_only', 'read_write', 'category', 'ip',
                       'room', 'organization', 'snmp_version']
-    LogEntry.compare_objects(account, old, new, attribute_list,
-                             censored_attributes=['read_only', 'read_write'])
+    LogEntry.compare_objects(request.account, old, new, attribute_list,
+                             censored_attributes=['read_only', 'read_write'],
+                             request=request)
 
 
 def netbox_edit(request, netbox_id=None):
@@ -69,7 +70,7 @@ def netbox_edit(request, netbox_id=None):
         if form.is_valid():
             netbox = netbox_do_save(form)
             messages.add_message(request, messages.SUCCESS, 'IP Device saved')
-            log_netbox_change(request.account, old_netbox, netbox)
+            log_netbox_change(request, old_netbox, netbox)
             return redirect(reverse('seeddb-netbox-edit', args=[netbox.pk]))
         else:
             messages.add_message(request, messages.ERROR, 'Form was not valid')

--- a/python/nav/web/seeddb/utils/delete.py
+++ b/python/nav/web/seeddb/utils/delete.py
@@ -101,11 +101,11 @@ def render_delete(request, model, redirect, whitelist=None, extra_context=None,
             if delete_operation:
                 new_message(request,
                             "Deleted %i rows" % len(objects), Messages.SUCCESS)
-                log_deleted(request.account, objects, template='{actor} deleted {object}')
+                log_deleted(request, objects, template='{actor} deleted {object}')
             else:
                 new_message(request,
                             "Scheduled %i rows for deletion" % len(objects), Messages.SUCCESS)
-                log_deleted(request.account, objects, template='{actor} scheduled {object} for deletion')
+                log_deleted(request, objects, template='{actor} scheduled {object} for deletion')
             return HttpResponseRedirect(reverse(redirect))
 
     info_dict = {
@@ -117,10 +117,11 @@ def render_delete(request, model, redirect, whitelist=None, extra_context=None,
         extra_context, RequestContext(request))
 
 
-def log_deleted(account, objects, template):
+def log_deleted(request, objects, template):
     """Log the deletion of each object"""
     for obj in objects:
-        LogEntry.add_delete_entry(account, obj, template=template)
+        LogEntry.add_delete_entry(request.account, obj, template=template,
+                                  request=request)
 
 
 def dependencies(queryset, whitelist):

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -220,7 +220,8 @@ def do_login(request):
         else:
             if account:
                 LogEntry.add_log_entry(
-                    account, 'log-in', '{actor} logged in', before=account)
+                    account, 'log-in', '{actor} logged in', before=account,
+                    request=request)
 
                 try:
                     request.session[ACCOUNT_ID_VAR] = account.id
@@ -261,7 +262,7 @@ def logout(request):
         request.session.set_expiry(datetime.now())
         request.session.save()
         LogEntry.add_log_entry(account, 'log-out', '{actor} logged out',
-                               before=account)
+                               before=account, request=request)
     return HttpResponseRedirect('/')
 
 


### PR DESCRIPTION
When a user operates as another user this is not indicated in the audit logs - you just see the user that is being operated/sudoed. I tried to find a general way of including "operating as" information when audit logging by accepting the request when logging.