### PR TITLE
make Account objects "sudo operator aware"

### DIFF
--- a/python/nav/django/auth.py
+++ b/python/nav/django/auth.py
@@ -47,6 +47,9 @@ class AuthenticationMiddleware(object):
         account = Account.objects.get(id=session[ACCOUNT_ID_VAR])
         request.account = account
 
+        if SUDOER_ID_VAR in session:
+            account.sudo_operator = get_sudoer(request)
+
         _logger.debug("Request for %s authenticated as user=%s",
                       request.get_full_path(), account.login)
 

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -95,12 +95,19 @@ class Account(models.Model):
 
     organizations = models.ManyToManyField(Organization, db_table='accountorg')
 
+    # Set this in order to provide a link to the actual operator when Account
+    # objects are retrieved from session data
+    sudo_operator = None
+
     class Meta(object):
         db_table = u'account'
         ordering = ('login',)
 
     def __str__(self):
-        return self.login
+        if self.sudo_operator and self.sudo_operator != self:
+            return '{} (operated by {})'.format(self.login, self.sudo_operator)
+        else:
+            return self.login
 
     def get_active_profile(self):
         """Returns the account's active alert profile"""


### PR DESCRIPTION
By setting the `sudo_operator` attribute of an Account object, its string
representation will reflect which account is operating as this account.

The AuthenticationMiddleware sets this attribute when necessary, and the
resulting string representation of the apparent logged-in user will be
reflected in the audit logs.

This fixes #1706 (as an alternative to #1707)