### PR TITLE
Clean Report code

### DIFF
--- a/python/nav/report/dbresult.py
+++ b/python/nav/report/dbresult.py
@@ -59,3 +59,5 @@ class DatabaseResult(object):
             #raise ProblemExistBetweenKeyboardAndChairException
             self.error = ("Configuration error! The report generator is not "
                           "able to do such things. " + str(error))
+        else:
+            self.error = report_config.error

--- a/python/nav/report/dbresult.py
+++ b/python/nav/report/dbresult.py
@@ -38,24 +38,21 @@ class DatabaseResult(object):
         self.hidden = []
 
         connection = db.getConnection('default')
-        database = connection.cursor()
+        cursor = connection.cursor()
 
         self.sql, self.parameters = report_config.make_sql()
 
-        ## Make a dictionary of which columns to summarize
-        self.sums = dict([(sum_key, '') for sum_key in report_config.sum])
+        # Make a dictionary of which columns to summarize
+        self.sums = {sum_key: '' for sum_key in report_config.sum}
 
         try:
-            database.execute(self.sql, self.parameters or None)
-            self.result = database.fetchall()
+            cursor.execute(self.sql, self.parameters or None)
+            self.result = cursor.fetchall()
 
             # A list of the column headers.
-            col_head = []
-            for col in range(0, len(database.description)):
-                col_head.append(database.description[col][0])
-            report_config.sql_select = col_head
+            report_config.sql_select = [col.name for col in cursor.description]
 
-            ## Total count of the rows returned.
+            # Total count of the rows returned.
             self.rowcount = len(self.result)
 
         except psycopg2.ProgrammingError as error:

--- a/python/nav/report/generator.py
+++ b/python/nav/report/generator.py
@@ -230,7 +230,6 @@ class ConfigParser(object):
 
 class ArgumentParser(object):
     """Handler of the uri arguments"""
-    SAFE_PATTERN = re.compile("(select|drop|update|delete).*(from|where)", re.I)
     GROUP_PATTERN = re.compile(r"^(?P<group>\S+?)_(?P<groupkey>\S+?)$")
 
     def __init__(self, configuration):
@@ -316,64 +315,60 @@ class ArgumentParser(object):
             else:
                 operat = "is"
         else:
-            if self.SAFE_PATTERN.search(value):
-                self.config.error = ("You are not allowed to make advanced "
-                                     "sql terms")
-            else:
-                if self.operator[field] == "eq":
-                    if neg:
-                        operat = "<>"
-                        neg = ""
-                    else:
-                        operat = "="
-                elif self.operator[field] == "like":
-                    operat = "ilike"
-                    value = value.replace("*", "%")
-                elif self.operator[field] == "gt":
-                    if neg:
-                        operat = "<="
-                        neg = ""
-                    else:
-                        operat = ">"
+            if self.operator[field] == "eq":
+                if neg:
+                    operat = "<>"
+                    neg = ""
+                else:
+                    operat = "="
+            elif self.operator[field] == "like":
+                operat = "ilike"
+                value = value.replace("*", "%")
+            elif self.operator[field] == "gt":
+                if neg:
+                    operat = "<="
+                    neg = ""
+                else:
+                    operat = ">"
 
-                elif self.operator[field] == "geq":
-                    if neg:
-                        operat = "<"
-                        neg = ""
-                    else:
-                        operat = ">="
-                elif self.operator[field] == "lt":
-                    if neg:
-                        operat = ">="
-                        neg = ""
-                    else:
-                        operat = "<"
-                elif self.operator[field] == "leq":
-                    if neg:
-                        operat = ">"
-                        neg = ""
-                    else:
-                        operat = "<="
-                elif self.operator[field] == "in":
-                    operat = "in"
-                    inlist = value.split(",")
-                    if inlist:
-                        value = tuple((a.strip() for a in inlist))
-                    else:
-                        self.config.error = ("The arguments to 'in' must "
-                                             "be comma separated")
+            elif self.operator[field] == "geq":
+                if neg:
+                    operat = "<"
+                    neg = ""
+                else:
+                    operat = ">="
+            elif self.operator[field] == "lt":
+                if neg:
+                    operat = ">="
+                    neg = ""
+                else:
+                    operat = "<"
+            elif self.operator[field] == "leq":
+                if neg:
+                    operat = ">"
+                    neg = ""
+                else:
+                    operat = "<="
+            elif self.operator[field] == "in":
+                operat = "in"
+                inlist = value.split(",")
+                if inlist:
+                    value = tuple((a.strip() for a in inlist))
+                else:
+                    self.config.error = ("The arguments to 'in' must "
+                                         "be comma separated")
 
-                elif self.operator[field] == "between":
-                    operat = "between %s and"
-                    between = value.split(",")
-                    if not len(between) == 2:
-                        between = value.split(":")
-                    if len(between) == 2:
-                        value = between
-                    else:
-                        self.config.error = ("The arguments to 'between' "
-                                             "must be comma separated")
-                        value = [None, None]
+            elif self.operator[field] == "between":
+                operat = "between %s and"
+                between = value.split(",")
+                if not len(between) == 2:
+                    between = value.split(":")
+                if len(between) == 2:
+                    value = between
+                else:
+                    self.config.error = ("The arguments to 'between' "
+                                         "must be comma separated")
+                    value = [None, None]
 
         self.config.where.append(field + " " + neg + operat + " %s")
         if type(value) is list:

--- a/python/nav/report/generator.py
+++ b/python/nav/report/generator.py
@@ -237,7 +237,7 @@ class ArgumentParser(object):
         # config is the config obtained from the config file
         self.config = configuration
         self.fields = {}
-        self.nott = {}
+        self.negated = {}
         self.operator = {}
 
     def parse_query(self, query):
@@ -250,7 +250,7 @@ class ArgumentParser(object):
         self._parse_arguments(query)
         self._parse_fields()
 
-        return self.fields, self.nott, self.operator
+        return self.fields, self.negated, self.operator
 
     def _parse_arguments(self, query):
         for argument, value in query.items():
@@ -289,7 +289,7 @@ class ArgumentParser(object):
         elif group in ("forklar", "explain", "description"):
             self.config.explain[group_key] = value
         elif group == "not":
-            self.nott[group_key] = value
+            self.negated[group_key] = value
         elif group == "op":
             self.operator[group_key] = value
         else:
@@ -306,26 +306,26 @@ class ArgumentParser(object):
             self.operator[field] = "eq"
         # Set a default operator
         operat = "="
-        neg = "not " if field in self.nott else ""
+        negate = "not " if field in self.negated else ""
 
         if value == "null":
-            operat, neg = ("is not", "") if neg else ("is", neg)
+            operat, negate = ("is not", "") if negate else ("is", negate)
         else:
             fieldoper = self.operator[field]
             if fieldoper == "eq":
-                operat, neg = ("<>", "") if neg else ("=", neg)
+                operat, negate = ("<>", "") if negate else ("=", negate)
             elif fieldoper == "like":
                 operat = "ilike"
                 value = value.replace("*", "%")
             elif fieldoper == "gt":
-                operat, neg = ("<=", "") if neg else (">", neg)
+                operat, negate = ("<=", "") if negate else (">", negate)
 
             elif fieldoper == "geq":
-                operat, neg = ("<", "") if neg else (">=", neg)
+                operat, negate = ("<", "") if negate else (">=", negate)
             elif fieldoper == "lt":
-                operat, neg = (">=", "") if neg else ("<", neg)
+                operat, negate = (">=", "") if negate else ("<", negate)
             elif fieldoper == "leq":
-                operat, neg = (">", "") if neg else ("<=", neg)
+                operat, negate = (">", "") if negate else ("<=", negate)
             elif fieldoper == "in":
                 operat = "in"
                 value = tuple(value.split(","))
@@ -342,7 +342,7 @@ class ArgumentParser(object):
                                          "must be comma- or colon-separated")
                     value = [None, None]
 
-        self.config.where.append(field + " " + neg + operat + " %s")
+        self.config.where.append(field + " " + negate + operat + " %s")
         if type(value) is list:
             self.config.parameters.extend(value)
         else:

--- a/python/nav/report/generator.py
+++ b/python/nav/report/generator.py
@@ -367,7 +367,7 @@ class ArgumentParser(object):
                     value = between
                 else:
                     self.config.error = ("The arguments to 'between' "
-                                         "must be comma separated")
+                                         "must be comma- or colon-separated")
                     value = [None, None]
 
         self.config.where.append(field + " " + neg + operat + " %s")
@@ -396,6 +396,7 @@ class ReportConfig(object):
         self.where = []
         self.parameters = []
         self.report_id = ''
+        self.error = None
 
     def __repr__(self):
         template = ("<ReportConfig sql={0!r}, sql_select={1!r}, where={2!r}, "

--- a/python/nav/report/generator.py
+++ b/python/nav/report/generator.py
@@ -230,10 +230,15 @@ class ConfigParser(object):
 
 class ArgumentParser(object):
     """Handler of the uri arguments"""
+    SAFE_PATTERN = re.compile("(select|drop|update|delete).*(from|where)", re.I)
 
     def __init__(self, configuration):
         """Initializes the configuration"""
-        self.configuration = configuration
+        # config is the config obtained from the config file
+        self.config = configuration
+        self.fields = {}
+        self.nott = {}
+        self.operator = {}
 
     def parse_query(self, query):
         """Parses the arguments of the uri, and modifies the
@@ -242,33 +247,31 @@ class ArgumentParser(object):
         :param query: a dict representing the argument-part of the uri
 
         """
+        self._parse_operations(query)
+        self._parse_fields()
 
-        ## config is the configuration obtained from the configuration file
-        config = self.configuration
-        fields = {}
-        nott = {}
-        operator = {}
-        safere = re.compile("(select|drop|update|delete).*(from|where)", re.I)
+        return self.fields, self.nott, self.operator
 
+    def _parse_operations(self, query):
         for key, value in query.items():
 
             if key == "sql" or key == "query":
-                #error("Access to make SQL-querys permitted")
+                # error("Access to make SQL-querys permitted")
                 pass
             elif key == "title":
-                config.title = value
+                self.config.title = value
             elif key == "order_by" or key == "sort":
-                config.order_by = value.split(",") + config.order_by
+                self.config.order_by = value.split(",") + self.config.order_by
             elif key == "skjul" or key == "hidden" or key == "hide":
-                config.hidden.extend(value.split(","))
+                self.config.hidden.extend(value.split(","))
             elif key == "ekstra" or key == "extra":
-                config.extra.extend(value.split(","))
+                self.config.extra.extend(value.split(","))
             elif key == "sum" or key == "total":
-                config.sum.extend(value.split(","))
+                self.config.sum.extend(value.split(","))
             elif key == "offset":
-                config.offset = value
+                self.config.offset = value
             elif key == "limit":
-                config.limit = value
+                self.config.limit = value
             else:
                 pattern = re.compile(r"^(?P<group>\S+?)_(?P<groupkey>\S+?)$")
                 match = pattern.search(key)
@@ -277,30 +280,31 @@ class ArgumentParser(object):
                     group = match.group('group')
                     group_key = match.group('groupkey')
                     if group in ("navn", "name"):
-                        config.name[group_key] = value
+                        self.config.name[group_key] = value
                     elif group in ("url", "uri"):
-                        config.uri[group_key] = value
+                        self.config.uri[group_key] = value
                     elif group in ("forklar", "explain", "description"):
-                        config.explain[group_key] = value
+                        self.config.explain[group_key] = value
                     elif group == "not":
-                        nott[group_key] = value
+                        self.nott[group_key] = value
                     elif group == "op":
-                        operator[group_key] = value
+                        self.operator[group_key] = value
                     else:
                         match = None
 
                 if not match:
                     if value:
-                        fields[key] = value
+                        self.fields[key] = value
 
-        for key, value in fields.items():
+    def _parse_fields(self):
+        for key, value in self.fields.items():
 
-            if not key in operator:
-                operator[key] = "eq"
+            if not key in self.operator:
+                self.operator[key] = "eq"
             # Set a default operator
             operat = "="
 
-            if key in nott:
+            if key in self.nott:
                 neg = "not "
             else:
                 neg = ""
@@ -312,54 +316,54 @@ class ArgumentParser(object):
                 else:
                     operat = "is"
             else:
-                if safere.search(value):
-                    config.error = ("You are not allowed to make advanced sql"
-                                    " terms")
+                if self.SAFE_PATTERN.search(value):
+                    self.config.error = ("You are not allowed to make advanced "
+                                         "sql terms")
                 else:
-                    if operator[key] == "eq":
+                    if self.operator[key] == "eq":
                         if neg:
                             operat = "<>"
                             neg = ""
                         else:
                             operat = "="
-                    elif operator[key] == "like":
+                    elif self.operator[key] == "like":
                         operat = "ilike"
                         value = value.replace("*", "%")
-                    elif operator[key] == "gt":
+                    elif self.operator[key] == "gt":
                         if neg:
                             operat = "<="
                             neg = ""
                         else:
                             operat = ">"
 
-                    elif operator[key] == "geq":
+                    elif self.operator[key] == "geq":
                         if neg:
                             operat = "<"
                             neg = ""
                         else:
                             operat = ">="
-                    elif operator[key] == "lt":
+                    elif self.operator[key] == "lt":
                         if neg:
                             operat = ">="
                             neg = ""
                         else:
                             operat = "<"
-                    elif operator[key] == "leq":
+                    elif self.operator[key] == "leq":
                         if neg:
                             operat = ">"
                             neg = ""
                         else:
                             operat = "<="
-                    elif operator[key] == "in":
+                    elif self.operator[key] == "in":
                         operat = "in"
                         inlist = value.split(",")
                         if inlist:
                             value = tuple((a.strip() for a in inlist))
                         else:
-                            config.error = ("The arguments to 'in' must be "
-                                            "comma separated")
+                            self.config.error = ("The arguments to 'in' must "
+                                                 "be comma separated")
 
-                    elif operator[key] == "between":
+                    elif self.operator[key] == "between":
                         operat = "between %s and"
                         between = value.split(",")
                         if not len(between) == 2:
@@ -367,17 +371,15 @@ class ArgumentParser(object):
                         if len(between) == 2:
                             value = between
                         else:
-                            config.error = ("The arguments to 'between' must "
-                                            "be comma separated")
+                            self.config.error = ("The arguments to 'between' "
+                                                 "must be comma separated")
                             value = [None, None]
 
-            config.where.append(key + " " + neg + operat + " %s")
+            self.config.where.append(key + " " + neg + operat + " %s")
             if type(value) is list:
-                config.parameters.extend(value)
+                self.config.parameters.extend(value)
             else:
-                config.parameters.append(value)
-
-        return fields, nott, operator
+                self.config.parameters.append(value)
 
 
 class ReportConfig(object):

--- a/python/nav/report/generator.py
+++ b/python/nav/report/generator.py
@@ -299,89 +299,87 @@ class ArgumentParser(object):
         return True
 
     def _parse_fields(self):
-        for key, value in self.fields.items():
+        for field, value in self.fields.items():
+            self._parse_single_field(field, value)
 
-            if not key in self.operator:
-                self.operator[key] = "eq"
-            # Set a default operator
-            operat = "="
+    def _parse_single_field(self, field, value):
+        if field not in self.operator:
+            self.operator[field] = "eq"
+        # Set a default operator
+        operat = "="
+        neg = "not " if field in self.nott else ""
 
-            if key in self.nott:
-                neg = "not "
-            else:
+        if value == "null":
+            if neg:
+                operat = "is not"
                 neg = ""
-
-            if value == "null":
-                if neg:
-                    operat = "is not"
-                    neg = ""
-                else:
-                    operat = "is"
             else:
-                if self.SAFE_PATTERN.search(value):
-                    self.config.error = ("You are not allowed to make advanced "
-                                         "sql terms")
-                else:
-                    if self.operator[key] == "eq":
-                        if neg:
-                            operat = "<>"
-                            neg = ""
-                        else:
-                            operat = "="
-                    elif self.operator[key] == "like":
-                        operat = "ilike"
-                        value = value.replace("*", "%")
-                    elif self.operator[key] == "gt":
-                        if neg:
-                            operat = "<="
-                            neg = ""
-                        else:
-                            operat = ">"
-
-                    elif self.operator[key] == "geq":
-                        if neg:
-                            operat = "<"
-                            neg = ""
-                        else:
-                            operat = ">="
-                    elif self.operator[key] == "lt":
-                        if neg:
-                            operat = ">="
-                            neg = ""
-                        else:
-                            operat = "<"
-                    elif self.operator[key] == "leq":
-                        if neg:
-                            operat = ">"
-                            neg = ""
-                        else:
-                            operat = "<="
-                    elif self.operator[key] == "in":
-                        operat = "in"
-                        inlist = value.split(",")
-                        if inlist:
-                            value = tuple((a.strip() for a in inlist))
-                        else:
-                            self.config.error = ("The arguments to 'in' must "
-                                                 "be comma separated")
-
-                    elif self.operator[key] == "between":
-                        operat = "between %s and"
-                        between = value.split(",")
-                        if not len(between) == 2:
-                            between = value.split(":")
-                        if len(between) == 2:
-                            value = between
-                        else:
-                            self.config.error = ("The arguments to 'between' "
-                                                 "must be comma separated")
-                            value = [None, None]
-
-            self.config.where.append(key + " " + neg + operat + " %s")
-            if type(value) is list:
-                self.config.parameters.extend(value)
+                operat = "is"
+        else:
+            if self.SAFE_PATTERN.search(value):
+                self.config.error = ("You are not allowed to make advanced "
+                                     "sql terms")
             else:
-                self.config.parameters.append(value)
+                if self.operator[field] == "eq":
+                    if neg:
+                        operat = "<>"
+                        neg = ""
+                    else:
+                        operat = "="
+                elif self.operator[field] == "like":
+                    operat = "ilike"
+                    value = value.replace("*", "%")
+                elif self.operator[field] == "gt":
+                    if neg:
+                        operat = "<="
+                        neg = ""
+                    else:
+                        operat = ">"
+
+                elif self.operator[field] == "geq":
+                    if neg:
+                        operat = "<"
+                        neg = ""
+                    else:
+                        operat = ">="
+                elif self.operator[field] == "lt":
+                    if neg:
+                        operat = ">="
+                        neg = ""
+                    else:
+                        operat = "<"
+                elif self.operator[field] == "leq":
+                    if neg:
+                        operat = ">"
+                        neg = ""
+                    else:
+                        operat = "<="
+                elif self.operator[field] == "in":
+                    operat = "in"
+                    inlist = value.split(",")
+                    if inlist:
+                        value = tuple((a.strip() for a in inlist))
+                    else:
+                        self.config.error = ("The arguments to 'in' must "
+                                             "be comma separated")
+
+                elif self.operator[field] == "between":
+                    operat = "between %s and"
+                    between = value.split(",")
+                    if not len(between) == 2:
+                        between = value.split(":")
+                    if len(between) == 2:
+                        value = between
+                    else:
+                        self.config.error = ("The arguments to 'between' "
+                                             "must be comma separated")
+                        value = [None, None]
+
+        self.config.where.append(field + " " + neg + operat + " %s")
+        if type(value) is list:
+            self.config.parameters.extend(value)
+        else:
+            self.config.parameters.append(value)
 
 
 class ReportConfig(object):

--- a/python/nav/report/generator.py
+++ b/python/nav/report/generator.py
@@ -328,12 +328,7 @@ class ArgumentParser(object):
                 operat, neg = (">", "") if neg else ("<=", neg)
             elif fieldoper == "in":
                 operat = "in"
-                inlist = value.split(",")
-                if inlist:
-                    value = tuple((a.strip() for a in inlist))
-                else:
-                    self.config.error = ("The arguments to 'in' must "
-                                         "be comma separated")
+                value = tuple(value.split(","))
 
             elif fieldoper == "between":
                 operat = "between %s and"

--- a/python/nav/report/generator.py
+++ b/python/nav/report/generator.py
@@ -309,47 +309,24 @@ class ArgumentParser(object):
         neg = "not " if field in self.nott else ""
 
         if value == "null":
-            if neg:
-                operat = "is not"
-                neg = ""
-            else:
-                operat = "is"
+            operat, neg = ("is not", "") if neg else ("is", neg)
         else:
-            if self.operator[field] == "eq":
-                if neg:
-                    operat = "<>"
-                    neg = ""
-                else:
-                    operat = "="
-            elif self.operator[field] == "like":
+            fieldoper = self.operator[field]
+            if fieldoper == "eq":
+                operat, neg = ("<>", "") if neg else ("=", neg)
+            elif fieldoper == "like":
                 operat = "ilike"
                 value = value.replace("*", "%")
-            elif self.operator[field] == "gt":
-                if neg:
-                    operat = "<="
-                    neg = ""
-                else:
-                    operat = ">"
+            elif fieldoper == "gt":
+                operat, neg = ("<=", "") if neg else (">", neg)
 
-            elif self.operator[field] == "geq":
-                if neg:
-                    operat = "<"
-                    neg = ""
-                else:
-                    operat = ">="
-            elif self.operator[field] == "lt":
-                if neg:
-                    operat = ">="
-                    neg = ""
-                else:
-                    operat = "<"
-            elif self.operator[field] == "leq":
-                if neg:
-                    operat = ">"
-                    neg = ""
-                else:
-                    operat = "<="
-            elif self.operator[field] == "in":
+            elif fieldoper == "geq":
+                operat, neg = ("<", "") if neg else (">=", neg)
+            elif fieldoper == "lt":
+                operat, neg = (">=", "") if neg else ("<", neg)
+            elif fieldoper == "leq":
+                operat, neg = (">", "") if neg else ("<=", neg)
+            elif fieldoper == "in":
                 operat = "in"
                 inlist = value.split(",")
                 if inlist:
@@ -358,7 +335,7 @@ class ArgumentParser(object):
                     self.config.error = ("The arguments to 'in' must "
                                          "be comma separated")
 
-            elif self.operator[field] == "between":
+            elif fieldoper == "between":
                 operat = "between %s and"
                 between = value.split(",")
                 if not len(between) == 2:

--- a/templates/report/frag_report_filters.html
+++ b/templates/report/frag_report_filters.html
@@ -103,7 +103,7 @@
 
           <dl class="no-bullet">
             <dt>=</dt>
-            <dd>"equals", enter null for empty string</dd>
+            <dd>"equals", enter <code>null</code> for empty string</dd>
             <dt>~</dt>
             <dd>case insensitive search, use * as wildcard</dd>
             <dt>[:]</dt>
@@ -117,8 +117,7 @@
 
           <p>&lt;, &gt;, &lt;= and &gt;= needs no explanation.</p>
 
-          <p>All these operators may be negated by clicking the "not"
-            checkbox.</p>
+          <p>All these operators may be negated by clicking the checkbox labeled <em>not</em>.</p>
         </div>
       </div>
 


### PR DESCRIPTION
After fixing bugs in Report, I was compelled to refactor and clean some of the code I found.

Primarily, this cleans the method responsible for parsing report query arguments from the web page, by breaking it into a set of smaller methods, improving variable names and removing dead or useless code.

It also fixes a problem wherein any errors flagged by the query argument parsing were never passed up to the user interface, but happily ignored with potentially strange consequences for the search result. 