### PR TITLE
Copyright changes

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -67,7 +67,7 @@ Other contributors and previous maintainers
   Wrote PortAdmin with John-Magne.
 
 * Ole Martin Bjørndalen <ole.martin.bjorndalen at uit.no>
-  Wrote the MailIn system based on a Perl implementation from UNINETT, and
+  Wrote the MailIn system based on a Perl implementation from Uninett, and
   periodically contributes to the service monitor.
 
 * Kai Arne Bjørnenak <kai.bjornenak at cc.uit.no>

--- a/NOTES.rst
+++ b/NOTES.rst
@@ -266,7 +266,7 @@ The room view now includes the new tab "Sensors in Racks". In this tab, you
 can create customized groupings of environment sensors present in a single
 communications room.
 
-At UNINETT, this view is used to get an overview of the power load and cooling
+At Uninett, this view is used to get an overview of the power load and cooling
 water temperature on a per-rack basis in large HPC installations. PDU sensors
 can nbe added to the left and right side of each "rack", and arbitrary sensors
 from other types of devices can be added to the center column.
@@ -430,14 +430,14 @@ New dashboard widgets are introduced:
 
 Alert
   This widget can monitor binary sensor values or arbitrary Graphite metrics
-  of a an otherwise boolean nature, to be used as an alert indicator. UNINETT's
+  of a an otherwise boolean nature, to be used as an alert indicator. Uninett's
   use-case for this is showing the status of the server room physical security
   system on the NOC screens.
 
 PDU load
   A very specific plugin to display the power load status of APC power
   distribution units (these are the only PDU units currently known to be
-  supported by NAV) on a room-by-room basis. UNINETT's use-case for this is
+  supported by NAV) on a room-by-room basis. Uninett's use-case for this is
   planning rack placements based on power consumption.
 
 UPS status

--- a/README.rst
+++ b/README.rst
@@ -14,12 +14,7 @@ License
 NAV is licensed under the GNU GPL version 2.  NAV includes software from third
 parties, which are either licensed under the GPL or compatible licenses.
 
-There are multiple copyright holders to NAV code.  The major copyright holders
-are:
-
 * Copyright 2002-2018 UNINETT AS
-* Copyright 1999-2010 Norwegian University of Science and Technology
-* Copyright 2007-2010 University of Tromsø
 
 See individual source files for more detailed copyright notices.
 

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ License
 NAV is licensed under the GNU GPL version 2.  NAV includes software from third
 parties, which are either licensed under the GPL or compatible licenses.
 
-* Copyright 2002-2018 UNINETT AS
+* Copyright 2002-2018 Uninett AS
 
 See individual source files for more detailed copyright notices.
 

--- a/bin/alertengine.py
+++ b/bin/alertengine.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- testargs: --test -*-
 #
-# Copyright (C) 2007, 2008, 2011, 2013, 2017 UNINETT AS
+# Copyright (C) 2007, 2008, 2011, 2013, 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/autoenable.py
+++ b/bin/autoenable.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2008 (C) Norwegian University of Science and Technology
+# Copyright (C) 2018 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/autoenable.py
+++ b/bin/autoenable.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2018 UNINETT AS
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/collect_active_ip.py
+++ b/bin/collect_active_ip.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- testargs: -h -*-
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/emailreports.py
+++ b/bin/emailreports.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -*- testargs: month -*-
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/macwatch.py
+++ b/bin/macwatch.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/mailin.py
+++ b/bin/mailin.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008,2009 University of Tromsø
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/maintengine.py
+++ b/bin/maintengine.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2003-2005 Norwegian University of Science and Technology
-# Copyright 2006, 2008, 2011 UNINETT AS
+# Copyright (C) 2006, 2008, 2011 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/maintengine.py
+++ b/bin/maintengine.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2006, 2008, 2011 UNINETT AS
+# Copyright (C) 2006, 2008, 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/nav
+++ b/bin/nav
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- testargs: list -*-
 #
-# Copyright (C) 2004 Norwegian University of Science and Technology
 # Copyright (C) 2006, 2011, 2016, 2017 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/bin/nav
+++ b/bin/nav
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- testargs: list -*-
 #
-# Copyright (C) 2006, 2011, 2016, 2017 UNINETT AS
+# Copyright (C) 2006, 2011, 2016, 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/navcheckservice
+++ b/bin/navcheckservice
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- testargs: 127.0.0.1 localhost dummy -*-
 #
-# Copyright (C) 2015 UNINETT AS
+# Copyright (C) 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/navcheckservice
+++ b/bin/navcheckservice
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- testargs: 127.0.0.1 localhost dummy -*-
 #
-# Copyright (C) 2003 Norwegian University of Science and Technology
 # Copyright (C) 2015 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/bin/navclean
+++ b/bin/navclean
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2017 UNINETT
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/navclean
+++ b/bin/navclean
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2004 Norwegian University of Science and Technology
 # Copyright (C) 2017 UNINETT
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/bin/navdf
+++ b/bin/navdf
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2014, 2016 UNINETT AS
+# Copyright (C) 2014, 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/navdump
+++ b/bin/navdump
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 # -*- testargs: -h -*-
 #
-# Copyright (C) 2004,2009 Norwegian University of Science and Technology
 # Copyright (C) 2010-2011, 2013-2015, 2017 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/bin/navdump
+++ b/bin/navdump
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- testargs: -h -*-
 #
-# Copyright (C) 2010-2011, 2013-2015, 2017 UNINETT AS
+# Copyright (C) 2010-2011, 2013-2015, 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/naventity
+++ b/bin/naventity
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- testargs: -h -*-
 #
-# Copyright (C) 2014 UNINETT
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/navoidverify
+++ b/bin/navoidverify
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- testargs: .1.3.6.1.2.1.1.2 -*-
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/navsnmp
+++ b/bin/navsnmp
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2016 UNINETT
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/navstats
+++ b/bin/navstats
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/navuser
+++ b/bin/navuser
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- testargs: list -*-
 #
-# Copyright (C) 2016 UNINETT
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/netbiostracker.py
+++ b/bin/netbiostracker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/powersupplywatch.py
+++ b/bin/powersupplywatch.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2011, 2012, 2014, 2017 UNINETT AS
+# Copyright (C) 2011, 2012, 2014, 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/pping.py
+++ b/bin/pping.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- testargs: -h -*-
 #
-# Copyright (C) 2002-2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/radiusparser.py
+++ b/bin/radiusparser.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- notest -*-
 #
-# Copyright 2008 University of Tromsø
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV)
 #

--- a/bin/radiusparser.py
+++ b/bin/radiusparser.py
@@ -21,10 +21,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 #
-# Authors: Roger Kristiansen <roger.kristiansen@gmail.com>
-#          Kai Arne Bjørnenak <kai.bjornenak@cc.uit.no>
-#
-
 """Radius error log parser.
 
 This program was written to run on a radius server, not on the NAV

--- a/bin/servicemon.py
+++ b/bin/servicemon.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- testargs: -h -*-
 #
-# Copyright 2002-2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/smsd.py
+++ b/bin/smsd.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # -*- testargs: -c -*-
 #
-# Copyright (C) 2006-2008, 2017 UNINETT AS
+# Copyright (C) 2006-2008, 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/snmptrapd.py
+++ b/bin/snmptrapd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- testargs: -h -*-
 #
-# Copyright (C) 2010, 2013, 2017, 2018 UNINETT AS
+# Copyright (C) 2010, 2013, 2017, 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/snmptrapd.py
+++ b/bin/snmptrapd.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- testargs: -h -*-
 #
-# Copyright (C) 2007 Norwegian University of Science and Technology
 # Copyright (C) 2010, 2013, 2017, 2018 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/bin/start_arnold.py
+++ b/bin/start_arnold.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- testargs: --list -*-
 #
-# Copyright 2008 (C) Norwegian University of Science and Technology
 # Copyright 2017 (C) UNINETT
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/bin/start_arnold.py
+++ b/bin/start_arnold.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- testargs: --list -*-
 #
-# Copyright 2017 (C) UNINETT
+# Copyright 2017 (C) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/t1000.py
+++ b/bin/t1000.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2008 Norwegian University of Science and Technology
+# Copyright 2018 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/t1000.py
+++ b/bin/t1000.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2018 UNINETT AS
+# Copyright 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/bin/whisper_update_many.py
+++ b/bin/whisper_update_many.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- testargs: -h -*-
 #
-# Copyright (C) 2014, 2017 UNINETT AS
+# Copyright (C) 2014, 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_CONFIG_AUX_DIR(conf)
 AM_INIT_AUTOMAKE([foreign])
 AC_PREFIX_DEFAULT(/usr/local/nav)
 AC_COPYRIGHT([
-Copyright 2002-2018 UNINETT AS
+Copyright 2002-2018 Uninett AS
 
 See individual source files for more detailed copyright notices.
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -5,12 +5,7 @@ AC_CONFIG_AUX_DIR(conf)
 AM_INIT_AUTOMAKE([foreign])
 AC_PREFIX_DEFAULT(/usr/local/nav)
 AC_COPYRIGHT([
-There are multiple copyright holders to NAV code.  The major copyright holders
-are:
-
 Copyright 2002-2018 UNINETT AS
-Copyright 1999-2010 Norwegian University of Science and Technology
-Copyright 2007-2010 University of Tromsø
 
 See individual source files for more detailed copyright notices.
 ])

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,7 +40,7 @@ master_doc = 'contents'
 
 # General information about the project.
 project = u'NAV'
-copyright = u'2012-2018, UNINETT AS'
+copyright = u'2012-2018, Uninett AS'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -238,7 +238,7 @@ htmlhelp_basename = 'NAVdoc'
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
   ('index', 'NAV.tex', u'NAV Documentation',
-   u'UNINETT AS', 'manual'),
+   u'Uninett AS', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/doc/faq/faq.rst
+++ b/doc/faq/faq.rst
@@ -117,5 +117,5 @@ problems. To do so, get a GSM device that's supported by `Gammu
 
 We've found it's best to avoid handsets, as these are built to be exactly
 that: Handsets. Sometimes, they require some form of user-interaction to
-continue operating, which isn't always feasible in a datacenter. At UNINETT,
+continue operating, which isn't always feasible in a datacenter. At Uninett,
 we've had good results with GSM terminals from Siemens/Cinterion/Gemalto.

--- a/doc/hacking/hacking.rst
+++ b/doc/hacking/hacking.rst
@@ -12,17 +12,17 @@ Contributing to NAV
 
 Originally, NAV was a closed source project, initiated by the
 Norwegian University of Science and Technology (NTNU), and eventually
-sponsored by UNINETT on behalf of the Norwegian higher education
-community.  In 2004, however, NTNU and UNINETT started distributing
+sponsored by Uninett on behalf of the Norwegian higher education
+community.  In 2004, however, NTNU and Uninett started distributing
 NAV under the GNU General Public License, making it a truly free
 software system.
 
-While UNINETT and NTNU are still the main contributors to NAV,
+While Uninett and NTNU are still the main contributors to NAV,
 developing NAV to support the needs of the Norwegian higher education
 community, contributions from third parties is highly appreciated.
 
 We communicate mainly through mailing lists, GitHub_, and the ``#nav`` IRC
-channel on *FreeNode*. At times, UNINETT also arranges workshops and
+channel on *FreeNode*. At times, Uninett also arranges workshops and
 gatherings for its customers: Norwegian universities, university colleges and
 research institutions.
 
@@ -263,7 +263,7 @@ Push access
 -----------
 
 Push access to the official repositories is limited to developers
-employed or commissioned by UNINETT.
+employed or commissioned by Uninett.
 
 Testing and Continuous Integration
 ==================================

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -38,7 +38,7 @@ department of the Norwegian University of Science and Technology in 1999 to
 cover their network monitoring needs, after HP OpenView had failed to meet
 their requirements.  At the time, NTNU's campus network had some 20.000 users.
 
-UNINETT, the Norwegian National Research and Education Network became
+Uninett, the Norwegian National Research and Education Network became
 interested in NTNU's work on NAV in 2001 and began sponsoring 50% of its
 development costs in exchange for licensing the software to all universities
 and university colleges in Norway.
@@ -46,7 +46,7 @@ and university colleges in Norway.
 In 2004, both parties agreed to release NAV to the world under the GPL
 license, version 2, effectively freeing the software.
 
-In 2006, UNINETT assumed the main responsibility of maintaining and developing
+In 2006, Uninett assumed the main responsibility of maintaining and developing
 the software further, and is continually doing so on behalf of its customers,
 the Norwegian universities and university colleges, and research network
 partners.

--- a/doc/reference/smsd.rst
+++ b/doc/reference/smsd.rst
@@ -115,8 +115,8 @@ UninettMailDispatcher
 
 :description:
 
-	This dispatcher sends SMS via UNINETT's `email-to-SMS` gateway.
-	UNINETT's gateway only works internally, but this plugin can serve as
+	This dispatcher sends SMS via Uninett's `email-to-SMS` gateway.
+	Uninett's gateway only works internally, but this plugin can serve as
 	a proof-of-concept for someone implementing a similar service.  The
 	e-mail adress is configurable in ``smsd.conf``.
 
@@ -134,7 +134,7 @@ UninettMailDispatcher
 :cons:
 
 	Unless you have a similar email-to-SMS gatway, this only works for
-	UNINETT.
+	Uninett.
 
 Extending
 =========

--- a/etc/init.d/functions.in
+++ b/etc/init.d/functions.in
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 #
-# $Id$
 # This file contains functions to be used by most or all shell scripts
 # in the NAV init.d directory.
 #
 #
-# Copyright 2002-2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV)
 #

--- a/etc/init.d/ipdevpoll.in
+++ b/etc/init.d/ipdevpoll.in
@@ -4,7 +4,7 @@
 # This file is part of Network Administration Visualized.
 # This script controls start/stop/status of the NAV ipdevpoll daemon
 #
-# Copyright (C) 2006-2011, 2015 UNINETT AS
+# Copyright (C) 2006-2011, 2015 Uninett AS
 #
 ####################
 ## info: Collects SNMP inventory data from IP devices.

--- a/htdocs/sass/nav/_table.scss
+++ b/htdocs/sass/nav/_table.scss
@@ -1,6 +1,5 @@
 /* Stylesheet for tables in NAV style
  *
- * Copyright (C) 2003-2005 Norwegian University of Science and Technology
  * Copyright (C) 2006-2008 UNINETT AS
  *
  * This file is part of Network Administration Visualized (NAV).

--- a/htdocs/sass/nav/_table.scss
+++ b/htdocs/sass/nav/_table.scss
@@ -1,6 +1,6 @@
 /* Stylesheet for tables in NAV style
  *
- * Copyright (C) 2006-2008 UNINETT AS
+ * Copyright (C) 2006-2008 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/sass/nav/_tabs.scss
+++ b/htdocs/sass/nav/_tabs.scss
@@ -1,6 +1,6 @@
 /* Stylesheet for tables in NAV style
  *
- * Copyright (C) 2007 UNINETT AS
+ * Copyright (C) 2007 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/sass/nav/calendar.scss
+++ b/htdocs/sass/nav/calendar.scss
@@ -1,6 +1,6 @@
 /* Calendar style sheet for NAV
  *
- * Copyright (C) 2006-2008 UNINETT AS
+ * Copyright (C) 2006-2008 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/sass/nav/ipdevinfo.scss
+++ b/htdocs/sass/nav/ipdevinfo.scss
@@ -1,6 +1,6 @@
 /* Subsystem stylesheet for NAV
  *
-  * Copyright 2006-2008 UNINETT AS
+  * Copyright 2006-2008 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV)
  *

--- a/htdocs/sass/nav/ipdevinfo.scss
+++ b/htdocs/sass/nav/ipdevinfo.scss
@@ -1,7 +1,6 @@
 /* Subsystem stylesheet for NAV
  *
- * Copyright 2003-2004 Norwegian University of Science and Technology
- * Copyright 2006-2008 UNINETT AS
+  * Copyright 2006-2008 UNINETT AS
  *
  * This file is part of Network Administration Visualized (NAV)
  *

--- a/htdocs/sass/nav/login.scss
+++ b/htdocs/sass/nav/login.scss
@@ -1,6 +1,6 @@
 /* Login stylesheet for NAV
  *
- * Copyright (C) 2007 UNINETT AS
+ * Copyright (C) 2007 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/sass/nav/quickselect.scss
+++ b/htdocs/sass/nav/quickselect.scss
@@ -1,6 +1,6 @@
 /* Quickselect stylesheet for NAV
  *
- * Copyright (C) 2008 UNINETT AS
+ * Copyright (C) 2008 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/sass/nav/subnet_matrix.scss
+++ b/htdocs/sass/nav/subnet_matrix.scss
@@ -1,6 +1,6 @@
 /* Subsystem stylesheet for NAV
  *
- * Copyright (C) 2006 UNINETT AS
+ * Copyright (C) 2006 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/sass/nav/subnet_matrix.scss
+++ b/htdocs/sass/nav/subnet_matrix.scss
@@ -1,6 +1,5 @@
 /* Subsystem stylesheet for NAV
  *
- * Copyright (C) 2003-2005 Norwegian University of Science and Technology
  * Copyright (C) 2006 UNINETT AS
  *
  * This file is part of Network Administration Visualized (NAV).

--- a/htdocs/sass/nav/treeselect.scss
+++ b/htdocs/sass/nav/treeselect.scss
@@ -1,6 +1,6 @@
 /* Treeselect stylesheet for NAV
  *
- * Copyright (C) 2008 UNINETT AS
+ * Copyright (C) 2008 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/static/js/geomap/Calendar.js
+++ b/htdocs/static/js/geomap/Calendar.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2010 UNINETT AS
+ * Copyright (C) 2009, 2010 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/static/js/geomap/MyHTTPProtocol.js
+++ b/htdocs/static/js/geomap/MyHTTPProtocol.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2010 UNINETT AS
+ * Copyright (C) 2009, 2010 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/static/js/geomap/NetworkLayer.js
+++ b/htdocs/static/js/geomap/NetworkLayer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2010, 2015 UNINETT AS
+ * Copyright (C) 2009, 2010, 2015 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/static/js/geomap/Permalink.js
+++ b/htdocs/static/js/geomap/Permalink.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2010 UNINETT AS
+ * Copyright (C) 2009, 2010 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/static/js/geomap/PopupControl.js
+++ b/htdocs/static/js/geomap/PopupControl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2010 UNINETT AS
+ * Copyright (C) 2009, 2010 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/static/js/geomap/Time.js
+++ b/htdocs/static/js/geomap/Time.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2010 UNINETT AS
+ * Copyright (C) 2009, 2010 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/static/js/geomap/TimeInterval.js
+++ b/htdocs/static/js/geomap/TimeInterval.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2010 UNINETT AS
+ * Copyright (C) 2009, 2010 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/static/js/geomap/TimeNavigator.js
+++ b/htdocs/static/js/geomap/TimeNavigator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2010 UNINETT AS
+ * Copyright (C) 2009, 2010 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/static/js/geomap/coordinates.js
+++ b/htdocs/static/js/geomap/coordinates.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2010 UNINETT AS
+ * Copyright (C) 2009, 2010 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/static/js/geomap/geomap.js
+++ b/htdocs/static/js/geomap/geomap.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2010, 2015 UNINETT AS
+ * Copyright (C) 2009, 2010, 2015 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/static/js/geomap/util.js
+++ b/htdocs/static/js/geomap/util.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2010 UNINETT AS
+ * Copyright (C) 2009, 2010 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/static/js/libs/ipadebug.js
+++ b/htdocs/static/js/libs/ipadebug.js
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2016 UNINETT AS
+// Copyright (C) 2016 Uninett AS
 //
 // This file is part of Network Administration Visualized (NAV).
 //

--- a/htdocs/static/js/libs/statist.js
+++ b/htdocs/static/js/libs/statist.js
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2016 UNINETT AS
+// Copyright (C) 2016 Uninett AS
 //
 // This file is part of Network Administration Visualized (NAV).
 //

--- a/htdocs/static/js/src/alertprofiles.js
+++ b/htdocs/static/js/src/alertprofiles.js
@@ -1,6 +1,6 @@
 /* JavaScripts for Alert the Profiles subsystem in NAV
  *
- * Copyright (C) 2008 UNINETT AS
+ * Copyright (C) 2008 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/static/js/src/devicehistory.js
+++ b/htdocs/static/js/src/devicehistory.js
@@ -1,4 +1,4 @@
-/* Copyright (C) 2008-2009, 2013-2015 UNINETT AS
+/* Copyright (C) 2008-2009, 2013-2015 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/static/js/src/plugins/quickselect.js
+++ b/htdocs/static/js/src/plugins/quickselect.js
@@ -1,6 +1,6 @@
 /* Quickselect JavaScripts for NAV
  *
- * Copyright (C) 2008 UNINETT AS
+ * Copyright (C) 2008 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/htdocs/static/js/treeselect.js
+++ b/htdocs/static/js/treeselect.js
@@ -1,6 +1,6 @@
 /* Treeselelct JavaScripts for NAV
  *
- * Copyright (C) 2008 UNINETT AS
+ * Copyright (C) 2008 Uninett AS
  *
  * This file is part of Network Administration Visualized (NAV).
  *

--- a/packages/rpm/CentOS/nav.spec
+++ b/packages/rpm/CentOS/nav.spec
@@ -5,7 +5,7 @@ Summary: Powerful network administration tool
 Name: nav
 Version: %{version}
 Release: 1
-Vendor: UNINETT AS
+Vendor: Uninett AS
 Packager: Alexander Krapivin <kaa@msu.net>
 Distribution: Network Administration Visualized
 URL: http://metanav.ntnu.no/

--- a/python/nav/Snmp/__init__.py
+++ b/python/nav/Snmp/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010, 2013 UNINETT AS
+# Copyright (C) 2010, 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/Snmp/pynetsnmp.py
+++ b/python/nav/Snmp/pynetsnmp.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/__init__.py
+++ b/python/nav/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2003, 2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/activeipcollector/collector.py
+++ b/python/nav/activeipcollector/collector.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/activeipcollector/manager.py
+++ b/python/nav/activeipcollector/manager.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/alertengine/base.py
+++ b/python/nav/alertengine/base.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008-2011 UNINETT AS
+# Copyright (C) 2008-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/alertengine/dispatchers/__init__.py
+++ b/python/nav/alertengine/dispatchers/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008, 2011 UNINETT AS
+# Copyright (C) 2008, 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/alertengine/dispatchers/email_dispatcher.py
+++ b/python/nav/alertengine/dispatchers/email_dispatcher.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 #
-# Copyright (C) 2008, 2011 UNINETT AS
+# Copyright (C) 2008, 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/alertengine/dispatchers/jabber_dispatcher.py
+++ b/python/nav/alertengine/dispatchers/jabber_dispatcher.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 #
-# Copyright (C) 2008, 2011 UNINETT AS
+# Copyright (C) 2008, 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/alertengine/dispatchers/sms_dispatcher.py
+++ b/python/nav/alertengine/dispatchers/sms_dispatcher.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 #
-# Copyright (C) 2008, 2011 UNINETT AS
+# Copyright (C) 2008, 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/arnold.py
+++ b/python/nav/arnold.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2008 (C) Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/asyncdns.py
+++ b/python/nav/asyncdns.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2011 UNINETT AS
+# Copyright (C) 2008-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/auditlog/__init__.py
+++ b/python/nav/auditlog/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# Copyright (C) 2017 UNINETT AS
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/auditlog/api.py
+++ b/python/nav/auditlog/api.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 UNINETT AS
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/auditlog/apps.py
+++ b/python/nav/auditlog/apps.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 UNINETT AS
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/auditlog/models.py
+++ b/python/nav/auditlog/models.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# Copyright (C) 2017 UNINETT AS
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/auditlog/urls.py
+++ b/python/nav/auditlog/urls.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 UNINETT AS
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/auditlog/views.py
+++ b/python/nav/auditlog/views.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# Copyright (C) 2017 UNINETT AS
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/bitvector.py
+++ b/python/nav/bitvector.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007, 2009 UNINETT AS
+# Copyright (C) 2007, 2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/bulkimport.py
+++ b/python/nav/bulkimport.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010, 2011, 2013-2015 UNINETT
+# Copyright (C) 2010, 2011, 2013-2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/bulkparse.py
+++ b/python/nav/bulkparse.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2015 UNINETT
+# Copyright (C) 2010-2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/colors.py
+++ b/python/nav/colors.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/config.py
+++ b/python/nav/config.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008, 2009, 2013, 2017, 2018 UNINETT AS
+# Copyright (C) 2008, 2009, 2013, 2017, 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/config.py
+++ b/python/nav/config.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2003, 2004 Norwegian University of Science and Technology
 # Copyright (C) 2008, 2009, 2013, 2017, 2018 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/daemon.py
+++ b/python/nav/daemon.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2006-2008, 2011 UNINETT AS
+# Copyright (C) 2006-2008, 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #
@@ -393,7 +393,7 @@ def safesleep(delay):
 
     See http://www.tummy.com/journals/entries/jafo_20070110_154659
     and https://bugs.launchpad.net/nav/+bug/352316
-    and https://github.com/UNINETT/nav/issues/462
+    and https://github.com/Uninett/nav/issues/462
 
     """
     try:

--- a/python/nav/db/__init__.py
+++ b/python/nav/db/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2009 UNINETT AS
+# Copyright (C) 2006-2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/db/__init__.py
+++ b/python/nav/db/__init__.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2003 Norwegian University of Science and Technology
 # Copyright (C) 2006-2009 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/debug.py
+++ b/python/nav/debug.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/debug.py
+++ b/python/nav/debug.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2006 Norwegian University of Science and Technology
 # Copyright (C) 2011 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/django/auth.py
+++ b/python/nav/django/auth.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/django/context_processors.py
+++ b/python/nav/django/context_processors.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007-2009 UNINETT AS
+# Copyright (C) 2007-2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/django/decorators.py
+++ b/python/nav/django/decorators.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/django/forms.py
+++ b/python/nav/django/forms.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/django/legacy.py
+++ b/python/nav/django/legacy.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2015 UNINETT AS
+# Copyright (C) 2007-2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/django/templatetags/thresholds.py
+++ b/python/nav/django/templatetags/thresholds.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/django/templatetags/tools.py
+++ b/python/nav/django/templatetags/tools.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/django/templatetags/watchdog.py
+++ b/python/nav/django/templatetags/watchdog.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/django/urls.py
+++ b/python/nav/django/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2013 UNINETT AS
+# Copyright (C) 2007-2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/django/utils.py
+++ b/python/nav/django/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008-2011 UNINETT AS
+# Copyright (C) 2008-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/django/validators.py
+++ b/python/nav/django/validators.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/django/views.py
+++ b/python/nav/django/views.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/django/widgets.py
+++ b/python/nav/django/widgets.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/errors.py
+++ b/python/nav/errors.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2003 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/event.py
+++ b/python/nav/event.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2005 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/event2.py
+++ b/python/nav/event2.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 UNINETT AS
+# Copyright (C) 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/eventengine/__init__.py
+++ b/python/nav/eventengine/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/eventengine/alerts.py
+++ b/python/nav/eventengine/alerts.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/eventengine/config.py
+++ b/python/nav/eventengine/config.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/eventengine/daemon.py
+++ b/python/nav/eventengine/daemon.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/eventengine/engine.py
+++ b/python/nav/eventengine/engine.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/eventengine/plugin.py
+++ b/python/nav/eventengine/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/eventengine/plugins/aggregatelinkstate.py
+++ b/python/nav/eventengine/plugins/aggregatelinkstate.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 UNINETT
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/eventengine/plugins/bgpstate.py
+++ b/python/nav/eventengine/plugins/bgpstate.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/eventengine/plugins/boxstate.py
+++ b/python/nav/eventengine/plugins/boxstate.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/eventengine/plugins/delayedstate.py
+++ b/python/nav/eventengine/plugins/delayedstate.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/eventengine/plugins/linkstate.py
+++ b/python/nav/eventengine/plugins/linkstate.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/eventengine/plugins/maintenancestate.py
+++ b/python/nav/eventengine/plugins/maintenancestate.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/eventengine/plugins/modulestate.py
+++ b/python/nav/eventengine/plugins/modulestate.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012, 2014 UNINETT
+# Copyright (C) 2012, 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/eventengine/plugins/servicestate.py
+++ b/python/nav/eventengine/plugins/servicestate.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/eventengine/plugins/snmpagentstate.py
+++ b/python/nav/eventengine/plugins/snmpagentstate.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/eventengine/plugins/thresholdstate.py
+++ b/python/nav/eventengine/plugins/thresholdstate.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/eventengine/topology.py
+++ b/python/nav/eventengine/topology.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/eventengine/unresolved.py
+++ b/python/nav/eventengine/unresolved.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ip.py
+++ b/python/nav/ip.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/__init__.py
+++ b/python/nav/ipdevpoll/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2012 UNINETT AS
+# Copyright (C) 2008-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/config.py
+++ b/python/nav/ipdevpoll/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009-2012 UNINETT AS
+# Copyright (C) 2009-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/control.py
+++ b/python/nav/ipdevpoll/control.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/daemon.py
+++ b/python/nav/ipdevpoll/daemon.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008-2012 UNINETT AS
+# Copyright (C) 2008-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/dataloader.py
+++ b/python/nav/ipdevpoll/dataloader.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008-2012 UNINETT AS
+# Copyright (C) 2008-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/db.py
+++ b/python/nav/ipdevpoll/db.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2013 UNINETT AS
+# Copyright (C) 2009-2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/descrparsers.py
+++ b/python/nav/ipdevpoll/descrparsers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010 UNINETT AS
+# Copyright (C) 2010 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #
@@ -87,7 +87,7 @@ UNINETT_PATTERN = re.compile(r"""
 
 
 def parse_uninett_convention(_sysname, ifalias):
-    """Parse router port description, using UNINETT conventions."""
+    """Parse router port description, using Uninett conventions."""
     # Strip leading and trailing whitespace from each part individually
     string = ','.join([s.strip() for s in ifalias.split(',')])
     match = UNINETT_PATTERN.match(string)

--- a/python/nav/ipdevpoll/jobs.py
+++ b/python/nav/ipdevpoll/jobs.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2012 UNINETT AS
+# Copyright (C) 2009-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/log.py
+++ b/python/nav/ipdevpoll/log.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2012 UNINETT AS
+# Copyright (C) 2008-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/neighbor.py
+++ b/python/nav/ipdevpoll/neighbor.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/__init__.py
+++ b/python/nav/ipdevpoll/plugins/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2012 UNINETT AS
+# Copyright (C) 2008-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/arp.py
+++ b/python/nav/ipdevpoll/plugins/arp.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009-2012 UNINETT AS
+# Copyright (C) 2009-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/bgp.py
+++ b/python/nav/ipdevpoll/plugins/bgp.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/bridge.py
+++ b/python/nav/ipdevpoll/plugins/bridge.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2012 UNINETT AS
+# Copyright (C) 2009-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/cam.py
+++ b/python/nav/ipdevpoll/plugins/cam.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/cdp.py
+++ b/python/nav/ipdevpoll/plugins/cdp.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/ciscovlan.py
+++ b/python/nav/ipdevpoll/plugins/ciscovlan.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2012 UNINETT AS
+# Copyright (C) 2009-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/debugging.py
+++ b/python/nav/ipdevpoll/plugins/debugging.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT AS
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/dnsname.py
+++ b/python/nav/ipdevpoll/plugins/dnsname.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2012, 2015 UNINETT AS
+# Copyright (C) 2008-2012, 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/dot1q.py
+++ b/python/nav/ipdevpoll/plugins/dot1q.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2012 UNINETT AS
+# Copyright (C) 2009-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/entity.py
+++ b/python/nav/ipdevpoll/plugins/entity.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2012, 2015 UNINETT
+# Copyright (C) 2009-2012, 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/extremevlan.py
+++ b/python/nav/ipdevpoll/plugins/extremevlan.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011,2012 UNINETT AS
+# Copyright (C) 2011,2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/interfaces.py
+++ b/python/nav/ipdevpoll/plugins/interfaces.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008-2012 UNINETT AS
+# Copyright (C) 2008-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/juniperdot1q.py
+++ b/python/nav/ipdevpoll/plugins/juniperdot1q.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 UNINETT
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/linkaggregate.py
+++ b/python/nav/ipdevpoll/plugins/linkaggregate.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 UNINETT
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/linkstate.py
+++ b/python/nav/ipdevpoll/plugins/linkstate.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011,2012 UNINETT AS
+# Copyright (C) 2011,2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/lldp.py
+++ b/python/nav/ipdevpoll/plugins/lldp.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/modules.py
+++ b/python/nav/ipdevpoll/plugins/modules.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2012 UNINETT AS
+# Copyright (C) 2009-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/poe.py
+++ b/python/nav/ipdevpoll/plugins/poe.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT AS
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/prefix.py
+++ b/python/nav/ipdevpoll/plugins/prefix.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2012 UNINETT AS
+# Copyright (C) 2008-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/propserial.py
+++ b/python/nav/ipdevpoll/plugins/propserial.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/psu.py
+++ b/python/nav/ipdevpoll/plugins/psu.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2011, 2014 UNINETT AS
+# Copyright (C) 2008-2011, 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/sensors.py
+++ b/python/nav/ipdevpoll/plugins/sensors.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2011, 2016 UNINETT AS
+# Copyright (C) 2008-2011, 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/snmpcheck.py
+++ b/python/nav/ipdevpoll/plugins/snmpcheck.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011, 2012, 2016 UNINETT AS
+# Copyright (C) 2011, 2012, 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/staticroutes.py
+++ b/python/nav/ipdevpoll/plugins/staticroutes.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/statmulticast.py
+++ b/python/nav/ipdevpoll/plugins/statmulticast.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/statports.py
+++ b/python/nav/ipdevpoll/plugins/statports.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/statsensors.py
+++ b/python/nav/ipdevpoll/plugins/statsensors.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/statsystem.py
+++ b/python/nav/ipdevpoll/plugins/statsystem.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/system.py
+++ b/python/nav/ipdevpoll/plugins/system.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011,2012 UNINETT AS
+# Copyright (C) 2011,2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/typeoid.py
+++ b/python/nav/ipdevpoll/plugins/typeoid.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008-2012 UNINETT AS
+# Copyright (C) 2008-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/uptime.py
+++ b/python/nav/ipdevpoll/plugins/uptime.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/plugins/virtualrouter.py
+++ b/python/nav/ipdevpoll/plugins/virtualrouter.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/pool.py
+++ b/python/nav/ipdevpoll/pool.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT AS
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/schedule.py
+++ b/python/nav/ipdevpoll/schedule.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2012 UNINETT AS
+# Copyright (C) 2008-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/shadows/__init__.py
+++ b/python/nav/ipdevpoll/shadows/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2012, 2016 UNINETT AS
+# Copyright (C) 2009-2012, 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/shadows/adjacency.py
+++ b/python/nav/ipdevpoll/shadows/adjacency.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/shadows/cam.py
+++ b/python/nav/ipdevpoll/shadows/cam.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/shadows/entity.py
+++ b/python/nav/ipdevpoll/shadows/entity.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 UNINETT
+# Copyright (C) 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/shadows/gwpeers.py
+++ b/python/nav/ipdevpoll/shadows/gwpeers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/shadows/interface.py
+++ b/python/nav/ipdevpoll/shadows/interface.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2012 UNINETT AS
+# Copyright (C) 2009-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/shadows/netbox.py
+++ b/python/nav/ipdevpoll/shadows/netbox.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2012, 2015 UNINETT AS
+# Copyright (C) 2009-2012, 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/shadows/prefix.py
+++ b/python/nav/ipdevpoll/shadows/prefix.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2012, 2016 UNINETT
+# Copyright (C) 2008-2012, 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/shadows/swportblocked.py
+++ b/python/nav/ipdevpoll/shadows/swportblocked.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/signals.py
+++ b/python/nav/ipdevpoll/signals.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010 UNINETT AS
+# Copyright (C) 2010 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/snmp/__init__.py
+++ b/python/nav/ipdevpoll/snmp/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/snmp/common.py
+++ b/python/nav/ipdevpoll/snmp/common.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/snmp/pynetsnmp.py
+++ b/python/nav/ipdevpoll/snmp/pynetsnmp.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011,2012 UNINETT AS
+# Copyright (C) 2011,2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/storage.py
+++ b/python/nav/ipdevpoll/storage.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2012 UNINETT AS
+# Copyright (C) 2009-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/timestamps.py
+++ b/python/nav/ipdevpoll/timestamps.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012-2015 UNINETT AS
+# Copyright (C) 2012-2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/ipdevpoll/utils.py
+++ b/python/nav/ipdevpoll/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009-2012 UNINETT AS
+# Copyright (C) 2009-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/logengine.py
+++ b/python/nav/logengine.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007, 2009-2011 UNINETT AS
+# Copyright (C) 2007, 2009-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/logengine.py
+++ b/python/nav/logengine.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2003, 2004 Norwegian University of Science and Technology
 # Copyright (C) 2007, 2009-2011 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/logs.py
+++ b/python/nav/logs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2006, 2007, 2009, 2011, 2012, 2014, 2017 UNINETT AS
+# Copyright (C) 2006, 2007, 2009, 2011, 2012, 2014, 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/macaddress.py
+++ b/python/nav/macaddress.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2013 (C) UNINETT AS
+# Copyright 2013 (C) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mailin/__init__.py
+++ b/python/nav/mailin/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008,2009 University of Tromsø
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mailin/plugins/whatsup.py
+++ b/python/nav/mailin/plugins/whatsup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008,2009 University of Tromsø
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/maintengine.py
+++ b/python/nav/maintengine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2012-2015 UNINETT AS
+# Copyright (C) 2012-2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/metrics/__init__.py
+++ b/python/nav/metrics/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/metrics/carbon.py
+++ b/python/nav/metrics/carbon.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/metrics/data.py
+++ b/python/nav/metrics/data.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/metrics/errors.py
+++ b/python/nav/metrics/errors.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/metrics/graphs.py
+++ b/python/nav/metrics/graphs.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/metrics/lookup.py
+++ b/python/nav/metrics/lookup.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/metrics/names.py
+++ b/python/nav/metrics/names.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2015 UNINETT
+# Copyright (C) 2013-2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/metrics/templates.py
+++ b/python/nav/metrics/templates.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/metrics/thresholds.py
+++ b/python/nav/metrics/thresholds.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/__init__.py
+++ b/python/nav/mibs/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009 UNINETT AS
+# Copyright (C) 2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/bgp4_mib.py
+++ b/python/nav/mibs/bgp4_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/bgp4_v2_mib_juniper.py
+++ b/python/nav/mibs/bgp4_v2_mib_juniper.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/bridge_mib.py
+++ b/python/nav/mibs/bridge_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009, 2011, 2012, 2017, 2018 UNINETT AS
+# Copyright (C) 2009, 2011, 2012, 2017, 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/cisco_bgp4_mib.py
+++ b/python/nav/mibs/cisco_bgp4_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/cisco_c2900_mib.py
+++ b/python/nav/mibs/cisco_c2900_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/cisco_cdp_mib.py
+++ b/python/nav/mibs/cisco_cdp_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/cisco_entity_fru_control_mib.py
+++ b/python/nav/mibs/cisco_entity_fru_control_mib.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2008 - 2011 (C) UNINETT AS
+# Copyright 2008 - 2011 (C) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/cisco_entity_sensor_mib.py
+++ b/python/nav/mibs/cisco_entity_sensor_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2012 UNINETT AS
+# Copyright (C) 2009-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/cisco_envmon_mib.py
+++ b/python/nav/mibs/cisco_envmon_mib.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008-2011 UNINETT AS
+# Copyright (C) 2008-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/cisco_hsrp_mib.py
+++ b/python/nav/mibs/cisco_hsrp_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/cisco_ietf_ip_mib.py
+++ b/python/nav/mibs/cisco_ietf_ip_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2011 UNINETT AS
+# Copyright (C) 2009-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/cisco_memory_pool_mib.py
+++ b/python/nav/mibs/cisco_memory_pool_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/cisco_power_ethernet_ext_mib.py
+++ b/python/nav/mibs/cisco_power_ethernet_ext_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/cisco_process_mib.py
+++ b/python/nav/mibs/cisco_process_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/cisco_stack_mib.py
+++ b/python/nav/mibs/cisco_stack_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/cisco_vlan_iftable_relationship_mib.py
+++ b/python/nav/mibs/cisco_vlan_iftable_relationship_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/cisco_vlan_membership_mib.py
+++ b/python/nav/mibs/cisco_vlan_membership_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009 UNINETT AS
+# Copyright (C) 2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/cisco_vtp_mib.py
+++ b/python/nav/mibs/cisco_vtp_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009, 2012, 2013, 2016 UNINETT AS
+# Copyright (C) 2009, 2012, 2013, 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/comet.py
+++ b/python/nav/mibs/comet.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/eltek_distributed_mib.py
+++ b/python/nav/mibs/eltek_distributed_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 UNINETT
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/entity_mib.py
+++ b/python/nav/mibs/entity_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2011, 2014 UNINETT AS
+# Copyright (C) 2009-2011, 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/entity_sensor_mib.py
+++ b/python/nav/mibs/entity_sensor_mib.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008-2011 UNINETT AS
+# Copyright (C) 2008-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/esswitch_mib.py
+++ b/python/nav/mibs/esswitch_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/etherlike_mib.py
+++ b/python/nav/mibs/etherlike_mib.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009 UNINETT AS
+# Copyright (C) 2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/extreme_vlan_mib.py
+++ b/python/nav/mibs/extreme_vlan_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/geist_mibv3.py
+++ b/python/nav/mibs/geist_mibv3.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008-20011, 2015 UNINETT AS
+# Copyright (C) 2008-20011, 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/hp_entity_fru_control_mib.py
+++ b/python/nav/mibs/hp_entity_fru_control_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2008 - 2011 (C) UNINETT AS
+# Copyright 2008 - 2011 (C) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/hp_httpmanageable_mib.py
+++ b/python/nav/mibs/hp_httpmanageable_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 UNINETT
+# Copyright (C) 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/hpicf_fan_mib.py
+++ b/python/nav/mibs/hpicf_fan_mib.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-# Copyright 2008 - 2011 (C) UNINETT AS
+# Copyright 2008 - 2011 (C) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/hpicf_powersupply_mib.py
+++ b/python/nav/mibs/hpicf_powersupply_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2008 - 2011, 2014 (C) UNINETT AS
+# Copyright 2008 - 2011, 2014 (C) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/ibm_pdu_mib.py
+++ b/python/nav/mibs/ibm_pdu_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/ieee8023_lag_mib.py
+++ b/python/nav/mibs/ieee8023_lag_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 UNINETT
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/if_mib.py
+++ b/python/nav/mibs/if_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2012 UNINETT AS
+# Copyright (C) 2008-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/ip_forward_mib.py
+++ b/python/nav/mibs/ip_forward_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/ip_mib.py
+++ b/python/nav/mibs/ip_mib.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009-2011 UNINETT AS
+# Copyright (C) 2009-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/ipv6_mib.py
+++ b/python/nav/mibs/ipv6_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2011 UNINETT AS
+# Copyright (C) 2009-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/itw_mib.py
+++ b/python/nav/mibs/itw_mib.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008-2011 UNINETT AS
+# Copyright (C) 2008-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/itw_mibv3.py
+++ b/python/nav/mibs/itw_mibv3.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008-2011 UNINETT AS
+# Copyright (C) 2008-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/juniper_dom_mib.py
+++ b/python/nav/mibs/juniper_dom_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/juniper_mib.py
+++ b/python/nav/mibs/juniper_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/lldp_mib.py
+++ b/python/nav/mibs/lldp_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012, 2016 UNINETT AS
+# Copyright (C) 2012, 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/mg_snmp_ups_mib.py
+++ b/python/nav/mibs/mg_snmp_ups_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2008 - 2011 (C) UNINETT AS
+# Copyright 2008 - 2011 (C) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/mibretriever.py
+++ b/python/nav/mibs/mibretriever.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009-2012, 2014, 2015 UNINETT AS
+# Copyright (C) 2009-2012, 2014, 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/netswitch_mib.py
+++ b/python/nav/mibs/netswitch_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/old_cisco_cpu_mib.py
+++ b/python/nav/mibs/old_cisco_cpu_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/pdu2_mib.py
+++ b/python/nav/mibs/pdu2_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/power_ethernet_mib.py
+++ b/python/nav/mibs/power_ethernet_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/powernet_mib.py
+++ b/python/nav/mibs/powernet_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2014 UNINETT AS
+# Copyright (C) 2008-2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/qbridge_mib.py
+++ b/python/nav/mibs/qbridge_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009, 2011, 2012 UNINETT AS
+# Copyright (C) 2009, 2011, 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/rittal_cmc_iii.py
+++ b/python/nav/mibs/rittal_cmc_iii.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/snmpv2_mib.py
+++ b/python/nav/mibs/snmpv2_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2012, 2015 UNINETT AS
+# Copyright (C) 2009-2012, 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/spagent_mib.py
+++ b/python/nav/mibs/spagent_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/statistics_mib.py
+++ b/python/nav/mibs/statistics_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/ups_mib.py
+++ b/python/nav/mibs/ups_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2008 - 2011, 2014 (C) UNINETT AS
+# Copyright 2008 - 2011, 2014 (C) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/vrrp_mib.py
+++ b/python/nav/mibs/vrrp_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/mibs/xups_mib.py
+++ b/python/nav/mibs/xups_mib.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2008 - 2011 (C) UNINETT AS
+# Copyright 2008 - 2011 (C) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/models/__init__.py
+++ b/python/nav/models/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007, 2016 UNINETT AS
+# Copyright (C) 2007, 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/models/arnold.py
+++ b/python/nav/models/arnold.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 (SD -311000) UNINETT AS
+# Copyright (C) 2012 (SD -311000) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/models/cabling.py
+++ b/python/nav/models/cabling.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007-2011 UNINETT AS
+# Copyright (C) 2007-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/models/event.py
+++ b/python/nav/models/event.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007-2015 UNINETT AS
+# Copyright (C) 2007-2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/models/fields.py
+++ b/python/nav/models/fields.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007-2011 UNINETT AS
+# Copyright (C) 2007-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/models/logger.py
+++ b/python/nav/models/logger.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2011 UNINETT AS
+# Copyright (C) 2007-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007-2015 UNINETT AS
+# Copyright (C) 2007-2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/models/msgmaint.py
+++ b/python/nav/models/msgmaint.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007, 2011 UNINETT AS
+# Copyright (C) 2007, 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007-2011 UNINETT AS
+# Copyright (C) 2007-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/models/rack.py
+++ b/python/nav/models/rack.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007-2017 UNINETT AS
+# Copyright (C) 2007-2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/models/service.py
+++ b/python/nav/models/service.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007, 2011-2015 UNINETT AS
+# Copyright (C) 2007, 2011-2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/models/thresholds.py
+++ b/python/nav/models/thresholds.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/natsort.py
+++ b/python/nav/natsort.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007 UNINETT AS
+# Copyright (C) 2007 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/netbiostracker/config.py
+++ b/python/nav/netbiostracker/config.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/netbiostracker/tracker.py
+++ b/python/nav/netbiostracker/tracker.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2010 University of Tromsø
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/netmap/metadata.py
+++ b/python/nav/netmap/metadata.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012-2015 UNINETT AS
+# Copyright (C) 2012-2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/netmap/stubs/__init__.py
+++ b/python/nav/netmap/stubs/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/netmap/topology.py
+++ b/python/nav/netmap/topology.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/netmap/traffic.py
+++ b/python/nav/netmap/traffic.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012, 2013 UNINETT AS
+# Copyright (C) 2012, 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/oidparsers.py
+++ b/python/nav/oidparsers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 UNINETT
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/oids.py
+++ b/python/nav/oids.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/pgdump.py
+++ b/python/nav/pgdump.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/pgsync.py
+++ b/python/nav/pgsync.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2008, 2011-2013 UNINETT AS
+# Copyright (C) 2008, 2011-2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/portadmin/snmputils.py
+++ b/python/nav/portadmin/snmputils.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2010 Norwegian University of Science and Technology
 # Copyright (C) 2011-2015 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/portadmin/snmputils.py
+++ b/python/nav/portadmin/snmputils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2015 UNINETT AS
+# Copyright (C) 2011-2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/pwhash.py
+++ b/python/nav/pwhash.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/pwhash.py
+++ b/python/nav/pwhash.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2005 Norwegian University of Science and Technology
 # Copyright (C) 2016 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/report/IPtools.py
+++ b/python/nav/report/IPtools.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2011 UNINETT AS
+# Copyright (C) 2007-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/report/IPtree.py
+++ b/python/nav/report/IPtree.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007-2008, 2011 UNINETT AS
+# Copyright (C) 2007-2008, 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/report/__init__.py
+++ b/python/nav/report/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008 UNINETT AS
+# Copyright (C) 2008 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/report/dbresult.py
+++ b/python/nav/report/dbresult.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008 UNINETT AS
+# Copyright (C) 2008 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/report/dbresult.py
+++ b/python/nav/report/dbresult.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2003-2004 Norwegian University of Science and Technology
 # Copyright (C) 2008 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/report/generator.py
+++ b/python/nav/report/generator.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2011 UNINETT AS
+# Copyright (C) 2008-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/report/generator.py
+++ b/python/nav/report/generator.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2003-2005 Norwegian University of Science and Technology
 # Copyright (C) 2008-2011 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/report/matrix.py
+++ b/python/nav/report/matrix.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/report/matrix.py
+++ b/python/nav/report/matrix.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2003-2004 Norwegian University of Science and Technology
 # Copyright (C) 2012 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/report/matrixIPv4.py
+++ b/python/nav/report/matrixIPv4.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2008 UNINETT AS
+# Copyright (C) 2007-2008 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/report/matrixIPv6.py
+++ b/python/nav/report/matrixIPv6.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2008 UNINETT AS
+# Copyright (C) 2007-2008 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/report/metaIP.py
+++ b/python/nav/report/metaIP.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2012 UNINETT AS
+# Copyright (C) 2007-2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/report/report.py
+++ b/python/nav/report/report.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008-2011 UNINETT
+# Copyright (C) 2008-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/report/report.py
+++ b/python/nav/report/report.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2003-2005 Norwegian University of Science and Technology
 # Copyright (C) 2008-2011 UNINETT
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/smsd/__init__.py
+++ b/python/nav/smsd/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2006 UNINETT AS
+# Copyright (C) 2006 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/smsd/boostdispatcher.py
+++ b/python/nav/smsd/boostdispatcher.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2006 UNINETT AS
+# Copyright (C) 2006 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/smsd/debugdispatcher.py
+++ b/python/nav/smsd/debugdispatcher.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009 UNINETT AS
+# Copyright (C) 2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/smsd/dispatcher.py
+++ b/python/nav/smsd/dispatcher.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2006-2009 UNINETT AS
+# Copyright (C) 2006-2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/smsd/gammudispatcher.py
+++ b/python/nav/smsd/gammudispatcher.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006, 2016 UNINETT AS
+# Copyright (C) 2006, 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/smsd/navdbqueue.py
+++ b/python/nav/smsd/navdbqueue.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006, 2013 UNINETT AS
+# Copyright (C) 2006, 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/smsd/uninettmaildispatcher.py
+++ b/python/nav/smsd/uninettmaildispatcher.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006, 2018 UNINETT AS
+# Copyright (C) 2006, 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #
@@ -13,9 +13,9 @@
 # details.  You should have received a copy of the GNU General Public License
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
-"""A dispatcher for UNINETT's mail-to-SMS gateway.
+"""A dispatcher for Uninett's mail-to-SMS gateway.
 
-This dispatcher sends SMS messages via UNINETT's mail-to-SMS gateway. The
+This dispatcher sends SMS messages via Uninett's mail-to-SMS gateway. The
 gateway accepts e-mails with the recipient's phone number in the subject and
 the text message in the body. The mail must be sent from a uninett.no host,
 so this is of little use for others, unless they have a similar interface.
@@ -31,7 +31,7 @@ from nav.smsd.dispatcher import Dispatcher, DispatcherError
 
 
 class UninettMailDispatcher(Dispatcher):
-    """The smsd dispatcher for UNINETT's mail-to-SMS gateway."""
+    """The smsd dispatcher for Uninett's mail-to-SMS gateway."""
 
     def __init__(self, config):
         """Constructor"""
@@ -45,7 +45,7 @@ class UninettMailDispatcher(Dispatcher):
 
     def sendsms(self, phone, msgs):
         """
-        Sends SMS using UNINETT's mail-to-SMS gateway.
+        Sends SMS using Uninett's mail-to-SMS gateway.
 
         :param phone: The phone number the messages are to be dispatched to.
         :param msgs: A list of message strings, ordered by descending severity.

--- a/python/nav/snmptrapd/agent.py
+++ b/python/nav/snmptrapd/agent.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010, 2013 UNINETT AS
+# Copyright (C) 2010, 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/snmptrapd/agent_pynetsnmp.py
+++ b/python/nav/snmptrapd/agent_pynetsnmp.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/snmptrapd/handlers/airespace.py
+++ b/python/nav/snmptrapd/handlers/airespace.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2007, 2010 (C) Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/snmptrapd/handlers/handlertemplate.py
+++ b/python/nav/snmptrapd/handlers/handlertemplate.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2007 (C) Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/snmptrapd/handlers/linkupdown.py
+++ b/python/nav/snmptrapd/handlers/linkupdown.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011 (C) UNINETT AS
+# Copyright 2011 (C) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/snmptrapd/handlers/linkupdown.py
+++ b/python/nav/snmptrapd/handlers/linkupdown.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2007, 2010 (C) Norwegian University of Science and Technology
 # Copyright 2011 (C) UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/snmptrapd/handlers/ups.py
+++ b/python/nav/snmptrapd/handlers/ups.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011 (C) UNINETT AS
+# Copyright 2011 (C) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/snmptrapd/handlers/weathergoose.py
+++ b/python/nav/snmptrapd/handlers/weathergoose.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011, 2015 UNINETT AS
+# Copyright (C) 2011, 2015 Uninett AS
 # Copyright (C) 2011 Narvik University College
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/snmptrapd/handlers/weathergoose.py
+++ b/python/nav/snmptrapd/handlers/weathergoose.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2009 Norwegian University of Science and Technology
 # Copyright (C) 2011, 2015 UNINETT AS
 # Copyright (C) 2011 Narvik University College
 #

--- a/python/nav/snmptrapd/handlers/weathergoose.py
+++ b/python/nav/snmptrapd/handlers/weathergoose.py
@@ -1,6 +1,5 @@
 #
 # Copyright (C) 2011, 2015 Uninett AS
-# Copyright (C) 2011 Narvik University College
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/snmptrapd/plugin.py
+++ b/python/nav/snmptrapd/plugin.py
@@ -1,6 +1,5 @@
 #
 # Copyright 2013 (C) UNINETT
-# Copyright 2007 (C) Norwegian University of Science and Technology
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/snmptrapd/plugin.py
+++ b/python/nav/snmptrapd/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2013 (C) UNINETT
+# Copyright 2013 (C) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/snmptrapd/trap.py
+++ b/python/nav/snmptrapd/trap.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2007 (C) Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/startstop.py
+++ b/python/nav/startstop.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006, 2010, 2016 UNINETT AS
+# Copyright (C) 2006, 2010, 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/startstop.py
+++ b/python/nav/startstop.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2003, 2004 Norwegian University of Science and Technology
 # Copyright (C) 2006, 2010, 2016 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/statemon/RunQueue.py
+++ b/python/nav/statemon/RunQueue.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2003 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV)
 #

--- a/python/nav/statemon/__init__.py
+++ b/python/nav/statemon/__init__.py
@@ -1,21 +1,3 @@
-#
-# Copyright 2004 Norwegian University of Science and Technology
-#
-# This file is part of Network Administration Visualized (NAV)
-#
-# NAV is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# NAV is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with NAV; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
 It just needs to be here :o)
 """

--- a/python/nav/statemon/abstractchecker.py
+++ b/python/nav/statemon/abstractchecker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2003,2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/DcChecker.py
+++ b/python/nav/statemon/checker/DcChecker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2003,2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/DhcpChecker.py
+++ b/python/nav/statemon/checker/DhcpChecker.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2010 University of Tromsø
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/DnsChecker.py
+++ b/python/nav/statemon/checker/DnsChecker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2003,2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/DummyChecker.py
+++ b/python/nav/statemon/checker/DummyChecker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2003, 2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/FtpChecker.py
+++ b/python/nav/statemon/checker/FtpChecker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2003,2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/HttpChecker.py
+++ b/python/nav/statemon/checker/HttpChecker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2003,2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/HttpsChecker.py
+++ b/python/nav/statemon/checker/HttpsChecker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2003,2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/ImapChecker.py
+++ b/python/nav/statemon/checker/ImapChecker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2003,2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/ImapsChecker.py
+++ b/python/nav/statemon/checker/ImapsChecker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2003,2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/LdapChecker.py
+++ b/python/nav/statemon/checker/LdapChecker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/LdapChecker.py
+++ b/python/nav/statemon/checker/LdapChecker.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2003,2004 Norwegian University of Science and Technology
 # Copyright (C) 2013 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/statemon/checker/MysqlChecker.py
+++ b/python/nav/statemon/checker/MysqlChecker.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007 University of Tromsø
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/OracleChecker.py
+++ b/python/nav/statemon/checker/OracleChecker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2003,2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/Pop3Checker.py
+++ b/python/nav/statemon/checker/Pop3Checker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2003, 2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/PortChecker.py
+++ b/python/nav/statemon/checker/PortChecker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2003,2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/PostgresqlChecker.py
+++ b/python/nav/statemon/checker/PostgresqlChecker.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 University of Tromsø
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/RadiusChecker.py
+++ b/python/nav/statemon/checker/RadiusChecker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2004,2005 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/RpcChecker.py
+++ b/python/nav/statemon/checker/RpcChecker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2003,2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/SmbChecker.py
+++ b/python/nav/statemon/checker/SmbChecker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2003,2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/SmtpChecker.py
+++ b/python/nav/statemon/checker/SmtpChecker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2003,2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checker/SshChecker.py
+++ b/python/nav/statemon/checker/SshChecker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2003,2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/checkermap.py
+++ b/python/nav/statemon/checkermap.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2002, 2005 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV)
 #

--- a/python/nav/statemon/circbuf.py
+++ b/python/nav/statemon/circbuf.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2003, 2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV)
 #

--- a/python/nav/statemon/config.py
+++ b/python/nav/statemon/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2003, 2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV)
 #

--- a/python/nav/statemon/db.py
+++ b/python/nav/statemon/db.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010, 2012 UNINETT AS
+# Copyright (C) 2010, 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/db.py
+++ b/python/nav/statemon/db.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2002 Norwegian University of Science and Technology
 # Copyright (C) 2010, 2012 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/statemon/event.py
+++ b/python/nav/statemon/event.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2002 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV)
 #

--- a/python/nav/statemon/icmppacket.py
+++ b/python/nav/statemon/icmppacket.py
@@ -1,6 +1,6 @@
 #
 # Copyright (C) 23. Feb. 2004 - Lars Strand <lars strand at gnist org>
-# Copyright (C) 2011, 2012 UNINETT AS
+# Copyright (C) 2011, 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/megaping.py
+++ b/python/nav/statemon/megaping.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011, 2012 UNINETT AS
+# Copyright (C) 2011, 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/statemon/megaping.py
+++ b/python/nav/statemon/megaping.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2002-2004 Norwegian University of Science and Technology
 # Copyright (C) 2011, 2012 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/statemon/netbox.py
+++ b/python/nav/statemon/netbox.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2003, 2004 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV)
 #

--- a/python/nav/statemon/statistics.py
+++ b/python/nav/statemon/statistics.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/tableformat.py
+++ b/python/nav/tableformat.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010 UNINETT AS
+# Copyright (C) 2010 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/tests/cases.py
+++ b/python/nav/tests/cases.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT AS
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/thresholdmon.py
+++ b/python/nav/thresholdmon.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/topology/analyze.py
+++ b/python/nav/topology/analyze.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011, 2012, 2015, 2017, 2018 UNINETT AS
+# Copyright (C) 2011, 2012, 2015, 2017, 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/topology/detector.py
+++ b/python/nav/topology/detector.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011, 2012 UNINETT AS
+# Copyright (C) 2011, 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/topology/diff.py
+++ b/python/nav/topology/diff.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011, 2012 UNINETT AS
+# Copyright (C) 2011, 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/topology/layer2.py
+++ b/python/nav/topology/layer2.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/topology/vlan.py
+++ b/python/nav/topology/vlan.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2015, 2017, 2018 UNINETT AS
+# Copyright (C) 2011-2015, 2017, 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/toposort.py
+++ b/python/nav/toposort.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009 UNINETT AS
+# Copyright (C) 2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/util.py
+++ b/python/nav/util.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007, 2011-2013 UNINETT AS
+# Copyright (C) 2007, 2011-2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/util.py
+++ b/python/nav/util.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2005 Norwegian University of Science and Technology
 # Copyright (C) 2007, 2011-2013 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/watchdog/tests.py
+++ b/python/nav/watchdog/tests.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/watchdog/util.py
+++ b/python/nav/watchdog/util.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/__init__.py
+++ b/python/nav/web/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006, 2007, 2009, 2011, 2013 UNINETT AS
+# Copyright (C) 2006, 2007, 2009, 2011, 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/__init__.py
+++ b/python/nav/web/__init__.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2003, 2004 Norwegian University of Science and Technology
 # Copyright (C) 2006, 2007, 2009, 2011, 2013 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/web/ajax/urls.py
+++ b/python/nav/web/ajax/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/ajax/views.py
+++ b/python/nav/web/ajax/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/alertprofiles/decorators.py
+++ b/python/nav/web/alertprofiles/decorators.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/alertprofiles/forms.py
+++ b/python/nav/web/alertprofiles/forms.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007, 2008, 2011 UNINETT AS
+# Copyright (C) 2007, 2008, 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/alertprofiles/shortcuts.py
+++ b/python/nav/web/alertprofiles/shortcuts.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007, 2008, 2011 UNINETT AS
+# Copyright (C) 2007, 2008, 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/alertprofiles/urls.py
+++ b/python/nav/web/alertprofiles/urls.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007, 2008, 2011 UNINETT AS
+# Copyright (C) 2007, 2008, 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/alertprofiles/utils.py
+++ b/python/nav/web/alertprofiles/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007, 2008, 2011 UNINETT AS
+# Copyright (C) 2007, 2008, 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/alertprofiles/views.py
+++ b/python/nav/web/alertprofiles/views.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007, 2008, 2011 UNINETT AS
+# Copyright (C) 2007, 2008, 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/api/urls.py
+++ b/python/nav/web/api/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/api/v1/alert_serializers.py
+++ b/python/nav/web/api/v1/alert_serializers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 UNINETT AS
+# Copyright (C) 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/api/v1/auth.py
+++ b/python/nav/web/api/v1/auth.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/api/v1/filter_backends.py
+++ b/python/nav/web/api/v1/filter_backends.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 UNINETT AS
+# Copyright (C) 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/api/v1/helpers/prefix_collector.py
+++ b/python/nav/web/api/v1/helpers/prefix_collector.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/api/v1/serializers.py
+++ b/python/nav/web/api/v1/serializers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/api/v1/urls.py
+++ b/python/nav/web/api/v1/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/arnold/forms.py
+++ b/python/nav/web/arnold/forms.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 (SD -311000) UNINETT AS
+# Copyright (C) 2012 (SD -311000) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/arnold/urls.py
+++ b/python/nav/web/arnold/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 (SD -311000) UNINETT AS
+# Copyright (C) 2012 (SD -311000) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/arnold/views.py
+++ b/python/nav/web/arnold/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 (SD -311000) UNINETT AS
+# Copyright (C) 2012 (SD -311000) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/auth.py
+++ b/python/nav/web/auth.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2003, 2004 Norwegian University of Science and Technology
 # Copyright (C) 2010, 2011 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/web/auth.py
+++ b/python/nav/web/auth.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010, 2011 UNINETT AS
+# Copyright (C) 2010, 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/business/reportengine.py
+++ b/python/nav/web/business/reportengine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/crispyforms.py
+++ b/python/nav/web/crispyforms.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/devicehistory/forms.py
+++ b/python/nav/web/devicehistory/forms.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/devicehistory/urls.py
+++ b/python/nav/web/devicehistory/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2009 UNINETT AS
+# Copyright (C) 2008-2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/devicehistory/utils/__init__.py
+++ b/python/nav/web/devicehistory/utils/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008-2009 UNINETT AS
+# Copyright (C) 2008-2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/devicehistory/utils/error.py
+++ b/python/nav/web/devicehistory/utils/error.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008-2009 UNINETT AS
+# Copyright (C) 2008-2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/devicehistory/utils/history.py
+++ b/python/nav/web/devicehistory/utils/history.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2011 UNINETT AS
+# Copyright (C) 2008-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/devicehistory/views.py
+++ b/python/nav/web/devicehistory/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2013 UNINETT AS
+# Copyright (C) 2008-2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/geomap/conf.py
+++ b/python/nav/web/geomap/conf.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009, 2010 UNINETT AS
+# Copyright (C) 2009, 2010 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/geomap/coordinates.py
+++ b/python/nav/web/geomap/coordinates.py
@@ -1,6 +1,6 @@
 #
 # Copyright (C) 2009 Russ Nelson
-# Copyright (C) 2009, 2010 UNINETT AS
+# Copyright (C) 2009, 2010 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/geomap/db.py
+++ b/python/nav/web/geomap/db.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009, 2010, 2013-2015 UNINETT AS
+# Copyright (C) 2009, 2010, 2013-2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/geomap/features.py
+++ b/python/nav/web/geomap/features.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009, 2010 UNINETT AS
+# Copyright (C) 2009, 2010 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/geomap/graph.py
+++ b/python/nav/web/geomap/graph.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009, 2010, 2013, 2015 UNINETT AS
+# Copyright (C) 2009, 2010, 2013, 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/geomap/output_formats.py
+++ b/python/nav/web/geomap/output_formats.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009, 2010 UNINETT AS
+# Copyright (C) 2009, 2010 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/geomap/urls.py
+++ b/python/nav/web/geomap/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009, 2010 UNINETT AS
+# Copyright (C) 2009, 2010 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/geomap/utils.py
+++ b/python/nav/web/geomap/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009, 2010, 2013, 2015 UNINETT AS
+# Copyright (C) 2009, 2010, 2013, 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/geomap/views.py
+++ b/python/nav/web/geomap/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009, 2010, 2014, 2015 UNINETT AS
+# Copyright (C) 2009, 2010, 2014, 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/graphite/urls.py
+++ b/python/nav/web/graphite/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/graphite/views.py
+++ b/python/nav/web/graphite/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/info/forms.py
+++ b/python/nav/web/info/forms.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/info/images/urls.py
+++ b/python/nav/web/info/images/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT AS
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/info/images/utils.py
+++ b/python/nav/web/info/images/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/info/location/urls.py
+++ b/python/nav/web/info/location/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/info/location/views.py
+++ b/python/nav/web/info/location/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT AS
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/info/netboxgroup/urls.py
+++ b/python/nav/web/info/netboxgroup/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/info/netboxgroup/views.py
+++ b/python/nav/web/info/netboxgroup/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2015 UNINETT AS
+# Copyright (C) 2013-2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/info/prefix/urls.py
+++ b/python/nav/web/info/prefix/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/info/prefix/views.py
+++ b/python/nav/web/info/prefix/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/info/room/urls.py
+++ b/python/nav/web/info/room/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/info/room/views.py
+++ b/python/nav/web/info/room/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012-2018 UNINETT AS
+# Copyright (C) 2012-2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/info/searchproviders.py
+++ b/python/nav/web/info/searchproviders.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 (SD -311000) UNINETT AS
+# Copyright (C) 2012 (SD -311000) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/info/urls.py
+++ b/python/nav/web/info/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/info/views.py
+++ b/python/nav/web/info/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 (SD -311000) UNINETT AS
+# Copyright (C) 2012 (SD -311000) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/info/vlan/urls.py
+++ b/python/nav/web/info/vlan/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/info/vlan/views.py
+++ b/python/nav/web/info/vlan/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/ipam/api.py
+++ b/python/nav/web/ipam/api.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/ipam/prefix_tree.py
+++ b/python/nav/web/ipam/prefix_tree.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/ipam/urls.py
+++ b/python/nav/web/ipam/urls.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/ipam/util.py
+++ b/python/nav/web/ipam/util.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/ipam/views.py
+++ b/python/nav/web/ipam/views.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/ipdevinfo/context_processors.py
+++ b/python/nav/web/ipdevinfo/context_processors.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007-2008 UNINETT AS
+# Copyright (C) 2007-2008 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/ipdevinfo/forms.py
+++ b/python/nav/web/ipdevinfo/forms.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007-2008 UNINETT AS
+# Copyright (C) 2007-2008 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/ipdevinfo/host_information.py
+++ b/python/nav/web/ipdevinfo/host_information.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/ipdevinfo/urls.py
+++ b/python/nav/web/ipdevinfo/urls.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2007-2011 UNINETT AS
+# Copyright (C) 2007-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/ipdevinfo/utils.py
+++ b/python/nav/web/ipdevinfo/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008, 2011 UNINETT AS
+# Copyright (C) 2008, 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/ipdevinfo/views.py
+++ b/python/nav/web/ipdevinfo/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2008 UNINETT AS
+# Copyright (C) 2007-2008 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/l2trace/__init__.py
+++ b/python/nav/web/l2trace/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007, 2010, 2011, 2014 UNINETT AS
+# Copyright (C) 2007, 2010, 2011, 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/l2trace/__init__.py
+++ b/python/nav/web/l2trace/__init__.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2003, 2004 Norwegian University of Science and Technology
 # Copyright (C) 2007, 2010, 2011, 2014 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/web/l2trace/forms.py
+++ b/python/nav/web/l2trace/forms.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013, 2014 UNINETT AS
+# Copyright (C) 2013, 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/l2trace/urls.py
+++ b/python/nav/web/l2trace/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/l2trace/views.py
+++ b/python/nav/web/l2trace/views.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2003, 2004 Norwegian University of Science and Technology
 # Copyright (C) 2007, 2010, 2011, 2013, 2014 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/web/l2trace/views.py
+++ b/python/nav/web/l2trace/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007, 2010, 2011, 2013, 2014 UNINETT AS
+# Copyright (C) 2007, 2010, 2011, 2013, 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/ldapauth.py
+++ b/python/nav/web/ldapauth.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2004 Norwegian University of Science and Technology
 # Copyright (C) 2007, 2010, 2011, 2014, 2015, 2017, 2018 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/web/ldapauth.py
+++ b/python/nav/web/ldapauth.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007, 2010, 2011, 2014, 2015, 2017, 2018 UNINETT AS
+# Copyright (C) 2007, 2010, 2011, 2014, 2015, 2017, 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/machinetracker/forms.py
+++ b/python/nav/web/machinetracker/forms.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2013 UNINETT AS
+# Copyright (C) 2009-2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/machinetracker/urls.py
+++ b/python/nav/web/machinetracker/urls.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009-2011 UNINETT AS
+# Copyright (C) 2009-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/machinetracker/utils.py
+++ b/python/nav/web/machinetracker/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2013 UNINETT AS
+# Copyright (C) 2009-2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/machinetracker/views.py
+++ b/python/nav/web/machinetracker/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009, 2011-2013 UNINETT AS
+# Copyright (C) 2009, 2011-2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/macwatch/forms.py
+++ b/python/nav/web/macwatch/forms.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/macwatch/models.py
+++ b/python/nav/web/macwatch/models.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/macwatch/urls.py
+++ b/python/nav/web/macwatch/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/macwatch/utils.py
+++ b/python/nav/web/macwatch/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/macwatch/views.py
+++ b/python/nav/web/macwatch/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/maintenance/forms.py
+++ b/python/nav/web/maintenance/forms.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/maintenance/urls.py
+++ b/python/nav/web/maintenance/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/maintenance/utils.py
+++ b/python/nav/web/maintenance/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/maintenance/views.py
+++ b/python/nav/web/maintenance/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/message.py
+++ b/python/nav/web/message.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008, 2013 UNINETT AS
+# Copyright (C) 2008, 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/messages/__init__.py
+++ b/python/nav/web/messages/__init__.py
@@ -1,33 +1,3 @@
-#! /usr/bin/env python
-# -*- coding: utf-8 -*-
-#
-# Copyright 2006-2008 UNINETT AS
-#
-# This file is part of Network Administration Visualized (NAV)
-#
-# NAV is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# NAV is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with NAV; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-#
-#
-# Author: Stein Magnus Jodal <stein.magnus.jodal@uninett.no>
-#
-
 """
 Package placeholder. If you remove it, the package won't work.
 """
-
-__copyright__ = "Copyright 2006-2008 UNINETT AS"
-__license__ = "GPL"
-__author__ = "Stein Magnus Jodal (stein.magnus.jodal@uninett.no)"
-__id__ = "$Id: __init__.py 3445 2006-06-15 08:32:39Z jodal $"

--- a/python/nav/web/messages/feeds.py
+++ b/python/nav/web/messages/feeds.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/messages/forms.py
+++ b/python/nav/web/messages/forms.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/messages/urls.py
+++ b/python/nav/web/messages/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/messages/views.py
+++ b/python/nav/web/messages/views.py
@@ -1,4 +1,4 @@
-#Copyright (C) 2006-2008, 2013 UNINETT AS
+#Copyright (C) 2006-2008, 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/modpython.py
+++ b/python/nav/web/modpython.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/__init__.py
+++ b/python/nav/web/navlets/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/alert.py
+++ b/python/nav/web/navlets/alert.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/env_rack.py
+++ b/python/nav/web/navlets/env_rack.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/error.py
+++ b/python/nav/web/navlets/error.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/feedreader.py
+++ b/python/nav/web/navlets/feedreader.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/gettingstarted.py
+++ b/python/nav/web/navlets/gettingstarted.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/graph.py
+++ b/python/nav/web/navlets/graph.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/linklist.py
+++ b/python/nav/web/navlets/linklist.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/locationstatus.py
+++ b/python/nav/web/navlets/locationstatus.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/machinetracker.py
+++ b/python/nav/web/navlets/machinetracker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/messages.py
+++ b/python/nav/web/navlets/messages.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/navblog.py
+++ b/python/nav/web/navlets/navblog.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/pdu.py
+++ b/python/nav/web/navlets/pdu.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/portadmin.py
+++ b/python/nav/web/navlets/portadmin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/report.py
+++ b/python/nav/web/navlets/report.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 UNINETT AS
+# Copyright (C) 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/room_map.py
+++ b/python/nav/web/navlets/room_map.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/roomstatus.py
+++ b/python/nav/web/navlets/roomstatus.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/sensor.py
+++ b/python/nav/web/navlets/sensor.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 UNINETT AS
+# Copyright (C) 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/status2.py
+++ b/python/nav/web/navlets/status2.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/ups.py
+++ b/python/nav/web/navlets/ups.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 UNINETT AS
+# Copyright (C) 2016 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/urls.py
+++ b/python/nav/web/navlets/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/vlangraph.py
+++ b/python/nav/web/navlets/vlangraph.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/watchdog.py
+++ b/python/nav/web/navlets/watchdog.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/navlets/welcome.py
+++ b/python/nav/web/navlets/welcome.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/neighbors/views.py
+++ b/python/nav/web/neighbors/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 UNINETT AS
+# Copyright (C) 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/netmap/__init__.py
+++ b/python/nav/web/netmap/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2007 UNINETT AS
+# Copyright 2007 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV)
 #

--- a/python/nav/web/netmap/cache.py
+++ b/python/nav/web/netmap/cache.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 UNINETT AS
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/netmap/common.py
+++ b/python/nav/web/netmap/common.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/netmap/graph.py
+++ b/python/nav/web/netmap/graph.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007, 2010, 2011, 2014 UNINETT AS
+# Copyright (C) 2007, 2010, 2011, 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/netmap/mixins.py
+++ b/python/nav/web/netmap/mixins.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/netmap/serializers.py
+++ b/python/nav/web/netmap/serializers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/netmap/urls.py
+++ b/python/nav/web/netmap/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/netmap/views.py
+++ b/python/nav/web/netmap/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007, 2010, 2011, 2014 UNINETT AS
+# Copyright (C) 2007, 2010, 2011, 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/networkexplorer/search.py
+++ b/python/nav/web/networkexplorer/search.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2008 UNINETT AS
+# Copyright (C) 2007-2008 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/networkexplorer/urls.py
+++ b/python/nav/web/networkexplorer/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2008 UNINETT AS
+# Copyright (C) 2007-2008 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/networkexplorer/views.py
+++ b/python/nav/web/networkexplorer/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2008 UNINETT AS
+# Copyright (C) 2007-2008 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/portadmin/forms.py
+++ b/python/nav/web/portadmin/forms.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/portadmin/urls.py
+++ b/python/nav/web/portadmin/urls.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2010 Norwegian University of Science and Technology
 # Copyright (C) 2011, 2013-2015 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/web/portadmin/urls.py
+++ b/python/nav/web/portadmin/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011, 2013-2015 UNINETT AS
+# Copyright (C) 2011, 2013-2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/portadmin/utils.py
+++ b/python/nav/web/portadmin/utils.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2010 Norwegian University of Science and Technology
 # Copyright (C) 2011-2015 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/web/portadmin/utils.py
+++ b/python/nav/web/portadmin/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2015 UNINETT AS
+# Copyright (C) 2011-2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2010 Norwegian University of Science and Technology
 # Copyright (C) 2011-2015 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2015 UNINETT AS
+# Copyright (C) 2011-2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/preferences.py
+++ b/python/nav/web/preferences.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2003 Norwegian University of Science and Technology
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/quickselect.py
+++ b/python/nav/web/quickselect.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008 UNINETT AS
+# Copyright (C) 2008 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/radius/forms.py
+++ b/python/nav/web/radius/forms.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/radius/radius_config.py
+++ b/python/nav/web/radius/radius_config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2008 University of Tromsø
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV)
 #

--- a/python/nav/web/radius/radius_config.py
+++ b/python/nav/web/radius/radius_config.py
@@ -19,9 +19,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 #
-# Authors: Roger Kristiansen <roger.kristiansen@gmail.com>
-#
-
 
 # Enable reloading of imported modules
 DEBUG = 1

--- a/python/nav/web/radius/radiuslib.py
+++ b/python/nav/web/radius/radiuslib.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008-2010, 2012 University of Tromsø
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV)
 #

--- a/python/nav/web/radius/views.py
+++ b/python/nav/web/radius/views.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008 University of Tromsø
+# Copyright (C) 2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/report/__init__.py
+++ b/python/nav/web/report/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008 UNINETT AS
+# Copyright (C) 2008 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/report/urls.py
+++ b/python/nav/web/report/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012-2018 UNINETT AS
+# Copyright (C) 2012-2018 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/report/views.py
+++ b/python/nav/web/report/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2013 UNINETT AS
+# Copyright (C) 2008-2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/report/views.py
+++ b/python/nav/web/report/views.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2003-2005 Norwegian University of Science and Technology
 # Copyright (C) 2008-2013 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/web/seeddb/__init__.py
+++ b/python/nav/web/seeddb/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/constants.py
+++ b/python/nav/web/seeddb/constants.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/forms/__init__.py
+++ b/python/nav/web/seeddb/forms/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-#
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/forms/bulk.py
+++ b/python/nav/web/seeddb/forms/bulk.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/page/__init__.py
+++ b/python/nav/web/seeddb/page/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/page/cabling.py
+++ b/python/nav/web/seeddb/page/cabling.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/page/location.py
+++ b/python/nav/web/seeddb/page/location.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/page/netbox/__init__.py
+++ b/python/nav/web/seeddb/page/netbox/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/page/netbox/edit.py
+++ b/python/nav/web/seeddb/page/netbox/edit.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011, 2012 UNINETT AS
+# Copyright (C) 2011, 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/page/netbox/forms.py
+++ b/python/nav/web/seeddb/page/netbox/forms.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011, 2012 UNINETT AS
+# Copyright (C) 2011, 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/page/netboxgroup.py
+++ b/python/nav/web/seeddb/page/netboxgroup.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #
@@ -16,7 +16,7 @@
 """Module comment"""
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/page/netboxtype.py
+++ b/python/nav/web/seeddb/page/netboxtype.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/page/organization.py
+++ b/python/nav/web/seeddb/page/organization.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/page/patch/__init__.py
+++ b/python/nav/web/seeddb/page/patch/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/page/prefix.py
+++ b/python/nav/web/seeddb/page/prefix.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/page/room.py
+++ b/python/nav/web/seeddb/page/room.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/page/service/__init__.py
+++ b/python/nav/web/seeddb/page/service/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/page/service/edit.py
+++ b/python/nav/web/seeddb/page/service/edit.py
@@ -1,6 +1,6 @@
 """Forms and view functions for editing services in SeedDB"""
 #
-# Copyright (C) 2011, 2013-2015 UNINETT AS
+# Copyright (C) 2011, 2013-2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/page/usage.py
+++ b/python/nav/web/seeddb/page/usage.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/page/vendor.py
+++ b/python/nav/web/seeddb/page/vendor.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/page/vlan.py
+++ b/python/nav/web/seeddb/page/vlan.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/urls.py
+++ b/python/nav/web/seeddb/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/utils/bulk.py
+++ b/python/nav/web/seeddb/utils/bulk.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/utils/delete.py
+++ b/python/nav/web/seeddb/utils/delete.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011, 2012 UNINETT AS
+# Copyright (C) 2011, 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/utils/edit.py
+++ b/python/nav/web/seeddb/utils/edit.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/utils/list.py
+++ b/python/nav/web/seeddb/utils/list.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/seeddb/utils/move.py
+++ b/python/nav/web/seeddb/utils/move.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/servicecheckers.py
+++ b/python/nav/web/servicecheckers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/servicecheckers.py
+++ b/python/nav/web/servicecheckers.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2003, 2004 Norwegian University of Science and Technology
 # Copyright (C) 2011 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/python/nav/web/sortedstats/__init__.py
+++ b/python/nav/web/sortedstats/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/sortedstats/forms.py
+++ b/python/nav/web/sortedstats/forms.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/sortedstats/statmodules.py
+++ b/python/nav/web/sortedstats/statmodules.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/sortedstats/urls.py
+++ b/python/nav/web/sortedstats/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/sortedstats/views.py
+++ b/python/nav/web/sortedstats/views.py
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2006 Norwegian University of Science and Technology
 # Copyright (C) 2011 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV)

--- a/python/nav/web/sortedstats/views.py
+++ b/python/nav/web/sortedstats/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV)
 #

--- a/python/nav/web/status2/forms.py
+++ b/python/nav/web/status2/forms.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014, 2015 UNINETT AS
+# Copyright (C) 2014, 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/status2/urls.py
+++ b/python/nav/web/status2/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/status2/views.py
+++ b/python/nav/web/status2/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014, 2015 UNINETT
+# Copyright (C) 2014, 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/styleguide.py
+++ b/python/nav/web/styleguide.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/syslogger/urls.py
+++ b/python/nav/web/syslogger/urls.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/syslogger/views.py
+++ b/python/nav/web/syslogger/views.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2011 UNINETT AS
+# Copyright (C) 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/threshold/forms.py
+++ b/python/nav/web/threshold/forms.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011 UNINETT AS
+# Copyright 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/threshold/urls.py
+++ b/python/nav/web/threshold/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011 UNINETT AS
+# Copyright 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/threshold/views.py
+++ b/python/nav/web/threshold/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011 UNINETT AS
+# Copyright 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/useradmin/forms.py
+++ b/python/nav/web/useradmin/forms.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008 UNINETT AS
+# Copyright (C) 2008 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/useradmin/urls.py
+++ b/python/nav/web/useradmin/urls.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2008, 2011 UNINETT AS
+# Copyright 2008, 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV)
 #

--- a/python/nav/web/useradmin/views.py
+++ b/python/nav/web/useradmin/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008, 2011 UNINETT AS
+# Copyright (C) 2008, 2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/utils.py
+++ b/python/nav/web/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 (SD -311000) UNINETT AS
+# Copyright (C) 2012 (SD -311000) Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/watchdog/urls.py
+++ b/python/nav/web/watchdog/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/watchdog/views.py
+++ b/python/nav/web/watchdog/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/webfront/forms.py
+++ b/python/nav/web/webfront/forms.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009 UNINETT AS
+# Copyright (C) 2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/webfront/urls.py
+++ b/python/nav/web/webfront/urls.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009 UNINETT AS
+# Copyright (C) 2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/webfront/utils.py
+++ b/python/nav/web/webfront/utils.py
@@ -1,6 +1,6 @@
 """Utility functions for various parts of the frontpage, navbar etc."""
 #
-# Copyright (C) 2009, 2012 UNINETT AS
+# Copyright (C) 2009, 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009-2011 UNINETT AS
+# Copyright (C) 2009-2011 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/python/nav/wsgi.py
+++ b/python/nav/wsgi.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/sql/historic-upgrades/mergedb.sh
+++ b/sql/historic-upgrades/mergedb.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright 2008 UNINETT AS
+# Copyright 2008 Uninett AS
 # License: GPLv2
 # Author: Morten Brekkevold <morten.brekkevold@uninett.no>
 #
@@ -25,7 +25,7 @@ do
 	  ;;
 
       ?) cat <<EOF >&2
-Copyright 2008 UNINETT AS
+Copyright 2008 Uninett AS
 
 This script automates the task of merging the four NAV 3.4 databases
 into a single multi-namespaced NAV 3.5 database.

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -11,16 +11,16 @@
 
       <p>
         <a href="{% url 'webfront-about' %}">NAV (Network Administration Visualized)</a> is a free network management
-        utility from UNINETT, suitable for monitoring large computer networks.
+        utility from Uninett, suitable for monitoring large computer networks.
       </p>
     </div>
 
     <div class="about">
       <img class="footer-logo uninett-logo"
-           src="{{ STATIC_URL }}images/main/uninett-logo-grey.svg" alt="UNINETT AS">
+           src="{{ STATIC_URL }}images/main/uninett-logo-grey.svg" alt="Uninett AS">
 
       <p>
-        <a href="https://www.uninett.no/">UNINETT</a>
+        <a href="https://www.uninett.no/">Uninett</a>
         supplies a range of services connected to research, network
         management, mobility, security, purchasing, and identity management.
       </p>

--- a/templates/webfront/about.html
+++ b/templates/webfront/about.html
@@ -7,12 +7,12 @@
 
 <div style="float: right;">
         {% comment %}
-        Margins around the UNINETT logo are as suggested by the UNINETT logo
+        Margins around the Uninett logo are as suggested by the Uninett logo
         policy; they should be about the vertical height of the logo font on all
         sides.
         {% endcomment %}
         <a href="http://www.uninett.no/index.en.html"><img
-        src="{{ STATIC_URL }}images/about/uninett.png" width="157" height="43" alt="UNINETT"
+        src="{{ STATIC_URL }}images/about/uninett.png" width="157" height="43" alt="Uninett"
         style="margin: 22px; margin-top: 0;"/></a><br />
         <a href="http://www.ntnu.no/"><img src="{{ STATIC_URL }}images/about/ntnu.jpg"
         width="200" height="58" alt="NTNU" /></a>
@@ -30,7 +30,7 @@
   NAV was originally developed at the Norwegian University of Science and
   Technology (<a href="http://www.ntnu.no/">NTNU</a>) since 1999, to meet the
   needs of the university's campus network operators.  The Norwegian national
-  research network, <a href="http://www.uninett.no/index.en.html">UNINETT</a>,
+  research network, <a href="http://www.uninett.no/index.en.html">Uninett</a>,
   became involved in 2001, and has been leading the development of NAV since
   2006, on behalf of all universities and university colleges in Norway.
 </p>
@@ -65,7 +65,7 @@
              electronic postcards - use snail mail - send the postcard to:</p>
 
           <p class="infobox">
-            UNINETT AS<br />
+            Uninett AS<br />
             Att: The NAV project team / Morten Brekkevold / Vidar Faltinsen<br />
             Abels gate 5 - Teknobyen<br />
             NO-7465 Trondheim<br />

--- a/tests/functional/arnold_test.py
+++ b/tests/functional/arnold_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/functional/geomap_test.py
+++ b/tests/functional/geomap_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/functional/navbar_test.py
+++ b/tests/functional/navbar_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 UNINETT
+# Copyright (C) 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/functional/status_test.py
+++ b/tests/functional/status_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 UNINETT AS
+# Copyright (C) 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/unittests/general/bitvector_test.py
+++ b/tests/unittests/general/bitvector_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2009 UNINETT AS
+# Copyright (C) 2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/unittests/general/config_test.py
+++ b/tests/unittests/general/config_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2009 UNINETT AS
+# Copyright (C) 2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/unittests/general/objectcache_test.py
+++ b/tests/unittests/general/objectcache_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/unittests/general/pwhash_test.py
+++ b/tests/unittests/general/pwhash_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2009 UNINETT AS
+# Copyright (C) 2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/unittests/general/util_test.py
+++ b/tests/unittests/general/util_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2009 UNINETT AS
+# Copyright (C) 2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/unittests/info/room_views_test.py
+++ b/tests/unittests/info/room_views_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/unittests/info/views_test.py
+++ b/tests/unittests/info/views_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/unittests/ipdevpoll/config_test.py
+++ b/tests/unittests/ipdevpoll/config_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/unittests/ipdevpoll/descrparsers_test.py
+++ b/tests/unittests/ipdevpoll/descrparsers_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010 UNINETT AS
+# Copyright (C) 2010 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/unittests/ipdevpoll/ipdevpoll_test.py
+++ b/tests/unittests/ipdevpoll/ipdevpoll_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2008, 2009 UNINETT AS
+# Copyright (C) 2008, 2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/unittests/ipdevpoll/mibs_test.py
+++ b/tests/unittests/ipdevpoll/mibs_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008, 2009, 2011, 2012, 2015 UNINETT AS
+# Copyright (C) 2008, 2009, 2011, 2012, 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/unittests/macaddress/macaddress_test.py
+++ b/tests/unittests/macaddress/macaddress_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/unittests/netmap/metadata_json_test.py
+++ b/tests/unittests/netmap/metadata_json_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/unittests/portadmin/snmputils_test.py
+++ b/tests/unittests/portadmin/snmputils_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 UNINETT AS
+# Copyright (C) 2013 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/unittests/smsd/dispatcher_test.py
+++ b/tests/unittests/smsd/dispatcher_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009 UNINETT AS
+# Copyright (C) 2009 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/unittests/statemon/runqueue_test.py
+++ b/tests/unittests/statemon/runqueue_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 UNINETT AS
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/unittests/topology/analyze_test.py
+++ b/tests/unittests/topology/analyze_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 UNINETT AS
+# Copyright (C) 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tests/unittests/watchdog/tests_test.py
+++ b/tests/unittests/watchdog/tests_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 UNINETT AS
+# Copyright (C) 2014 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tools/buglog.py
+++ b/tools/buglog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2008, 2011, 2017 UNINETT AS
+# Copyright (C) 2008, 2011, 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #
@@ -40,7 +40,7 @@ def main():
     else:
         hub = Github()
 
-    repo = hub.get_user('UNINETT').get_repo('nav')
+    repo = hub.get_user('Uninett').get_repo('nav')
     milestones = [m for m in repo.get_milestones(state='all')
                   if m.title == args.version]
     if milestones:

--- a/tools/eventgenerators/boxevent.py
+++ b/tools/eventgenerators/boxevent.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2015 UNINETT AS
+# Copyright (C) 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV)
 #

--- a/tools/eventgenerators/genericstate.py
+++ b/tools/eventgenerators/genericstate.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tools/eventgenerators/linkevent.py
+++ b/tools/eventgenerators/linkevent.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (C) 2007, 2012, 2015 UNINETT AS
+# Copyright (C) 2007, 2012, 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tools/eventgenerators/moduleevent.py
+++ b/tools/eventgenerators/moduleevent.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 #
-# Copyright (C) 2003, 2004 Norwegian University of Science and Technology
 # Copyright (C) 2007, 2012 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/tools/eventgenerators/moduleevent.py
+++ b/tools/eventgenerators/moduleevent.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (C) 2007, 2012 UNINETT AS
+# Copyright (C) 2007, 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tools/eventgenerators/servicestate.py
+++ b/tools/eventgenerators/servicestate.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tools/eventgenerators/snmpevent.py
+++ b/tools/eventgenerators/snmpevent.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (C) 2007, 2012, 2017 UNINETT AS
+# Copyright (C) 2007, 2012, 2017 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tools/eventgenerators/snmpevent.py
+++ b/tools/eventgenerators/snmpevent.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 #
-# Copyright (C) 2003, 2004 Norwegian University of Science and Technology
 # Copyright (C) 2007, 2012, 2017 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV).

--- a/tools/eventgenerators/thresholdstate.py
+++ b/tools/eventgenerators/thresholdstate.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2012 UNINETT AS
+# Copyright (C) 2012 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tools/iana-enterprise.py
+++ b/tools/iana-enterprise.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2015 UNINETT
+# Copyright (C) 2015 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #

--- a/tools/testsql.sh
+++ b/tools/testsql.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2008 UNINETT AS
+# Copyright 2008 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV)
 #

--- a/tools/testsql.sh
+++ b/tools/testsql.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 #
-# Copyright 2004 Norwegian University of Science and Technology
 # Copyright 2008 UNINETT AS
 #
 # This file is part of Network Administration Visualized (NAV)

--- a/tools/updatetypes.py
+++ b/tools/updatetypes.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2006, 2010 UNINETT AS
+# Copyright (C) 2006, 2010 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #


### PR DESCRIPTION
A few necessary changes to copyright statements all over the codebase:

- The Norwegian University of Science and Technology has signed over its copyright to Uninett AS
- The University of Tromsø has signed over its copyright to Uninett AS
  - The University College of Narvik merged with the University of Tromsø a few years back, which means their copyright is now also signed over to Uninett AS.
- The powers that be have decreed that Uninett is no longer to be styled _"UNINETT"_, but _"Uninett"_.
