### PR TITLE
Upgrade python-ldap

### DIFF
--- a/python/nav/web/ldapauth.py
+++ b/python/nav/web/ldapauth.py
@@ -25,6 +25,8 @@ import configparser
 from os.path import join
 from io import StringIO
 
+from django.utils import six
+
 from nav.buildconf import sysconfdir
 import nav.errors
 
@@ -340,9 +342,10 @@ def __test():
     logging.basicConfig()
     logging.getLogger('').setLevel(logging.DEBUG)
 
-    print("Username: ", end=' ')
-    uid = sys.stdin.readline().strip()
+    uid = six.moves.input("Username: ").strip()
     password = getpass('Password: ')
+    if six.PY2:
+        password = password.decode('utf-8')
 
     user = authenticate(uid, password)
 
@@ -352,6 +355,7 @@ def __test():
         print("User's full name is %s" % user.get_real_name())
     else:
         print("User was not authenticated")
+
 
 if __name__ == '__main__':
     __test()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ networkx>=1.7,<1.8
 xmpppy==0.5.0rc1  # optional, for alerting via Jabber
 Pillow==3.0.0
 pyrad==2.1
-python-ldap==2.4.10 ; python_version < '3' # optional for LDAP authentication, requires libldap (OpenLDAP) to build
+python-ldap==3.0.0 # optional for LDAP authentication, requires libldap (OpenLDAP) to build
 sphinx>=1.0
 feedparser>=5.1.2,<5.2
 markdown==2.5.1

--- a/tests/unittests/general/webfront_test.py
+++ b/tests/unittests/general/webfront_test.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from unittest import TestCase
 from mock import patch, Mock
-import pytest
+from django.utils import six
 
 import nav.web.ldapauth
 from nav.web import auth
@@ -70,8 +70,6 @@ class NormalAuthenticateTest(TestCase):
             self.assertFalse(auth.authenticate('knight', 'rabbit'))
 
 
-@pytest.mark.skipif(nav.web.ldapauth.ldap is None,
-                    reason="ldap library not available")
 class LdapUserTestCase(TestCase):
     @patch.dict("nav.web.ldapauth._config._sections",
                 {'ldap': {'__name__': 'ldap',
@@ -101,7 +99,7 @@ class LdapUserTestCase(TestCase):
     def test_non_ascii_password_should_work(self):
         """LP#1213818"""
         conn = Mock(**{
-            'simple_bind_s.side_effect': lambda x, y: (str(x), str(y)),
+            'simple_bind_s.side_effect': lambda x, y: (six.text_type(x), six.text_type(y)),
         })
         u = nav.web.ldapauth.LDAPUser(u"zaphod", conn)
         u.bind(u"æøå")
@@ -117,8 +115,8 @@ class LdapUserTestCase(TestCase):
     def test_is_group_member_for_non_ascii_user_should_not_raise(self):
         """LP#1301794"""
         def fake_search(base, scope, filtr):
-            str(base)
-            str(filtr)
+            six.text_type(base)
+            six.text_type(filtr)
             return []
 
         conn = Mock(**{


### PR DESCRIPTION
New versions of `python-ldap` were introduced earlier in 2018 which support Python 3. This enables us to move forward with our push towards Python 3.

This sets out to upgrade the `python-ldap` dependency and updating the codebase to work on both Python 2 and 3. This document was very useful in doing so:

https://github.com/python-ldap/python-ldap/blob/3.0/Doc/bytes_mode.rst