### PR TITLE
Make logging and daemonization options more consistent across NAV daemons

### DIFF
--- a/NOTES.rst
+++ b/NOTES.rst
@@ -39,6 +39,35 @@ The version requirements have changed for these dependencies:
 * :mod:`python-ldap` must be any version of the *3.0* series.
 
 
+Backwards incompatible changes
+------------------------------
+
+Changed command line options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some of the NAV programs have changed their command line interface:
+
+* :program:`alertengine.py`: The nonworking ``--loglevel`` option was removed.
+* :program:`pping.py`: The ``-n/--nofork`` option was renamed to ``-f/--foreground``.
+* :program:`servicemon.py`: The ``-n/--nofork`` option was renamed to ``-f/--foreground``.
+* :program:`smsd.py`: The ``-n/--nofork`` option was renamed to
+  ``-f/--foreground``, while the ``-f/--factor`` option was renamed to
+  ``-D/--delayfactor``.
+* :program:`snmptrapd.py`: The ``-d/--daemon`` option was changed into a
+  ``-f/--foreground``, while daemon mode was made the default.
+
+
+Changed configuration files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These configuration files changed:
+
+* :file:`smsd.conf`: The ``loglevel`` option is no longer supported. Use
+  :file:`logging.conf` to configure log levels.
+* :file:`alertengine.conf`: The ``loglevel`` option is no longer supported. Use
+  :file:`logging.conf` to configure log levels.
+
+
 News
 ----
 

--- a/bin/alertengine.py
+++ b/bin/alertengine.py
@@ -127,6 +127,8 @@ def main():
 
         # Reopen log files on SIGHUP
         signal.signal(signal.SIGHUP, signalhandler)
+    else:
+        nav.daemon.writepidfile(pidfile)
 
     # Log reception of SIGTERM before quitting
     signal.signal(signal.SIGTERM, signalhandler)

--- a/bin/alertengine.py
+++ b/bin/alertengine.py
@@ -130,8 +130,9 @@ def main():
     else:
         nav.daemon.writepidfile(pidfile)
 
-    # Log reception of SIGTERM before quitting
+    # Log reception of SIGTERM/SIGINT before quitting
     signal.signal(signal.SIGTERM, signalhandler)
+    signal.signal(signal.SIGINT, signalhandler)
 
     # Loop forever
     logger.info('Starting alertengine loop.')
@@ -204,6 +205,9 @@ def signalhandler(signum, _):
         logger.info('Log files reopened.')
     elif signum == signal.SIGTERM:
         logger.warning('SIGTERM received: Shutting down')
+        sys.exit(0)
+    elif signum == signal.SIGINT:
+        logger.warning('SIGINT received: Shutting down')
         sys.exit(0)
 
 

--- a/bin/alertengine.py
+++ b/bin/alertengine.py
@@ -189,11 +189,6 @@ def parse_args():
     parser.add_argument("-f", "--foreground", action="store_true",
                         help="run in the foreground")
 
-    levels = getattr(logging, '_levelNames', {})
-    levels = [name for lvl, name in sorted(levels.items()) if type(lvl) is int]
-    parser.add_argument("--loglevel", metavar="LEVEL", choices=levels,
-                        help="set the daemon log level")
-
     return parser.parse_args()
 
 

--- a/bin/pping.py
+++ b/bin/pping.py
@@ -53,14 +53,14 @@ def main():
 
     socket = megaping.make_sockets()  # make raw sockets while we have root
     switch_user()
-    start(args.nofork, socket)
+    start(args.foreground, socket)
 
 
 def make_argparser():
     parser = argparse.ArgumentParser(
         description="Parallel pinger daemon (part of NAV)",
     )
-    parser.add_argument("-n", "--nofork", action="store_true",
+    parser.add_argument("-f", "--foreground", action="store_true",
                         help="run in foreground")
     return parser
 
@@ -219,10 +219,10 @@ class Pinger(object):
             LOGGER.critical("Caught %s. Resuming operation.", signum)
 
 
-def start(nofork, socket):
+def start(foreground, socket):
     """
-    Forks a new prosess, letting the service run as
-    a daemon.
+    Starts a new prosess, letting the service run as a daemon if `foreground`
+    is false.
     """
     conf = config.pingconf()
     pidfilename = conf.get(
@@ -239,7 +239,7 @@ def start(nofork, socket):
         sys.stderr.write("%s\n" % error)
         sys.exit(1)
 
-    if not nofork:
+    if not foreground:
         logfile_path = conf.get(
             'logfile',
             os.path.join(buildconf.localstatedir, 'log', 'pping.log'))

--- a/bin/servicemon.py
+++ b/bin/servicemon.py
@@ -41,8 +41,11 @@ LOGGER = logging.getLogger('nav.servicemon')
 
 class Controller:
     def __init__(self, foreground=False):
-        signal.signal(signal.SIGHUP, self.signalhandler)
+        if not foreground:
+            signal.signal(signal.SIGHUP, self.signalhandler)
         signal.signal(signal.SIGTERM, self.signalhandler)
+        signal.signal(signal.SIGINT, self.signalhandler)
+
         self.conf = config.serviceconf()
         init_generic_logging(stderr=True, read_config=True)
         self._isrunning = 1
@@ -124,6 +127,10 @@ class Controller:
     def signalhandler(self, signum, _):
         if signum == signal.SIGTERM:
             LOGGER.info("Caught SIGTERM. Exiting.")
+            self._runqueue.terminate()
+            sys.exit(0)
+        elif signum == signal.SIGINT:
+            LOGGER.info("Caught SIGINT. Exiting.")
             self._runqueue.terminate()
             sys.exit(0)
         elif signum == signal.SIGHUP:

--- a/bin/smsd.py
+++ b/bin/smsd.py
@@ -130,8 +130,8 @@ def main():
         logger.info("All %d unsent messages ignored.", ignored_count)
         sys.exit(0)
 
-    if args.factor:
-        retryvars['delayfactor'] = args.factor
+    if args.delayfactor:
+        retryvars['delayfactor'] = args.delayfactor
     if args.maxdelay:
         retryvars['maxdelay'] = args.maxdelay
     if args.limit:
@@ -189,7 +189,7 @@ def main():
         sys.exit(1)
 
     # Daemonize
-    if not args.nofork:
+    if not args.foreground:
         try:
             nav.daemon.daemonize(pidfile,
                                  stderr=nav.logs.get_logfile_from_logger())
@@ -293,7 +293,7 @@ def parse_args():
         help="cancel (mark as ignored) all unsent messages")
     arg("-d", "--delay", type=int,
         help="set delay (in seconds) between queue checks")
-    arg("-f", "--factor", type=int,
+    arg("-D", "--delayfactor", type=int,
         help="set the factor DELAY will be multiplied with for each attempt")
     arg("-m", "--maxdelay", type=int,
         help="maximum delay (in seconds)")
@@ -314,7 +314,7 @@ def parse_args():
     arg("--message", metavar="MESSAGE",
         help="Used in combination with -t or -T to specify the message content")
     arg("-u", "--uid", type=int, help="NAV user/account id to queue message to")
-    arg("-n", "--nofork", action="store_true",
+    arg("-f", "--foreground", action="store_true",
         help="run process in the foreground")
 
     args = parser.parse_args()

--- a/bin/smsd.py
+++ b/bin/smsd.py
@@ -200,8 +200,9 @@ def main():
     else:
         nav.daemon.writepidfile(pidfile)
 
-    # Exit on SIGTERM
+    # Exit on SIGTERM/SIGINT
     signal.signal(signal.SIGTERM, signalhandler)
+    signal.signal(signal.SIGINT, signalhandler)
 
     # Initialize queue
     # NOTE: If we're initalizing a queue with a DB connection before
@@ -437,6 +438,9 @@ def signalhandler(signum, _):
         logger.info('Log files reopened.')
     elif signum == signal.SIGTERM:
         logger.warning('SIGTERM received: Shutting down.')
+        sys.exit(0)
+    elif signum == signal.SIGINT:
+        logger.warning('SIGINT received: Shutting down.')
         sys.exit(0)
 
 

--- a/bin/smsd.py
+++ b/bin/smsd.py
@@ -393,6 +393,7 @@ def backoffaction(error, retrylimitaction):
     queue = nav.smsd.navdbqueue.NAVDBQueue()
     msgs = queue.getmsgs('N')
 
+    # FIXME This needs a look-over for Python3/unicode issues
     if retrylimitaction == "ignore":
         # Queued messages are marked as ignored, logs a critical error with
         # message details, then resumes run.

--- a/bin/smsd.py
+++ b/bin/smsd.py
@@ -104,7 +104,7 @@ def main():
     mailaddr = config['main']['mailaddr']
     fromaddr = config['main']['fromaddr']
 
-    # Switch user to $NAV_USER (only works if we're root)
+    # Drop privileges if running as root
     if os.geteuid() == 0:
         try:
             nav.daemon.switchuser(username)

--- a/bin/smsd.py
+++ b/bin/smsd.py
@@ -71,7 +71,6 @@ def main():
         'retrylimitaction': 'ignore',
         'exit_on_permanent_error': 'yes',
         'autocancel': '0',
-        'loglevel': 'INFO',
         'mailwarnlevel': 'ERROR',
         'mailserver': 'localhost',
         'mailaddr': nav.config.read_flat_config('nav.conf')['ADMIN_MAIL'],
@@ -100,7 +99,6 @@ def main():
 
     username = config['main']['username']
     autocancel = config['main']['autocancel']
-    loglevel = logging.getLevelName(config['main']['loglevel'])
     mailwarnlevel = logging.getLevelName(config['main']['mailwarnlevel'])
     mailserver = config['main']['mailserver']
     mailaddr = config['main']['mailaddr']

--- a/bin/snmptrapd.py
+++ b/bin/snmptrapd.py
@@ -83,15 +83,13 @@ def main():
     minport = min(port for addr, port in opts.address)
     if minport < 1024:
         if os.geteuid() != 0:
-            print("Must be root to bind to ports < 1024, exiting")
-            sys.exit(-1)
+            sys.exit("Must be root to bind to ports < 1024, exiting")
 
     # Check if already running
     try:
         daemon.justme(pidfile)
     except daemon.DaemonError as why:
-        print(why)
-        sys.exit(-1)
+        sys.exit(why)
 
     # Create SNMP agent object
     server = agent.TrapListener(*opts.address)
@@ -103,13 +101,12 @@ def main():
         if os.geteuid() == 0:
             daemon.switchuser(runninguser)
     except daemon.DaemonError as why:
-        print(why)
         server.close()
-        sys.exit(-1)
+        sys.exit(why)
 
     global handlermodules
 
-    nav.logs.init_generic_logging(stderr=True, read_config=True)
+    nav.logs.init_stderr_logging()
 
     logger.debug("using %r as SNMP backend", agent.BACKEND)
 
@@ -135,9 +132,8 @@ def main():
             server.close()
             sys.exit(1)
 
-        # Daemonized; reopen log files
-        nav.logs.reopen_log_files()
-        logger.debug('Daemonization complete; reopened log files.')
+        # Daemonized
+        logger.info('snmptrapd is now running in daemon mode')
 
         # Reopen lost db connection
         # This is a workaround for a double free bug in psycopg 2.0.7
@@ -159,12 +155,13 @@ def main():
             logger.critical("Fatal exception ocurred", exc_info=True)
 
     else:
+        daemon.writepidfile(pidfile)
         # Start listening and exit cleanly if interrupted.
         try:
             logger.info("Listening on %s", addresses_text)
             server.listen(opts.community, trap_handler)
         except KeyboardInterrupt as why:
-            logger.error("Received keyboardinterrupt, exiting.")
+            logger.error("Received keyboard interrupt, exiting.")
             server.close()
 
 
@@ -252,12 +249,15 @@ def signal_handler(signum, _):
     if signum == signal.SIGHUP:
         logger.info("SIGHUP received; reopening log files.")
         nav.logs.reopen_log_files()
-        logfile = nav.logs.get_logfile_from_logger()
+        logfile = open(logfile_path, "a")
         daemon.redirect_std_fds(stdout=logfile, stderr=logfile)
-        logger.info("Log files reopened.")
+        nav.logs.reset_log_levels()
+        nav.logs.set_log_config()
+        logger.info('Log files reopened.')
     elif signum == signal.SIGTERM:
         logger.warning('SIGTERM received: Shutting down.')
         sys.exit(0)
+
 
 if __name__ == '__main__':
     main()

--- a/bin/snmptrapd.py
+++ b/bin/snmptrapd.py
@@ -124,7 +124,7 @@ def main():
 
     addresses_text = ", ".join(address_to_string(*addr)
                                for addr in opts.address)
-    if opts.daemon:
+    if not opts.foreground:
         # Daemonize and listen for traps
         try:
             logger.debug("Going into daemon mode...")
@@ -177,8 +177,8 @@ def parse_args():
                "appears to support IPv6, also [::]:162, which means the daemon "
                "will accept traps on any IPv4/IPv6 interface, UDP port 162."
     )
-    parser.add_argument("-d", "--daemon", action="store_true",
-                        help="Run as daemon")
+    parser.add_argument("-f", "--foreground", action="store_true",
+                        help="Run in foreground")
     parser.add_argument("-c", "--community", default="public",
                         help="Which SNMP community incoming traps must use. "
                              "The default is 'public'")

--- a/etc/alertengine.conf.in
+++ b/etc/alertengine.conf.in
@@ -7,9 +7,9 @@
 # Delay in seconds between queue checks
 #delay: 30
 
-# Logging settings
-# Valid options are DEBUG, INFO, WARNING, ERROR, CRITICAL
-#loglevel: INFO
+# Log messages of <mailwarning> level or higher are also sent via e-mail
+# to the nav admin from nav.conf. Generic log levels are set in logging.conf.
+# Valid mailwarnlevels are DEBUG, INFO, WARNING, ERROR, CRITICAL
 #mailwarnlevel: ERROR
 #mailserver: localhost
 

--- a/etc/alertengine.conf.in
+++ b/etc/alertengine.conf.in
@@ -7,7 +7,7 @@
 # Delay in seconds between queue checks
 #delay: 30
 
-# Log messages of <mailwarning> level or higher are also sent via e-mail
+# Log messages of <mailwarnlevel> or higher are also sent via e-mail
 # to the nav admin from nav.conf. Generic log levels are set in logging.conf.
 # Valid mailwarnlevels are DEBUG, INFO, WARNING, ERROR, CRITICAL
 #mailwarnlevel: ERROR

--- a/etc/init.d/snmptrapd.in
+++ b/etc/init.d/snmptrapd.in
@@ -17,7 +17,7 @@ case "$1" in
 	start)
 		# Start daemons (it will switch to an unprivileged user itself)
 		echo -n "Starting snmptrapd: "
-		daemon "$SNMPTRAPD -d"
+		daemon "$SNMPTRAPD"
 		rc=$?
 		echo
 		exit $rc

--- a/etc/smsd.conf.in
+++ b/etc/smsd.conf.in
@@ -35,9 +35,9 @@
 # Format like the PostgreSQL interval type, e.g. '1 day 12 hours'
 #autocancel: 0
 
-# Logging settings
-# Valid options are DEBUG, INFO, WARNING, ERROR, CRITICAL
-#loglevel: INFO
+# Log messages of <mailwarnlevel> or higher are also sent via e-mail
+# to the nav admin from nav.conf. Generic log levels are set in logging.conf.
+# Valid mailwarnlevels are DEBUG, INFO, WARNING, ERROR, CRITICAL
 #mailwarnlevel: ERROR
 #mailserver: localhost
 

--- a/python/nav/eventengine/daemon.py
+++ b/python/nav/eventengine/daemon.py
@@ -41,6 +41,8 @@ def main():
     exit_if_already_running()
     if not options.foreground:
         daemonize()
+    else:
+        nav.daemon.writepidfile(PIDFILE)
     start_engine()
 
 

--- a/tests/integration/pping_test.py
+++ b/tests/integration/pping_test.py
@@ -105,7 +105,7 @@ timeout = 1
 nrping = 2
 delay = 2
 logfile = {localstatedir}/log/pping.log
-pidfile = {localstatedir}run/pping.pid
+pidfile = {localstatedir}/run/pping.pid
 """.format(user=nav_user, localstatedir=localstatedir))
     yield configfile
     print("restoring ping config")

--- a/tests/integration/pping_test.py
+++ b/tests/integration/pping_test.py
@@ -64,7 +64,7 @@ def get_pping_output(timeout=5):
 
     Also asserts that pping shouldn't unexpectedly exit with a zero exitcode.
     """
-    cmd = get_root_method() + [os.path.join(bindir, 'pping.py'), '-n']
+    cmd = get_root_method() + [os.path.join(bindir, 'pping.py'), '-f']
     try:
         output = check_output(cmd, stderr=STDOUT, timeout=timeout)
     except TimeoutExpired as error:


### PR DESCRIPTION
Goals of this PR:

* Ensure all NAV daemons have the same command line options to select "foreground mode"
* Ensure all NAV daemons log to `stderr` until they eventually daemonize, at which point `stderr` will be redirected into the configured log file
* No daemons need to reload log files on `SIGHUP` while running in the foreground, since they arent logging to a file.
* All daemons that can be run in the foreground should be able to handle `SIGINT` without crashing with a traceback.

Motivation for these changes is mainly to allow for external control of how daemons are started and where their logs are sent - which is a big factor if NAV is being run in container systems likes Kubernetes.