### PR TITLE
WIP: Interface tooltip

### DIFF
--- a/htdocs/sass/nav/custom.scss
+++ b/htdocs/sass/nav/custom.scss
@@ -403,7 +403,9 @@ select[multiple] {
     line-height: inherit;
 }
 
-.tooltip > h5 {
+.tooltip h3,
+.tooltip > h5
+{
     color: white;
 }
 

--- a/htdocs/static/js/src/plugins/delegate_tooltip.js
+++ b/htdocs/static/js/src/plugins/delegate_tooltip.js
@@ -5,7 +5,7 @@ define([], function() {
      * This function attaches a listener to a parent element that creates
      * tooltips whenever the mouseover event triggers on the child elements
      * defined by the selector string
-     * 
+     *
      * This is necessary because of the way Foundation loops through each
      * element and creates dom-elements on page load, thus totally killing
      * performance when the number of tooltips grow large.
@@ -22,20 +22,41 @@ define([], function() {
 
         $parent.on('mouseenter', selector, function(event) {
             var $target = $(event.target);
-            if (!$target.data('selector')) {
-                // selector data attribute is only there if create has been run
-                // before
-                // Enable using a separate element for the tooltip text.
+            // selector data attribute is only there if create has been run before
+            if ($target.data('selector')) {
+                Foundation.libs.tooltip.showTip($target);
+            } else {
+                var url = $target.data('url');
                 var tipTextElement = $target.find('.tooltip-text');
-                if (tipTextElement.length) {
+
+                // Support fetching tooltip from API
+                if (url) {
+                    $.ajax({
+                        url: $target.data('url'),
+                        headers: {
+                            'Accept': 'text/x-nav-html'
+                        },
+                        success: function(data) {
+                            $target.attr('title', data);
+                            createTooltip($target);
+                        }
+                    });
+                } else if (tipTextElement.length) {
+                    // Enable using a separate element for the tooltip text.
                     $target.attr('title', tipTextElement.html());
+                    createTooltip($target);
+                } else {
+                    createTooltip($target);
                 }
-                Foundation.libs.tooltip.create($target);
-                $target.on('mouseleave', function (event) {
-                    Foundation.libs.tooltip.hide($target);
-                });
             }
-            Foundation.libs.tooltip.showTip($target);
+        });
+    }
+
+    function createTooltip($target) {
+        Foundation.libs.tooltip.create($target);
+        Foundation.libs.tooltip.showTip($target);
+        $target.on('mouseleave', function (event) {
+            Foundation.libs.tooltip.hide($target);
         });
     }
 

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -368,6 +368,11 @@ class NetboxViewSet(LoggerMixin, NAVAPIMixin, viewsets.ModelViewSet):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
+class InterfaceFragmentRenderer(TemplateHTMLRenderer):
+    media_type = 'text/x-nav-html'
+    template_name = 'ipdevinfo/port-details-api-frag.html'
+
+
 class InterfaceViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):
     """Lists all interfaces.
 
@@ -405,6 +410,11 @@ class InterfaceViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):
             return serializers.InterfaceWithCamSerializer
         else:
             return serializers.InterfaceSerializer
+
+    def get_renderers(self):
+        if self.action == 'retrieve':
+            self.renderer_classes += (InterfaceFragmentRenderer,)
+        return super(InterfaceViewSet, self).get_renderers()
 
 
 class PatchViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):

--- a/templates/ipdevinfo/port-details-api-frag.html
+++ b/templates/ipdevinfo/port-details-api-frag.html
@@ -16,9 +16,9 @@
 
     <li>
       {% if ifadminstatus == 1 %}
-        <div class="label success">Is up</div>
+        <div class="label success">Enabled</div>
       {% else %}
-        <div class="label warning">Not up</div>
+        <div class="label warning">Disabled</div>
       {% endif %}
     </li>
 

--- a/templates/ipdevinfo/port-details-api-frag.html
+++ b/templates/ipdevinfo/port-details-api-frag.html
@@ -1,0 +1,42 @@
+<div>
+  <h3>Interface {{ ifname }}</h3>
+
+  {% if ifalias %}
+    <p>{{ ifalias }}</p>
+  {% endif %}
+
+  <ul class="inline-list">
+    <li>
+      {% if ifoperstatus == 1 %}
+        <div class="label success">Has link</div>
+      {% else %}
+        <div class="label warning">No link</div>
+      {% endif %}
+    </li>
+
+    <li>
+      {% if ifadminstatus == 1 %}
+        <div class="label success">Is up</div>
+      {% else %}
+        <div class="label warning">Not up</div>
+      {% endif %}
+    </li>
+
+    {% if trunk %}
+      <li>
+        <div class="label label-info">Trunk</div>
+      </li>
+    {% endif %}
+  </ul>
+
+  <ul class="no-bullet">
+    <li><strong>Speed</strong>: {{ speed }}</li>
+    <li><strong>Vlan</strong>: {{ vlan }}</li>
+    {% if to_interface %}
+      <li><strong>To interface</strong>: {{ to_interface.ifname }}</li>
+    {% endif %}
+    {% if to_netbox %}
+      <li><strong>To netbox</strong>: {{ to_netbox.sysname }}</li>
+    {% endif %}
+  </ul>
+</div>

--- a/templates/navlets/status2_view.html
+++ b/templates/navlets/status2_view.html
@@ -26,7 +26,12 @@
           <tr>
             <td>
               {% if result.subject_url %}
-                <a href="{{ result.subject_url }}" class="toooltip" data-url="{% url 'api:interface-detail' result.subid %}">{{ result.subject }}</a>
+                {# check for interface #}
+                {% if result.subject_type == 'Interface' %}
+                  <a href="{{ result.subject_url }}" class="toooltip" data-url="{% url 'api:interface-detail' result.subid %}">{{ result.subject }}</a>
+                {% else %}
+                  <a href="{{ result.subject_url }}">{{ result.subject }}</a>
+                {% endif %}
               {% else %}
                 {{ result.subject }}
               {% endif %}

--- a/templates/navlets/status2_view.html
+++ b/templates/navlets/status2_view.html
@@ -26,7 +26,7 @@
           <tr>
             <td>
               {% if result.subject_url %}
-                <a href="{{ result.subject_url }}">{{ result.subject }}</a>
+                <a href="{{ result.subject_url }}" class="toooltip" data-url="{% url 'api:interface-detail' result.subid %}">{{ result.subject }}</a>
               {% else %}
                 {{ result.subject }}
               {% endif %}
@@ -71,5 +71,12 @@
     </div>
 
   {% endif %}
+
+  <script>
+   var navletid = "{{ navlet.account_navlet.pk }}";
+   require(['plugins/delegate_tooltip'], function(dgt) {
+       dgt($('[data-id=' + navletid + '] .status2table'), '.toooltip');
+   });
+  </script>
 
 {% endblock %}


### PR DESCRIPTION
Fixes #1667 

Create a template for the API interface endpoint that is returned when using the special text/x-nav-html accept header.

Use this to render a tooltip displaying information about an interface in the status widget when hovering above the interface name.