### PR TITLE
No warnings for Django 1.8

### DIFF
--- a/python/nav/models/fields.py
+++ b/python/nav/models/fields.py
@@ -53,7 +53,10 @@ class DateTimeInfinityField(models.DateTimeField):
         else:
             return super(DateTimeInfinityField, self).get_db_prep_value(
                 value, connection, prepared=prepared)
-        return connection.ops.value_to_db_datetime(value)
+        try:
+            return connection.ops.value_to_db_datetime(value)  # <= 1.8
+        except AttributeError:
+            return connection.ops.adapt_datetimefield_value(value)  # >= 1.9
 
 
 class VarcharField(models.TextField):

--- a/python/nav/models/fields.py
+++ b/python/nav/models/fields.py
@@ -27,14 +27,15 @@ from django.db import models
 from django.core import exceptions
 from django.db.models import Q
 from django.utils import six
+
 try:
-    # Django < 1.9
-    from django.db.models import get_models
-except ImportError:
     # Django >= 1.8
     from django.apps import apps
     get_models = apps.get_models
     del apps
+except ImportError:
+    # Django < 1.9
+    from django.db.models import get_models
 
 from nav.util import is_valid_cidr, is_valid_ip
 from nav.django import validators, forms as navforms

--- a/python/nav/web/devicehistory/utils/history.py
+++ b/python/nav/web/devicehistory/utils/history.py
@@ -14,11 +14,11 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 from functools import reduce
+from collections import OrderedDict
 
 from django.core.paginator import InvalidPage
 
 from django.db.models import Q
-from django.utils.datastructures import SortedDict
 
 from nav.models.event import AlertHistory, AlertHistoryMessage
 from nav.models.manage import (Netbox, Device, Location, Room, Module,
@@ -155,7 +155,7 @@ def get_messages_for_history(alert_history):
 
 
 def group_history_and_messages(history, messages, group_by=None):
-    grouped_history = SortedDict()
+    grouped_history = OrderedDict()
     for a in history:
         a.extra_messages = {}
         for m in messages:

--- a/python/nav/web/devicehistory/views.py
+++ b/python/nav/web/devicehistory/views.py
@@ -62,8 +62,8 @@ def devicehistory_search(request):
     """Implements the device history landing page / search form"""
     device_quickselect = QuickSelect(**DEVICEQUICKSELECT_VIEW_HISTORY_KWARGS)
 
-    if 'from_date' in request.REQUEST:
-        form = DeviceHistoryViewFilter(request.REQUEST)
+    if 'from_date' in request.GET:
+        form = DeviceHistoryViewFilter(request.GET)
         if form.is_valid():
             return devicehistory_view(request)
     else:
@@ -87,21 +87,21 @@ def devicehistory_view(request):
     """Device history search results view"""
 
     selection = {
-        'organization': request.REQUEST.getlist('org'),
-        'category': request.REQUEST.getlist('cat'),
-        'room__location': request.REQUEST.getlist('loc'),
-        'room': request.REQUEST.getlist('room'),
-        'netbox': request.REQUEST.getlist('netbox'),
-        'groups': request.REQUEST.getlist('netboxgroup'),
-        'module': request.REQUEST.getlist('module'),
-        'mode': request.REQUEST.getlist('mode')
+        'organization': request.GET.getlist('org'),
+        'category': request.GET.getlist('cat'),
+        'room__location': request.GET.getlist('loc'),
+        'room': request.GET.getlist('room'),
+        'netbox': request.GET.getlist('netbox'),
+        'groups': request.GET.getlist('netboxgroup'),
+        'module': request.GET.getlist('module'),
+        'mode': request.GET.getlist('mode')
     }
 
     grouped_history = None
     valid_params = ['to_date', 'from_date', 'eventtype', 'group_by',
                     'netbox', 'room']
-    if len(set(valid_params) & set(request.REQUEST.keys())) >= 1:
-        form = DeviceHistoryViewFilter(request.REQUEST)
+    if len(set(valid_params) & set(request.GET.keys())) >= 1:
+        form = DeviceHistoryViewFilter(request.GET)
     else:
         form = DeviceHistoryViewFilter()
     if form.is_valid():

--- a/python/nav/web/machinetracker/utils.py
+++ b/python/nav/web/machinetracker/utils.py
@@ -18,14 +18,13 @@
 from datetime import datetime
 from socket import gethostbyaddr, herror
 from IPy import IP
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 
 from django.utils import six
 
 from nav import asyncdns
 from nav.models.manage import Prefix, Netbox, Interface
 
-from django.utils.datastructures import SortedDict
 from django.db import DatabaseError, transaction
 
 _cached_hostname = {}
@@ -118,7 +117,7 @@ def ip_dict(rows):
     :param rows: IP search result rows.
     :return: A dict mapping IP addresses to matching result rows.
     """
-    result = SortedDict()
+    result = OrderedDict()
     for row in rows:
         ip = IP(row.ip)
         if ip not in result:
@@ -157,7 +156,7 @@ def track_mac(keys, resultset, dns):
         ips_to_lookup = [row.ip for row in resultset]
         dns_lookups = asyncdns.reverse_lookup(ips_to_lookup)
 
-    tracker = SortedDict()
+    tracker = OrderedDict()
     for row in resultset:
         if row.end_time > datetime.now():
             row.still_active = "Still active"

--- a/python/nav/web/machinetracker/views.py
+++ b/python/nav/web/machinetracker/views.py
@@ -17,12 +17,12 @@
 
 from IPy import IP
 from datetime import date, timedelta
+from collections import OrderedDict
 
 from django.db.models import Q
 from django.template import RequestContext
 from django.shortcuts import render_to_response
 from django.utils import six
-from django.utils.datastructures import SortedDict
 
 from nav.models.manage import Arp, Cam, Netbios
 
@@ -163,7 +163,7 @@ def create_tracker(active, dns, inactive, ip_range, ip_result):
         ips_to_lookup = [str(ip) for ip in ip_range]
         dns_lookups = asyncdns.reverse_lookup(ips_to_lookup)
 
-    tracker = SortedDict()
+    tracker = OrderedDict()
     for ip_key in ip_range:
         if active and ip_key in ip_result:
             create_active_row(tracker, dns, dns_lookups, ip_key, ip_result)

--- a/tests/integration/models/model_test.py
+++ b/tests/integration/models/model_test.py
@@ -20,7 +20,15 @@ themselves.
 import os
 
 from django.db import connection
-from django.db.models import get_models
+
+try:
+    # Django >= 1.8
+    import django.apps
+    get_models = django.apps.apps.get_models
+    del django.apps
+except ImportError:
+    # Django < 1.9
+    from django.db.models import get_models
 
 import pytest
 


### PR DESCRIPTION
This PR gets rid of the remaining warnings for running NAV on Django 1.8, in code that we control.