### PR TITLE
Portlist tool detected vlans

### DIFF
--- a/htdocs/static/js/src/interface_browser.js
+++ b/htdocs/static/js/src/interface_browser.js
@@ -110,6 +110,20 @@ define(function(require) {
         },
 
         {
+            data: "detected_vlans",
+            name: "detected_vlans",
+            render: function(data, type, row, meta) {
+                return data.map(function(vlan) {
+                    var url = NAV.urls.vlan_index + vlan['vlan']['id'];
+                    var vlan_number = vlan['vlan']['vlan'];
+                    var net_type = vlan['vlan']['net_type'];
+                    return "<a href='" + url + "'>" + vlan_number + " (" + net_type + ")" + "</a>";
+                }).join(', ');
+            },
+            title: "Detected vlans"
+        },
+
+        {
             data: "speed",
             name: 'speed',
             render: function(data, type, row, meta) {

--- a/htdocs/static/js/src/interface_browser.js
+++ b/htdocs/static/js/src/interface_browser.js
@@ -104,7 +104,12 @@ define(function(require) {
                     return "<span title='Trunk' style='border: 3px double black; padding: 0 5px'>" + data + "</span>"
                 }
 
-                return "<a href='" + NAV.urls.vlan_index + "?query=" + data + "'>" + data + "</a>";
+                if (row['detected_vlans'].length === 1) {
+                    var url = NAV.urls.vlan_index + row['detected_vlans'][0]['vlan']['id'];
+                    return "<a href='" + url + "'>" + data + "</a>";
+                } else {
+                    return "<a href='" + NAV.urls.vlan_index + "?query=" + data + "'>" + data + "</a>";
+                }
             },
             title: 'Vlan'
         },

--- a/python/nav/web/api/v1/serializers.py
+++ b/python/nav/web/api/v1/serializers.py
@@ -188,6 +188,21 @@ class SubInterfaceSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+class VlanSerializer(serializers.ModelSerializer):
+    """Serializer for the vlan model"""
+    class Meta(object):
+        model = manage.Vlan
+        fields = '__all__'
+
+
+class SwportVlanSerializer(serializers.ModelSerializer):
+    vlan = VlanSerializer()
+
+    class Meta(object):
+        model = manage.SwPortVlan
+        fields = '__all__'
+
+
 class InterfaceSerializer(serializers.ModelSerializer):
     """Serializer for the interface model"""
     patches = SpecificPatchSerializer()
@@ -196,6 +211,7 @@ class InterfaceSerializer(serializers.ModelSerializer):
     to_netbox = SubNetboxSerializer()
     to_interface = SubInterfaceSerializer()
     netbox = SubNetboxSerializer()
+    detected_vlans = SwportVlanSerializer(source='get_sorted_vlans', many=True)
 
     class Meta(object):
         model = manage.Interface
@@ -254,13 +270,6 @@ class RackSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = rack.Rack
         exclude = ('_configuration',)
-
-
-class VlanSerializer(serializers.ModelSerializer):
-    """Serializer for the vlan model"""
-    class Meta(object):
-        model = manage.Vlan
-        fields = '__all__'
 
 
 class PrefixSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
This is a separate PR for including detected vlans in the Interface browser.

The reason for the separation is that this puts even more information inline in the interface endpoint thus slowing it down and making it even more bloated. However it gives value to the user and should be considered.