### PR TITLE
Make middlewares work correctly on Django 1.10+

### DIFF
--- a/python/nav/django/auth.py
+++ b/python/nav/django/auth.py
@@ -25,6 +25,10 @@ from django.http import HttpResponseRedirect, HttpResponse
 from django.contrib.sessions.backends.db import SessionStore
 from django.conf import settings
 from django.utils.encoding import python_2_unicode_compatible
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:  # Django <= 1.9
+    MiddlewareMixin = object
 
 
 _logger = getLogger(__name__)
@@ -38,7 +42,7 @@ SUDOER_ID_VAR = 'sudoer'
 LOGIN_URL = '/index/login/'
 
 
-class AuthenticationMiddleware(object):
+class AuthenticationMiddleware(MiddlewareMixin):
     def process_request(self, request):
         session = request.session
 
@@ -54,7 +58,7 @@ class AuthenticationMiddleware(object):
                       request.get_full_path(), account.login)
 
 
-class AuthorizationMiddleware(object):
+class AuthorizationMiddleware(MiddlewareMixin):
     def process_request(self, request):
         account = request.account
 

--- a/python/nav/django/legacy.py
+++ b/python/nav/django/legacy.py
@@ -14,16 +14,21 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Various functionality to bridge legacy NAV code with Django"""
+
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:  # Django <= 1.9
+    MiddlewareMixin = object
+
 from nav import db
 
 
-class LegacyCleanupMiddleware(object):
+class LegacyCleanupMiddleware(MiddlewareMixin):
     """Django middleware to clean up NAV legacy database connections at the
     end of each request cycle.
 
     """
-    @staticmethod
-    def process_response(_request, response):
+    def process_response(self, _request, response):
         """Rolls back any uncommitted legacy database connections,
         to avoid idling indefinitely in transactions.
 


### PR DESCRIPTION
I get an ImportMismatchError when testing locally again so here's to hoping the official CI is sufficiently different.