### PR TITLE
Fix geomap templatetags

### DIFF
--- a/etc/geomap/popup_network.html
+++ b/etc/geomap/popup_network.html
@@ -1,3 +1,4 @@
+{% load geomap %}
 <div class="network-popup">
   {% if network.subedges|length_is:"1" %}
   {% else %}

--- a/etc/geomap/popup_network_open.html
+++ b/etc/geomap/popup_network_open.html
@@ -1,3 +1,4 @@
+{% load geomap %}
 <div class="network-popup">
   <table class="vertitable">
     <caption>

--- a/etc/geomap/popup_place.html
+++ b/etc/geomap/popup_place.html
@@ -1,3 +1,4 @@
+{% load geomap %}
 <div class="place-popup">
 
   <table class="listtable">

--- a/etc/geomap/popup_place_open.html
+++ b/etc/geomap/popup_place_open.html
@@ -1,3 +1,4 @@
+{% load geomap %}
 <div class="place-popup">
 
   <table class="vertitable">

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -220,6 +220,7 @@ INSTALLED_APPS = (
     'rest_framework',
     'nav.auditlog',
     'nav.web.macwatch',
+    'nav.web.geomap',
 )
 
 if tuple(django.VERSION[:2]) == (1, 7):

--- a/python/nav/web/geomap/features.py
+++ b/python/nav/web/geomap/features.py
@@ -39,7 +39,7 @@ from django import template
 
 import nav
 from nav.web.geomap.conf import get_configuration
-from nav.web.geomap.utils import union_dict, subdict, concat_list, is_nan
+from nav.web.geomap.utils import union_dict, subdict, concat_list
 
 _logger = logging.getLogger('nav.web.geomap.features')
 
@@ -74,55 +74,13 @@ def create_features(variant, graph, do_create_edges=True):
     return nodes+edges
 
 
-def filter_nan2none(value):
-    """Convert the NaN value to None, leaving everything else unchanged.
-
-    This function is meant to be used as a Django template filter. It
-    is useful in combination with filters that handle None (or any
-    false value) specially, such as the 'default' filter, when one
-    wants special treatment for the NaN value. It is also useful
-    before the 'format' filter to avoid the NaN value being formatted.
-
-    """
-    if is_nan(value):
-        return None
-    return value
-
-
-def filter_format(value, arg):
-    """Format value according to format string arg.
-
-    This function is meant to be used as a Django template filter.
-
-    """
-    try:
-        return arg % value
-    except TypeError:
-        return ''
-
-
 def load_popup_template(filename):
-    """Load the template for a popup.
+    """Loads the template for a popup.
 
-    Returns a django.template.Template object.
+    :param filename: name of a configuration file containing template source
+                     (relative to the geomap configuration directory)
 
-    """
-    filters = {'nan2none': filter_nan2none,
-               'format': filter_format}
-    return template_from_config(filename, filters)
-
-
-def template_from_config(filename, filters):
-    """Create a Django template from a configuration file.
-
-    Arguments:
-
-    filename -- name of configuration file containing template
-    (relative to the geomap configuration directory)
-
-    filters -- additional template filters (see
-    compile_template_with_filters)
-
+    :returns: A django.template.Template object.
     """
     if filename is None:
         return None
@@ -131,35 +89,7 @@ def template_from_config(filename, filters):
     afile = open(abs_filename, 'r')
     content = afile.read()
     afile.close()
-    return compile_template_with_filters(content, filters)
-
-
-def compile_template_with_filters(template_string, filters):
-    """Compile a Django template, using additional filters.
-
-    This is like Template(template_string) except that additional
-    filters to be made available to the template may be specified.
-
-    Normally, one would define filters as documented in [1], but this
-    requires the INSTALLED_APPS settings to be set, which is not the
-    case in NAV[2]. This function is just a hack to get around that
-    limitation. The code is based on
-    django.template.compile_string[3].
-
-    filters should be a dictionary mapping filter names to functions.
-
-    [1]: http://docs.djangoproject.com/en/dev/howto/custom-template-tags/
-    [2]: https://nav.uninett.no/wiki/devel:django_introduction#settings
-    [3]: http://code.djangoproject.com/browser/django/trunk/django/template/__init__.py
-
-    """
-    lib = template.Library()
-    for name in filters.keys():
-        lib.filter(name, filters[name])
-    lexer = template.Lexer(template_string, None)
-    parser = template.Parser(lexer.tokenize())
-    parser.add_library(lib)
-    return parser.parse()
+    return template.Template(content)
 
 
 def apply_indicator(ind, properties):

--- a/python/nav/web/geomap/output_formats.py
+++ b/python/nav/web/geomap/output_formats.py
@@ -35,7 +35,7 @@ def make_geojson(featurelist):
 
     """
     geojson = {'type': 'FeatureCollection',
-               'features': map(make_geojson_feature, featurelist)}
+               'features': [make_geojson_feature(f) for f in featurelist]}
     return json.dumps(geojson)
 
 

--- a/python/nav/web/geomap/templatetags/geomap.py
+++ b/python/nav/web/geomap/templatetags/geomap.py
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2018 UNINETT
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 2 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.  You should have received a copy of the GNU General Public License
+# along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+from nav.web.geomap.utils import is_nan
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter(name='nan2none')
+def filter_nan2none(value):
+    """Convert the NaN value to None, leaving everything else unchanged.
+
+    This function is meant to be used as a Django template filter. It
+    is useful in combination with filters that handle None (or any
+    false value) specially, such as the 'default' filter, when one
+    wants special treatment for the NaN value. It is also useful
+    before the 'format' filter to avoid the NaN value being formatted.
+
+    """
+    if is_nan(value):
+        return None
+    return value
+
+
+@register.filter(name='format')
+def filter_format(value, arg):
+    """Format value according to format string arg.
+
+    This function is meant to be used as a Django template filter.
+
+    """
+    try:
+        return arg % value
+    except TypeError:
+        return ''

--- a/tests/integration/web/geomap_test.py
+++ b/tests/integration/web/geomap_test.py
@@ -1,0 +1,4 @@
+def test_geomap_data_should_not_crash(client):
+    url = '/geomap/normal/data?format=geojson&limit=30&viewportWidth=1789&viewportHeight=817&create_edges=true&fetch_data=true&timeStart=10%3A10_20181109&timeEnd=10%3A20_20181109&bbox=10.381361116473,63.411482408125,10.419748891889,63.419327821103'
+    response = client.get(url)
+    assert response.status_code == 200


### PR DESCRIPTION
Remove strange Geomap hack used to provide two template tags to its popup templates. The setup-py branch added a test that uncovered this problem for Django >= 1.8.