### PR TITLE
Gracefully handle exceptions from individual search providers

### DIFF
--- a/templates/info/base.html
+++ b/templates/info/base.html
@@ -119,6 +119,17 @@
                 <div class="alert-box secondary">No results for "{{ form.data.query }}"</div>
               {% endif %}
             </div>
+            {% if failed_providers %}
+                <div class="alert-box alert">
+                    <p>Additionally, these search providers crashed:</p>
+                    <ul>
+                    {% for provider, error in failed_providers %}
+                        <li><var>{{ provider }}</var>:<br/><blockquote>{{ error|stringformat:'r' }}</blockquote></li>
+                    {% endfor %}
+                    </ul>
+                    <p>Error details have been logged.</p>
+                </div>
+            {% endif %}
           {% endif %}
         </div>
       </div>

--- a/tests/integration/web/info_test.py
+++ b/tests/integration/web/info_test.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+from django.core.urlresolvers import reverse
+
+from nav.web.info.searchproviders import SearchProvider
+
+#########
+# Tests #
+#########
+
+
+def test_search_for_nonascii_characters_should_not_crash(client):
+    url = reverse('info-search') + '?query=æøå'
+    response = client.get(url)
+    assert response.status_code == 200
+
+
+def test_failing_searchprovider_should_not_crash_search_page(
+        client, failing_searchprovider):
+    url = reverse('info-search') + '?query=Da%20Truf'
+    response = client.get(url)
+    assert response.status_code == 200
+
+
+def test_failures_should_be_mentioned_in_search_page(client,
+                                                     failing_searchprovider):
+    url = reverse('info-search') + '?query=Da%20Truf'
+    response = client.get(url)
+    assert failing_searchprovider in response.content
+
+
+############
+# Fixtures #
+############
+
+
+@pytest.fixture
+def failing_searchprovider():
+    """
+    Inserts (into NAV's list of search providers to use) a provider that
+    raises an exception.
+    """
+    from django.conf import settings
+    provider = '{module}.{klass}'.format(module=__name__,
+                                         klass=FailingSearchProvider.__name__)
+    if provider not in settings.SEARCHPROVIDERS:
+        settings.SEARCHPROVIDERS.append(provider)
+
+    yield provider
+
+    if provider in settings.SEARCHPROVIDERS:
+        index = settings.SEARCHPROVIDERS.index(provider)
+        del settings.SEARCHPROVIDERS[index]
+
+
+class FailingSearchProvider(SearchProvider):
+    """A search provider that only raises exceptions"""
+    def fetch_results(self):
+        raise Exception("Riddikulus")


### PR DESCRIPTION
This fixes #1796 by catching unhandled exceptions in individual search providers, and providing this information to the user (as well as logging the actual tracebacks to the logging system).
