### PR TITLE
The /alert API endpoint crashes with a TypeError

### DIFF
--- a/python/nav/web/api/v1/filter_backends.py
+++ b/python/nav/web/api/v1/filter_backends.py
@@ -117,6 +117,11 @@ class AlertHistoryFilterBackend(filters.BaseFilterBackend):
     }
 
     def filter_queryset(self, request, queryset, view):
+        if view.is_single_alert_by_primary_key():
+            # no really, the client asked for a specific single alert, screw
+            # all the other filters!
+            return queryset
+
         for arg, field in self.MULTIVALUE_FILTERS.items():
             values = request.query_params.getlist(arg, None)
             if values:

--- a/tests/integration/api_test.py
+++ b/tests/integration/api_test.py
@@ -276,6 +276,14 @@ def test_update_prefix_remove_usage(db, api_client, token, serializer_models):
     json_response = json.loads(response.content.decode('utf-8'))
     assert json_response.get('usages') == ['ans']
 
+# Alert specific tests
+
+
+def test_nonexistent_alert_should_give_404(db, api_client, token):
+    create_token_endpoint(token, 'alert')
+    response = api_client.get('{}9999/'.format(ENDPOINTS['alert']))
+    print(response)
+    assert response.status_code == 404
 
 # Helpers
 

--- a/tests/integration/api_test.py
+++ b/tests/integration/api_test.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 import json
 import pytest
 
+from nav.models.event import AlertHistory
 from nav.models.fields import INFINITY
 from nav.web.api.v1.views import get_endpoints
 
@@ -284,6 +285,21 @@ def test_nonexistent_alert_should_give_404(db, api_client, token):
     response = api_client.get('{}9999/'.format(ENDPOINTS['alert']))
     print(response)
     assert response.status_code == 404
+
+
+def test_alert_should_be_visible_in_api(db, api_client, token,
+                                        serializer_models):
+    create_token_endpoint(token, 'alert')
+    alert = AlertHistory.objects.all()[0]
+    response = api_client.get('{url}{id}/'.format(
+        url=ENDPOINTS['alert'], id=alert.id))
+    print(response)
+    assert response.status_code == 200
+    content = response.content.decode('utf-8')
+    # Simple string tests, but they might just as well parse the JSON structure
+    assert str(alert.id) in content
+    assert str(alert.netbox.id) in content
+
 
 # Helpers
 


### PR DESCRIPTION
The problem seems to stem from upgrading the Django REST Framework dependency on the _master_ branch.

I'm not entirely sure of how to solve this quite yet, but  I'm adding a test to expose the issue here.