### PR TITLE
Add hook to customize tabs in ipdevinfo and info/room

### DIFF
--- a/doc/hacking/index.rst
+++ b/doc/hacking/index.rst
@@ -15,3 +15,4 @@
    /api/searchproviders
    adding-environment-probe-support
    /howto/using_the_api
+   web-interface-customization

--- a/doc/hacking/web-interface-customization.rst
+++ b/doc/hacking/web-interface-customization.rst
@@ -1,0 +1,112 @@
+===============================================
+ How to customize parts of NAV's web interface
+===============================================
+
+Some users like to modify parts of the NAV web interface to add their own
+information from, or links to, third party systems. In doing so, they override
+some of NAV's existing Django templates. *This is an unhealthy practice*, as it
+may cause errors or missing functionality the next time they upgrade NAV and
+the forked template changes.
+
+This guide serves to document the various official hooks into the NAV web
+interface. It is assumed you have a working knowledge of the `Django templating
+system <https://docs.djangoproject.com/en/1.8/topics/templates/>`_.
+
+
+How to add custom templates
+===========================
+
+NAV's Django templates are located inside its Python module directories. *You
+should not be modifying these directly*. If you need to override existing
+templates, or add custom hook templates, you should do so in a location that
+Django will search for templates *before* it looks into NAV's internal template
+directories.
+
+There are two ways to do this:
+
+1. The simple way: NAV includes a :file:`templates/` directory, relative to its
+   config directory, in its template search patch. If your NAV config is
+   located in :file:`/etc/nav/`, you can create the directory
+   :file:`/etc/nav/tempaltes/` and have Django find your custom templates
+   there.
+
+2. The "proper" way: You write your own Django application and include into
+   NAV's site configuration by way of a
+   :file:`/etc/nav/python/local_settings.py` file. Just include templates in
+   your app as you normally would in any Django app.
+
+Hooks
+=====
+
+Adding custom tabs to ipdevinfo
+-------------------------------
+
+*ipdevinfo* is the tabbed interface that displays NAV's information about
+single IP devices.
+
+The tabbing system HTML is built around using unordered list elements
+(``ul/li``) as tab headers, with hyperlinks to anchor tags. The content of each
+tab is a ``div`` with an id that matches those anchor tags.
+
+ipdevinfo tries to include the custom template ``ipdevinfo/custom-tabs.html``
+to add extra tab header elements, and ``ipdevinfo/custom-fragments.html`` to
+include the ``div`` elements with their corresponding contents.
+
+A simple customization example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: html
+   :caption: ipdevinfo/custom-tabs.html
+
+   <li><a href="#foobar">Foobar</a></li>
+   <li><a href="#frobnicate">Frobnication</a></li>
+
+
+.. code-block:: html
+   :caption: ipdevinfo/custom-fragments.html
+
+   <div id="foobar">
+       <h2>This is a custom tab for {{ netbox }}</h2>
+       <p>It's got stuff in it.</p>
+   </div>
+   <div id="frobnicate">
+       <h2>Frobnication data for {{ netbox }}</h2>
+       <p>A perfectly cromulent tab.</p>
+   </div>
+
+
+Adding custom tabs to the room overview page
+--------------------------------------------
+
+The *info* subsystem is the part of NAV that displays information about other
+NAV objects, such as VLANs, rooms, locations and so on. The room information
+page is also tabbed, but its tabs are more dynamic in nature than ipdevinfo's.
+
+As with ipdevinfo, the tabbing system HTML is built around using unordered list
+elements (``ul/li``) as tab headers, with hyperlinks to *other URLs that will
+provide the content of the tab* dynamically as the tab is selected. This
+functionality is provided by *jQuery UI*.
+
+Each list element must reference a placeholder ``div`` using the
+``aria-controls`` element attribute, as shown in the example below.
+
+The room page tries to include the custom template
+``info/room/custom-tabs.html`` to add extra tab header elements, and
+``info/room/custom-fragments.html`` to include the ``div`` elements that will
+be placeholders for the dynamically fetched content.
+
+A simple customization example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: html
+   :caption: info/room/custom-tabs.html
+
+   <li aria-controls="foobar">
+       <a href="http://example.org/my-exciting-html-snippet-generating-url">Foobar</a>
+   </li>
+
+
+.. code-block:: html
+   :caption: info/room/custom-fragments.html
+
+   <div id="foobar"></div>

--- a/python/nav/web/templates/info/room/roominfo.html
+++ b/python/nav/web/templates/info/room/roominfo.html
@@ -1,4 +1,5 @@
 {% extends "info/room/base.html" %}
+{% load silent_include %}
 
 {% block base_content %}
 
@@ -65,6 +66,9 @@
                 Sensors in racks
               </a>
             </li>
+
+            {% try_to_include "info/room/custom-tabs.html" %}
+
         </ul>
 
         <div id="roominfo">
@@ -78,6 +82,8 @@
         <div id="sensors"></div>  {# sensors #}
 
         <div id="racks"></div>
+
+        {% try_to_include "info/room/custom-fragments.html" %}
 
     </div>
 

--- a/python/nav/web/templates/ipdevinfo/ipdev-details.html
+++ b/python/nav/web/templates/ipdevinfo/ipdev-details.html
@@ -78,6 +78,9 @@
             What if
           </a>
         </li>
+
+        {% try_to_include "ipdevinfo/custom-tabs.html" %}
+
       </ul>
       {% include "ipdevinfo/frag-ipdevinfo.html" %}
       <div id="neighbors"></div>
@@ -93,6 +96,9 @@
 
       {% include "ipdevinfo/frag-poe.html" %}
       <div id="affected"></div>
+
+      {% try_to_include "ipdevinfo/custom-fragments.html" %}
+
     {% else %}
 
       <ul>


### PR DESCRIPTION
We need to add hooks to include custom tabs on the ipdevinfo and room/info pages, as several users are already using "unhealthy" practices by overriding entire NAV templates - a behavior that will likely break their NAV sites, at worst, or render new functionality missing on upgrades, at best

This adds and documents a simple hook for including third party templates into the tabbing code of these pages.