### PR TITLE
Fix python3 breakage in seeddb bulk import

### DIFF
--- a/python/nav/web/seeddb/forms/bulk.py
+++ b/python/nav/web/seeddb/forms/bulk.py
@@ -18,6 +18,7 @@ from nav.bulkparse import BulkParseError, CommentStripper
 from nav.bulkimport import BulkImportError
 
 from django import forms
+from django.utils import six
 
 
 class BulkImportForm(forms.Form):
@@ -49,7 +50,7 @@ class BulkImportForm(forms.Form):
     def get_raw_data(self):
         """Returns the bulk data as an utf-8 encoded string"""
         data = self.data.get('bulk_data', None)
-        if isinstance(data, unicode):
+        if six.PY2 and isinstance(data, six.string_type):
             return data.encode('utf-8')
         else:
             return data


### PR DESCRIPTION
Note that receiving end of this function expects string (bytes) on python2 and string (unicode) on python3, hence we only encode the data on python2