### PR TITLE
Fix IPAM subnet allocation suggestions for ipv6

### DIFF
--- a/python/nav/web/ipam/api.py
+++ b/python/nav/web/ipam/api.py
@@ -43,7 +43,7 @@ from rest_framework import serializers
 class SuggestParams(serializers.Serializer):
     prefix = serializers.CharField()
     n = serializers.IntegerField(default=10)
-    size = serializers.IntegerField(default=256)
+    prefixlen = serializers.IntegerField(default=24)
     offset = serializers.IntegerField(default=0)
 
 
@@ -108,7 +108,7 @@ class PrefixViewSet(viewsets.ViewSet):
                             status=status.HTTP_400_BAD_REQUEST)
         params = params.validated_data
         payload = suggest_range(params["prefix"], offset=params["offset"],
-                                size=params["size"], n=params["n"])
+                                prefixlen=params["prefixlen"], n=params["n"])
         return Response(payload, status=status.HTTP_200_OK)
 
     @detail_route(methods=["get"])

--- a/python/nav/web/ipam/api.py
+++ b/python/nav/web/ipam/api.py
@@ -23,7 +23,7 @@ API specific code for the private IPAM API. Exports a router for easy mounting.
 from rest_framework import viewsets, status, routers
 from rest_framework.response import Response
 from rest_framework.decorators import detail_route, list_route
-from IPy import IP
+from nav.ip import IP
 
 from .prefix_tree import make_tree, make_tree_from_ip
 
@@ -35,7 +35,7 @@ from nav.web.ipam.util import PrefixQuerysetBuilder, get_available_subnets, \
 
 
 from rest_framework import serializers
-#from nav.models.fields import CIDRField
+# from nav.models.fields import CIDRField
 
 
 # Inspired by
@@ -43,8 +43,17 @@ from rest_framework import serializers
 class SuggestParams(serializers.Serializer):
     prefix = serializers.CharField()
     n = serializers.IntegerField(default=10)
-    prefixlen = serializers.IntegerField(default=24)
+    prefixlen = serializers.IntegerField(default=24, min_value=1, max_value=128)
     offset = serializers.IntegerField(default=0)
+
+    def validate(self, data):
+        try:
+            if IP(data['prefix']).version() == 4 and data['prefixlen'] > 32:
+                raise serializers.ValidationError(
+                    "Prefixlen can not be higher than 32 for ipv4 prefixes")
+        except ValueError:
+            raise serializers.ValidationError("Invalid prefix")
+        return data
 
 
 class PrefixViewSet(viewsets.ViewSet):

--- a/python/nav/web/static/js/src/ipam/views/subnetallocator.js
+++ b/python/nav/web/static/js/src/ipam/views/subnetallocator.js
@@ -290,7 +290,6 @@ define(function(require, exports, module) {
       if (!(sizeOfNetwork && prefix)) {
         return;
       }
-      var url = "/ipam/api/suggest/?size=" + sizeOfNetwork + "&prefix=" + prefix;
       var optionTemplate = _.template("<%= prefix %> (<%= start%>-<%= end %>)");
       var pageSize = 10;
       selectElem.select2({
@@ -301,7 +300,7 @@ define(function(require, exports, module) {
           data: function(term, page) {
             return {
               n: pageSize,
-              size: sizeOfNetwork,
+              prefixlen: sizeOfNetwork,
               prefix: prefix,
               offset: pageSize * (page - 1)
             };

--- a/python/nav/web/templates/ipam/includes/allocate-subnet.html
+++ b/python/nav/web/templates/ipam/includes/allocate-subnet.html
@@ -24,7 +24,7 @@
   <div class="panel white">
     <h5>Creating new reservation</h5>
     <form class="allocation-tree-reserve-form">
-      <label for="Size of network">Number of addresses required (minimum)</label>
+      <label for="Size of network">Wanted prefix length</label>
       <input type="number" class="size-of-network" value="<%= network_size %>" min="2" />
       <button class="button small choose-network-size">Suggest subnets of this size</button>
       <% if (state === "CHOSEN_RESERVATION_SIZE" || state === "CHOSEN_SUBNET") { %>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,6 +5,7 @@ asciitree==0.3.3  # optional, for naventity
 configparser==3.5.0 ; python_version < '3'
 psycopg2==2.5.4  # requires libpq to build
 IPy==0.83
+py2-ipaddress==3.4.1 ; python_version < '3'
 pyaml
 
 twisted>=14.0.1,<18 ; python_version < '3'


### PR DESCRIPTION
Changes UI to ask for a prefix length, rather than number of addresses wanted. Assume NAV users are networking people and know how this works. Asking for number of addresses makes no sense for ipv6.
The `partition_subnet()` function is essensially the same as the ipaddress modules `IPXNetwork.subnets()` function, so use that (include polyfill on python2)

Fixes #1594