### PR TITLE
get rid of DeprecationWarning, array.tostring()

### DIFF
--- a/python/nav/bitvector.py
+++ b/python/nav/bitvector.py
@@ -20,6 +20,8 @@ import re
 
 from django.utils import six
 
+from .six import encode_array
+
 
 class BitVector(object):
     """
@@ -35,7 +37,7 @@ class BitVector(object):
         self.vector = array.array("B", octetstring)
 
     def to_bytes(self):
-        return self.vector.tostring()
+        return encode_array(self.vector)
 
     def __len__(self):
         return len(self.vector)*8

--- a/python/nav/oidparsers.py
+++ b/python/nav/oidparsers.py
@@ -27,7 +27,10 @@ from struct import unpack
 import array
 from IPy import IP
 from itertools import islice
+
 from .oids import OID
+from .six import encode_array
+
 
 IPV4_ID = 1
 IPV6_ID = 2
@@ -65,7 +68,7 @@ def oid_to_ipv6(oid):
     if len(oid) != 16:
         raise ValueError("IPv6 address must be 16 octets, not %d" % len(oid))
     try:
-        high, low = unpack("!QQ", array.array("B", oid).tostring())
+        high, low = unpack("!QQ", encode_array(array.array("B", oid)))
     except OverflowError as error:
         raise ValueError(error)
     addr = (high << 64) + low
@@ -82,7 +85,7 @@ def oid_to_ipv4(oid):
     if len(oid) != 4:
         raise ValueError("IPv4 address must be 4 octets, not %d" % len(oid))
     try:
-        addr, = unpack("!I", array.array("B", oid).tostring())
+        addr, = unpack("!I", encode_array(array.array("B", oid)))
     except OverflowError as error:
         raise ValueError(error)
     return IP(addr, ipversion=4)

--- a/python/nav/six.py
+++ b/python/nav/six.py
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2019 Uninett AS
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.  You should have received a copy of the GNU General Public License
+# along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Various functions that we need to keep code in python2 and python3 looking the
+same that six lacks.
+
+"""
+from __future__ import absolute_import
+
+
+from django.utils import six
+
+if six.PY3:
+    def encode_array(a):
+        return a.tobytes()
+else:
+    def encode_array(a):
+        return a.tostring()


### PR DESCRIPTION
DeprecationWarning: tostring() is deprecated. Use tobytes() instead.

This was not solved in six.

Note: this gives a deprecation warning all the way up to and including python 3.7, so it is not exactly a high priority to fix, but warnings are annoying and can hide real problems, so..