### PR TITLE
Update to most recent version of networkx

### DIFF
--- a/python/nav/eventengine/topology.py
+++ b/python/nav/eventengine/topology.py
@@ -139,7 +139,7 @@ def strip_down_nodes_from_graph(graph, keep=None):
     :param keep: A node to keep regardless of its current status.
 
     """
-    removable = set(node for node in graph.nodes_iter()
+    removable = set(node for node in graph.nodes()
                     if node.up != node.UP_UP and node != keep)
     graph.remove_nodes_from(removable)
     return len(removable)
@@ -156,7 +156,7 @@ def strip_down_links_from_graph(graph):
 
     removable = set(
         (u, v, key)
-        for u, v, key, data in graph.edges_iter(data=True, keys=True)
+        for u, v, key, data in graph.edges(data=True, keys=True)
         if _is_down(data)
     )
     graph.remove_edges_from(removable)

--- a/python/nav/topology/analyze.py
+++ b/python/nav/topology/analyze.py
@@ -132,7 +132,7 @@ class AdjacencyAnalyzer(object):
 
     def get_single_edges_from_ports(self):
         """Returns a list of edges from ports whose degree is 1"""
-        edges = [self.graph.edges(port)[0]
+        edges = [list(self.graph.edges(port))[0]
                  for port in self.get_ports_by_degree(1)]
         return edges
 
@@ -238,7 +238,7 @@ class AdjacencyReducer(AdjacencyAnalyzer):
 
     def _visit_unvisited(self, unvisited):
         for port in unvisited:
-            for source, dest, proto in self.graph.edges(port, keys=True):
+            for source, dest, proto in list(self.graph.edges(port, keys=True)):
                 _logger.debug("Considering %s %s source %s",
                               source, dest, proto)
                 if dest == source[0]:

--- a/python/nav/topology/vlan.py
+++ b/python/nav/topology/vlan.py
@@ -264,7 +264,7 @@ class RoutedVlanTopologyAnalyzer(object):
     def _out_edges_on_vlan(self, node):
         return (
             (u, v, w)
-            for u, v, w in self.layer2.out_edges_iter(node, keys=True)
+            for u, v, w in self.layer2.out_edges(node, keys=True)
             if self._ifc_has_vlan(w))
 
     def _ifc_has_vlan(self, ifc):

--- a/python/nav/web/netmap/graph.py
+++ b/python/nav/web/netmap/graph.py
@@ -80,7 +80,7 @@ def _json_layer2(load_traffic=False, view=None):
         'vlans': get_vlan_lookup_json(vlan_by_interface),
         'nodes': _get_nodes(node_to_json_layer2, graph),
         'links': [edge_to_json_layer2(get_edge_from_meta(meta), meta) for
-                  u, v, meta in graph.edges_iter(data=True)]
+                  u, v, meta in graph.edges(data=True)]
     }
     return result
 
@@ -105,14 +105,14 @@ def _json_layer3(load_traffic=False, view=None):
         'vlans': [vlan_to_json(prefix.vlan) for prefix in vlans_map],
         'nodes': _get_nodes(node_to_json_layer3, graph),
         'links': [edge_to_json_layer3(get_edge_from_meta(meta), meta) for
-                  u, v, meta in graph.edges_iter(data=True)]
+                  u, v, meta in graph.edges(data=True)]
     }
     return result
 
 
 def _get_nodes(node_to_json_function, graph):
     nodes = {}
-    for node, nx_metadata in graph.nodes_iter(data=True):
+    for node, nx_metadata in graph.nodes(data=True):
         nodes.update(node_to_json_function(node, nx_metadata))
     return nodes
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ pyaml
 twisted>=14.0.1,<18 ; python_version < '3'
 twisted>=16.6.0,<18 ; python_version >= '3'
 
-networkx>=1.7,<1.8
+networkx>=2.2,<2.3
 xmpppy==0.5.0rc1  # optional, for alerting via Jabber
 Pillow==3.0.0
 pyrad==2.1

--- a/tests/unittests/netmap/multidigraph_to_undirect_test.py
+++ b/tests/unittests/netmap/multidigraph_to_undirect_test.py
@@ -57,12 +57,12 @@ class Layer2MultiGraphToUndirectTests(TopologyLayer2TestCase):
 
         # should be the same as
         #  test_edges_length_of_netmap_graph_is_reduced_properly
-        assert (
+        self.assertEqual(
             [
                 (self.a, self.b),
                 (self.a, self.c),
                 (self.c, self.d)
-            ] ==
+            ],
             list(self.netmap_graph.edges())
         )
 

--- a/tests/unittests/netmap/multidigraph_to_undirect_test.py
+++ b/tests/unittests/netmap/multidigraph_to_undirect_test.py
@@ -45,7 +45,7 @@ class Layer2MultiGraphToUndirectTests(TopologyLayer2TestCase):
                 (self.a, self.c),
                 (self.c, self.d)
             ],
-            self.netmap_graph.edges()
+            list(self.netmap_graph.edges())
         )
 
     def test_layer2_create_directional_metadata_from_nav_graph(self):
@@ -57,13 +57,13 @@ class Layer2MultiGraphToUndirectTests(TopologyLayer2TestCase):
 
         # should be the same as
         #  test_edges_length_of_netmap_graph_is_reduced_properly
-        self.assertEqual(
+        assert (
             [
                 (self.a, self.b),
                 (self.a, self.c),
                 (self.c, self.d)
-            ],
-            self.netmap_graph.edges()
+            ] ==
+            list(self.netmap_graph.edges())
         )
 
         self.assertEqual(2,


### PR DESCRIPTION
This fixes a bunch of warnings when running tests. The version we were using did not officially support python 3.5+