### PR TITLE
Use pip-tools to keep test environment dependencies in sync

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,16 +4,12 @@
  * Jenkins.
 */
 def lastStage = ''
-def requirementsChanged = false
 node {
   setDisplayNameIfPullRequest()
 
   stage("Checkout") {
       lastStage = env.STAGE_NAME
       def scmVars = checkout scm
-      requirementsChanged = sh(
-                               returnStatus: true,
-                               script: "git diff --name-only ${scmVars.GIT_PREVIOUS_SUCCESSFUL_COMMIT} ${scmVars.GIT_COMMIT} | egrep '^(tests/)?requirements.*txt\$'") == 0
   }
 
   try {
@@ -31,10 +27,6 @@ node {
             sh "env"  // debug print environment
             sh "git fetch --tags" // seems tags arent't cloned by Jenkins :P
             sh "rm -rf ${WORKSPACE}/reports/*"  // remove old, potentially stale reports
-            if (requirementsChanged) {
-              echo '============================= Some requirements files changed, recreating tox environments ============================='
-              sh "tox --recreate --notest"
-            }
         }
 
         try {

--- a/tox.ini
+++ b/tox.ini
@@ -12,13 +12,10 @@ toxworkdir = /source/.tox
 
 [testenv]
 # Baseline test environment
-deps = -rtests/requirements.txt
-       -rrequirements/base.txt
-       django18: -rrequirements/django18.txt
-       django19: -rrequirements/django19.txt
-       django110: -rrequirements/django110.txt
-       django111: -rrequirements/django111.txt
+deps = pip-tools
 setenv =
+    LC_ALL=C.UTF-8
+    LANG=C.UTF-8
     PYTHONPATH = {toxinidir}/tests
     BUILDDIR = {envdir}
     CHROME_BIN = /usr/bin/google-chrome
@@ -28,7 +25,14 @@ whitelist_externals =
                       /bin/sh
                       /bin/sed
 commands =
+         django18: pip-compile --output-file {envname}-requirements.txt tests/requirements.txt requirements/base.txt requirements/django18.txt
+         django19: pip-compile --output-file {envname}-requirements.txt tests/requirements.txt requirements/base.txt requirements/django19.txt
+         django110: pip-compile --output-file {envname}-requirements.txt tests/requirements.txt requirements/base.txt requirements/django110.txt
+         django111: pip-compile --output-file {envname}-requirements.txt tests/requirements.txt requirements/base.txt requirements/django111.txt
+
+         pip-sync {envname}-requirements.txt
          pip install -e .
+
          unit: pytest -o junit_suite_name="{envname} unit tests" --cov-config {toxinidir}/tests/.coveragerc --cov={toxinidir}/python --cov-report=xml:reports/{envname}/coverage.xml --junitxml=reports/{envname}/unit-results.xml --verbose {posargs:tests/unittests}
 
          {integration,functional}: python setup.py build_sass
@@ -59,23 +63,26 @@ commands =
          /sbin/start-stop-daemon --stop --quiet --pidfile /var/tmp/xvfb.pid
 
 [testenv:pylint]
-deps =
-    -rtests/requirements.txt
-    -rrequirements.txt
+deps = pip-tools
 description = PyLint run on default environment
 setenv = PYLINTHOME = {toxinidir}
-commands = {toxinidir}/tests/docker/scripts/pylint.sh python/nav --jobs=4 --rcfile=python/pylint.rc --disable=I,similarities --output-format=parseable
+commands =
+         pip-compile --output-file {envname}-requirements.txt tests/requirements.txt requirements/base.txt requirements/django18.txt
+         pip-sync {envname}-requirements.txt
+
+         {toxinidir}/tests/docker/scripts/pylint.sh python/nav --jobs=4 --rcfile=python/pylint.rc --disable=I,similarities --output-format=parseable
 
 [testenv:docs]
 description = Just build the Sphinx documentation
 usedevelop=True
-deps =
-    -rtests/requirements.txt
-    -rrequirements.txt
+deps = pip-tools
 setenv =
     PYTHONPATH = {toxinidir}/python:{toxinidir}/tests
     DJANGO_SETTINGS_MODULE = nav.django.settings
 whitelist_externals = /bin/sh
 commands =
+         pip-compile --output-file {envname}-requirements.txt tests/requirements.txt requirements/base.txt requirements/django18.txt
+         pip-sync {envname}-requirements.txt
+
          python setup.py build_sphinx
          sh -c "cd doc; python -c 'import conf; print conf.version' > {toxinidir}/reports/doc_version"

--- a/tox.ini
+++ b/tox.ini
@@ -20,16 +20,16 @@ setenv =
     BUILDDIR = {envdir}
     CHROME_BIN = /usr/bin/google-chrome
     DJANGO_SETTINGS_MODULE = nav.django.settings
+    django18: DJANGO_VER=18
+    django19: DJANGO_VER=19
+    django110: DJANGO_VER=110
+    django111: DJANGO_VER=111
 passenv = WORKSPACE DISPLAY
 whitelist_externals =
                       /bin/sh
                       /bin/sed
 commands =
-         django18: pip-compile --output-file {envname}-requirements.txt tests/requirements.txt requirements/base.txt requirements/django18.txt
-         django19: pip-compile --output-file {envname}-requirements.txt tests/requirements.txt requirements/base.txt requirements/django19.txt
-         django110: pip-compile --output-file {envname}-requirements.txt tests/requirements.txt requirements/base.txt requirements/django110.txt
-         django111: pip-compile --output-file {envname}-requirements.txt tests/requirements.txt requirements/base.txt requirements/django111.txt
-
+         pip-compile --output-file {envname}-requirements.txt tests/requirements.txt requirements/base.txt requirements/django{env:DJANGO_VER}.txt
          pip-sync {envname}-requirements.txt
          pip install -e .
 


### PR DESCRIPTION
This should remove the need to completely rebuild tox environments from scratch when NAV requirements  change.

`pip-compile` is used to build a complete requirements manifest for each tox environment, and `pip-sync` is used to keep the environment in sync with this manifest.