### PR TITLE
Refactor nav.web.auth.authenticate

### DIFF
--- a/python/nav/web/auth.py
+++ b/python/nav/web/auth.py
@@ -30,7 +30,7 @@ def authenticate_account(username=None, password=None):
 
     Returns account object if user was authenticated, else None.
     """
-    if not username and password:
+    if not username and not password:
         return None
 
     try:
@@ -57,7 +57,7 @@ def authenticate_ldap(username=None, password=None):
 
     Returns account object if user was authenticated, else None.
     """
-    if not username and password:
+    if not username and not password:
         return None
 
     if not ldapauth.available:

--- a/python/nav/web/auth.py
+++ b/python/nav/web/auth.py
@@ -28,7 +28,8 @@ def authenticate_account(username=None, password=None):
     """
     Authenticate username and password against database
 
-    Returns account object if user was authenticated, else None.
+    Returns account object if user was authenticated, False if the user is
+    invlid or otherwise is not allowed to log in, else None.
     """
     if not username and not password:
         return None
@@ -55,7 +56,8 @@ def authenticate_ldap(username=None, password=None):
     """
     Authenticate username and password against LDAP, if available
 
-    Returns account object if user was authenticated, else None.
+    Returns account object if user was authenticated, False if the user is
+    invlid or otherwise is not allowed to log in, else None.
     """
     if not username and not password:
         return None

--- a/python/nav/web/auth.py
+++ b/python/nav/web/auth.py
@@ -38,6 +38,12 @@ def authenticate_account(username=None, password=None):
     except Account.DoesNotExist:
         return None
 
+    # Bail out! Potentially evil user
+    if account.locked:
+        logger.info("Locked user %s tried to log in", account.login)
+        # Needs auditlog
+        return None
+
     if account.check_password(password):
         return account
 

--- a/python/nav/web/auth.py
+++ b/python/nav/web/auth.py
@@ -82,8 +82,8 @@ def authenticate_ldap(username=None, password=None):
     except Account.DoesNotExist:
         # Store the ldapuser in the database and return the new account
         account = Account(
-            login=user.username,
-            name=user.get_real_name(),
+            login=ldapuser.username,
+            name=ldapuser.get_real_name(),
             ext_sync='ldap'
         )
         account.set_password(password)

--- a/python/nav/web/auth.py
+++ b/python/nav/web/auth.py
@@ -97,21 +97,12 @@ def authenticate_ldap(username=None, password=None):
         # Needs auditlog
         return None
 
-    save = False
-    # Ensure ext_sync is correct
-    if not account.ext_sync == 'ldap':
-        account.ext_sync = 'ldap'
-        logger.info("Correctly set ext_sync for user %s", account.login)
-        save = True
-
     # Sync password from ldap to local db
     if not account.check_password(password):
         account.set_password(password)
         logger.info("Synced user %s's password from LDAP", account.login)
-        save = True
-
-    if save:
         account.save()
+
     return account
 
 

--- a/tests/unittests/general/webfront_test.py
+++ b/tests/unittests/general/webfront_test.py
@@ -31,27 +31,33 @@ class TestLdapAuthenticate(object):
             assert auth.authenticate_ldap('knight', 'shrubbery') is None
 
 
-@patch("nav.web.auth.Account.objects.get",
-       new=MagicMock(return_value=PLAIN_ACCOUNT))
-@patch("nav.web.ldapauth.available", new=False)
 class TestNormalAuthenticate(object):
     def test_authenticate_account_should_return_account_when_password_is_ok(self):
-        with patch("nav.web.auth.Account.check_password", return_value=True):
-            assert auth.authenticate_account('knight', 'shrubbery') == PLAIN_ACCOUNT
+        with patch("nav.web.auth.Account.objects.get",
+                   new=MagicMock(return_value=PLAIN_ACCOUNT)):
+            with patch("nav.web.auth.Account.check_password", return_value=True):
+                assert auth.authenticate_account('knight', 'shrubbery') == PLAIN_ACCOUNT
+
+    def test_authenticate_account_shouldnt_care_about_ext_sync(self):
+        with patch("nav.web.auth.Account.objects.get",
+                   new=MagicMock(return_value=LDAP_ACCOUNT)):
+            with patch("nav.web.auth.Account.check_password", return_value=True):
+                assert auth.authenticate_account('knight', 'shrubbery') == LDAP_ACCOUNT
 
     def test_authenticate_account_should_return_falsey_when_password_is_wrong(self):
-        with patch("nav.web.auth.Account.check_password", return_value=False):
-            assert not auth.authenticate_account('knight', 'rabbit')
+        with patch("nav.web.auth.Account.objects.get",
+                   new=MagicMock(return_value=PLAIN_ACCOUNT)):
+            with patch("nav.web.auth.Account.check_password", return_value=False):
+                assert not auth.authenticate_account('knight', 'rabbit')
 
 
 def test_authenticate_should_return_ldap_account_when_ldap_user_exists():
     with patch("nav.web.ldapauth.available", new=True):
         with patch("nav.web.ldapauth.authenticate", return_value=True):
-            with patch("nav.web.auth.Account.save", new=MagicMock(return_value=True)):
+            with patch("nav.web.auth.Account.objects.get",
+                        new=MagicMock(return_value=LDAP_ACCOUNT)):
                 with patch("nav.web.auth.Account.check_password", return_value=True):
-                    with patch("nav.web.auth.Account.objects.get",
-                               new=MagicMock(return_value=LDAP_ACCOUNT)):
-                        assert auth.authenticate('knight', 'shrubbery') == LDAP_ACCOUNT
+                    assert auth.authenticate('knight', 'shrubbery') == LDAP_ACCOUNT
 
 
 def test_authenticate_should_return_none_when_ldap_user_does_not_exist():

--- a/tests/unittests/general/webfront_test.py
+++ b/tests/unittests/general/webfront_test.py
@@ -52,18 +52,19 @@ class TestNormalAuthenticate(object):
 
 
 def test_authenticate_should_return_ldap_account_when_ldap_user_exists():
-    with patch("nav.web.ldapauth.available", new=True):
-        with patch("nav.web.ldapauth.authenticate", return_value=True):
-            with patch("nav.web.auth.Account.objects.get",
-                        new=MagicMock(return_value=LDAP_ACCOUNT)):
-                with patch("nav.web.auth.Account.check_password", return_value=True):
-                    assert auth.authenticate('knight', 'shrubbery') == LDAP_ACCOUNT
+    with patch("nav.web.auth.authenticate_ldap", return_value=LDAP_ACCOUNT):
+        assert auth.authenticate('knight', 'shrubbery') == LDAP_ACCOUNT
 
 
-def test_authenticate_should_return_none_when_ldap_user_does_not_exist():
-    with patch("nav.web.ldapauth.available", new=True):
-        with patch("nav.web.ldapauth.authenticate", return_value=False):
-            assert auth.authenticate('knight', 'shrubbery') == None
+def test_authenticate_should_return_none_when_ldap_says_no():
+    with patch("nav.web.auth.authenticate_ldap", return_value=False):
+        assert auth.authenticate('knight', 'shrubbery') == None
+
+
+def test_authenticate_should_fallback_to_account_if_ldap_fails():
+    with patch("nav.web.auth.authenticate_ldap", return_value=None):
+        with patch("nav.web.auth.authenticate_account", return_value=LDAP_ACCOUNT):
+            assert auth.authenticate('knight', 'shrubbery') == LDAP_ACCOUNT
 
 
 class TestLdapUser(object):

--- a/tests/unittests/general/webfront_test.py
+++ b/tests/unittests/general/webfront_test.py
@@ -16,33 +16,48 @@ PLAIN_ACCOUNT = auth.Account(login='knight', password='shrubbery')
 @patch("nav.web.auth.Account.objects.get",
        new=MagicMock(return_value=LDAP_ACCOUNT))
 class TestLdapAuthenticate(object):
-    def test_authenticate_should_return_account_when_ldap_says_yes(self):
+    def test_authenticate_ldap_should_return_account_when_ldap_says_yes(self):
         with patch("nav.web.ldapauth.available", new=True):
             with patch("nav.web.ldapauth.authenticate", return_value=True):
                 assert auth.authenticate_ldap('knight', 'shrubbery') == LDAP_ACCOUNT
 
-    def test_authenticate_should_return_false_when_ldap_says_no(self):
+    def test_authenticate_ldap_should_return_false_when_ldap_says_no(self):
         with patch("nav.web.ldapauth.available", new=True):
             with patch("nav.web.ldapauth.authenticate", return_value=False):
-                assert auth.authenticate_ldap('knight', 'shrubbery') is None
+                assert auth.authenticate_ldap('knight', 'shrubbery') is False
 
-    def test_authenticate_should_fallback_when_ldap_is_disabled(self):
+    def test_authenticate_ldap_should_fallback_when_ldap_is_disabled(self):
         with patch("nav.web.ldapauth.available", new=False):
             assert auth.authenticate_ldap('knight', 'shrubbery') is None
 
 
-@patch("nav.web.auth.Account.save", new=MagicMock(return_value=True))
 @patch("nav.web.auth.Account.objects.get",
        new=MagicMock(return_value=PLAIN_ACCOUNT))
 @patch("nav.web.ldapauth.available", new=False)
 class TestNormalAuthenticate(object):
-    def test_authenticate_should_return_account_when_password_is_ok(self):
+    def test_authenticate_account_should_return_account_when_password_is_ok(self):
         with patch("nav.web.auth.Account.check_password", return_value=True):
-            assert auth.authenticate('knight', 'shrubbery') == PLAIN_ACCOUNT
+            assert auth.authenticate_account('knight', 'shrubbery') == PLAIN_ACCOUNT
 
-    def test_authenticate_should_return_false_when_ldap_says_no(self):
+    def test_authenticate_account_should_return_falsey_when_password_is_wrong(self):
         with patch("nav.web.auth.Account.check_password", return_value=False):
-            assert not auth.authenticate('knight', 'rabbit')
+            assert not auth.authenticate_account('knight', 'rabbit')
+
+
+def test_authenticate_should_return_ldap_account_when_ldap_user_exists():
+    with patch("nav.web.ldapauth.available", new=True):
+        with patch("nav.web.ldapauth.authenticate", return_value=True):
+            with patch("nav.web.auth.Account.save", new=MagicMock(return_value=True)):
+                with patch("nav.web.auth.Account.check_password", return_value=True):
+                    with patch("nav.web.auth.Account.objects.get",
+                               new=MagicMock(return_value=LDAP_ACCOUNT)):
+                        assert auth.authenticate('knight', 'shrubbery') == LDAP_ACCOUNT
+
+
+def test_authenticate_should_return_none_when_ldap_user_does_not_exist():
+    with patch("nav.web.ldapauth.available", new=True):
+        with patch("nav.web.ldapauth.authenticate", return_value=False):
+            assert auth.authenticate('knight', 'shrubbery') == None
 
 
 class TestLdapUser(object):

--- a/tests/unittests/general/webfront_test.py
+++ b/tests/unittests/general/webfront_test.py
@@ -19,16 +19,16 @@ class TestLdapAuthenticate(object):
     def test_authenticate_should_return_account_when_ldap_says_yes(self):
         with patch("nav.web.ldapauth.available", new=True):
             with patch("nav.web.ldapauth.authenticate", return_value=True):
-                assert auth.authenticate('knight', 'shrubbery') == LDAP_ACCOUNT
+                assert auth.authenticate_ldap('knight', 'shrubbery') == LDAP_ACCOUNT
 
     def test_authenticate_should_return_false_when_ldap_says_no(self):
         with patch("nav.web.ldapauth.available", new=True):
             with patch("nav.web.ldapauth.authenticate", return_value=False):
-                assert not auth.authenticate('knight', 'shrubbery')
+                assert auth.authenticate_ldap('knight', 'shrubbery') is None
 
     def test_authenticate_should_fallback_when_ldap_is_disabled(self):
         with patch("nav.web.ldapauth.available", new=False):
-            assert auth.authenticate('knight', 'shrubbery') == LDAP_ACCOUNT
+            assert auth.authenticate_ldap('knight', 'shrubbery') is None
 
 
 @patch("nav.web.auth.Account.save", new=MagicMock(return_value=True))


### PR DESCRIPTION
Behold, much less complex `if`s!

Cannot test `auth.authenticate` directly here because the patch of
`Account.objects.get` also overwrites the account in
'authenticate_account', so that `LDAP_ACCOUNT` is always returned. If
`auth.authenticate` is to be tested also here, only the first
`Account.objects.get` found should be patched.