### PR TITLE
Support REMOTE_USER

### DIFF
--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -17,6 +17,7 @@ This section contains reference material for end-users.
    ipam
    ipdevpoll
    ldap
+   web_authentication
    mailin
    navstats
    portadmin

--- a/doc/reference/web_authentication.rst
+++ b/doc/reference/web_authentication.rst
@@ -1,0 +1,16 @@
+================================
+Web authentication (REMOTE_USER)
+================================
+
+If you set ``AUTH_SUPPORT_REMOTE_USER`` to ``True`` in ``nav.conf``, NAV will
+check for the HTTP header ``REMOTE_USER`` on every page load, and attempt to
+log in the username found there. An account will be created if one does not
+already exist for that username.
+
+``REMOTE_USER`` can be set by the web server hosting NAV, and is a simple way
+of supporting federated logins via eg. Kerberors or SAML, provided the web
+server has the necessary support/modules/plugins.
+
+Since the password is controlled from a system externally to NAV, the user does
+not have access to change the password from inside NAV. If an account is set to
+invalid in NAV, the user will not be logged in, even if the header is set.

--- a/doc/reference/web_authentication.rst
+++ b/doc/reference/web_authentication.rst
@@ -2,10 +2,13 @@
 Web authentication (REMOTE_USER)
 ================================
 
-If you set ``AUTH_SUPPORT_REMOTE_USER`` to ``True`` in ``nav.conf``, NAV will
-check for the HTTP header ``REMOTE_USER`` on every page load, and attempt to
-log in the username found there. An account will be created if one does not
-already exist for that username.
+Whether the ``REMOTE_USER`` http header is honored is configured in
+``webfront.conf``. In the section ``[remote-user]``, set ``enabled`` to ``on``
+or ``yes``. (A missing section or value is interpreted as
+``REMOTE_USER``-support being off.) When enabled, NAV will check for the HTTP
+header ``REMOTE_USER`` on every page load, and attempt to log in the username
+found there. An account will be created if one does not already exist for that
+username.
 
 ``REMOTE_USER`` can be set by the web server hosting NAV, and is a simple way
 of supporting federated logins via eg. Kerberors or SAML, provided the web

--- a/python/nav/django/auth.py
+++ b/python/nav/django/auth.py
@@ -50,11 +50,10 @@ class AuthenticationMiddleware(MiddlewareMixin):
         account = None
 
         if ACCOUNT_ID_VAR not in session:  # Not logged in
-            if NAV_CONFIG.get('AUTH_SUPPORT_REMOTE_USER', False):
-                # Get or create an account from the REMOTE_USER http header
-                account = authenticate_remote_user(request)
-                if account:
-                    session[ACCOUNT_ID_VAR]  = account.id
+            # Get or create an account from the REMOTE_USER http header
+            account = authenticate_remote_user(request)
+            if account:
+                session[ACCOUNT_ID_VAR]  = account.id
             else:
                 # Set account id to anonymous user
                 session[ACCOUNT_ID_VAR] = Account.DEFAULT_ACCOUNT

--- a/python/nav/django/auth.py
+++ b/python/nav/django/auth.py
@@ -17,8 +17,10 @@
 import os
 from logging import getLogger
 
+from nav.config import NAV_CONFIG
 from nav.models.profiles import Account
 from nav.django.utils import is_admin, get_account
+from nav.web.auth import authenticate_remote_user
 
 from django.http import HttpResponseRedirect, HttpResponse
 from django.contrib.sessions.backends.db import SessionStore
@@ -45,10 +47,19 @@ LOGIN_URL = '/index/login/'
 class AuthenticationMiddleware(MiddlewareMixin):
     def process_request(self, request):
         session = request.session
+        account = None
 
-        if ACCOUNT_ID_VAR not in session:
-            session[ACCOUNT_ID_VAR] = Account.DEFAULT_ACCOUNT
-        account = Account.objects.get(id=session[ACCOUNT_ID_VAR])
+        if ACCOUNT_ID_VAR not in session:  # Not logged in
+            if NAV_CONFIG.get('AUTH_SUPPORT_REMOTE_USER', False):
+                # Get or create an account from the REMOTE_USER http header
+                account = authenticate_remote_user(request)
+                if account:
+                    session[ACCOUNT_ID_VAR]  = account.id
+            else:
+                # Set account id to anonymous user
+                session[ACCOUNT_ID_VAR] = Account.DEFAULT_ACCOUNT
+        if not account:
+            account = Account.objects.get(id=session[ACCOUNT_ID_VAR])
         request.account = account
 
         if SUDOER_ID_VAR in session:

--- a/python/nav/etc/nav.conf
+++ b/python/nav/etc/nav.conf
@@ -51,6 +51,3 @@ DOMAIN_SUFFIX = .example.com
 # Any timestamp NAV generates (using Django) will be relative to this time
 # zone.
 #TIME_ZONE = Europe/Oslo
-
-# Should it be possible to log in with the user set in the header REMOTE_USER?
-#AUTH_SUPPORT_REMOTE_USER = False

--- a/python/nav/etc/nav.conf
+++ b/python/nav/etc/nav.conf
@@ -51,3 +51,6 @@ DOMAIN_SUFFIX = .example.com
 # Any timestamp NAV generates (using Django) will be relative to this time
 # zone.
 #TIME_ZONE = Europe/Oslo
+
+# Should it be possible to log in with the user set in the header REMOTE_USER?
+#AUTH_SUPPORT_REMOTE_USER = False

--- a/python/nav/etc/webfront/webfront.conf
+++ b/python/nav/etc/webfront/webfront.conf
@@ -87,3 +87,7 @@ basedn = ou=people,dc=example,dc=com
 # stderr.  If enabled, you will typically find this output in the Apache error
 # log.
 #debug = no
+
+# Should it be possible to log in with the user set in the header REMOTE_USER?
+[remote-user]
+enabled = no

--- a/python/nav/web/auth.py
+++ b/python/nav/web/auth.py
@@ -29,8 +29,8 @@ except ImportError:
     import string
 
     def fake_password(length):
-        S = string.ascii_letters + string.punctuation + string.digits
-        return u"".join(choice(S) for i in range(length))
+        symbols = string.ascii_letters + string.punctuation + string.digits
+        return u"".join(choice(symbols) for i in range(length))
 
 
 from nav.config import NAV_CONFIG

--- a/python/nav/web/auth.py
+++ b/python/nav/web/auth.py
@@ -111,6 +111,14 @@ def authenticate(username, password):
 
 
 def authenticate_remote_user(request=None):
+    '''Authenticate username from htpp header REMOTE_USER
+
+    Returns:
+
+    * account object if user was authenticated
+    * False if authentcaired but blocked from logging in
+    * None in all other cases
+    '''
     try:
         if not _config.getboolean('remote-user', 'enabled'):
             return None

--- a/python/nav/web/auth.py
+++ b/python/nav/web/auth.py
@@ -103,7 +103,7 @@ def authenticate_remote_user(request=None):
     if not request:
         return None
 
-    username = request.META.get('REMOTE_USER', None)
+    username = request.META.get('REMOTE_USER', '').strip()
     if not username:
         return None
 

--- a/python/nav/web/auth.py
+++ b/python/nav/web/auth.py
@@ -112,7 +112,7 @@ def authenticate_remote_user(request=None):
     try:
         account = Account.objects.get(login=username)
     except Account.DoesNotExist:
-        # Store the ldapuser in the database and return the new account
+        # Store the remote user in the database and return the new account
         account = Account(
             login=username,
             name=username,

--- a/python/nav/web/auth.py
+++ b/python/nav/web/auth.py
@@ -40,7 +40,7 @@ from nav.web import ldapauth
 from nav.models.profiles import Account
 
 
-logger = logging.getLogger("nav.web.auth")
+_logger = logging.getLogger(__name__)
 
 
 class RemoteUserConfigParser(NAVConfigParser):
@@ -82,7 +82,7 @@ def authenticate(username, password):
                 auth = True
 
     if account and account.locked:
-        logger.info("Locked user %s tried to log in", account.login)
+        _logger.info("Locked user %s tried to log in", account.login)
 
     if (account and
             account.ext_sync == 'ldap' and
@@ -145,7 +145,7 @@ def authenticate_remote_user(request=None):
         )
         account.set_password(fake_password(32))
         account.save()
-        logger.info("Created user %s from header REMOTE_USER", account.login)
+        _logger.info("Created user %s from header REMOTE_USER", account.login)
         template = 'Account "{actor}" created due to REMOTE_USER HTTP header'
         LogEntry.add_log_entry(account, 'create-account', template=template,
                                subsystem='auth')
@@ -153,7 +153,7 @@ def authenticate_remote_user(request=None):
 
     # Bail out! Potentially evil user
     if account.locked:
-        logger.info("Locked user %s tried to log in", account.login)
+        _logger.info("Locked user %s tried to log in", account.login)
         template = 'Account "{actor}" was prevented from logging in: blocked'
         LogEntry.add_log_entry(account, 'login-prevent', template=template,
                                subsystem='auth')

--- a/tests/unittests/general/web_middleware_test.py
+++ b/tests/unittests/general/web_middleware_test.py
@@ -65,11 +65,10 @@ class TestAuthenticationMiddleware(object):
         fake_request = FakeRequest(
             META={'REMOTE_USER': 'tim'}
         )
-        with patch.dict('nav.django.auth.NAV_CONFIG', {'AUTH_SUPPORT_REMOTE_USER': True}):
-            with patch('nav.django.auth.authenticate_remote_user', return_value=PLAIN_ACCOUNT):
-                AuthenticationMiddleware().process_request(fake_request)
-                assert fake_request.account == PLAIN_ACCOUNT
-                assert fake_request.session[ACCOUNT_ID_VAR] == fake_request.account.id
+        with patch('nav.django.auth.authenticate_remote_user', return_value=PLAIN_ACCOUNT):
+            AuthenticationMiddleware().process_request(fake_request)
+            assert fake_request.account == PLAIN_ACCOUNT
+            assert fake_request.session[ACCOUNT_ID_VAR] == fake_request.account.id
 
 
 class TestAuthorizationMiddleware(object):

--- a/tests/unittests/general/web_middleware_test.py
+++ b/tests/unittests/general/web_middleware_test.py
@@ -1,9 +1,13 @@
 from mock import patch
 import os
 
-from nav.django.auth import ACCOUNT_ID_VAR
+import pytest
+
+from nav.django.auth import ACCOUNT_ID_VAR, SUDOER_ID_VAR
 from nav.django.auth import AuthenticationMiddleware
 from nav.django.auth import AuthorizationMiddleware
+from nav.django.auth import sudo, desudo
+from nav.django.auth import SudoRecursionError, SudoNotAdminError
 from nav.web import auth
 
 
@@ -13,10 +17,16 @@ DEFAULT_ACCOUNT = auth.Account(id=0, login='anonymous', password='bah')
 
 class FakeRequest(object):
 
-    def __init__(self, session=None, META=None, sudo_operator=None, full_path=''):
-        self.session = session if session else {}
+    class _FakeSession(dict):
+
+        def save(*_):
+            return
+
+    def __init__(self, session=None, META=None, full_path=''):
+        self.session = self._FakeSession()
+        if session:
+            self.session.update(**session)
         self.META = META if META else {}
-        self.sudo_operator = sudo_operator
         self.full_path = full_path
 
     def get_full_path(self):
@@ -27,10 +37,22 @@ class TestAuthenticationMiddleware(object):
 
     def test_process_request_logged_in(self):
         fake_request = FakeRequest(session={ACCOUNT_ID_VAR: 101})
-        with patch('nav.web.auth.Account.objects.get', return_value=PLAIN_ACCOUNT):
+        with patch('nav.django.auth.Account.objects.get', return_value=PLAIN_ACCOUNT):
             AuthenticationMiddleware().process_request(fake_request)
             assert fake_request.account == PLAIN_ACCOUNT
             assert fake_request.session[ACCOUNT_ID_VAR] == fake_request.account.id
+
+    def test_process_request_set_sudoer(self):
+        fake_request = FakeRequest(
+            session={
+                ACCOUNT_ID_VAR: 101,
+                SUDOER_ID_VAR: True,
+            }
+        )
+        with patch('nav.django.auth.Account.objects.get'):
+            with patch('nav.django.auth.get_sudoer', return_value='foo'):
+                AuthenticationMiddleware().process_request(fake_request)
+                assert getattr(fake_request.account, 'sudo_operator', None) == 'foo'
 
     def test_process_request_not_logged_in(self):
         fake_request = FakeRequest(session={})
@@ -38,7 +60,6 @@ class TestAuthenticationMiddleware(object):
             AuthenticationMiddleware().process_request(fake_request)
             assert fake_request.account == DEFAULT_ACCOUNT
             assert fake_request.session[ACCOUNT_ID_VAR] == fake_request.account.id
-            assert fake_request.sudo_operator == None
 
     def test_process_request_logged_in_remote_user(self):
         fake_request = FakeRequest(
@@ -80,3 +101,47 @@ class TestAuthorizationMiddleware(object):
                     result = AuthorizationMiddleware().process_request(fake_request)
                     assert result == 'here'
                     assert os.environ.get('REMOTE_USER', None) != PLAIN_ACCOUNT.login
+
+
+class TestSudo(object):
+
+    def test_sudo_already(self):
+        fake_request = FakeRequest(session={SUDOER_ID_VAR: True})
+        with pytest.raises(SudoRecursionError):
+            sudo(fake_request, None)
+
+    def test_sudo_not_admin(self):
+        fake_request = FakeRequest()
+        with pytest.raises(SudoNotAdminError):
+            with patch('nav.django.auth.is_admin', return_value=False):
+                with patch('nav.django.auth.get_account', return_value=None):
+                    sudo(fake_request, None)
+
+    def test_sudo_ok(self):
+        fake_request = FakeRequest(
+            session={ACCOUNT_ID_VAR: PLAIN_ACCOUNT.id}
+        )
+        fake_request.account = PLAIN_ACCOUNT
+        with patch('nav.django.auth.is_admin', return_value=True):
+            with patch('nav.django.auth.get_account', return_value=None):
+                sudo(fake_request, DEFAULT_ACCOUNT)
+                assert fake_request.account == DEFAULT_ACCOUNT
+                assert fake_request.session[ACCOUNT_ID_VAR] == DEFAULT_ACCOUNT.id
+                assert fake_request.session[SUDOER_ID_VAR] == PLAIN_ACCOUNT.id
+
+
+class TestDesudo(object):
+
+    def test_desudo(self):
+        fake_request = FakeRequest(
+            session={
+                SUDOER_ID_VAR: PLAIN_ACCOUNT.id,
+                ACCOUNT_ID_VAR: DEFAULT_ACCOUNT.id,
+            }
+        )
+        fake_request.account = DEFAULT_ACCOUNT
+        with patch('nav.django.auth.Account.objects.get', return_value=PLAIN_ACCOUNT):
+            desudo(fake_request)
+            assert fake_request.account == PLAIN_ACCOUNT
+            assert fake_request.session[ACCOUNT_ID_VAR] == PLAIN_ACCOUNT.id
+            assert SUDOER_ID_VAR not in fake_request.session

--- a/tests/unittests/general/web_middleware_test.py
+++ b/tests/unittests/general/web_middleware_test.py
@@ -1,0 +1,82 @@
+from mock import patch
+import os
+
+from nav.django.auth import ACCOUNT_ID_VAR
+from nav.django.auth import AuthenticationMiddleware
+from nav.django.auth import AuthorizationMiddleware
+from nav.web import auth
+
+
+PLAIN_ACCOUNT = auth.Account(id=101, login='tim', password='wizard')
+DEFAULT_ACCOUNT = auth.Account(id=0, login='anonymous', password='bah')
+
+
+class FakeRequest(object):
+
+    def __init__(self, session=None, META=None, sudo_operator=None, full_path=''):
+        self.session = session if session else {}
+        self.META = META if META else {}
+        self.sudo_operator = sudo_operator
+        self.full_path = full_path
+
+    def get_full_path(self):
+        return self.full_path
+
+
+class TestAuthenticationMiddleware(object):
+
+    def test_process_request_logged_in(self):
+        fake_request = FakeRequest(session={ACCOUNT_ID_VAR: 101})
+        with patch('nav.web.auth.Account.objects.get', return_value=PLAIN_ACCOUNT):
+            AuthenticationMiddleware().process_request(fake_request)
+            assert fake_request.account == PLAIN_ACCOUNT
+            assert fake_request.session[ACCOUNT_ID_VAR] == fake_request.account.id
+
+    def test_process_request_not_logged_in(self):
+        fake_request = FakeRequest(session={})
+        with patch('nav.web.auth.Account.objects.get', return_value=DEFAULT_ACCOUNT):
+            AuthenticationMiddleware().process_request(fake_request)
+            assert fake_request.account == DEFAULT_ACCOUNT
+            assert fake_request.session[ACCOUNT_ID_VAR] == fake_request.account.id
+            assert fake_request.sudo_operator == None
+
+    def test_process_request_logged_in_remote_user(self):
+        fake_request = FakeRequest(
+            META={'REMOTE_USER': 'tim'}
+        )
+        with patch.dict('nav.django.auth.NAV_CONFIG', {'AUTH_SUPPORT_REMOTE_USER': True}):
+            with patch('nav.django.auth.authenticate_remote_user', return_value=PLAIN_ACCOUNT):
+                AuthenticationMiddleware().process_request(fake_request)
+                assert fake_request.account == PLAIN_ACCOUNT
+                assert fake_request.session[ACCOUNT_ID_VAR] == fake_request.account.id
+
+
+class TestAuthorizationMiddleware(object):
+
+    def teardown_method(self, method):
+        if 'REMOTE_USER' in os.environ:
+            del os.environ['REMOTE_USER']
+
+    def test_process_request_anonymous(self):
+        fake_request = FakeRequest()
+        fake_request.account = DEFAULT_ACCOUNT
+        with patch('nav.django.auth.authorization_not_required', return_value=True):
+            AuthorizationMiddleware().process_request(fake_request)
+            assert 'REMOTE_USER' not in os.environ
+
+    def test_process_request_authorized(self):
+        fake_request = FakeRequest()
+        fake_request.account = PLAIN_ACCOUNT
+        with patch('nav.django.auth.authorization_not_required', return_value=True):
+            AuthorizationMiddleware().process_request(fake_request)
+            assert os.environ.get('REMOTE_USER', None) == PLAIN_ACCOUNT.login
+
+    def test_process_request_not_authorized(self):
+        fake_request = FakeRequest()
+        fake_request.account = PLAIN_ACCOUNT
+        with patch('nav.django.auth.authorization_not_required', return_value=False):
+            with patch('nav.django.auth.Account.has_perm', return_value=False):
+                with patch('nav.django.auth.AuthorizationMiddleware.redirect_to_login', return_value='here'):
+                    result = AuthorizationMiddleware().process_request(fake_request)
+                    assert result == 'here'
+                    assert os.environ.get('REMOTE_USER', None) != PLAIN_ACCOUNT.login

--- a/tests/unittests/general/webfront_test.py
+++ b/tests/unittests/general/webfront_test.py
@@ -10,6 +10,8 @@ from nav.web import auth
 LDAP_ACCOUNT = auth.Account(login='knight', ext_sync='ldap',
                             password='shrubbery')
 PLAIN_ACCOUNT = auth.Account(login='knight', password='shrubbery')
+REMOTE_USER_ACCOUNT = auth.Account(login='knight', ext_sync='REMOTE_USER',
+                                   password='shrubbery')
 
 
 @patch("nav.web.auth.Account.save", new=MagicMock(return_value=True))
@@ -43,6 +45,34 @@ class TestNormalAuthenticate(object):
     def test_authenticate_should_return_false_when_ldap_says_no(self):
         with patch("nav.web.auth.Account.check_password", return_value=False):
             assert not auth.authenticate('knight', 'rabbit')
+
+
+class TestRemoteUserAuthenticate(object):
+    class FakeRequest(object):
+
+        def __init__(self, **kwargs):
+            self.META = {}
+            self.META.update(**kwargs)
+
+    def test_authenticate_remote_user_should_return_account_if_header_set(self):
+        request = self.FakeRequest(REMOTE_USER='knight')
+        with patch.dict("nav.web.auth.NAV_CONFIG", {'AUTH_SUPPORT_REMOTE_USER': True}):
+            with patch("nav.web.auth.Account.objects.get",
+                       new=MagicMock(return_value=REMOTE_USER_ACCOUNT)):
+                assert auth.authenticate_remote_user(request) == REMOTE_USER_ACCOUNT
+
+    def test_authenticate_remote_user_should_return_none_if_header_not_set(self):
+        request = self.FakeRequest()
+        with patch.dict("nav.web.auth.NAV_CONFIG", {'AUTH_SUPPORT_REMOTE_USER': True}):
+            assert auth.authenticate_remote_user(request) == None
+
+    def test_authenticate_remote_user_should_return_false_if_account_locked(self):
+        request = self.FakeRequest(REMOTE_USER='knight')
+        with patch.dict("nav.web.auth.NAV_CONFIG", {'AUTH_SUPPORT_REMOTE_USER': True}):
+            with patch("nav.web.auth.Account.objects.get",
+                       new=MagicMock(return_value=REMOTE_USER_ACCOUNT)):
+                with patch("nav.web.auth.Account.locked", return_value=True):
+                    assert auth.authenticate_remote_user(request) == False
 
 
 class TestLdapUser(object):

--- a/tests/unittests/general/webfront_test.py
+++ b/tests/unittests/general/webfront_test.py
@@ -56,23 +56,23 @@ class TestRemoteUserAuthenticate(object):
 
     def test_authenticate_remote_user_should_return_account_if_header_set(self):
         request = self.FakeRequest(REMOTE_USER='knight')
-        with patch.dict("nav.web.auth.NAV_CONFIG", {'AUTH_SUPPORT_REMOTE_USER': True}):
+        with patch("nav.web.auth._config.getboolean", return_value=True):
             with patch("nav.web.auth.Account.objects.get",
                        new=MagicMock(return_value=REMOTE_USER_ACCOUNT)):
                 assert auth.authenticate_remote_user(request) == REMOTE_USER_ACCOUNT
 
     def test_authenticate_remote_user_should_return_none_if_header_not_set(self):
         request = self.FakeRequest()
-        with patch.dict("nav.web.auth.NAV_CONFIG", {'AUTH_SUPPORT_REMOTE_USER': True}):
+        with patch("nav.web.auth._config.getboolean", return_value=True):
             assert auth.authenticate_remote_user(request) == None
 
     def test_authenticate_remote_user_should_return_false_if_account_locked(self):
         request = self.FakeRequest(REMOTE_USER='knight')
-        with patch.dict("nav.web.auth.NAV_CONFIG", {'AUTH_SUPPORT_REMOTE_USER': True}):
-            with patch("nav.web.auth.Account.objects.get",
-                       new=MagicMock(return_value=REMOTE_USER_ACCOUNT)):
-                with patch("nav.web.auth.Account.locked", return_value=True):
-                    assert auth.authenticate_remote_user(request) == False
+        with patch("nav.web.auth._config.getboolean", return_value=True):
+            with patch("nav.web.auth.Account.objects.get", return_value=REMOTE_USER_ACCOUNT):
+                with patch("nav.web.auth.LogEntry.add_log_entry"):
+                    with patch("nav.web.auth.Account.locked", return_value=True):
+                        assert auth.authenticate_remote_user(request) == False
 
 
 class TestLdapUser(object):


### PR DESCRIPTION
Add support for logging in with REMOTE_USER without changing the existing `authenticate`.