### PR TITLE
Verify nav.conf values as part of nav start

### DIFF
--- a/NOTES.rst
+++ b/NOTES.rst
@@ -145,6 +145,21 @@ Changed configuration files
 
 These configuration files changed:
 
+* :file:`nav.conf`: New options have been added. Some of these will be
+  *required*, as the new build system will no longer build their values into
+  the NAV binaries and libraries. All of them are present in the new example
+  config file:
+
+  ``NAV_USER``
+    **REQUIRED**: Which user to run NAV processes as.
+  ``PID_DIR``
+    **REQUIRED**: Which directory to store process PID files in.
+  ``LOG_DIR``
+    **REQUIRED**: Which directory to store log files in.
+  ``UPLOAD_DIR``
+    Where to store images uploaded through the web interface. This option has a
+    default value based on the system build parameters, but it is recommended to
+    verify its value with your system.
 * :file:`smsd.conf`: The ``loglevel`` option is no longer supported. Use
   :file:`logging.conf` to configure log levels.
 * :file:`alertengine.conf`: The ``loglevel`` option is no longer supported. Use

--- a/bin/nav
+++ b/bin/nav
@@ -212,6 +212,12 @@ def c_start(args):
     """starts services"""
     if not args.nonroot:
         verify_root()
+    from nav import config
+    try:
+        config.verify_nav_config(config.NAV_CONFIG)
+    except config.ConfigurationError as error:
+        sys.exit("There is a problem with nav.conf:\n{}".format(error))
+
     action_iterator(args.service, "start", "Starting", "Failed",
                     verbose=args.verbose)
 

--- a/doc/intro/install.rst
+++ b/doc/intro/install.rst
@@ -182,8 +182,8 @@ Users and privileges
 Apart from the ``pping`` and ``snmptrapd`` daemons, no NAV processes should
 ever be run as ``root``. You should create a non-privileged system user and
 group, and ensure the ``NAV_USER`` option in :file:`nav.conf` is set
-accordingly. Also make sure this user has permissions to write to your
-configured PID-file and log directories.
+accordingly. Also make sure this user has permissions to write to the directories
+configured in ``PID_DIR``, ``LOG_DIR`` and ``UPLOAD_DIR``.
 
 .. note:: The ``pping`` and ``snmptrapd`` daemons must be started as ``root``
           to be able to create privileged communication sockets. Both daemons


### PR DESCRIPTION
To avoid having every NAV daemon individually fail on startup because of faulty or missing options in `nav.conf`, the `nav start` command should make some attempt to verify the validity of the minimally required options and refuse to start NAV if the requirements aren't met.

Required options were added to NAV 4.9, but several users have been confused as to why NAV would not start, when they forgot to update their `nav.conf` as part of the upgrade.
