### PR TITLE
Fix Django 2.0 specific warnings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,8 +55,8 @@ node {
             recordIssues      tool: pyLint(pattern: 'reports/pylint.txt'),
                 sourceCodeEncoding: 'UTF-8',
                       qualityGates: [
-                                     [threshold: 1660, type: 'TOTAL', unstable: true],
-                                     [threshold: 1670, type: 'TOTAL', unstable: false]
+                                     [threshold: 1840, type: 'TOTAL', unstable: true],
+                                     [threshold: 1850, type: 'TOTAL', unstable: false]
                                     ]
 
         } // PyLint

--- a/python/nav/django/auth.py
+++ b/python/nav/django/auth.py
@@ -36,7 +36,7 @@ _logger = getLogger(__name__)
 ACCOUNT_ID_VAR = 'account_id'
 SUDOER_ID_VAR = 'sudoer'
 
-# This may seem like redundant information, but it seems urlresolvers.reverse
+# This may seem like redundant information, but it seems django's reverse
 # will hang under some usages of these middleware classes - so until we figure
 # out what's going on, we'll hardcode this here.
 LOGIN_URL = '/index/login/'

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -123,7 +123,7 @@ TEMPLATES = [
 ]
 
 # Middleware
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'nav.django.auth.AuthenticationMiddleware',
@@ -131,6 +131,8 @@ MIDDLEWARE_CLASSES = (
     'nav.django.legacy.LegacyCleanupMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
 )
+if django.VERSION[:2] == (1, 8):  # Django <= 1.8
+    MIDDLEWARE_CLASSES = MIDDLEWARE
 
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 SESSION_ENGINE = 'django.contrib.sessions.backends.db'

--- a/python/nav/django/utils.py
+++ b/python/nav/django/utils.py
@@ -53,7 +53,11 @@ def get_verbose_name(model, lookup):
 
     foreign_key, lookup = lookup.split('__', 1)
     try:
-        foreign_model = model._meta.get_field(foreign_key).rel.to
+        foreign_model_field = model._meta.get_field(foreign_key)
+        try:
+            foreign_model = foreign_model_field.remote_field.model
+        except AttributeError:  # Django <= 1.8
+            foreign_model = foreign_model_field.rel.to
         return get_verbose_name(foreign_model, lookup)
     except FieldDoesNotExist:
         pass

--- a/python/nav/ipdevpoll/storage.py
+++ b/python/nav/ipdevpoll/storage.py
@@ -255,7 +255,10 @@ class Shadow(object):
         for field in cls._meta.fields:
             if issubclass(field.__class__,
                           django.db.models.fields.related.ForeignKey):
-                django_dependency = field.rel.to
+                try:
+                    django_dependency = field.remote_field.model
+                except AttributeError:  # Django <= 1.8
+                    django_dependency = field.rel.to
 
                 shadow_dependency = MetaShadow.shadowed_classes.get(
                     django_dependency, None)

--- a/python/nav/metrics/graphs.py
+++ b/python/nav/metrics/graphs.py
@@ -16,10 +16,9 @@
 """Getting graphs of NAV-collected data from Graphite"""
 import re
 from django.utils.six.moves.urllib.parse import urlencode
-
+from nav.six import reverse
 from django.utils import six
 
-from django.core.urlresolvers import reverse
 
 TIMETICKS_IN_DAY = 100 * 3600 * 24
 TARGET_TOKENS = re.compile(r'[\w\-*?]+|[(){}\[\]]|,|\.')

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -18,7 +18,7 @@
 from datetime import datetime
 
 from django.db import models
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.utils.encoding import python_2_unicode_compatible
 
 from nav.adapters import HStoreField

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -40,7 +40,11 @@ class APIToken(models.Model):
     token = VarcharField()
     expires = models.DateTimeField()
     created = models.DateTimeField(auto_now_add=True)
-    client = models.ForeignKey(Account, db_column='client')
+    client = models.ForeignKey(
+        Account,
+        on_delete=models.CASCADE,
+        db_column='client'
+    )
     scope = models.IntegerField(null=True, default=0)
     comment = models.TextField(null=True, blank=True)
     revoked = models.BooleanField(default=False)

--- a/python/nav/models/arnold.py
+++ b/python/nav/models/arnold.py
@@ -46,9 +46,16 @@ class Identity(models.Model):
     id = models.AutoField(db_column='identityid', primary_key=True)
     mac = models.CharField(db_column='mac', max_length=17)
     status = VarcharField(db_column='blocked_status', choices=STATUSES)
-    justification = models.ForeignKey('Justification',
-                                      db_column='blocked_reasonid')
-    interface = models.ForeignKey(Interface, db_column='swportid')
+    justification = models.ForeignKey(
+        'Justification',
+        on_delete=models.CASCADE,
+        db_column='blocked_reasonid'
+    )
+    interface = models.ForeignKey(
+        Interface,
+        on_delete=models.CASCADE,
+        db_column='swportid'
+    )
     ip = models.GenericIPAddressField(null=True, default='0.0.0.0')
     dns = VarcharField(blank=True)
     netbios = VarcharField(blank=True)
@@ -58,13 +65,21 @@ class Identity(models.Model):
     autoenable = models.DateTimeField(null=True)
     autoenablestep = models.IntegerField(null=True, default=2)
     mail = VarcharField(blank=True)
-    organization = models.ForeignKey('Organization', db_column='orgid',
-                                     null=True)
+    organization = models.ForeignKey(
+        'Organization',
+        on_delete=models.CASCADE,
+        db_column='orgid',
+        null=True
+    )
     keep_closed = models.CharField(db_column='determined', default='n',
                                    choices=KEEP_CLOSED_CHOICES, max_length=1)
     fromvlan = models.IntegerField(null=True)
-    tovlan = models.ForeignKey('QuarantineVlan', db_column='tovlan',
-                               to_field='vlan', null=True, default=None)
+    tovlan = models.ForeignKey(
+        'QuarantineVlan',
+        on_delete=models.CASCADE,
+        db_column='tovlan',
+        to_field='vlan',null=True,default=None
+    )
     # If the interface does not exist any longer in the database, the user
     # needs a hint of what interface was blocked as information as ifname
     # and netbox naturally no longer exists based on interfaceid.
@@ -92,11 +107,18 @@ class Identity(models.Model):
 class Event(models.Model):
     """A class representing an action taken"""
     id = models.AutoField(db_column='eventid', primary_key=True)
-    identity = models.ForeignKey('Identity', db_column='identityid')
+    identity = models.ForeignKey(
+        'Identity',
+        on_delete=models.CASCADE,
+        db_column='identityid'
+    )
     comment = VarcharField(db_column='event_comment', blank=True)
     action = VarcharField(db_column='blocked_status', choices=STATUSES)
-    justification = models.ForeignKey('Justification',
-                                      db_column='blocked_reasonid')
+    justification = models.ForeignKey(
+        'Justification',
+        on_delete=models.CASCADE,
+        db_column='blocked_reasonid'
+    )
     event_time = models.DateTimeField(db_column='eventtime', auto_now_add=True)
     autoenablestep = models.IntegerField(null=True)
     executor = VarcharField(db_column='username')
@@ -146,7 +168,11 @@ class DetentionProfile(models.Model):
     name = VarcharField(db_column='blocktitle')
     description = VarcharField(db_column='blockdesc', blank=True)
     mailfile = VarcharField(blank=True)
-    justification = models.ForeignKey('Justification', db_column='reasonid')
+    justification = models.ForeignKey(
+        'Justification',
+        on_delete=models.CASCADE,
+        db_column='reasonid'
+    )
     keep_closed = models.CharField(db_column='determined', default='n',
                                    choices=KEEP_CLOSED_CHOICES, max_length=1)
     incremental = models.CharField(default='n', max_length=1)
@@ -159,8 +185,11 @@ class DetentionProfile(models.Model):
     active_on_vlans = VarcharField(db_column='activeonvlans')
     detention_type = VarcharField(db_column='detainmenttype',
                                   choices=DETENTION_TYPE_CHOICES)
-    quarantine_vlan = models.ForeignKey('QuarantineVlan',
-                                        db_column='quarantineid', null=True)
+    quarantine_vlan = models.ForeignKey(
+        'QuarantineVlan',
+        on_delete=models.CASCADE,
+        db_column='quarantineid',null=True
+    )
 
     def __str__(self):
         return self.name

--- a/python/nav/models/cabling.py
+++ b/python/nav/models/cabling.py
@@ -29,7 +29,10 @@ class Cabling(models.Model):
     closet's jack number to the end user's room number."""
 
     id = models.AutoField(db_column='cablingid', primary_key=True)
-    room = models.ForeignKey(Room, db_column='roomid')
+    room = models.ForeignKey(
+        Room,
+        on_delete=models.CASCADE,
+        db_column='roomid')
     jack = VarcharField()
     building = VarcharField(blank=True)
     target_room = VarcharField(db_column='targetroom', blank=True)
@@ -56,9 +59,17 @@ class Patch(models.Model):
     port to jack."""
 
     id = models.AutoField(db_column='patchid', primary_key=True)
-    interface = models.ForeignKey(Interface, db_column='interfaceid',
-                                  related_name='patches')
-    cabling = models.ForeignKey(Cabling, db_column='cablingid')
+    interface = models.ForeignKey(
+        Interface,
+        on_delete=models.CASCADE,
+        db_column='interfaceid',
+        related_name='patches'
+    )
+    cabling = models.ForeignKey(
+        Cabling,
+        on_delete=models.CASCADE,
+        db_column='cablingid'
+    )
     split = VarcharField(default='no')
 
     class Meta(object):

--- a/python/nav/models/event.py
+++ b/python/nav/models/event.py
@@ -323,15 +323,37 @@ class EventQueue(models.Model, EventMixIn):
     STATE_CHOICES = STATE_CHOICES
 
     id = models.AutoField(db_column='eventqid', primary_key=True)
-    source = models.ForeignKey('Subsystem', db_column='source',
-                               related_name='source_of_events')
-    target = models.ForeignKey('Subsystem', db_column='target',
-                               related_name='target_of_events')
-    device = models.ForeignKey('models.Device', db_column='deviceid', null=True)
-    netbox = models.ForeignKey('models.Netbox', db_column='netboxid', null=True)
+    source = models.ForeignKey(
+        'Subsystem',
+        on_delete=models.CASCADE,
+        db_column='source',
+        related_name='source_of_events'
+    )
+    target = models.ForeignKey(
+        'Subsystem',
+        on_delete=models.CASCADE,
+        db_column='target',
+        related_name='target_of_events'
+    )
+    device = models.ForeignKey(
+        'models.Device',
+        on_delete=models.CASCADE,
+        db_column='deviceid',
+        null=True
+    )
+    netbox = models.ForeignKey(
+        'models.Netbox',
+        on_delete=models.CASCADE,
+        db_column='netboxid',
+        null=True
+    )
     subid = VarcharField(default='')
     time = models.DateTimeField(default=dt.datetime.now)
-    event_type = models.ForeignKey('EventType', db_column='eventtypeid')
+    event_type = models.ForeignKey(
+        'EventType',
+        on_delete=models.CASCADE,
+        db_column='eventtypeid'
+    )
     state = models.CharField(max_length=1, choices=STATE_CHOICES,
                              default=STATE_STATELESS)
     value = models.IntegerField(default=100)
@@ -391,8 +413,12 @@ class EventQueueVar(models.Model):
     """From NAV Wiki: Defines additional (key,value) tuples that follow
     events."""
 
-    event_queue = models.ForeignKey('EventQueue', db_column='eventqid',
-                                    related_name='variables')
+    event_queue = models.ForeignKey(
+        'EventQueue',
+        on_delete=models.CASCADE,
+        db_column='eventqid',
+        related_name='variables'
+    )
     variable = VarcharField(db_column='var')
     value = models.TextField(db_column='val')
 
@@ -422,21 +448,48 @@ class AlertQueue(models.Model, EventMixIn):
     STATE_CHOICES = STATE_CHOICES
 
     id = models.AutoField(db_column='alertqid', primary_key=True)
-    source = models.ForeignKey('Subsystem', db_column='source')
-    device = models.ForeignKey('models.Device', db_column='deviceid', null=True)
-    netbox = models.ForeignKey('models.Netbox', db_column='netboxid', null=True)
+    source = models.ForeignKey(
+        'Subsystem',
+        on_delete=models.CASCADE,
+        db_column='source'
+    )
+    device = models.ForeignKey(
+        'models.Device',
+        on_delete=models.CASCADE,
+        db_column='deviceid',
+        null=True
+    )
+    netbox = models.ForeignKey(
+        'models.Netbox',
+        on_delete=models.CASCADE,
+        db_column='netboxid',
+        null=True
+    )
     subid = VarcharField(default='')
     time = models.DateTimeField()
-    event_type = models.ForeignKey('EventType', db_column='eventtypeid')
-    alert_type = models.ForeignKey('AlertType', db_column='alerttypeid',
-                                   null=True)
+    event_type = models.ForeignKey(
+        'EventType',
+        on_delete=models.CASCADE,
+        db_column='eventtypeid'
+    )
+    alert_type = models.ForeignKey(
+        'AlertType',
+        on_delete=models.CASCADE,
+        db_column='alerttypeid',
+        null=True
+    )
     state = models.CharField(max_length=1, choices=STATE_CHOICES,
                              default=STATE_STATELESS)
     value = models.IntegerField()
     severity = models.IntegerField()
 
-    history = models.ForeignKey('AlertHistory', null=True, blank=True,
-                                db_column='alerthistid')
+    history = models.ForeignKey(
+        'AlertHistory',
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        db_column='alerthistid'
+    )
 
     varmap = VariableMap()
 
@@ -461,7 +514,11 @@ class AlertType(models.Model):
     types."""
 
     id = models.AutoField(db_column='alerttypeid', primary_key=True)
-    event_type = models.ForeignKey('EventType', db_column='eventtypeid')
+    event_type = models.ForeignKey(
+        'EventType',
+        on_delete=models.CASCADE,
+        db_column='eventtypeid'
+    )
     name = VarcharField(db_column='alerttype')
     description = VarcharField(db_column='alerttypedesc')
 
@@ -481,8 +538,12 @@ class AlertQueueMessage(models.Model):
     alertmsg table."""
 
     id = models.AutoField(primary_key=True)
-    alert_queue = models.ForeignKey('AlertQueue', db_column='alertqid',
-                                    related_name='messages')
+    alert_queue = models.ForeignKey(
+        'AlertQueue',
+        on_delete=models.CASCADE,
+        db_column='alertqid',
+        related_name='messages'
+    )
     type = VarcharField(db_column='msgtype')
     language = VarcharField()
     message = models.TextField(db_column='msg')
@@ -502,8 +563,12 @@ class AlertQueueVariable(models.Model):
     the variables may be used in alert profiles."""
 
     id = models.AutoField(primary_key=True)
-    alert_queue = models.ForeignKey('AlertQueue', db_column='alertqid',
-                                    related_name='variables')
+    alert_queue = models.ForeignKey(
+        'AlertQueue',
+        on_delete=models.CASCADE,
+        db_column='alertqid',
+        related_name='variables'
+    )
     variable = VarcharField(db_column='var')
     value = models.TextField(db_column='val')
 
@@ -540,15 +605,37 @@ class AlertHistory(models.Model, EventMixIn):
     objects = AlertHistoryManager()
 
     id = models.AutoField(db_column='alerthistid', primary_key=True)
-    source = models.ForeignKey('Subsystem', db_column='source')
-    device = models.ForeignKey('models.Device', db_column='deviceid', null=True)
-    netbox = models.ForeignKey('models.Netbox', db_column='netboxid', null=True)
+    source = models.ForeignKey(
+        'Subsystem',
+        on_delete=models.CASCADE,
+        db_column='source'
+    )
+    device = models.ForeignKey(
+        'models.Device',
+        on_delete=models.CASCADE,
+        db_column='deviceid',
+        null=True
+    )
+    netbox = models.ForeignKey(
+        'models.Netbox',
+        on_delete=models.CASCADE,
+        db_column='netboxid',
+        null=True
+    )
     subid = VarcharField(default='')
     start_time = models.DateTimeField()
     end_time = DateTimeInfinityField(null=True)
-    event_type = models.ForeignKey('EventType', db_column='eventtypeid')
-    alert_type = models.ForeignKey('AlertType', db_column='alerttypeid',
-                                   null=True)
+    event_type = models.ForeignKey(
+        'EventType',
+        on_delete=models.CASCADE,
+        db_column='eventtypeid'
+    )
+    alert_type = models.ForeignKey(
+        'AlertType',
+        on_delete=models.CASCADE,
+        db_column='alerttypeid',
+        null=True
+    )
     value = models.IntegerField()
     severity = models.IntegerField()
 
@@ -634,8 +721,12 @@ class AlertHistoryMessage(models.Model):
     STATE_CHOICES = STATE_CHOICES
 
     id = models.AutoField(primary_key=True)
-    alert_history = models.ForeignKey('AlertHistory', db_column='alerthistid',
-                                      related_name='messages')
+    alert_history = models.ForeignKey(
+        'AlertHistory',
+        on_delete=models.CASCADE,
+        db_column='alerthistid',
+        related_name='messages'
+    )
     state = models.CharField(max_length=1, choices=STATE_CHOICES,
                              default=STATE_STATELESS)
     type = VarcharField(db_column='msgtype')
@@ -661,8 +752,12 @@ class AlertHistoryVariable(models.Model):
     STATE_CHOICES = STATE_CHOICES
 
     id = models.AutoField(primary_key=True)
-    alert_history = models.ForeignKey('AlertHistory', db_column='alerthistid',
-                                      related_name='variables')
+    alert_history = models.ForeignKey(
+        'AlertHistory',
+        on_delete=models.CASCADE,
+        db_column='alerthistid',
+        related_name='variables'
+    )
     state = models.CharField(max_length=1, choices=STATE_CHOICES,
                              default=STATE_STATELESS)
     variable = VarcharField(db_column='var')
@@ -679,9 +774,19 @@ class AlertHistoryVariable(models.Model):
 @python_2_unicode_compatible
 class Acknowledgement(models.Model):
     """Alert acknowledgements"""
-    alert = models.OneToOneField('AlertHistory', null=False, blank=False,
-                                 primary_key=True)
-    account = models.ForeignKey('Account', null=False, blank=False)
+    alert = models.OneToOneField(
+        'AlertHistory',
+        on_delete=models.CASCADE,
+        null=False,
+        blank=False,
+        primary_key=True
+    )
+    account = models.ForeignKey(
+        'Account',
+        on_delete=models.CASCADE,
+        null=False,
+        blank=False
+    )
     comment = VarcharField(blank=True)
     date = models.DateTimeField(null=False, default=dt.datetime.now)
 

--- a/python/nav/models/fields.py
+++ b/python/nav/models/fields.py
@@ -21,6 +21,7 @@ import json
 from datetime import datetime
 from decimal import Decimal
 
+import django
 from django import forms
 from django.db import models
 from django.db.models import signals
@@ -181,7 +182,10 @@ class LegacyGenericForeignKey(object):
         self.name = name
         self.model = cls
         self.cache_attr = "_%s_cache" % name
-        cls._meta.virtual_fields.append(self)
+        if django.VERSION[:2] == (1, 8):  # Django <= 1.8
+            cls._meta.virtual_fields.append(self)
+        else:
+            cls._meta.private_fields.append(self)
 
         if not cls._meta.abstract:
             signals.pre_init.connect(self.instance_pre_init, sender=cls)

--- a/python/nav/models/images.py
+++ b/python/nav/models/images.py
@@ -11,13 +11,27 @@ from django.conf import settings
 class Image(models.Model):
     """Model representing an uploaded image"""
     id = models.AutoField(db_column='imageid', primary_key=True)
-    room = models.ForeignKey(Room, db_column='roomid', null=True)
-    location = models.ForeignKey(Location, db_column='locationid', null=True)
+    room = models.ForeignKey(
+        Room,
+        on_delete=models.CASCADE,
+        db_column='roomid',
+        null=True
+    )
+    location = models.ForeignKey(
+        Location,
+        on_delete=models.CASCADE,
+        db_column='locationid',
+        null=True
+    )
     title = VarcharField()
     path = VarcharField()
     name = VarcharField()
     created = models.DateTimeField(auto_now_add=True)
-    uploader = models.ForeignKey(Account, db_column='uploader')
+    uploader = models.ForeignKey(
+        Account,
+        on_delete=models.CASCADE,
+        db_column='uploader'
+    )
     priority = models.IntegerField()
 
     class Meta(object):

--- a/python/nav/models/logger.py
+++ b/python/nav/models/logger.py
@@ -45,7 +45,11 @@ class Origin(models.Model):
     """
     origin = models.AutoField(db_column='origin', primary_key=True)
     name = VarcharField(db_column='name')
-    category = models.ForeignKey(LoggerCategory, db_column='category')
+    category = models.ForeignKey(
+        LoggerCategory,
+        on_delete=models.CASCADE,
+        db_column='category'
+    )
 
     def __str__(self):
         return self.name
@@ -76,7 +80,11 @@ class LogMessageType(models.Model):
     Model for the logger.log_message_type-table
     """
     type = models.AutoField(db_column='type', primary_key=True)
-    priority = models.ForeignKey(Priority, db_column='priority')
+    priority = models.ForeignKey(
+        Priority,
+        on_delete=models.CASCADE,
+        db_column='priority'
+    )
     facility = VarcharField(db_column='facility')
     mnemonic = VarcharField(db_column='mnemonic')
 
@@ -98,9 +106,21 @@ class LogMessage(models.Model):
     """
     id = models.AutoField(db_column='id', primary_key=True)
     time = models.DateTimeField(db_column='time', auto_now=True)
-    origin = models.ForeignKey(Origin, db_column='origin')
-    newpriority = models.ForeignKey(Priority, db_column='newpriority')
-    type = models.ForeignKey(LogMessageType, db_column='type')
+    origin = models.ForeignKey(
+        Origin,
+        on_delete=models.CASCADE,
+        db_column='origin'
+    )
+    newpriority = models.ForeignKey(
+        Priority,
+        on_delete=models.CASCADE,
+        db_column='newpriority'
+    )
+    type = models.ForeignKey(
+        LogMessageType,
+        on_delete=models.CASCADE,
+        db_column='type'
+    )
     message = VarcharField(db_column='message')
 
     class Meta(object):
@@ -125,10 +145,27 @@ class MessageView(models.Model):
     Do not change attributes unless You know what You are doing!
     Check: https://docs.djangoproject.com/en/dev/ref/models/options/
     """
-    origin = models.ForeignKey(Origin, db_column='origin', primary_key=True)
-    type = models.ForeignKey(LogMessageType, db_column='type')
-    newpriority = models.ForeignKey(Priority, db_column='newpriority')
-    category = models.ForeignKey(LoggerCategory, db_column='category')
+    origin = models.ForeignKey(
+        Origin,
+        on_delete=models.CASCADE,
+        db_column='origin',
+        primary_key=True
+    )
+    type = models.ForeignKey(
+        LogMessageType,
+        on_delete=models.CASCADE,
+        db_column='type'
+    )
+    newpriority = models.ForeignKey(
+        Priority,
+        on_delete=models.CASCADE,
+        db_column='newpriority'
+    )
+    category = models.ForeignKey(
+        LoggerCategory,
+        on_delete=models.CASCADE,
+        db_column='category'
+    )
     time = models.DateTimeField(db_column='time')
 
     class Meta(object):

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -87,15 +87,32 @@ class Netbox(models.Model):
 
     id = models.AutoField(db_column='netboxid', primary_key=True)
     ip = models.GenericIPAddressField(unique=True)
-    room = models.ForeignKey('Room', db_column='roomid')
-    type = models.ForeignKey('NetboxType', db_column='typeid',
-                             blank=True, null=True)
+    room = models.ForeignKey(
+        'Room',
+        on_delete=models.CASCADE,
+        db_column='roomid'
+    )
+    type = models.ForeignKey(
+        'NetboxType',
+        on_delete=models.CASCADE,
+        db_column='typeid',
+        blank=True,
+        null=True
+    )
     sysname = VarcharField(unique=True, blank=True)
-    category = models.ForeignKey('Category', db_column='catid')
+    category = models.ForeignKey(
+        'Category',
+        on_delete=models.CASCADE,
+        db_column='catid'
+    )
     groups = models.ManyToManyField(
         'NetboxGroup', through='NetboxCategory', blank=True)
     groups.help_text = ''
-    organization = models.ForeignKey('Organization', db_column='orgid')
+    organization = models.ForeignKey(
+        'Organization',
+        on_delete=models.CASCADE,
+        db_column='orgid'
+    )
     read_only = VarcharField(db_column='ro', blank=True, null=True)
     read_write = VarcharField(db_column='rw', blank=True, null=True)
     up = models.CharField(max_length=1, choices=UP_CHOICES, default=UP_UP)
@@ -104,11 +121,17 @@ class Netbox(models.Model):
     up_to_date = models.BooleanField(db_column='uptodate', default=False)
     discovered = models.DateTimeField(auto_now_add=True)
     deleted_at = models.DateTimeField(blank=True, null=True, default=None)
-    master = models.ForeignKey('Netbox', db_column='masterid', null=True,
-                               blank=True, default=None,
-                               related_name='instances')
-
+    master = models.ForeignKey(
+        'Netbox',
+        on_delete=models.CASCADE,
+        db_column='masterid',
+        null=True,
+        blank=True,
+        default=None,
+        related_name='instances'
+    )
     data = HStoreField(blank=True, null=True, default={})
+
     objects = models.Manager()
     ups_objects = UpsManager()
 
@@ -393,8 +416,12 @@ class NetboxInfo(models.Model):
     to store additional info on a netbox."""
 
     id = models.AutoField(db_column='netboxinfoid', primary_key=True)
-    netbox = models.ForeignKey('Netbox', db_column='netboxid',
-                               related_name='info_set')
+    netbox = models.ForeignKey(
+        'Netbox',
+        on_delete=models.CASCADE,
+        db_column='netboxid',
+        related_name='info_set'
+    )
     key = VarcharField()
     variable = VarcharField(db_column='var')
     value = models.TextField(db_column='val')
@@ -450,21 +477,33 @@ class NetboxEntity(models.Model):
     )
 
     id = models.AutoField(db_column='netboxentityid', primary_key=True)
-    netbox = models.ForeignKey('Netbox', db_column='netboxid',
-                               related_name='entity_set')
-
+    netbox = models.ForeignKey(
+        'Netbox',
+        on_delete=models.CASCADE,
+        db_column='netboxid',
+        related_name='entity_set'
+    )
     index = models.IntegerField()
     source = VarcharField(default='ENTITY-MIB')
     descr = VarcharField(null=True)
     vendor_type = VarcharField(null=True)
-    contained_in = models.ForeignKey('NetboxEntity', null=True)
+    contained_in = models.ForeignKey(
+        'NetboxEntity',
+        on_delete=models.CASCADE,
+        null=True
+    )
     physical_class = models.IntegerField(choices=CLASS_CHOICES, null=True)
     parent_relpos = models.IntegerField(null=True)
     name = VarcharField(null=True)
     hardware_revision = VarcharField(null=True)
     firmware_revision = VarcharField(null=True)
     software_revision = VarcharField(null=True)
-    device = models.ForeignKey('Device', null=True, db_column='deviceid')
+    device = models.ForeignKey(
+        'Device',
+        on_delete=models.CASCADE,
+        null=True,
+        db_column='deviceid'
+    )
     mfg_name = VarcharField(null=True)
     model_name = VarcharField(null=True)
     alias = VarcharField(null=True)
@@ -557,10 +596,18 @@ class NetboxPrefix(models.Model):
     This models the read-only netboxprefix view.
 
     """
-    netbox = models.OneToOneField('Netbox', db_column='netboxid',
-                                  primary_key=True)
-    prefix = models.ForeignKey('Prefix', db_column='prefixid',
-                               related_name='netbox_set')
+    netbox = models.OneToOneField(
+        'Netbox',
+        on_delete=models.CASCADE,
+        db_column='netboxid',
+        primary_key=True
+    )
+    prefix = models.ForeignKey(
+        'Prefix',
+        on_delete=models.CASCADE,
+        db_column='prefixid',
+        related_name='netbox_set'
+    )
 
     class Meta(object):
         db_table = 'netboxprefix'
@@ -610,8 +657,16 @@ class Module(models.Model):
     )
 
     id = models.AutoField(db_column='moduleid', primary_key=True)
-    device = models.ForeignKey('Device', db_column='deviceid')
-    netbox = models.ForeignKey('Netbox', db_column='netboxid')
+    device = models.ForeignKey(
+        'Device',
+        on_delete=models.CASCADE,
+        db_column='deviceid'
+    )
+    netbox = models.ForeignKey(
+        'Netbox',
+        on_delete=models.CASCADE,
+        db_column='netboxid'
+    )
     module_number = models.IntegerField(db_column='module')
     name = VarcharField()
     model = VarcharField()
@@ -716,7 +771,11 @@ class Memory(models.Model):
     (memory and nvram) of a netbox."""
 
     id = models.AutoField(db_column='memid', primary_key=True)
-    netbox = models.ForeignKey('Netbox', db_column='netboxid')
+    netbox = models.ForeignKey(
+        'Netbox',
+        on_delete=models.CASCADE,
+        db_column='netboxid'
+    )
     type = VarcharField(db_column='memtype')
     device = VarcharField()
     size = models.IntegerField()
@@ -739,7 +798,11 @@ class Room(models.Model):
     server room."""
 
     id = models.CharField(db_column='roomid', max_length=30, primary_key=True)
-    location = models.ForeignKey('Location', db_column='locationid')
+    location = models.ForeignKey(
+        'Location',
+        on_delete=models.CASCADE,
+        db_column='locationid'
+    )
     description = VarcharField(db_column='descr', blank=True)
     position = PointField(null=True, blank=True, default=None)
     data = HStoreField(blank=True, default={})
@@ -801,8 +864,13 @@ class Location(models.Model, TreeMixin):
 
     id = models.CharField(db_column='locationid',
                           max_length=30, primary_key=True)
-    parent = models.ForeignKey('self', db_column='parent',
-                               blank=True, null=True)
+    parent = models.ForeignKey(
+        'self',
+        on_delete=models.CASCADE,
+        db_column='parent',
+        blank=True,
+        null=True
+    )
     description = VarcharField(db_column='descr', blank=True)
     data = HStoreField(default={})
 
@@ -830,8 +898,12 @@ class Organization(models.Model, TreeMixin):
     of a given netbox and is the user of a given prefix."""
 
     id = models.CharField(db_column='orgid', max_length=30, primary_key=True)
-    parent = models.ForeignKey('self', db_column='parent',
-                               blank=True, null=True)
+    parent = models.ForeignKey(
+        'self',
+        on_delete=models.CASCADE,
+        db_column='parent',
+        blank=True,null=True
+    )
     description = VarcharField(db_column='descr', blank=True)
     contact = VarcharField(db_column='contact', blank=True)
     data = HStoreField(default={})
@@ -930,8 +1002,16 @@ class NetboxCategory(models.Model):
     # Django only supports specifying the name of the M2M-table, and not the
     # column names.
     id = models.AutoField(primary_key=True)  # Serial for faking a primary key
-    netbox = models.ForeignKey('Netbox', db_column='netboxid')
-    category = models.ForeignKey('NetboxGroup', db_column='category')
+    netbox = models.ForeignKey(
+        'Netbox',
+        on_delete=models.CASCADE,
+        db_column='netboxid'
+    )
+    category = models.ForeignKey(
+        'NetboxGroup',
+        on_delete=models.CASCADE,
+        db_column='category'
+    )
 
     class Meta(object):
         db_table = 'netboxcategory'
@@ -947,7 +1027,11 @@ class NetboxType(models.Model):
     sysobjectid being the unique identifier."""
 
     id = models.AutoField(db_column='typeid', primary_key=True)
-    vendor = models.ForeignKey('Vendor', db_column='vendorid')
+    vendor = models.ForeignKey(
+        'Vendor',
+        on_delete=models.CASCADE,
+        db_column='vendorid'
+    )
     name = VarcharField(db_column='typename', verbose_name="type name")
     sysobjectid = VarcharField(unique=True)
     description = VarcharField(db_column='descr')
@@ -1003,8 +1087,16 @@ class GwPortPrefix(models.Model):
     associated Prefix.
 
     """
-    interface = models.ForeignKey('Interface', db_column='interfaceid')
-    prefix = models.ForeignKey('Prefix', db_column='prefixid')
+    interface = models.ForeignKey(
+        'Interface',
+        on_delete=models.CASCADE,
+        db_column='interfaceid'
+    )
+    prefix = models.ForeignKey(
+        'Prefix',
+        on_delete=models.CASCADE,
+        db_column='prefixid'
+    )
     gw_ip = CIDRField(db_column='gwip', primary_key=True)
     virtual = models.BooleanField(default=False)
 
@@ -1053,7 +1145,11 @@ class Prefix(models.Model):
 
     id = models.AutoField(db_column='prefixid', primary_key=True)
     net_address = CIDRField(db_column='netaddr', unique=True)
-    vlan = models.ForeignKey('Vlan', db_column='vlanid')
+    vlan = models.ForeignKey(
+        'Vlan',
+        on_delete=models.CASCADE,
+        db_column='vlanid'
+    )
     usages = models.ManyToManyField('Usage', through='PrefixUsage',
                                     through_fields=('prefix', 'usage'))
 
@@ -1107,16 +1203,31 @@ class Vlan(models.Model):
 
     id = models.AutoField(db_column='vlanid', primary_key=True)
     vlan = models.IntegerField(null=True, blank=True)
-    net_type = models.ForeignKey('NetType', db_column='nettype')
-    organization = models.ForeignKey('Organization', db_column='orgid',
-                                     null=True, blank=True)
-    usage = models.ForeignKey('Usage', db_column='usageid',
-                              null=True, blank=True)
+    net_type = models.ForeignKey(
+        'NetType',
+        on_delete=models.CASCADE,
+        db_column='nettype'
+    )
+    organization = models.ForeignKey(
+        'Organization',
+        on_delete=models.CASCADE,
+        db_column='orgid',
+        null=True, blank=True
+    )
+    usage = models.ForeignKey(
+        'Usage',
+        on_delete=models.CASCADE,
+        db_column='usageid',
+        null=True,blank=True
+    )
     net_ident = VarcharField(db_column='netident', null=True, blank=True)
     description = VarcharField(null=True, blank=True)
-    netbox = models.ForeignKey('NetBox', db_column='netboxid',
-                               on_delete=models.SET_NULL,
-                               null=True, blank=True)
+    netbox = models.ForeignKey(
+        'NetBox',
+        on_delete=models.SET_NULL,
+        db_column='netboxid',
+        null=True,blank=True
+    )
 
     class Meta(object):
         db_table = 'vlan'
@@ -1187,8 +1298,16 @@ class NetType(models.Model):
 class PrefixUsage(models.Model):
     """Combines prefixes and usages for tagging of prefixes"""
     id = models.AutoField(db_column='prefix_usage_id', primary_key=True)
-    prefix = models.ForeignKey('Prefix', db_column='prefixid')
-    usage = models.ForeignKey('Usage', db_column='usageid')
+    prefix = models.ForeignKey(
+        'Prefix',
+        on_delete=models.CASCADE,
+        db_column='prefixid'
+    )
+    usage = models.ForeignKey(
+        'Usage',
+        on_delete=models.CASCADE,
+        db_column='usageid'
+    )
 
     class Meta(object):
         db_table = 'prefix_usage'
@@ -1220,8 +1339,17 @@ class Arp(models.Model):
     start, time end)."""
 
     id = models.AutoField(db_column='arpid', primary_key=True)
-    netbox = models.ForeignKey('Netbox', db_column='netboxid', null=True)
-    prefix = models.ForeignKey('Prefix', db_column='prefixid', null=True)
+    netbox = models.ForeignKey(
+        'Netbox',
+        on_delete=models.CASCADE,
+        db_column='netboxid', null=True
+    )
+    prefix = models.ForeignKey(
+        'Prefix',
+        on_delete=models.CASCADE,
+        db_column='prefixid',
+        null=True
+    )
     sysname = VarcharField()
     ip = models.GenericIPAddressField()
     # TODO: Create MACAddressField in Django
@@ -1257,8 +1385,16 @@ class SwPortVlan(models.Model):
     )
 
     id = models.AutoField(db_column='swportvlanid', primary_key=True)
-    interface = models.ForeignKey('Interface', db_column='interfaceid')
-    vlan = models.ForeignKey('Vlan', db_column='vlanid')
+    interface = models.ForeignKey(
+        'Interface',
+        on_delete=models.CASCADE,
+        db_column='interfaceid'
+    )
+    vlan = models.ForeignKey(
+        'Vlan',
+        on_delete=models.CASCADE,
+        db_column='vlanid'
+    )
     direction = models.CharField(max_length=1, choices=DIRECTION_CHOICES,
                                  default=DIRECTION_UNDEFINED)
 
@@ -1276,8 +1412,12 @@ class SwPortAllowedVlan(models.Model):
     traverse a trunk port.
 
     """
-    interface = models.OneToOneField('Interface', db_column='interfaceid',
-                                     primary_key=True)
+    interface = models.OneToOneField(
+        'Interface',
+        on_delete=models.CASCADE,
+        db_column='interfaceid',
+        primary_key=True
+    )
     hex_string = VarcharField(db_column='hexstring')
     _cached_hex_string = ''
     _cached_vlan_set = None
@@ -1331,7 +1471,11 @@ class SwPortBlocked(models.Model):
     a given switch port."""
 
     id = models.AutoField(db_column='swportblockedid', primary_key=True)
-    interface = models.ForeignKey('Interface', db_column='interfaceid')
+    interface = models.ForeignKey(
+        'Interface',
+        on_delete=models.CASCADE,
+        db_column='interfaceid'
+    )
     vlan = models.IntegerField()
 
     class Meta(object):
@@ -1352,13 +1496,29 @@ class AdjacencyCandidate(models.Model):
 
     """
     id = models.AutoField(db_column='adjacency_candidateid', primary_key=True)
-    netbox = models.ForeignKey('Netbox', db_column='netboxid')
-    interface = models.ForeignKey('Interface', db_column='interfaceid')
-    to_netbox = models.ForeignKey('Netbox', db_column='to_netboxid',
-                                  related_name='to_adjacencycandidate_set')
-    to_interface = models.ForeignKey('Interface', db_column='to_interfaceid',
-                                     null=True,
-                                     related_name='to_adjacencycandidate_set')
+    netbox = models.ForeignKey(
+        'Netbox',
+        on_delete=models.CASCADE,
+        db_column='netboxid'
+    )
+    interface = models.ForeignKey(
+        'Interface',
+        on_delete=models.CASCADE,
+        db_column='interfaceid'
+    )
+    to_netbox = models.ForeignKey(
+        'Netbox',
+        on_delete=models.CASCADE,
+        db_column='to_netboxid',
+        related_name='to_adjacencycandidate_set'
+    )
+    to_interface = models.ForeignKey(
+        'Interface',
+        on_delete=models.CASCADE,
+        db_column='to_interfaceid',
+        null=True,
+        related_name='to_adjacencycandidate_set'
+    )
     source = VarcharField()
     miss_count = models.IntegerField(db_column='misscnt', default=0)
 
@@ -1382,7 +1542,11 @@ class NetboxVtpVlan(models.Model):
     information."""
 
     id = models.AutoField(primary_key=True)  # Serial for faking a primary key
-    netbox = models.ForeignKey('Netbox', db_column='netboxid')
+    netbox = models.ForeignKey(
+        'Netbox',
+        on_delete=models.CASCADE,
+        db_column='netboxid'
+    )
     vtp_vlan = models.IntegerField(db_column='vtpvlan')
 
     class Meta(object):
@@ -1399,7 +1563,12 @@ class Cam(models.Model):
     end)"""
 
     id = models.AutoField(db_column='camid', primary_key=True)
-    netbox = models.ForeignKey('Netbox', db_column='netboxid', null=True)
+    netbox = models.ForeignKey(
+        'Netbox',
+        on_delete=models.CASCADE,
+        db_column='netboxid',
+        null=True
+    )
     sysname = VarcharField()
     ifindex = models.IntegerField()
     module = models.CharField(max_length=4)
@@ -1462,8 +1631,16 @@ class Interface(models.Model):
     )
 
     id = models.AutoField(db_column='interfaceid', primary_key=True)
-    netbox = models.ForeignKey('Netbox', db_column='netboxid')
-    module = models.ForeignKey('Module', db_column='moduleid', null=True)
+    netbox = models.ForeignKey(
+        'Netbox',
+        on_delete=models.CASCADE,
+        db_column='netboxid'
+    )
+    module = models.ForeignKey(
+        'Module',
+        on_delete=models.CASCADE,
+        db_column='moduleid', null=True
+    )
     ifindex = models.IntegerField()
     ifname = VarcharField()
     ifdescr = VarcharField()
@@ -1483,11 +1660,20 @@ class Interface(models.Model):
     trunk = models.BooleanField(default=False)
     duplex = models.CharField(max_length=1, choices=DUPLEX_CHOICES, null=True)
 
-    to_netbox = models.ForeignKey('Netbox', db_column='to_netboxid', null=True,
-                                  related_name='connected_to_interface')
-    to_interface = models.ForeignKey('self', db_column='to_interfaceid',
-                                     null=True,
-                                     related_name='connected_to_interface')
+    to_netbox = models.ForeignKey(
+        'Netbox',
+        on_delete=models.CASCADE,
+        db_column='to_netboxid',
+        null=True,
+        related_name='connected_to_interface'
+    )
+    to_interface = models.ForeignKey(
+        'self',
+        on_delete=models.CASCADE,
+        db_column='to_interfaceid',
+        null=True,
+        related_name='connected_to_interface'
+    )
 
     gone_since = models.DateTimeField()
 
@@ -1708,10 +1894,18 @@ class Interface(models.Model):
 
 class InterfaceStack(models.Model):
     """Interface layered stacking relationships"""
-    higher = models.ForeignKey(Interface, db_column='higher',
-                               related_name='higher_layer')
-    lower = models.ForeignKey(Interface, db_column='lower',
-                              related_name='lower_layer')
+    higher = models.ForeignKey(
+        Interface,
+        on_delete=models.CASCADE,
+        db_column='higher',
+        related_name='higher_layer'
+    )
+    lower = models.ForeignKey(
+        Interface,
+        on_delete=models.CASCADE,
+        db_column='lower',
+        related_name='lower_layer'
+    )
 
     class Meta(object):
         db_table = u'interface_stack'
@@ -1719,10 +1913,18 @@ class InterfaceStack(models.Model):
 
 class InterfaceAggregate(models.Model):
     """Interface aggregation relationships"""
-    aggregator = models.ForeignKey(Interface, db_column='aggregator',
-                                   related_name='aggregators')
-    interface = models.ForeignKey(Interface, db_column='interface',
-                                  related_name='bundled')
+    aggregator = models.ForeignKey(
+        Interface,
+        on_delete=models.CASCADE,
+        db_column='aggregator',
+        related_name='aggregators'
+    )
+    interface = models.ForeignKey(
+        Interface,
+        on_delete=models.CASCADE,
+        db_column='interface',
+        related_name='bundled'
+    )
 
     class Meta(object):
         db_table = u'interface_aggregate'
@@ -1741,7 +1943,11 @@ class IanaIftype(models.Model):
 class RoutingProtocolAttribute(models.Model):
     """Routing protocol metric as configured on a routing interface"""
     id = models.IntegerField(primary_key=True)
-    interface = models.ForeignKey('Interface', db_column='interfaceid')
+    interface = models.ForeignKey(
+        'Interface',
+        on_delete=models.CASCADE,
+        db_column='interfaceid'
+    )
     name = VarcharField(db_column='protoname')
     metric = models.IntegerField()
 
@@ -1762,7 +1968,11 @@ class GatewayPeerSession(models.Model):
     )
 
     id = models.AutoField(primary_key=True, db_column='peersessionid')
-    netbox = models.ForeignKey('Netbox', db_column='netboxid')
+    netbox = models.ForeignKey(
+        'Netbox',
+        on_delete=models.CASCADE,
+        db_column='netboxid'
+    )
     protocol = models.IntegerField(choices=PROTOCOL_CHOICES)
     peer = models.GenericIPAddressField()
     state = VarcharField()
@@ -1929,8 +2139,17 @@ class Sensor(models.Model):
     )
 
     id = models.AutoField(db_column='sensorid', primary_key=True)
-    netbox = models.ForeignKey(Netbox, db_column='netboxid')
-    interface = models.ForeignKey(Interface, db_column='interfaceid', null=True)
+    netbox = models.ForeignKey(
+        Netbox,
+        on_delete=models.CASCADE,
+        db_column='netboxid'
+    )
+    interface = models.ForeignKey(
+        Interface,
+        on_delete=models.CASCADE,
+        db_column='interfaceid',
+        null=True
+    )
     oid = VarcharField(db_column="oid")
     unit_of_measurement = VarcharField(db_column="unit_of_measurement",
                                        choices=UNIT_OF_MEASUREMENTS_CHOICES)
@@ -2016,8 +2235,16 @@ class PowerSupplyOrFan(models.Model):
     )
 
     id = models.AutoField(db_column='powersupplyid', primary_key=True)
-    netbox = models.ForeignKey(Netbox, db_column='netboxid')
-    device = models.ForeignKey(Device, db_column='deviceid')
+    netbox = models.ForeignKey(
+        Netbox,
+        on_delete=models.CASCADE,
+        db_column='netboxid'
+    )
+    device = models.ForeignKey(
+        Device,
+        on_delete=models.CASCADE,
+        db_column='deviceid'
+    )
     name = VarcharField(db_column='name')
     model = VarcharField(db_column='model', null=True)
     descr = VarcharField(db_column='descr', null=True)
@@ -2054,8 +2281,16 @@ class PowerSupplyOrFan(models.Model):
 @python_2_unicode_compatible
 class UnrecognizedNeighbor(models.Model):
     id = models.AutoField(primary_key=True)
-    netbox = models.ForeignKey(Netbox, db_column='netboxid')
-    interface = models.ForeignKey('Interface', db_column='interfaceid')
+    netbox = models.ForeignKey(
+        Netbox,
+        on_delete=models.CASCADE,
+        db_column='netboxid'
+    )
+    interface = models.ForeignKey(
+        'Interface',
+        on_delete=models.CASCADE,
+        db_column='interfaceid'
+    )
     remote_id = VarcharField()
     remote_name = VarcharField()
     source = VarcharField()
@@ -2076,8 +2311,12 @@ class UnrecognizedNeighbor(models.Model):
 @python_2_unicode_compatible
 class IpdevpollJobLog(models.Model):
     id = models.AutoField(primary_key=True)
-    netbox = models.ForeignKey(Netbox, db_column='netboxid', null=False,
-                               related_name='job_log')
+    netbox = models.ForeignKey(
+        Netbox,
+        on_delete=models.CASCADE,
+        db_column='netboxid', null=False,
+        related_name='job_log'
+    )
     job_name = VarcharField(null=False, blank=False)
     end_time = models.DateTimeField(auto_now_add=True, null=False)
     duration = models.FloatField(null=True)
@@ -2167,9 +2406,17 @@ class Netbios(models.Model):
 class POEGroup(models.Model):
     """Model representing a group of power over ethernet ports"""
     id = models.AutoField(db_column='poegroupid', primary_key=True)
-    netbox = models.ForeignKey('Netbox', db_column='netboxid')
-    module = models.ForeignKey('Module', db_column='moduleid',
-                               null=True)
+    netbox = models.ForeignKey(
+        'Netbox',
+        on_delete=models.CASCADE,
+        db_column='netboxid'
+    )
+    module = models.ForeignKey(
+        'Module',
+        on_delete=models.CASCADE,
+        db_column='moduleid',
+        null=True
+    )
     index = models.IntegerField()
 
     STATUS_ON = 1
@@ -2209,10 +2456,22 @@ class POEGroup(models.Model):
 class POEPort(models.Model):
     """Model representing a PoE port"""
     id = models.AutoField(db_column='poeportid', primary_key=True)
-    netbox = models.ForeignKey('Netbox', db_column='netboxid')
-    poegroup = models.ForeignKey('POEGroup', db_column='poegroupid')
-    interface = models.ForeignKey('Interface', db_column='interfaceid',
-                                  null=True)
+    netbox = models.ForeignKey(
+        'Netbox',
+        on_delete=models.CASCADE,
+        db_column='netboxid'
+    )
+    poegroup = models.ForeignKey(
+        'POEGroup',
+        on_delete=models.CASCADE,
+        db_column='poegroupid'
+    )
+    interface = models.ForeignKey(
+        'Interface',
+        on_delete=models.CASCADE,
+        db_column='interfaceid',
+        null=True
+    )
     admin_enable = models.BooleanField(default=False)
     index = models.IntegerField()
 

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -28,9 +28,9 @@ import re
 import IPy
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models import Q
+from nav.six import reverse
 from django.utils.encoding import python_2_unicode_compatible
 
 from nav import util

--- a/python/nav/models/msgmaint.py
+++ b/python/nav/models/msgmaint.py
@@ -42,8 +42,12 @@ class Message(models.Model):
     author = VarcharField()
     last_changed = models.DateTimeField()
     replaces_message = models.ForeignKey(
-        'self', db_column='replaces_message',
-        related_name='replaced_by', null=True)
+        'self',
+        on_delete=models.CASCADE,
+        db_column='replaces_message',
+        related_name='replaced_by',
+        null=True
+    )
     maintenance_tasks = models.ManyToManyField(
         'MaintenanceTask', through='MessageToMaintenanceTask', blank=True)
 
@@ -158,8 +162,11 @@ class MaintenanceComponent(models.Model):
     maintenance tool."""
 
     id = models.AutoField(primary_key=True)  # Serial for faking primary key
-    maintenance_task = models.ForeignKey(MaintenanceTask,
-                                         db_column='maint_taskid')
+    maintenance_task = models.ForeignKey(
+        MaintenanceTask,
+        on_delete=models.CASCADE,
+        db_column='maint_taskid'
+    )
     key = VarcharField()
     value = VarcharField()
     component = LegacyGenericForeignKey('key', 'value')
@@ -178,9 +185,16 @@ class MessageToMaintenanceTask(models.Model):
     tasks."""
 
     id = models.AutoField(primary_key=True)  # Serial for faking primary key
-    message = models.ForeignKey(Message, db_column='messageid')
+    message = models.ForeignKey(
+        Message,
+        on_delete=models.CASCADE,
+        db_column='messageid'
+    )
     maintenance_task = models.ForeignKey(
-        MaintenanceTask, db_column='maint_taskid')
+        MaintenanceTask,
+        on_delete=models.CASCADE,
+        db_column='maint_taskid'
+    )
 
     class Meta(object):
         db_table = 'message_to_maint_task'

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -284,7 +284,11 @@ class AccountGroup(models.Model):
 @python_2_unicode_compatible
 class NavbarLink(models.Model):
     """A hyperlink on a user's navigation bar."""
-    account = models.ForeignKey('Account', db_column='accountid')
+    account = models.ForeignKey(
+        'Account',
+        on_delete=models.CASCADE,
+        db_column='accountid'
+    )
     name = models.CharField('Link text', blank=False, max_length=100)
     uri = models.CharField('URL', blank=False, max_length=100)
 
@@ -299,8 +303,16 @@ class NavbarLink(models.Model):
 @python_2_unicode_compatible
 class Privilege(models.Model):
     """A privilege granted to an AccountGroup."""
-    group = models.ForeignKey('AccountGroup', db_column='accountgroupid')
-    type = models.ForeignKey('PrivilegeType', db_column='privilegeid')
+    group = models.ForeignKey(
+        'AccountGroup',
+        on_delete=models.CASCADE,
+        db_column='accountgroupid'
+    )
+    type = models.ForeignKey(
+        'PrivilegeType',
+        on_delete=models.CASCADE,
+        db_column='privilegeid'
+    )
     target = VarcharField()
 
     class Meta(object):
@@ -331,8 +343,16 @@ class AlertAddress(models.Model):
     """
     DEBUG_MODE = False
 
-    account = models.ForeignKey('Account', db_column='accountid')
-    type = models.ForeignKey('AlertSender', db_column='type')
+    account = models.ForeignKey(
+        'Account',
+        on_delete=models.CASCADE,
+        db_column='accountid'
+    )
+    type = models.ForeignKey(
+        'AlertSender',
+        on_delete=models.CASCADE,
+        db_column='type'
+    )
     address = VarcharField()
 
     class Meta(object):
@@ -475,10 +495,17 @@ class AlertSender(models.Model):
 class AlertPreference(models.Model):
     """AlertProfile account preferences"""
 
-    account = models.OneToOneField('Account', primary_key=True,
-                                   db_column='accountid')
-    active_profile = models.OneToOneField('AlertProfile',
-                                          db_column='activeprofile', null=True)
+    account = models.OneToOneField(
+        'Account', primary_key=True,
+        on_delete=models.CASCADE,
+        db_column='accountid'
+    )
+    active_profile = models.OneToOneField(
+        'AlertProfile',
+        on_delete=models.CASCADE,
+        db_column='activeprofile',
+        null=True
+    )
     last_sent_day = models.DateTimeField(db_column='lastsentday')
     last_sent_week = models.DateTimeField(db_column='lastsentweek')
 
@@ -515,7 +542,11 @@ class AlertProfile(models.Model):
         (SUNDAY, _('sunday')),
     )
 
-    account = models.ForeignKey('Account', db_column='accountid')
+    account = models.ForeignKey(
+        'Account',
+        on_delete=models.CASCADE,
+        db_column='accountid'
+    )
     name = VarcharField()
     daily_dispatch_time = models.TimeField(default='08:00')
     weekly_dispatch_day = models.IntegerField(choices=VALID_WEEKDAYS,
@@ -581,7 +612,11 @@ class TimePeriod(models.Model):
         (WEEKENDS, _('weekends')),
     )
 
-    profile = models.ForeignKey('AlertProfile', db_column='alert_profile_id')
+    profile = models.ForeignKey(
+        'AlertProfile',
+        on_delete=models.CASCADE,
+        db_column='alert_profile_id'
+    )
     start = models.TimeField(db_column='start_time', default='08:00')
     valid_during = models.IntegerField(choices=VALID_DURING_CHOICES,
                                        default=ALL_WEEK)
@@ -612,9 +647,18 @@ class AlertSubscription(models.Model):
         (NEXT, _('at end of timeperiod')),
     )
 
-    alert_address = models.ForeignKey('AlertAddress')
-    time_period = models.ForeignKey('TimePeriod')
-    filter_group = models.ForeignKey('FilterGroup')
+    alert_address = models.ForeignKey(
+        'AlertAddress',
+        on_delete=models.CASCADE,
+    )
+    time_period = models.ForeignKey(
+        'TimePeriod',
+        on_delete=models.CASCADE,
+    )
+    filter_group = models.ForeignKey(
+        'FilterGroup',
+        on_delete=models.CASCADE,
+    )
     type = models.IntegerField(db_column='subscription_type',
                                choices=SUBSCRIPTION_TYPES, default=NOW)
     ignore_resolved_alerts = models.BooleanField(default=False)
@@ -659,8 +703,14 @@ class FilterGroupContent(models.Model):
     positive = models.BooleanField(default=False)
     priority = models.IntegerField()
 
-    filter = models.ForeignKey('Filter')
-    filter_group = models.ForeignKey('FilterGroup')
+    filter = models.ForeignKey(
+        'Filter',
+        on_delete=models.CASCADE,
+    )
+    filter_group = models.ForeignKey(
+        'FilterGroup',
+        on_delete=models.CASCADE,
+    )
 
     class Meta(object):
         db_table = u'filtergroupcontent'
@@ -750,7 +800,10 @@ class Operator(models.Model):
         ENDSWITH: "host(%s) ILIKE %%s + '%%%%'",
     }
     type = models.IntegerField(choices=OPERATOR_TYPES, db_column='operator_id')
-    match_field = models.ForeignKey('MatchField')
+    match_field = models.ForeignKey(
+        'MatchField',
+        on_delete=models.CASCADE,
+    )
 
     class Meta(object):
         db_table = u'operator'
@@ -774,8 +827,14 @@ class Expression(models.Model):
     can be evaluated.
 
     """
-    filter = models.ForeignKey('Filter')
-    match_field = models.ForeignKey('MatchField')
+    filter = models.ForeignKey(
+        'Filter',
+        on_delete=models.CASCADE,
+    )
+    match_field = models.ForeignKey(
+        'MatchField',
+        on_delete=models.CASCADE,
+    )
     operator = models.IntegerField(choices=Operator.OPERATOR_TYPES)
     value = VarcharField()
 
@@ -798,7 +857,11 @@ class Filter(models.Model):
     Handles the actual construction of queries to be run taking into account
     special cases like the IP datatype and WILDCARD lookups."""
 
-    owner = models.ForeignKey('Account', null=True)
+    owner = models.ForeignKey(
+        'Account',
+        on_delete=models.CASCADE,
+        null=True
+    )
     name = VarcharField()
 
     class Meta(object):
@@ -918,7 +981,11 @@ class FilterGroup(models.Model):
     given permission to.
 
     """
-    owner = models.ForeignKey('Account', null=True)
+    owner = models.ForeignKey(
+        'Account',
+        on_delete=models.CASCADE,
+        null=True
+    )
     name = VarcharField()
     description = VarcharField()
 
@@ -1138,7 +1205,12 @@ class SMSQueue(models.Model):
         (IGNORED, _('ignored')),
     )
 
-    account = models.ForeignKey('Account', db_column='accountid', null=True)
+    account = models.ForeignKey(
+        'Account',
+        on_delete=models.CASCADE,
+        db_column='accountid',
+        null=True
+    )
     time = models.DateTimeField(auto_now_add=True)
     phone = models.CharField(max_length=15)
     message = models.CharField(max_length=145, db_column='msg')
@@ -1165,9 +1237,21 @@ class SMSQueue(models.Model):
 class AccountAlertQueue(models.Model):
     """Defines which alerts should be keept around and sent at a later time"""
 
-    account = models.ForeignKey('Account', null=True)
-    subscription = models.ForeignKey('AlertSubscription', null=True)
-    alert = models.ForeignKey('AlertQueue', null=True)
+    account = models.ForeignKey(
+        'Account',
+        on_delete=models.CASCADE,
+        null=True
+    )
+    subscription = models.ForeignKey(
+        'AlertSubscription',
+        on_delete=models.CASCADE,
+        null=True
+    )
+    alert = models.ForeignKey(
+        'AlertQueue',
+        on_delete=models.CASCADE,
+        null=True
+    )
     insertion_time = models.DateTimeField(auto_now_add=True)
 
     class Meta(object):
@@ -1236,7 +1320,11 @@ LINK_TYPES = (2, 'Layer 2'), (3, 'Layer 3')
 class NetmapView(models.Model):
     """Properties for a specific view in Netmap"""
     viewid = models.AutoField(primary_key=True)
-    owner = models.ForeignKey(Account, db_column='owner')
+    owner = models.ForeignKey(
+        Account,
+        on_delete=models.CASCADE,
+        db_column='owner'
+    )
     title = models.TextField()
     description = models.TextField()
     topology = models.IntegerField(choices=LINK_TYPES)
@@ -1271,8 +1359,16 @@ class NetmapView(models.Model):
 class NetmapViewDefaultView(models.Model):
     """Default view for each user"""
     id = models.AutoField(primary_key=True)
-    view = models.ForeignKey(NetmapView, db_column='viewid')
-    owner = models.ForeignKey(Account, db_column='ownerid')
+    view = models.ForeignKey(
+        NetmapView,
+        on_delete=models.CASCADE,
+        db_column='viewid'
+    )
+    owner = models.ForeignKey(
+        Account,
+        on_delete=models.CASCADE,
+        db_column='ownerid'
+    )
 
     class Meta(object):
         db_table = u'netmap_view_defaultview'
@@ -1289,9 +1385,17 @@ class NetmapViewCategories(models.Model):
     """Saved categories for a selected view in Netmap"""
     id = models.AutoField(primary_key=True)  # Serial for faking a primary key
     view = models.ForeignKey(
-        NetmapView, db_column='viewid', related_name='categories_set')
+        NetmapView,
+        on_delete=models.CASCADE,
+        db_column='viewid',
+        related_name='categories_set'
+    )
     category = models.ForeignKey(
-        Category, db_column='catid', related_name='netmapview_set')
+        Category,
+        on_delete=models.CASCADE,
+        db_column='catid',
+        related_name='netmapview_set'
+    )
 
     def __str__(self):
         return u'%s in category %s' % (self.view, self.category)
@@ -1305,9 +1409,17 @@ class NetmapViewNodePosition(models.Model):
     """Saved positions for nodes for a selected view in Netmap"""
     id = models.AutoField(primary_key=True)  # Serial for faking a primary key
     viewid = models.ForeignKey(
-        NetmapView, db_column='viewid', related_name='node_position_set')
+        NetmapView,
+        on_delete=models.CASCADE,
+        db_column='viewid',
+        related_name='node_position_set'
+    )
     netbox = models.ForeignKey(
-        Netbox, db_column='netboxid', related_name='node_position_set')
+        Netbox,
+        on_delete=models.CASCADE,
+        db_column='netboxid',
+        related_name='node_position_set'
+    )
     x = models.IntegerField()
     y = models.IntegerField()
 
@@ -1320,7 +1432,11 @@ class AccountTool(models.Model):
     """Link between tool and account"""
     id = models.AutoField(primary_key=True, db_column='account_tool_id')
     toolname = VarcharField()
-    account = models.ForeignKey(Account, db_column='accountid')
+    account = models.ForeignKey(
+        Account,
+        on_delete=models.CASCADE,
+        db_column='accountid'
+    )
     display = models.BooleanField(default=True)
     priority = models.IntegerField(default=0)
 
@@ -1337,7 +1453,10 @@ class AccountDashboard(models.Model):
     name = VarcharField()
     is_default = models.BooleanField(default=False)
     num_columns = models.IntegerField(default=3)
-    account = models.ForeignKey(Account)
+    account = models.ForeignKey(
+        Account,
+        on_delete=models.CASCADE,
+    )
 
     def __str__(self):
         return self.name
@@ -1367,10 +1486,18 @@ class AccountNavlet(models.Model):
     """Store information about a users navlets"""
     navlet = VarcharField()
     order = models.IntegerField(default=0, db_column='displayorder')
-    account = models.ForeignKey(Account, db_column='account')
+    account = models.ForeignKey(
+        Account,
+        on_delete=models.CASCADE,
+        db_column='account'
+    )
     preferences = DictAsJsonField(null=True)
     column = models.IntegerField(db_column='col')
-    dashboard = models.ForeignKey(AccountDashboard, related_name='widgets')
+    dashboard = models.ForeignKey(
+        AccountDashboard,
+        on_delete=models.CASCADE,
+        related_name='widgets'
+    )
 
     def __str__(self):
         return "%s - %s" % (self.navlet, self.account)
@@ -1401,8 +1528,14 @@ class ReportSubscription(models.Model):
     LINK = 'link'
     TYPES = ((DEVICE, 'device availability'), (LINK, 'link availability'))
 
-    account = models.ForeignKey(Account)
-    address = models.ForeignKey(AlertAddress)
+    account = models.ForeignKey(
+        Account,
+        on_delete=models.CASCADE,
+    )
+    address = models.ForeignKey(
+        AlertAddress,
+        on_delete=models.CASCADE,
+    )
     period = VarcharField(choices=PERIODS)
     report_type = VarcharField(choices=TYPES)
     exclude_maintenance = models.BooleanField()

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -28,7 +28,7 @@ import json
 
 from django.utils import six
 from django.views.decorators.debug import sensitive_variables
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.db import models, transaction
 from django.utils.encoding import python_2_unicode_compatible
 from django.forms.models import model_to_dict

--- a/python/nav/models/rack.py
+++ b/python/nav/models/rack.py
@@ -47,7 +47,11 @@ class Rack(models.Model):
     objects = RackManager()
 
     id = models.AutoField(primary_key=True, db_column='rackid')
-    room = models.ForeignKey(Room, db_column='roomid')
+    room = models.ForeignKey(
+        Room,
+        on_delete=models.CASCADE,
+        db_column='roomid'
+    )
     rackname = VarcharField(blank=True)
     ordering = models.IntegerField()
     _configuration = VarcharField(default=None, db_column='configuration')

--- a/python/nav/models/service.py
+++ b/python/nav/models/service.py
@@ -45,7 +45,11 @@ class Service(models.Model):
     TIME_FRAMES = ('day', 'week', 'month')
 
     id = models.AutoField(db_column='serviceid', primary_key=True)
-    netbox = models.ForeignKey(Netbox, db_column='netboxid')
+    netbox = models.ForeignKey(
+        Netbox,
+        on_delete=models.CASCADE,
+        db_column='netboxid'
+    )
     active = models.BooleanField(default=True)
     handler = VarcharField(verbose_name='service')
     version = VarcharField()
@@ -136,7 +140,11 @@ class ServiceProperty(models.Model):
     They are defined here."""
 
     id = models.AutoField(primary_key=True)  # Serial for faking a primary key
-    service = models.ForeignKey(Service, db_column='serviceid')
+    service = models.ForeignKey(
+        Service,
+        on_delete=models.CASCADE,
+        db_column='serviceid'
+    )
     property = models.CharField(max_length=64)
     value = VarcharField()
 

--- a/python/nav/models/thresholds.py
+++ b/python/nav/models/thresholds.py
@@ -44,7 +44,7 @@ class ThresholdRule(models.Model):
         help_text="Inspection interval when calculating values. "
                   "For interface counters this should be set to 15 minutes")
     description = VarcharField(null=True, blank=True)
-    creator = models.ForeignKey(Account, null=True)
+    creator = models.ForeignKey(Account, on_delete=models.CASCADE, null=True)
     created = models.DateTimeField(auto_now=True)
 
     class Meta(object):

--- a/python/nav/netmap/metadata.py
+++ b/python/nav/netmap/metadata.py
@@ -16,7 +16,7 @@
 """Handles attaching and converting metadata in a netmap networkx toplogy
 graph"""
 from collections import defaultdict
-from django.core.urlresolvers import reverse, NoReverseMatch
+from nav.six import reverse, NoReverseMatch
 from django.utils import six
 
 from IPy import IP

--- a/python/nav/report/matrix.py
+++ b/python/nav/report/matrix.py
@@ -18,7 +18,7 @@ import math
 import IPy
 from collections import namedtuple
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 
 from nav.metrics.templates import metric_path_for_prefix
 from nav.metrics.graphs import get_simple_graph_url

--- a/python/nav/report/matrixIPv4.py
+++ b/python/nav/report/matrixIPv4.py
@@ -15,7 +15,7 @@
 #
 """This class serves as an interface for the prefix matrix."""
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 
 from nav.report import IPtools, metaIP
 from nav.report.matrix import Matrix, Link, Cell

--- a/python/nav/report/matrixIPv6.py
+++ b/python/nav/report/matrixIPv6.py
@@ -15,7 +15,7 @@
 #
 """This class serves as an interface for the prefix matrix."""
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 
 from nav.report import IPtools, metaIP
 from nav.report.matrix import Matrix, Link

--- a/python/nav/six.py
+++ b/python/nav/six.py
@@ -20,8 +20,13 @@ same that six lacks.
 """
 from __future__ import absolute_import
 
-
 from django.utils import six
+
+try:
+    from django.urls import reverse, NoReverseMatch, reverse_lazy
+except ImportError:
+    from django.core.urlresolvers import reverse, NoReverseMatch, reverse_lazy
+
 
 if six.PY3:
     def encode_array(array):

--- a/python/nav/web/alertprofiles/decorators.py
+++ b/python/nav/web/alertprofiles/decorators.py
@@ -15,7 +15,7 @@
 #
 """Alert Profiles helper decorators."""
 from django.http import HttpResponseRedirect
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.utils.functional import wraps
 
 from nav.web.message import new_message, Messages

--- a/python/nav/web/alertprofiles/views.py
+++ b/python/nav/web/alertprofiles/views.py
@@ -26,7 +26,7 @@
 
 from django.http import HttpResponseRedirect
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.db.models import Q
 from django.shortcuts import render
 from django.utils import six

--- a/python/nav/web/api/v1/alert_serializers.py
+++ b/python/nav/web/api/v1/alert_serializers.py
@@ -15,7 +15,7 @@
 #
 """Serializers for status API data"""
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.template.defaultfilters import urlize
 from django.utils.encoding import force_text
 from django.utils.html import strip_tags

--- a/python/nav/web/api/v1/helpers/prefix_collector.py
+++ b/python/nav/web/api/v1/helpers/prefix_collector.py
@@ -18,7 +18,7 @@
 from IPy import IP
 
 from django.db import connection
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 
 
 class UsageResult(object):

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -162,8 +162,13 @@ class RelatedOrderingFilter(filters.OrderingFilter):
                 return self.is_valid_field(field.model, components[1])
 
             # foreign key
-            if field.rel and len(components) == 2:
-                return self.is_valid_field(field.rel.to, components[1])
+            if len(components) == 2:
+                try:
+                    remote_model = field.remote_field.model
+                except AttributeError:  # Django <= 1.8
+                    remote_model = field.rel.to
+                if remote_model:
+                    return self.is_valid_field(remote_model, components[1])
             return True
         except FieldDoesNotExist:
             return False

--- a/python/nav/web/business/views.py
+++ b/python/nav/web/business/views.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from datetime import datetime
 from operator import attrgetter
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.views.generic import TemplateView
 from django.shortcuts import get_object_or_404, render
 from django.http import HttpResponse

--- a/python/nav/web/devicehistory/views.py
+++ b/python/nav/web/devicehistory/views.py
@@ -17,7 +17,7 @@
 
 from operator import attrgetter
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.db import connection, transaction
 from django.http import HttpResponseRedirect
 from django.shortcuts import render

--- a/python/nav/web/geomap/views.py
+++ b/python/nav/web/geomap/views.py
@@ -25,7 +25,7 @@ from django.http import HttpResponse
 from django.http import HttpResponseForbidden
 from django.http import HttpResponseRedirect
 from django.http import Http404
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.shortcuts import render
 from django.utils.six import itervalues
 

--- a/python/nav/web/info/location/views.py
+++ b/python/nav/web/info/location/views.py
@@ -17,7 +17,7 @@
 
 import logging
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.db.models import Q
 from django.shortcuts import (redirect, render, get_object_or_404)
 

--- a/python/nav/web/info/netboxgroup/views.py
+++ b/python/nav/web/info/netboxgroup/views.py
@@ -16,7 +16,7 @@
 """Views for the netbox groups"""
 
 from django.shortcuts import render, redirect, get_object_or_404
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.db.models import Q
 
 from nav.web.info.forms import SearchForm

--- a/python/nav/web/info/prefix/views.py
+++ b/python/nav/web/info/prefix/views.py
@@ -16,7 +16,7 @@
 """Controllers and Forms for prefix details page"""
 
 from django import forms
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.db.utils import DatabaseError
 from django.http import HttpResponse
 from django.shortcuts import render, get_object_or_404

--- a/python/nav/web/info/room/views.py
+++ b/python/nav/web/info/room/views.py
@@ -19,7 +19,7 @@ import datetime
 import logging
 import csv
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.db import IntegrityError
 from django.db.models import Q, Max
 from django.http import HttpResponse

--- a/python/nav/web/info/searchproviders.py
+++ b/python/nav/web/info/searchproviders.py
@@ -17,7 +17,7 @@
 
 from collections import namedtuple
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.db.models import Q, Count
 
 from IPy import IP

--- a/python/nav/web/info/views.py
+++ b/python/nav/web/info/views.py
@@ -17,7 +17,7 @@
 import importlib
 import logging
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.conf import settings

--- a/python/nav/web/info/vlan/views.py
+++ b/python/nav/web/info/vlan/views.py
@@ -20,7 +20,7 @@ from IPy import IP
 from operator import methodcaller, attrgetter
 from functools import partial
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.db.models import Q
 from django.shortcuts import render, get_object_or_404, redirect
 from django.http import HttpResponse

--- a/python/nav/web/ipam/prefix_tree.py
+++ b/python/nav/web/ipam/prefix_tree.py
@@ -26,7 +26,7 @@ import functools
 import logging
 from IPy import IP, IPSet
 
-from django.core.urlresolvers import reverse, NoReverseMatch
+from nav.six import reverse, NoReverseMatch
 from django.utils import six
 
 from nav.web.ipam.util import get_available_subnets

--- a/python/nav/web/ipdevinfo/views.py
+++ b/python/nav/web/ipdevinfo/views.py
@@ -19,7 +19,7 @@ import logging
 import datetime as dt
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.http import HttpResponseRedirect, Http404, HttpResponse
 from django.db.models import Q
 from django.shortcuts import (get_object_or_404, redirect,

--- a/python/nav/web/macwatch/models.py
+++ b/python/nav/web/macwatch/models.py
@@ -33,7 +33,12 @@ class MacWatch(models.Model):
     id = models.AutoField(db_column='id', primary_key=True)
     # TODO: Create MACAddressField in Django
     mac = models.CharField(db_column='mac', max_length=17, unique=True)
-    userid = models.ForeignKey(Account, db_column='userid', null=False)
+    userid = models.ForeignKey(
+        Account,
+        on_delete=models.CASCADE,
+        db_column='userid',
+        null=False
+    )
     description = VarcharField(db_column='description', null=True)
     created = models.DateTimeField(db_column='created', auto_now_add=True)
     # Used only when a mac-address prefix is given.  This is value of
@@ -72,8 +77,18 @@ class MacWatchMatch(models.Model):
     """Extra model (helper-model) for mac-watch when macwatch
     only has a mac-adress prefix"""
     id = models.AutoField(db_column='id', primary_key=True)
-    macwatch = models.ForeignKey(MacWatch, db_column='macwatch', null=False)
-    cam = models.ForeignKey(Cam, db_column='cam', null=False)
+    macwatch = models.ForeignKey(
+        MacWatch,
+        on_delete=models.CASCADE,
+        db_column='macwatch',
+        null=False
+    )
+    cam = models.ForeignKey(
+        Cam,
+        on_delete=models.CASCADE,
+        db_column='cam',
+        null=False
+    )
     posted = models.DateTimeField(db_column='posted', auto_now_add=True)
 
     class Meta(object):

--- a/python/nav/web/maintenance/utils.py
+++ b/python/nav/web/maintenance/utils.py
@@ -18,7 +18,7 @@ from calendar import HTMLCalendar
 from datetime import date, datetime, timedelta
 from time import strftime
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.utils.html import conditional_escape
 from django.utils.six.moves import range
 

--- a/python/nav/web/maintenance/views.py
+++ b/python/nav/web/maintenance/views.py
@@ -19,7 +19,7 @@ import logging
 import time
 from datetime import datetime, date
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.db import transaction, connection
 from django.db.models import Count, Q
 from django.shortcuts import render, get_object_or_404, redirect

--- a/python/nav/web/messages/feeds.py
+++ b/python/nav/web/messages/feeds.py
@@ -17,7 +17,7 @@
 import datetime
 
 from django.contrib.syndication.views import Feed
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 
 from nav.models.msgmaint import Message
 

--- a/python/nav/web/messages/views.py
+++ b/python/nav/web/messages/views.py
@@ -16,7 +16,7 @@
 import datetime
 
 from django.db.models import Q
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import render, get_object_or_404, redirect
 

--- a/python/nav/web/navlets/__init__.py
+++ b/python/nav/web/navlets/__init__.py
@@ -50,7 +50,7 @@ import json
 from operator import attrgetter
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render, get_object_or_404
 from django.views.decorators.http import require_POST

--- a/python/nav/web/navlets/pdu.py
+++ b/python/nav/web/navlets/pdu.py
@@ -15,7 +15,7 @@
 #
 """Module containing PDUWidget"""
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 
 from nav.models.manage import Room
 import nav.natsort

--- a/python/nav/web/navlets/room_map.py
+++ b/python/nav/web/navlets/room_map.py
@@ -17,7 +17,7 @@
 
 from nav.web.navlets import Navlet
 from nav.web.info.room.views import SearchForm
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 
 
 class RoomMapNavlet(Navlet):

--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -24,7 +24,7 @@ from functools import reduce
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render, get_object_or_404
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.db.models import Q
 from django.views.decorators.http import require_POST
 

--- a/python/nav/web/radius/views.py
+++ b/python/nav/web/radius/views.py
@@ -15,7 +15,7 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """radius accounting interface views"""
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.shortcuts import render
 from nav.web.utils import create_title
 from .forms import (AccountChartsForm,

--- a/python/nav/web/report/views.py
+++ b/python/nav/web/report/views.py
@@ -30,7 +30,7 @@ import re
 # this is just here to make sure Django finds NAV's settings file
 # pylint: disable=W0611
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.core.paginator import Paginator, InvalidPage
 from django.shortcuts import render
 from django.http import HttpResponse, Http404, HttpResponseRedirect

--- a/python/nav/web/seeddb/__init__.py
+++ b/python/nav/web/seeddb/__init__.py
@@ -15,7 +15,7 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 
 from nav.web.seeddb.constants import TITLE_DEFAULT, NAVPATH_DEFAULT
 

--- a/python/nav/web/seeddb/page/netbox/edit.py
+++ b/python/nav/web/seeddb/page/netbox/edit.py
@@ -22,7 +22,7 @@ import copy
 import json
 import socket
 from socket import error as SocketError
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect, render, get_object_or_404

--- a/python/nav/web/seeddb/page/prefix.py
+++ b/python/nav/web/seeddb/page/prefix.py
@@ -19,7 +19,7 @@ Forms and controllers for the prefix functionality in SeedDB
 """
 
 from django import forms
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.db import transaction
 from django.shortcuts import render
 from django.http import HttpResponseRedirect

--- a/python/nav/web/seeddb/page/service/edit.py
+++ b/python/nav/web/seeddb/page/service/edit.py
@@ -16,7 +16,7 @@
 #
 
 from django import forms
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.shortcuts import render
 from django.http import HttpResponseRedirect
 from django.db import transaction

--- a/python/nav/web/seeddb/utils/bulk.py
+++ b/python/nav/web/seeddb/utils/bulk.py
@@ -15,7 +15,7 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Module for handling bulk import requests"""
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.shortcuts import render
 from django.http import HttpResponseRedirect
 

--- a/python/nav/web/seeddb/utils/delete.py
+++ b/python/nav/web/seeddb/utils/delete.py
@@ -20,7 +20,7 @@
 import logging
 
 from django.db import connection, transaction, IntegrityError
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.shortcuts import render
 from django.http import HttpResponseRedirect
 

--- a/python/nav/web/seeddb/utils/edit.py
+++ b/python/nav/web/seeddb/utils/edit.py
@@ -24,7 +24,7 @@ import logging
 from IPy import IP
 from socket import gethostbyaddr, gethostbyname, error as SocketError
 
-from django.core.urlresolvers import reverse, NoReverseMatch
+from nav.six import reverse, NoReverseMatch
 from django.shortcuts import render, get_object_or_404
 from django.http import HttpResponseRedirect, Http404
 from django.db.models import Q

--- a/python/nav/web/seeddb/utils/list.py
+++ b/python/nav/web/seeddb/utils/list.py
@@ -19,7 +19,7 @@
 from collections import defaultdict
 from functools import reduce
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.db.models import Model
 from django.shortcuts import render
 from django.db.models.fields import FieldDoesNotExist

--- a/python/nav/web/seeddb/utils/move.py
+++ b/python/nav/web/seeddb/utils/move.py
@@ -15,7 +15,7 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.shortcuts import render
 from django.http import HttpResponseRedirect
 

--- a/python/nav/web/sortedstats/statmodules.py
+++ b/python/nav/web/sortedstats/statmodules.py
@@ -20,7 +20,7 @@ import logging
 from operator import itemgetter
 
 from django.utils.six.moves.urllib.parse import urlencode
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 
 from nav.metrics.data import (get_metric_average, get_metric_max,
                               get_metric_data)

--- a/python/nav/web/status2/views.py
+++ b/python/nav/web/status2/views.py
@@ -19,7 +19,7 @@ import datetime
 import pickle
 
 from django.shortcuts import render
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.views.generic import View
 from django.http import HttpResponse, Http404
 

--- a/python/nav/web/syslogger/views.py
+++ b/python/nav/web/syslogger/views.py
@@ -15,7 +15,7 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """syslogger view definitions"""
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.db.models.aggregates import Count
 import json
 import datetime

--- a/python/nav/web/threshold/views.py
+++ b/python/nav/web/threshold/views.py
@@ -17,7 +17,7 @@
 
 import datetime
 import json
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.http import HttpResponse
 from django.shortcuts import render, redirect, get_object_or_404
 from django.utils import six

--- a/python/nav/web/useradmin/views.py
+++ b/python/nav/web/useradmin/views.py
@@ -19,7 +19,7 @@ import copy
 from datetime import datetime
 
 from django.contrib import messages
-from django.core.urlresolvers import reverse, reverse_lazy
+from nav.six import reverse, reverse_lazy
 from django.http import HttpResponseRedirect
 from django.shortcuts import render, get_object_or_404, redirect
 from django.views import generic

--- a/python/nav/web/webfront/forms.py
+++ b/python/nav/web/webfront/forms.py
@@ -16,7 +16,7 @@
 #
 
 from django import forms
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.forms.models import modelformset_factory
 from crispy_forms.helper import FormHelper
 from crispy_forms_foundation.layout import (Layout, Fieldset, Row, Column,

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -22,7 +22,7 @@ import json
 import logging
 from operator import attrgetter
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.http import (HttpResponseForbidden, HttpResponseRedirect,
                          HttpResponse, JsonResponse)
 from django.views.decorators.http import require_POST

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -144,7 +144,7 @@ def localhost():
 def client():
     """Provides a Django test Client object already logged in to the web UI as
     an admin"""
-    from django.core.urlresolvers import reverse
+    from nav.six import reverse
 
     client_ = Client()
     url = reverse('webfront-login')

--- a/tests/integration/report/generator_test.py
+++ b/tests/integration/report/generator_test.py
@@ -10,7 +10,7 @@ from __future__ import unicode_literals
 import pytest
 
 from django.http import QueryDict
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 
 from nav import db
 from nav.report.generator import ReportList, Generator

--- a/tests/integration/seeddb_test.py
+++ b/tests/integration/seeddb_test.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.http import Http404
 from django.test.client import RequestFactory
 from mock import MagicMock

--- a/tests/integration/web/alertprofiles_test.py
+++ b/tests/integration/web/alertprofiles_test.py
@@ -6,7 +6,7 @@ from mock import MagicMock
 import pytest
 
 from django.test.client import RequestFactory
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.utils.encoding import smart_text
 
 from nav.models.profiles import AlertProfile, Account, AlertPreference

--- a/tests/integration/web/arnold_test.py
+++ b/tests/integration/web/arnold_test.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 
 
 def test_arnold_manualdetention_should_not_crash(client):

--- a/tests/integration/web/info_test.py
+++ b/tests/integration/web/info_test.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 import pytest
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 
 from nav.web.info.searchproviders import SearchProvider
 

--- a/tests/integration/web/ipdevinfo_test.py
+++ b/tests/integration/web/ipdevinfo_test.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 from django.utils.encoding import smart_text
 
 from nav.models.manage import Netbox, Module, Interface, Device

--- a/tests/integration/web/netmap_test.py
+++ b/tests/integration/web/netmap_test.py
@@ -1,5 +1,5 @@
 import pytest
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 
 
 @pytest.mark.parametrize("layer", [2, 3])

--- a/tests/integration/widget_test.py
+++ b/tests/integration/widget_test.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 
 from nav.web.navlets.roomstatus import RoomStatus
 from nav.web.navlets.feedreader import FeedReaderNavlet

--- a/tests/unittests/web/urls_test.py
+++ b/tests/unittests/web/urls_test.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from nav.six import reverse
 
 
 def test_ipdevinfo_interface_details_should_support_typical_sysnames():


### PR DESCRIPTION
This is the final version of this branch. It fixes all RemovedInDjango20Warnings that can be fixed and still remain compatible with Django 1.8.

PS: remember to

```sed -i 's/from nav.six import reverse/from django.urls import reverse/'```

as soon as Django 1.11 is the target.