### PR TITLE
Standardize even more logging-statements

### DIFF
--- a/bin/maintengine.py
+++ b/bin/maintengine.py
@@ -44,15 +44,15 @@ def main():
         formatter=fmt,
         read_config=True,
     )
-    logger = logging.getLogger('')
+    _logger = logging.getLogger('')
 
-    logger.debug('------------------------------------------------------------')
+    _logger.debug('-'*60)  # Visual separation line
     try:
         check_devices_on_maintenance()
     except Exception:
-        logger.exception("An unhandled exception occurred:")
-    logger.debug('Finished in %.3fs' % (time.clock() - before))
-    logger.debug('------------------------------------------------------------')
+        _logger.exception("An unhandled exception occurred:")
+    _logger.debug('Finished in %.3fs' % (time.clock() - before))
+    _logger.debug('-'*60)  # Visual separation line
 
 
 if __name__ == '__main__':

--- a/bin/smsd.py
+++ b/bin/smsd.py
@@ -48,9 +48,14 @@ logfile = os.path.join(NAV_CONFIG['LOG_DIR'], 'smsd.log')
 pidfile = os.path.join(NAV_CONFIG['PID_DIR'], 'smsd.pid')
 
 #
+# Logging
+#
+_logger = logging.getLogger('nav.smsd')
+
+#
 # Globals
 #
-logger = config = delay = failed = defaults = None
+config = delay = failed = defaults = None
 
 #
 #  MAIN FUNCTION
@@ -115,14 +120,12 @@ def main():
                  username, sys.argv[0]))
 
     # Initialize logging
-    global logger
-    logger = logging.getLogger('nav.smsd')
     nav.logs.init_stderr_logging()
     if not loginitsmtp(mailwarnlevel, mailaddr, fromaddr, mailserver):
         sys.exit('Failed to init SMTP logging.')
 
     # First log message
-    logger.info('Starting smsd.')
+    _logger.info('Starting smsd.')
 
     # Set custom loop delay
     if args.delay:
@@ -132,7 +135,7 @@ def main():
     if args.cancel:
         queue = nav.smsd.navdbqueue.NAVDBQueue()
         ignored_count = queue.cancel()
-        logger.info("All %d unsent messages ignored.", ignored_count)
+        _logger.info("All %d unsent messages ignored.", ignored_count)
         sys.exit(0)
 
     if args.delayfactor:
@@ -148,7 +151,7 @@ def main():
     try:
         dh = nav.smsd.dispatcher.DispatcherHandler(config)
     except PermanentDispatcherError as error:
-        logger.critical("Dispatcher configuration failed. Exiting. (%s)", error)
+        _logger.critical("Dispatcher configuration failed. Exiting. (%s)", error)
         sys.exit(1)
 
     # Send test message (in other words: test the dispatcher)
@@ -160,19 +163,19 @@ def main():
             try:
                 (sms, sent, ignored, smsid) = dh.sendsms(args.test, msg)
             except DispatcherError as error:
-                logger.critical("Sending failed. Exiting. (%s)", error)
+                _logger.critical("Sending failed. Exiting. (%s)", error)
                 sys.exit(1)
 
-            logger.info("SMS sent. Dispatcher returned reference %d.", smsid)
+            _logger.info("SMS sent. Dispatcher returned reference %d.", smsid)
 
         elif args.TEST and args.uid:
             queue = nav.smsd.navdbqueue.NAVDBQueue()
             rowsinserted = queue.inserttestmsgs(args.uid, args.TEST, text)
             if rowsinserted:
-                logger.info("SMS put in queue. %d row(s) inserted.",
+                _logger.info("SMS put in queue. %d row(s) inserted.",
                             rowsinserted)
             else:
-                logger.info("SMS not put in queue.")
+                _logger.info("SMS not put in queue.")
 
         sys.exit(0)
 
@@ -180,7 +183,7 @@ def main():
     try:
         nav.daemon.justme(pidfile)
     except nav.daemon.DaemonError as error:
-        logger.error(error)
+        _logger.error(error)
         sys.exit(1)
 
     # Daemonize
@@ -188,12 +191,12 @@ def main():
         try:
             nav.daemon.daemonize(pidfile, stderr=open(logfile, "a"))
         except nav.daemon.DaemonError as error:
-            logger.error(error)
+            _logger.error(error)
             sys.exit(1)
 
-        logger.info('smsd now running in daemon mode')
+        _logger.info('smsd now running in daemon mode')
         # Reopen log files on SIGHUP
-        logger.debug('Adding signal handler for reopening log files on SIGHUP.')
+        _logger.debug('Adding signal handler for reopening log files on SIGHUP.')
         signal.signal(signal.SIGHUP, signalhandler)
     else:
         nav.daemon.writepidfile(pidfile)
@@ -211,29 +214,29 @@ def main():
     # Automatically cancel unsent messages older than a given interval
     if autocancel != '0':
         ignored_count = queue.cancel(autocancel)
-        logger.info("%d unsent messages older than '%s' autocanceled.",
+        _logger.info("%d unsent messages older than '%s' autocanceled.",
                     ignored_count, autocancel)
 
     # Loop forever
     while True:
-        logger.debug("Starting loop.")
+        _logger.debug("Starting loop.")
 
         # Queue: Get users with unsent messages
         users = queue.getusers('N')
 
-        logger.info("Found %d user(s) with unsent messages.", len(users))
+        _logger.info("Found %d user(s) with unsent messages.", len(users))
 
         # Loop over cell numbers
         for user in users:
             # Queue: Get unsent messages for a user ordered by severity desc
             msgs = queue.getusermsgs(user, 'N')
-            logger.info("Found %d unsent message(s) for %s.", len(msgs), user)
+            _logger.info("Found %d unsent message(s) for %s.", len(msgs), user)
 
             # Dispatcher: Format and send SMS
             try:
                 (sms, sent, ignored, smsid) = dh.sendsms(user, msgs)
             except PermanentDispatcherError as error:
-                logger.critical("Sending failed permanently. Exiting. (%s)",
+                _logger.critical("Sending failed permanently. Exiting. (%s)",
                                 error)
                 sys.exit(1)
             except DispatcherError as error:
@@ -243,27 +246,27 @@ def main():
 
                     break  # End this run
                 except:
-                    logger.exception("")
+                    _logger.exception("")
                     raise
             except Exception as error:
-                logger.exception("Unknown exception: %s", error)
+                _logger.exception("Unknown exception: %s", error)
 
-            logger.info("SMS sent to %s.", user)
+            _logger.info("SMS sent to %s.", user)
 
             if failed:
                 resetdelay()
                 failed = 0
-                logger.debug("Resetting delay and number of failed runs.")
+                _logger.debug("Resetting delay and number of failed runs.")
 
             for msgid in sent:
                 queue.setsentstatus(msgid, 'Y', smsid)
             for msgid in ignored:
                 queue.setsentstatus(msgid, 'I', smsid)
-            logger.info("%d messages were sent and %d ignored.",
+            _logger.info("%d messages were sent and %d ignored.",
                         len(sent), len(ignored))
 
         # Sleep a bit before the next run
-        logger.debug("Sleeping for %d seconds.", delay)
+        _logger.debug("Sleeping for %d seconds.", delay)
         time.sleep(delay)
 
         # Devel only
@@ -325,10 +328,10 @@ def parse_args():
 def setdelay(seconds):
     """Set delay (in seconds) between queue checks."""
 
-    global delay, logger
+    global delay, _logger
 
     delay = seconds
-    logger.info("Setting delay to %d seconds.", delay)
+    _logger.info("Setting delay to %d seconds.", delay)
 
 
 def resetdelay():
@@ -360,7 +363,7 @@ def backoff(seconds, error, retryvars):
         retryvars['retrylimit'], retryvars['retrylimitaction'])
 
     failed += 1
-    logger.debug("Dispatcher failed %d time(s).", failed)
+    _logger.debug("Dispatcher failed %d time(s).", failed)
     increasedelay(seconds, delayfactor, maxdelay)
 
     queue = nav.smsd.navdbqueue.NAVDBQueue()
@@ -373,11 +376,11 @@ def backoff(seconds, error, retryvars):
     # If limit is disabled, report error and continue
     elif retrylimit == 0 and delay >= maxdelay:
         if len(msgs):
-            logger.critical("Dispatching SMS fails. %d unsent message(s), "
+            _logger.critical("Dispatching SMS fails. %d unsent message(s), "
                             "the oldest from %s. (%s)",
                             len(msgs), msgs[0]['time'], error)
         else:
-            logger.critical("Dispatching SMS fails. (%s)", error)
+            _logger.critical("Dispatching SMS fails. (%s)", error)
 
 
 def backoffaction(error, retrylimitaction):
@@ -402,14 +405,14 @@ def backoffaction(error, retrylimitaction):
                 msg['msg'].decode('utf-8'), msg['name'].decode('utf-8'))
 
         error_message += u"\nError message: %s" % error
-        logger.critical(error_message.encode('utf-8'))
+        _logger.critical(error_message.encode('utf-8'))
         failed = 0
         resetdelay()
 
     elif retrylimitaction == "shutdown":
         # Logs the number of unsent messages and time of the oldest in queue
         # before shutting down daemon.
-        logger.critical("Dispatch retry limit has been reached. Dispatching "
+        _logger.critical("Dispatch retry limit has been reached. Dispatching "
                         "SMS has failed %d times. %d unsent message(s), the "
                         "oldest from %s. \nError message: %s \nShutting down "
                         "daemon.\n",
@@ -417,7 +420,7 @@ def backoffaction(error, retrylimitaction):
         sys.exit(0)
 
     else:
-        logger.warning("No retry limit action is set or the configured option "
+        _logger.warning("No retry limit action is set or the configured option "
                        "is not valid.")
 
 
@@ -428,17 +431,17 @@ def signalhandler(signum, _):
     """
 
     if signum == signal.SIGHUP:
-        logger.info("SIGHUP received; reopening log files.")
+        _logger.info("SIGHUP received; reopening log files.")
         nav.logs.reopen_log_files()
         nav.daemon.redirect_std_fds(stderr=open(logfile, "a"))
         nav.logs.reset_log_levels()
         nav.logs.set_log_config()
-        logger.info('Log files reopened.')
+        _logger.info('Log files reopened.')
     elif signum == signal.SIGTERM:
-        logger.warning('SIGTERM received: Shutting down.')
+        _logger.warning('SIGTERM received: Shutting down.')
         sys.exit(0)
     elif signum == signal.SIGINT:
-        logger.warning('SIGINT received: Shutting down.')
+        _logger.warning('SIGINT received: Shutting down.')
         sys.exit(0)
 
 
@@ -455,8 +458,8 @@ def loginitsmtp(loglevel, mailaddr, fromaddr, mailserver):
         mailformatter = logging.Formatter(mailformat)
         mailhandler.setFormatter(mailformatter)
         mailhandler.setLevel(loglevel)
-        logger = logging.getLogger()
-        logger.addHandler(mailhandler)
+        _logger = logging.getLogger()
+        _logger.addHandler(mailhandler)
         return True
     except Exception as error:
         print("Failed creating SMTP loghandler. Daemon mode disabled. (%s)"

--- a/python/nav/activeipcollector/collector.py
+++ b/python/nav/activeipcollector/collector.py
@@ -22,7 +22,7 @@ import time
 from nav.models.manage import Netbox  # Needed!
 from django.db import connection
 
-LOG = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 def collect(days=None):
@@ -36,17 +36,17 @@ def collect(days=None):
     intervals = get_intervals(days) if days else 0
 
     if intervals:
-        LOG.debug('Collecting %s intervals', intervals)
+        _logger.debug('Collecting %s intervals', intervals)
         query = get_interval_query(intervals)
     else:
         query = get_static_query()
 
-    LOG.debug(query)
+    _logger.debug(query)
 
     cursor = connection.cursor()
     cursor.execute(query)
 
-    LOG.debug('Query executed in %.2f seconds', time.time() - starttime)
+    _logger.debug('Query executed in %.2f seconds', time.time() - starttime)
 
     return cursor.fetchall()
 

--- a/python/nav/activeipcollector/manager.py
+++ b/python/nav/activeipcollector/manager.py
@@ -26,7 +26,7 @@ import nav.activeipcollector.collector as collector
 from nav.metrics.carbon import send_metrics
 from nav.metrics.templates import metric_path_for_prefix
 
-LOG = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 DATABASE_CATEGORY = 'activeip'
 
 
@@ -51,7 +51,7 @@ def store(data):
             store_tuple(db_tuple)
         time.sleep(2)
 
-    LOG.info('Sent %s updates', len(data))
+    _logger.info('Sent %s updates', len(data))
 
 
 def store_tuple(db_tuple):
@@ -70,7 +70,7 @@ def store_tuple(db_tuple):
         (metric_path_for_prefix(prefix, 'mac_count'), (when, mac_count)),
         (metric_path_for_prefix(prefix, 'ip_range'), (when, ip_range))
     ]
-    LOG.debug(metrics)
+    _logger.debug(metrics)
     send_metrics(metrics)
 
 

--- a/python/nav/eventengine/engine.py
+++ b/python/nav/eventengine/engine.py
@@ -179,8 +179,8 @@ class EventEngine(object):
         self._log_task_queue()
 
     def _log_task_queue(self):
-        logger = logging.getLogger(__name__ + '.queue')
-        if not logger.isEnabledFor(logging.DEBUG):
+        _logger = logging.getLogger(__name__ + '.queue')
+        if not _logger.isEnabledFor(logging.DEBUG):
             return
 
         modified_queue = [
@@ -189,10 +189,10 @@ class EventEngine(object):
         ]
         if modified_queue:
             logtime = time.time()
-            logger.debug("%d tasks in queue at %s",
-                         len(modified_queue), logtime)
+            _logger.debug("%d tasks in queue at %s",
+                          len(modified_queue), logtime)
             for event in modified_queue:
-                logger.debug("In %s seconds: %r", event.time - logtime, event)
+                _logger.debug("In %s seconds: %r", event.time - logtime, event)
 
     def _post_generic_alert(self, event):
         alert = AlertGenerator(event)

--- a/python/nav/ipdevpoll/schedule.py
+++ b/python/nav/ipdevpoll/schedule.py
@@ -452,15 +452,15 @@ class JobScheduler(object):
         jobs.sort(key=itemgetter(2), reverse=True)
         table_formatter = SimpleTableFormatter(jobs)
 
-        logger = logging.getLogger("%s.joblist" % __name__)
+        _logger = logging.getLogger("%s.joblist" % __name__)
         if jobs:
-            logger.log(level,
-                       "currently active jobs (%d):\n%s",
-                       len(jobs), table_formatter)
+            _logger.log(level,
+                        "currently active jobs (%d):\n%s",
+                        len(jobs), table_formatter)
         else:
-            logger.log(level,
-                       "no active jobs (%d JobHandlers)",
-                       JobHandler.get_instance_count())
+            _logger.log(level,
+                        "no active jobs (%d JobHandlers)",
+                        JobHandler.get_instance_count())
 
 
 class CounterFlusher(defaultdict):

--- a/python/nav/logs.py
+++ b/python/nav/logs.py
@@ -52,8 +52,8 @@ def set_log_levels():
         # Allow the config file to specify the root logger as 'root'
         if logger_name.lower() == 'root':
             logger_name = ''
-        logger = logging.getLogger(logger_name)
-        logger.setLevel(_translate_log_level(level))
+        _logger = logging.getLogger(logger_name)
+        _logger.setLevel(_translate_log_level(level))
 
 
 def _translate_log_level(level):
@@ -86,11 +86,11 @@ def _set_custom_log_file():
         # Allow the config file to specify the root logger as 'root'
         if logger_name.lower() == 'root':
             logger_name = ''
-        logger = logging.getLogger(logger_name)
+        _logger = logging.getLogger(logger_name)
 
         filehandler = logging.FileHandler(_get_logfile_path(filename))
         filehandler.setFormatter(DEFAULT_LOG_FORMATTER)
-        logger.addHandler(filehandler)
+        _logger.addHandler(filehandler)
 
 
 def _get_logging_conf():

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -367,23 +367,23 @@ class AlertAddress(models.Model):
 
            Return value should indicate if message was sent"""
 
-        logger = logging.getLogger('nav.alertengine.alertaddress.send')
+        _logger = logging.getLogger('nav.alertengine.alertaddress.send')
 
         # Determine the right language for the user.
         lang = self.account.preferences.get(
             Account.PREFERENCE_KEY_LANGUAGE, 'en')
 
         if not (self.address or '').strip():
-            logger.error(
-                'Ignoring alert %d (%s: %s)! Account %s does not have an '
-                'address set for the alertaddress with id %d, this needs '
-                'to be fixed before the user will recieve any alerts.',
-                alert.id, alert, alert.netbox, self.account, self.id)
+            _logger.error(
+                 'Ignoring alert %d (%s: %s)! Account %s does not have an '
+                 'address set for the alertaddress with id %d, this needs '
+                 'to be fixed before the user will recieve any alerts.',
+                 alert.id, alert, alert.netbox, self.account, self.id)
 
             return True
 
         if self.type.is_blacklisted():
-            logger.warning(
+            _logger.warning(
                 'Not sending alert %s to %s as handler %s is blacklisted: %s',
                 alert.id, self.address, self.type,
                 self.type.blacklist_reason())
@@ -391,27 +391,27 @@ class AlertAddress(models.Model):
 
         try:
             self.type.send(self, alert, language=lang)
-            logger.info(
+            _logger.info(
                 'alert %d sent by %s to %s due to %s subscription %d',
                 alert.id, self.type, self.address,
                 subscription.get_type_display(), subscription.id)
 
         except FatalDispatcherException as error:
-            logger.error(
+            _logger.error(
                 '%s raised a FatalDispatcherException indicating that the '
                 'alert never will be sent: %s',
                 self.type, error)
             raise
 
         except DispatcherException as error:
-            logger.error(
+            _logger.error(
                 '%s raised a DispatcherException indicating that an alert '
                 'could not be sent at this time: %s',
                 self.type, error)
             return False
 
         except Exception as error:
-            logger.exception(
+            _logger.exception(
                 'Unhandled error from %s (the handler has been blacklisted)',
                 self.type)
             self.type.blacklist(error)
@@ -564,7 +564,7 @@ class AlertProfile(models.Model):
         # Could have been done with a ModelManager, but the logic
         # is somewhat tricky to do with the django ORM.
 
-        logger = logging.getLogger(
+        _logger = logging.getLogger(
             'nav.alertengine.alertprofile.get_active_timeperiod')
 
         now = datetime.now()
@@ -590,10 +590,10 @@ class AlertProfile(models.Model):
                     active_timeperiod = period
 
         if active_timeperiod:
-            logger.debug("Active timeperiod for alertprofile %d is %s (%d)",
-                         self.id, active_timeperiod, active_timeperiod.id)
+            _logger.debug("Active timeperiod for alertprofile %d is %s (%d)",
+                          self.id, active_timeperiod, active_timeperiod.id)
         else:
-            logger.debug("No active timeperiod for alertprofile %d", self.id)
+            _logger.debug("No active timeperiod for alertprofile %d", self.id)
 
         return active_timeperiod
 
@@ -882,7 +882,7 @@ class Filter(models.Model):
 
         :type alert: nav.models.event.AlertQueue
         """
-        logger = logging.getLogger('nav.alertengine.filter.check')
+        _logger = logging.getLogger('nav.alertengine.filter.check')
 
         filtr = {}
         exclude = {}
@@ -959,7 +959,7 @@ class Filter(models.Model):
         if not extra['where']:
             extra = {}
 
-        logger.debug(
+        _logger.debug(
             'alert %d: checking against filter %d with filter: %s, exclude: '
             '%s and extra: %s',
             alert.id, self.id, filtr, exclude, extra)
@@ -968,10 +968,10 @@ class Filter(models.Model):
         # db doesn't have to work as much.
         if AlertQueue.objects.filter(**filtr).exclude(**exclude).extra(
                 **extra).count():
-            logger.debug('alert %d: matches filter %d', alert.id, self.id)
+            _logger.debug('alert %d: matches filter %d', alert.id, self.id)
             return True
 
-        logger.debug('alert %d: did not match filter %d', alert.id, self.id)
+        _logger.debug('alert %d: did not match filter %d', alert.id, self.id)
         return False
 
 
@@ -1170,7 +1170,7 @@ class MatchField(models.Model):
 
     def get_lookup_mapping(self):
         """Returns the field lookup represented by this MatchField."""
-        logger = logging.getLogger(
+        _logger = logging.getLogger(
             'nav.alertengine.matchfield.get_lookup_mapping')
 
         try:
@@ -1182,7 +1182,7 @@ class MatchField(models.Model):
             return value
 
         except KeyError:
-            logger.error(
+            _logger.error(
                 "Tried to lookup mapping for %s which is not supported",
                 self.value_id)
         return None
@@ -1293,12 +1293,12 @@ class AccountAlertQueue(models.Model):
                     "failed db upgrade from 3.4 to 3.5" % address)
 
         except AlertQueue.DoesNotExist:
-            logger = logging.getLogger(
+            _logger = logging.getLogger(
                 'nav.alertengine.accountalertqueue.send')
-            logger.error(('Inconsistent database state, alertqueue entry %d ' +
-                          'missing for account-alert. If you know how the ' +
-                          'database got into this state please update ' +
-                          'LP#494036'), self.alert_id)
+            _logger.error(('Inconsistent database state, alertqueue entry %d ' +
+                           'missing for account-alert. If you know how the ' +
+                           'database got into this state please update ' +
+                           'LP#494036'), self.alert_id)
 
             super(AccountAlertQueue, self).delete()
             return False

--- a/python/nav/topology/detector.py
+++ b/python/nav/topology/detector.py
@@ -100,9 +100,9 @@ def with_exception_logging(func):
             return func(*args, **kwargs)
         except Exception:
             stacktrace = inspect.trace()[1:]
-            logger = logging.getLogger(__name__)
-            logger.exception("An unhandled exception occurred")
-            log_last_django_query(logger)
+            _logger = logging.getLogger(__name__)
+            _logger.exception("An unhandled exception occurred")
+            log_last_django_query(_logger)
             log_stacktrace(logging.getLogger('nav.topology.stacktrace'),
                            stacktrace)
             raise

--- a/python/nav/web/auth.py
+++ b/python/nav/web/auth.py
@@ -21,7 +21,8 @@ import logging
 from nav.web import ldapauth
 from nav.models.profiles import Account
 
-_logger = logging.getLogger("nav.web.auth")
+
+_logger = logging.getLogger(__name__)
 
 
 def authenticate(username, password):


### PR DESCRIPTION
Some of these are really weird. It might be necessary to split the easy ones out, and deal with the true weirdos separately. 

Things found: setting the logger in a function or method with `global`, passing a logger around, functions with their own separate loggers, etc.

Remains: mucho magic in `nav.logs`, and usage of that magic.