### PR TITLE
Make fresh code forwards compatible with Django2.2

### DIFF
--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -119,8 +119,16 @@ class ManagementProfile(models.Model):
 class NetboxProfile(models.Model):
     """Stores the relation between Netboxes and their management profiles"""
     id = models.AutoField(primary_key=True, db_column='netbox_profileid')
-    netbox = models.ForeignKey('Netbox', db_column='netboxid')
-    profile = models.ForeignKey('ManagementProfile', db_column='profileid')
+    netbox = models.ForeignKey(
+        'Netbox',
+        on_delete=models.CASCADE,
+        db_column='netboxid'
+    )
+    profile = models.ForeignKey(
+        'ManagementProfile',
+        on_delete=models.CASCADE,
+        db_column='profileid'
+    )
 
     class Meta(object):
         db_table = 'netbox_profile'


### PR DESCRIPTION
The argument `on_delete` is obligatory (and positional, second position) in Django 2.2, for every ForeignKey/OneToOneKey. The previous implicit default was `on_delete=models.CASCADE`.

Adding this to the new models will make for a simpler merge of the Django 2.2 branch and this PR itself serves as a reminder that all new models with ForeignKey/OneToOneKey should have an explicit `on_delete` from now on.