### PR TITLE
Add option to control user administrator privileges from LDAP

### DIFF
--- a/doc/reference/ldap.rst
+++ b/doc/reference/ldap.rst
@@ -62,6 +62,14 @@ Available options:
   A string defining the name of an entitlement that the user object must have
   in order for the user to be allowed to log in to NAV.
 
+**admin_entitlement**
+  .. versionadded:: 4.9.7
+
+  If a user object has this entitlement, the user will be granted membership
+  in the NAV Administrators group. If the user object does not have this
+  entitlement, the user will be stripped of their Administrator privileges. If
+  unset, nothing happens.
+
 **entitlement_attribute**
   .. versionadded:: 4.9.6
 

--- a/doc/reference/ldap.rst
+++ b/doc/reference/ldap.rst
@@ -57,13 +57,13 @@ Available options:
   ``(member:1.2.840.113556.1.4.1941:=%%s)`` to enable this AD extension
 
 **require_entitlement**
-  .. versionadded:: 4.10
+  .. versionadded:: 4.9.6
 
   A string defining the name of an entitlement that the user object must have
   in order for the user to be allowed to log in to NAV.
 
 **entitlement_attribute**
-  .. versionadded:: 4.10
+  .. versionadded:: 4.9.6
 
   Can be used to customize the user object attribute used to verify entitlements.
   The default value is ``eduPersonEntitlement``.

--- a/python/nav/etc/webfront/webfront.conf
+++ b/python/nav/etc/webfront/webfront.conf
@@ -84,6 +84,11 @@ basedn = ou=people,dc=example,dc=com
 # allowing a NAV login
 #require_entitlement=
 
+# Give Administrator privileges to any user with this entitlement value. If set,
+# will also remove admin privileges from a user that lacks the entitlement, as
+# that user logs in.
+#admin_entitlement=
+
 # Set the specific user object attribute to use when looking for entitlements.
 #entitlement_attribute=eduPersonEntitlement
 

--- a/python/nav/web/auth.py
+++ b/python/nav/web/auth.py
@@ -48,7 +48,7 @@ def authenticate(username, password):
                 )
                 account.set_password(password)
                 account.save()
-                _handle_admin_status(user, account)
+                _handle_ldap_admin_status(user, account)
                 # We're authenticated now
                 auth = True
 
@@ -69,7 +69,7 @@ def authenticate(username, password):
             if auth:
                 account.set_password(password)
                 account.save()
-                _handle_admin_status(auth, account)
+                _handle_ldap_admin_status(auth, account)
             else:
                 return
 
@@ -82,7 +82,7 @@ def authenticate(username, password):
         return None
 
 
-def _handle_admin_status(ldap_user, nav_account):
+def _handle_ldap_admin_status(ldap_user, nav_account):
     is_admin = ldap_user.is_admin()
     # Only modify admin status if an entitlement is configured in webfront.conf
     if is_admin is not None:

--- a/python/nav/web/auth.py
+++ b/python/nav/web/auth.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010, 2011 Uninett AS
+# Copyright (C) 2010, 2011, 2019 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #
@@ -19,7 +19,7 @@ Contains web authentication functionality for NAV.
 import logging
 
 from nav.web import ldapauth
-from nav.models.profiles import Account
+from nav.models.profiles import Account, AccountGroup
 
 logger = logging.getLogger("nav.web.auth")
 
@@ -48,6 +48,7 @@ def authenticate(username, password):
                 )
                 account.set_password(password)
                 account.save()
+                _handle_admin_status(user, account)
                 # We're authenticated now
                 auth = True
 
@@ -68,6 +69,7 @@ def authenticate(username, password):
             if auth:
                 account.set_password(password)
                 account.save()
+                _handle_admin_status(auth, account)
             else:
                 return
 
@@ -78,3 +80,14 @@ def authenticate(username, password):
         return account
     else:
         return None
+
+
+def _handle_admin_status(ldap_user, nav_account):
+    is_admin = ldap_user.is_admin()
+    # Only modify admin status if an entitlement is configured in webfront.conf
+    if is_admin is not None:
+        admin_group = AccountGroup.objects.get(id=AccountGroup.ADMIN_GROUP)
+        if is_admin:
+            nav_account.accountgroup_set.add(admin_group)
+        else:
+            nav_account.accountgroup_set.remove(admin_group)

--- a/python/nav/web/ldapauth.py
+++ b/python/nav/web/ldapauth.py
@@ -49,6 +49,7 @@ manager=
 manager_password=
 group_search=(member=%%s)
 require_entitlement=
+admin_entitlement=
 entitlement_attribute=eduPersonEntitlement
 encoding=utf-8
 """
@@ -354,6 +355,17 @@ class LDAPUser(object):
     def has_entitlement(self, entitlement):
         """Verifies whether the user has a specific entitlement"""
         return entitlement in self.get_entitlements()
+
+    def is_admin(self):
+        """Verifies whether the user should have administrator privileges.
+
+        :returns: True if the user should be an administrator, False if not. If no admin
+        entitlement is configure, None is returned, as we cannot make such a decision.
+
+        """
+        admin_entitlement = _config.get('ldap', 'admin_entitlement')
+        if admin_entitlement:
+            return self.has_entitlement(admin_entitlement)
 
 
 #

--- a/tests/unittests/general/webfront_test.py
+++ b/tests/unittests/general/webfront_test.py
@@ -30,7 +30,9 @@ class LdapAuthenticateTest(TestCase):
         self.patched_get.stop()
 
     def test_authenticate_should_return_account_when_ldap_says_yes(self):
-        with patch("nav.web.ldapauth.authenticate", return_value=True):
+        ldap_user = Mock()
+        ldap_user.is_admin.return_value = None  # mock to avoid database access
+        with patch("nav.web.ldapauth.authenticate", return_value=ldap_user):
             self.assertEquals(auth.authenticate('knight', 'shrubbery'),
                               self.mock_account)
 

--- a/tests/unittests/general/webfront_test.py
+++ b/tests/unittests/general/webfront_test.py
@@ -140,48 +140,20 @@ class LdapUserTestCase(TestCase):
                       },
              })
 class TestLdapEntitlements(object):
-    def test_required_entitlement_should_be_verified(self):
-        conn = Mock(**{
-            'search_s.return_value': [
-                (
-                    u'uid=zaphod,cn=users,dc=example,dc=org',
-                    {u'eduPersonEntitlement': [b'president']}
-                )]
-        })
-        u = nav.web.ldapauth.LDAPUser("zaphod", conn)
+    def test_required_entitlement_should_be_verified(self, user_zaphod):
+        u = nav.web.ldapauth.LDAPUser("zaphod", user_zaphod)
         assert u.has_entitlement('president')
 
-    def test_missing_entitlement_should_not_be_verified(self):
-        conn = Mock(**{
-            'search_s.return_value': [
-                (
-                    u'uid=marvin,cn=users,dc=example,dc=org',
-                    {u'eduPersonEntitlement': [b'paranoid']}
-                )]
-        })
-        u = nav.web.ldapauth.LDAPUser("marvin", conn)
+    def test_missing_entitlement_should_not_be_verified(self, user_marvin):
+        u = nav.web.ldapauth.LDAPUser("marvin", user_marvin)
         assert not u.has_entitlement('president')
 
-    def test_admin_entitlement_should_be_verified(self):
-        conn = Mock(**{
-            'search_s.return_value': [
-                (
-                    u'uid=zaphod,cn=users,dc=example,dc=org',
-                    {u'eduPersonEntitlement': [b'president', b'boss']}
-                )]
-        })
-        u = nav.web.ldapauth.LDAPUser("zaphod", conn)
+    def test_admin_entitlement_should_be_verified(self, user_zaphod):
+        u = nav.web.ldapauth.LDAPUser("zaphod", user_zaphod)
         assert u.is_admin()
 
-    def test_missing_admin_entitlement_should_be_verified(self):
-        conn = Mock(**{
-            'search_s.return_value': [
-                (
-                    u'uid=marvin,cn=users,dc=example,dc=org',
-                    {u'eduPersonEntitlement': [b'paranoid']}
-                )]
-        })
-        u = nav.web.ldapauth.LDAPUser("marvin", conn)
+    def test_missing_admin_entitlement_should_be_verified(self, user_marvin):
+        u = nav.web.ldapauth.LDAPUser("marvin", user_marvin)
         assert not u.is_admin()
 
 
@@ -196,14 +168,33 @@ class TestLdapEntitlements(object):
                       'entitlement_attribute': 'eduPersonEntitlement',
                       },
              })
-def test_no_admin_entitlement_option_should_make_no_admin_decision():
-    conn = Mock(**{
+def test_no_admin_entitlement_option_should_make_no_admin_decision(user_zaphod):
+    u = nav.web.ldapauth.LDAPUser("zaphod", user_zaphod)
+    assert u.is_admin() is None
+
+
+#
+# Pytest fixtures
+#
+
+
+@pytest.fixture
+def user_zaphod():
+    return Mock(**{
         'search_s.return_value': [
             (
                 u'uid=zaphod,cn=users,dc=example,dc=org',
                 {u'eduPersonEntitlement': [b'president', b'boss']}
             )]
     })
-    u = nav.web.ldapauth.LDAPUser("zaphod", conn)
-    assert u.is_admin() is None
 
+
+@pytest.fixture
+def user_marvin():
+    return Mock(**{
+        'search_s.return_value': [
+            (
+                u'uid=marvin,cn=users,dc=example,dc=org',
+                {u'eduPersonEntitlement': [b'paranoid']}
+            )]
+    })


### PR DESCRIPTION
This adds the `admin_entitlement` option to the `[ldap]` section of `webfront.conf`. The new option enables using LDAP entitlements to configure which users should receive administrator privileges in NAV.

This is basically a newly discovered requirement of the CNaaS pilot project.