### PR TITLE
Fix binary/string/unicode issues in the neighbor discovery system when running under Python 3

### DIFF
--- a/python/nav/ipdevpoll/neighbor.py
+++ b/python/nav/ipdevpoll/neighbor.py
@@ -34,7 +34,7 @@ from nav.util import cachedfor, synchronized
 from nav.models import manage
 from nav.ipdevpoll.log import ContextLogger
 from nav.ipdevpoll import shadows
-from nav.ipdevpoll.utils import is_invalid_utf8
+from nav.ipdevpoll.utils import is_invalid_database_string
 
 HSRP_MAC_PREFIXES = ('00:00:0c:07:ac',)
 VRRP_MAC_PREFIXES = ('00:00:5e:00:01', '00:00:5e:00:02')  # RFC5798
@@ -207,7 +207,7 @@ class Neighbor(object):
         if not (self.netbox and name):
             return
 
-        if is_invalid_utf8(name):
+        if is_invalid_database_string(name):
             self._logger.warning("cannot search database for malformed "
                                  "neighboring port name %r", name)
             return

--- a/python/nav/ipdevpoll/neighbor.py
+++ b/python/nav/ipdevpoll/neighbor.py
@@ -31,10 +31,7 @@ from django.db.models import Q
 from django.utils import six
 
 from nav.util import cachedfor, synchronized
-
 from nav.models import manage
-from nav.mibs.lldp_mib import IdSubtypes
-
 from nav.ipdevpoll.log import ContextLogger
 from nav.ipdevpoll import shadows
 from nav.ipdevpoll.utils import is_invalid_utf8
@@ -243,99 +240,3 @@ class Neighbor(object):
                 'interfaces={interfaces}>'
                 ).format(myclass=self.__class__.__name__,
                          **vars(self))
-
-
-class CDPNeighbor(Neighbor):
-    "Parses a CDP tuple from nav.mibs.cisco_cdp_mib to identify a neighbor"
-
-    def _identify_netbox(self):
-        netbox = None
-        if self.record.ip:
-            netbox = self._netbox_from_ip(self.record.ip)
-
-        if not netbox and self.record.deviceid:
-            netbox = self._netbox_from_sysname(self.record.deviceid)
-
-        return netbox
-
-    def _identify_interfaces(self):
-        return self._interfaces_from_name(self.record.deviceport)
-
-
-class LLDPNeighbor(Neighbor):
-    "Parses an LLDP tuple from nav.mibs.lldp_mib to identify a neighbor"
-
-    def _identify_netbox(self):
-        chassid = self.record.chassis_id
-        netbox = None
-        if chassid:
-            lookup = None
-            if isinstance(chassid, IdSubtypes.macAddress):
-                lookup = self._netbox_from_mac
-            elif isinstance(chassid, IdSubtypes.networkAddress):
-                lookup = self._netbox_from_ip
-            elif isinstance(chassid, IdSubtypes.local):
-                lookup = self._netbox_from_sysname
-
-            if lookup:
-                netbox = lookup(str(chassid))
-
-        if not netbox and self.record.sysname:
-            netbox = self._netbox_from_sysname(self.record.sysname)
-
-        return netbox
-
-    def _netbox_from_mac(self, mac):
-        mac_map = get_netbox_macs()
-        if mac in mac_map:
-            return self._netbox_query(Q(id=mac_map[mac]))
-
-    def _identify_interfaces(self):
-        portid = self.record.port_id
-        if self.netbox and portid:
-            lookup = None
-            if isinstance(portid, (IdSubtypes.interfaceAlias,
-                                   IdSubtypes.interfaceName)):
-                lookup = self._interfaces_from_name
-            elif isinstance(portid, (IdSubtypes.local)):
-                lookup = self._interfaces_from_local
-            elif isinstance(portid, (IdSubtypes.macAddress)):
-                lookup = self._interfaces_from_mac
-            elif isinstance(portid, (IdSubtypes.networkAddress)):
-                lookup = self._interfaces_from_ip
-
-            if lookup:
-                result = lookup(str(portid))
-                if not result:
-                    # IEEE 802.1AB-2005 9.5.5.2
-                    portdesc = self.record.port_desc
-                    if portdesc:
-                        return self._interfaces_from_name(str(portdesc))
-                else:
-                    return result
-
-    def _interfaces_from_local(self, portid):
-        """Implements a heuristic seen on Juniper, where the port id is an
-        ifIndex and the remote port description is the port's ifAlias value.
-        If no match can be made this way, just revert to the regular "portid
-        interpreted as name" lookup
-
-        """
-        portdesc = self.record.port_desc
-        if portdesc and portid.isdigit():
-            query = Q(ifindex=int(portid)) & Q(ifalias=portdesc)
-            ifc = self._interface_query(query)
-            if ifc:
-                return ifc
-        return self._interfaces_from_name(portid)
-
-    def _interfaces_from_mac(self, mac):
-        assert mac
-        return self._interface_query(Q(ifphysaddress=mac))
-
-    def _interfaces_from_ip(self, ip):
-        ip = six.text_type(ip)
-        assert ip
-        if ip in self._invalid_neighbor_ips:
-            return
-        return self._interface_query(Q(gwportprefix__gw_ip=ip))

--- a/python/nav/ipdevpoll/plugins/cdp.py
+++ b/python/nav/ipdevpoll/plugins/cdp.py
@@ -133,7 +133,7 @@ class CDP(Plugin):
         ifc = self.containers.factory(record.ifindex, shadows.Interface)
         ifc.ifindex = record.ifindex
 
-        key = (record.ifindex, record.ip, SOURCE)
+        key = (record.ifindex, six.text_type(record.ip), SOURCE)
         neighbor = self.containers.factory(
             key, shadows.UnrecognizedNeighbor)
         neighbor.netbox = self.netbox

--- a/python/nav/ipdevpoll/plugins/cdp.py
+++ b/python/nav/ipdevpoll/plugins/cdp.py
@@ -20,7 +20,7 @@ from twisted.internet import defer
 from nav.models import manage
 from nav.ipdevpoll import Plugin, shadows
 from nav.mibs.cisco_cdp_mib import CiscoCDPMib
-from nav.ipdevpoll.neighbor import CDPNeighbor
+from nav.ipdevpoll.neighbor import Neighbor
 from nav.ipdevpoll.db import run_in_thread
 from nav.ipdevpoll.timestamps import TimestampChecker
 
@@ -141,3 +141,20 @@ class CDP(Plugin):
         neighbor.remote_id = six.text_type(record.ip)
         neighbor.remote_name = record.deviceid
         neighbor.source = SOURCE
+
+
+class CDPNeighbor(Neighbor):
+    "Parses a CDP tuple from nav.mibs.cisco_cdp_mib to identify a neighbor"
+
+    def _identify_netbox(self):
+        netbox = None
+        if self.record.ip:
+            netbox = self._netbox_from_ip(self.record.ip)
+
+        if not netbox and self.record.deviceid:
+            netbox = self._netbox_from_sysname(self.record.deviceid)
+
+        return netbox
+
+    def _identify_interfaces(self):
+        return self._interfaces_from_name(self.record.deviceport)

--- a/python/nav/ipdevpoll/shadows/__init__.py
+++ b/python/nav/ipdevpoll/shadows/__init__.py
@@ -145,7 +145,7 @@ class Module(Shadow):
     def _fix_binary_garbage(self):
         """Fixes string attributes that appear as binary garbage."""
 
-        if utils.is_invalid_utf8(self.model):
+        if utils.is_invalid_database_string(self.model):
             self._logger.warning("Invalid value for model: %r", self.model)
             self.model = repr(self.model)
 
@@ -242,7 +242,7 @@ class Device(Shadow):
                      'firmware_version',
                      'serial'):
             value = getattr(self, attr)
-            if utils.is_invalid_utf8(value):
+            if utils.is_invalid_database_string(value):
                 self._logger.warning("Invalid value for %s: %r",
                                      attr, value)
                 setattr(self, attr, repr(value))

--- a/python/nav/ipdevpoll/shadows/adjacency.py
+++ b/python/nav/ipdevpoll/shadows/adjacency.py
@@ -46,7 +46,7 @@ from django.utils import six
 
 from nav.models import manage
 from nav.ipdevpoll.storage import Shadow, DefaultManager
-from nav.ipdevpoll.utils import is_invalid_utf8
+from nav.ipdevpoll.utils import is_invalid_database_string
 from .netbox import Netbox
 
 MAX_MISS_COUNT = 3
@@ -213,7 +213,7 @@ class UnrecognizedNeighbor(Shadow):
 
     def prepare(self, _=None):
         for attr in ('remote_id', 'remote_name'):
-            if getattr(self, attr) and is_invalid_utf8(getattr(self, attr)):
+            if getattr(self, attr) and is_invalid_database_string(getattr(self, attr)):
                 self._logger.debug("converting invalid %s: %r",
                                    attr, getattr(self, attr))
                 setattr(self, attr, repr(getattr(self, attr)))

--- a/python/nav/ipdevpoll/utils.py
+++ b/python/nav/ipdevpoll/utils.py
@@ -89,6 +89,18 @@ def find_prefix(ip, prefix_list):
     return ret
 
 
+def is_invalid_database_string(string):
+    """Returns True if string cannot be stored in PostgreSQL in its current
+    representation. I.e. if string contains NUL characters, or is a binary object
+    that cannot be decoded as UTF-8, or is another type of object, it is considered
+    invalid.
+    """
+    return (
+        (isinstance(string, six.text_type) and "\x00" in string)
+        or is_invalid_utf8(string)
+    )
+
+
 def is_invalid_utf8(string):
     """Returns True if string is invalid UTF-8.
 

--- a/python/nav/mibs/lldp_mib.py
+++ b/python/nav/mibs/lldp_mib.py
@@ -24,7 +24,7 @@ from nav.ip import IP
 from nav.mibs.if_mib import IfMib
 from nav.smidumps import get_mib
 from nav.mibs import mibretriever, reduce_index
-from nav.ipdevpoll.utils import binary_mac_to_hex
+from nav import macaddress
 
 
 class LLDPMib(mibretriever.MibRetriever):
@@ -185,8 +185,11 @@ class IdType(str):
 class MacAddress(IdType):
     def __new__(cls, *args, **_kwargs):
         arg = args[0]
-        if isinstance(arg, six.string_types):
-            arg = binary_mac_to_hex(arg)
+        if isinstance(arg, six.binary_type):
+            try:
+                arg = macaddress.MacAddress.from_octets(arg)
+            except ValueError:
+                arg = macaddress.MacAddress(arg.decode('utf-8'))
         elif isinstance(arg, cls):
             return arg
         return IdType.__new__(cls, arg)
@@ -197,13 +200,15 @@ class NetworkAddress(IdType):
     IPV6 = 2
     ADDR_FAMILY = {
         IPV4: socket.AF_INET,
-        IPV6: socket.AF_INET6
-        }
+        IPV6: socket.AF_INET6,
+        bytes(IPV4): socket.AF_INET,
+        bytes(IPV6): socket.AF_INET6,
+    }
 
     def __new__(cls, *args, **_kwargs):
         arg = args[0]
-        if arg and isinstance(arg, six.string_types):
-            addr_type = ord(arg[0])
+        if arg and isinstance(arg, six.binary_type):
+            addr_type = arg[0]
             addr_string = arg[1:]
             if addr_type in cls.ADDR_FAMILY:
                 try:

--- a/python/nav/mibs/lldp_mib.py
+++ b/python/nav/mibs/lldp_mib.py
@@ -182,6 +182,19 @@ class IdType(str):
             return False
 
 
+class BinaryOrString(IdType):
+    def __new__(cls, *args, **_kwargs):
+        arg = args[0]
+        if isinstance(arg, six.binary_type):
+            try:
+                arg = arg.decode('utf-8')
+            except (ValueError, UnicodeDecodeError):
+                pass
+        elif isinstance(arg, cls):
+            return arg
+        return IdType.__new__(cls, arg)
+
+
 class MacAddress(IdType):
     def __new__(cls, *args, **_kwargs):
         arg = args[0]
@@ -235,7 +248,7 @@ class IdSubtypes(object):
     class chassisComponent(IdType):
         pass
 
-    class interfaceAlias(IdType):
+    class interfaceAlias(BinaryOrString):
         pass
 
     class portComponent(IdType):
@@ -247,10 +260,10 @@ class IdSubtypes(object):
     class networkAddress(NetworkAddress):
         pass
 
-    class interfaceName(IdType):
+    class interfaceName(BinaryOrString):
         pass
 
-    class local(IdType):
+    class local(BinaryOrString):
         pass
 
     class agentCircuitId(IdType):

--- a/tests/unittests/ipdevpoll/neighbor_test.py
+++ b/tests/unittests/ipdevpoll/neighbor_test.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
-from nav.ipdevpoll.neighbor import _get_netbox_macs, CDPNeighbor
+from nav.ipdevpoll.neighbor import _get_netbox_macs
+from nav.ipdevpoll.plugins.cdp import CDPNeighbor
 from mock import patch, Mock
 
 


### PR DESCRIPTION
@sigmunau initiated #1957 - but there were multiple problems running the unaltered LLDP and CDP plugins under Python 3 on the master branch. These issues had to be fixed first.

This PR also incorporates part of Sigmund's PR (specifically, the `CDPNeighbor` and `LLDPNeighbor` classes have been moved to their respective plugins).