### PR TITLE
Properly display sensor data scale on sensor details page.

### DIFF
--- a/python/nav/web/templates/ipdevinfo/sensor-details.html
+++ b/python/nav/web/templates/ipdevinfo/sensor-details.html
@@ -88,7 +88,7 @@
         </tr>
         <tr>
           <th>Scale</th>
-          <td>{{sensor.scale}}</td>
+          <td>{{sensor.data_scale}}</td>
         </tr>
         <tr>
           <th>Thresholds</th>


### PR DESCRIPTION
There was a typo in the attribute name, causing the scale attribute to always be displayed as empty.