### PR TITLE
Use Juniper 802.1X VLAN workaround in default configuration

### DIFF
--- a/python/nav/etc/ipdevpoll.conf
+++ b/python/nav/etc/ipdevpoll.conf
@@ -44,9 +44,8 @@ interfaces=
 bridge=
 typeoid=
 dnsname=
-dot1q=
-# juniperdot1q can replace dot1q, with handling of broken juniper switches
-juniperdot1q=
+# juniperdot1q replaces dot1q, but with workarounds for broken juniper switches
+dot1q=nav.ipdevpoll.plugins.juniperdot1q.JuniperDot1q
 ciscovlan=
 prefix=
 virtualrouter=


### PR DESCRIPTION
More and more people use NAV with Juniper switches. The presence of the juniperdot1 plugin, and the option to use it instead of the regular dot1q plugin in Juniper shops is not very obvious to the user. Since the plugin does not break functionality for non-Juniper-devices, this example config change will apply it as the default implementation for dot1q in ipdevpoll.conf - which should be more user friendly to Juniper users.