### PR TITLE
Netmap layer 2 traffic data requests to Graphite are too slow and too large

### DIFF
--- a/python/nav/netmap/traffic.py
+++ b/python/nav/netmap/traffic.py
@@ -174,15 +174,6 @@ def _fetch_data(interface, cache=None):
 def get_interface_data(interface):
     """Get ifin/outoctets for an interface using a single request"""
     _logger.debug("getting traffic data for single interface %r", interface)
-    in_bps = out_bps = None
-    targets = [metric_path_for_interface(interface.netbox.sysname,
-                                         interface.ifname, counter)
-               for counter in (INOCTETS, OUTOCTETS)]
-    targets = [get_metric_meta(t)['target'] for t in targets]
-    data = get_metric_average(targets, start=TRAFFIC_TIMEPERIOD)
-    for key, value in iteritems(data):
-        if 'ifInOctets' in key:
-            in_bps = value
-        elif 'ifOutOctets' in key:
-            out_bps = value
+    data = get_traffic_for([interface])[interface]
+    in_bps, out_bps = data.get(INOCTETS), data.get(OUTOCTETS)
     return in_bps, out_bps

--- a/python/nav/netmap/traffic.py
+++ b/python/nav/netmap/traffic.py
@@ -96,6 +96,9 @@ def get_traffic_for(interfaces):
     metric_mapping = {}  # Store metric_name -> interface
     targets = []
     traffic = defaultdict(dict)
+
+    _logger.debug("preparing to get traffic data for %d interfaces", len(interfaces))
+
     for interface in interfaces:
         metrics = [m for m in interface.get_port_metrics()
                    if m['suffix'] in [INOCTETS, OUTOCTETS]]
@@ -103,6 +106,8 @@ def get_traffic_for(interfaces):
             target = get_metric_meta(metric['id'])['target']
             metric_mapping[target] = interface
             targets.append(target)
+
+    _logger.debug("getting data for %d targets", len(targets))
 
     data = get_metric_average(sorted(targets), start=TRAFFIC_TIMEPERIOD)
     for metric, value in iteritems(data):
@@ -152,6 +157,7 @@ def _fetch_data(interface, cache=None):
 
 def get_interface_data(interface):
     """Get ifin/outoctets for an interface using a single request"""
+    _logger.debug("getting traffic data for single interface %r", interface)
     in_bps = out_bps = None
     targets = [metric_path_for_interface(interface.netbox.sysname,
                                          interface.ifname, counter)

--- a/python/nav/netmap/traffic.py
+++ b/python/nav/netmap/traffic.py
@@ -160,7 +160,7 @@ def _fetch_data(interface, cache=None):
     in_bps = out_bps = speed = None
     if isinstance(interface, Interface):
         speed = interface.speed
-        if cache:
+        if cache is not None:
             interface_data = cache[interface]
             if interface_data:
                 in_bps = interface_data.get(INOCTETS)

--- a/python/nav/netmap/traffic.py
+++ b/python/nav/netmap/traffic.py
@@ -130,7 +130,7 @@ def get_traffic_for(interfaces):
         interface = metric_mapping[metric]
         if INOCTETS in metric:
             traffic[interface].update({INOCTETS: value})
-        elif OUTOCTETS:
+        elif OUTOCTETS in metric:
             traffic[interface].update({OUTOCTETS: value})
 
     return traffic

--- a/python/nav/util.py
+++ b/python/nav/util.py
@@ -221,6 +221,14 @@ def first_true(iterable, default=None, pred=None):
     return next(ifilter(pred, iterable), default)
 
 
+def chunks(lst, size):
+    """
+    Yields successive `size`-sized chunks from lst.
+    """
+    for i in range(0, len(lst), size):
+        yield lst[i:i+size]
+
+
 class IPRange(object):
     """An IP range representation.
 

--- a/python/nav/web/geomap/db.py
+++ b/python/nav/web/geomap/db.py
@@ -39,7 +39,8 @@ from nav.metrics.names import escape_metric_name
 from nav.metrics.templates import (metric_path_for_interface,
                                    metric_path_for_cpu_load,
                                    metric_path_for_cpu_utilization)
-from nav.web.geomap.utils import lazy_dict, subdict, is_nan, chunks
+from nav.web.geomap.utils import lazy_dict, subdict, is_nan
+from nav.util import chunks
 from django.core.cache import cache
 
 _logger = logging.getLogger(__name__)

--- a/python/nav/web/geomap/utils.py
+++ b/python/nav/web/geomap/utils.py
@@ -25,7 +25,6 @@ from itertools import groupby
 from functools import reduce
 
 from django.utils.six import iteritems
-from django.utils.six.moves import range
 
 
 def identity(obj):
@@ -425,9 +424,3 @@ def first(lst):
     return lst[0]
 
 
-def chunks(lst, size):
-    """
-    Yields successive `size`-sized chunks from lst.
-    """
-    for i in range(0, len(lst), size):
-        yield lst[i:i+size]

--- a/python/nav/web/netmap/graph.py
+++ b/python/nav/web/netmap/graph.py
@@ -127,28 +127,6 @@ def get_traffic_gradient():
     ]
 
 
-def get_traffic_interfaces(edges, interfaces):
-    """Gives list of edges and interfaces, filter out the interfaces we are to
-    fetch traffic for
-
-    :param set edges: a set of edges represented by netbox pairs
-    :param QuerySet interfaces: all interfaces
-    :returns: The list of interfaces we have to fetch traffic for.
-    """
-    storage = {}
-    for source, target in edges:
-        edge_interfaces = interfaces.filter(
-            netbox_id=source,
-            to_netbox_id=target
-        )
-        for interface in edge_interfaces:
-            storage[interface.pk] = interface
-            if interface.to_interface:
-                storage[interface.to_interface.pk] = interface.to_interface
-
-    return storage.values()
-
-
 @cache_traffic("layer 2")
 def get_layer2_traffic(location_or_room_id=None):
     """Fetches traffic data for layer 2"""
@@ -176,23 +154,25 @@ def get_layer2_traffic(location_or_room_id=None):
         else:
             interfaces = interfaces.filter(netbox__room=room)
 
-    edges = set([
-        (
-            interface.netbox_id,
-            interface.to_netbox_id
-        )
-        for interface in interfaces
-    ])
+    edges = defaultdict(set)
+    for interface in interfaces:
+        edges[(interface.netbox_id, interface.to_netbox_id)].add(interface)
+
+    _logger.debug(
+        "Produced %d edges from %d interfaces in %s",
+        len(edges),
+        len(interfaces),
+        datetime.now() - start,
+    )
+
+    complete_interface_set = set(interfaces) | set(
+        ifc.to_interface for ifc in interfaces if ifc.to_interface
+    )
+    traffic_cache = get_traffic_for(complete_interface_set)
+    _logger.debug('Traffic cache built. Time used so far: %s', datetime.now() - start)
 
     traffic = []
-    traffic_cache = get_traffic_for(
-        get_traffic_interfaces(edges, interfaces))
-
-    for source, target in edges:
-        edge_interfaces = interfaces.filter(
-            netbox_id=source,
-            to_netbox_id=target
-        )
+    for (source, target), edge_interfaces in edges.items():
         edge_traffic = []
         for interface in edge_interfaces:
             to_interface = interface.to_interface
@@ -209,7 +189,7 @@ def get_layer2_traffic(location_or_room_id=None):
             'edges': edge_traffic,
         })
 
-    _logger.debug('Time used: %s', datetime.now() - start)
+    _logger.debug('Total time used: %s', datetime.now() - start)
     return traffic
 
 


### PR DESCRIPTION
I set out to fix an issue with failing Graphite-web requests from Netmap, and ended up discovering a hive of bad code, having been groped by multiple developers over time, with several issues that I fixed along the way.

The triggering issue was this: On a customer's installation, every Netmap layer 2 map generated would cause Graphite-web to produce a **400 Bad Request** response, as the request Netmap created would exceed Django's limit of 1000 variables in a single GET/POST-request (due to the fact that the generated request would contain a single `target` variable for *each traffic counter for each interface involved*, resulting in a request with **2200 targets**).

To fix this problem, I did two things:

1. I changed the code to split graphite requests into chunks of 500 targets each.
2. I changed the code to leverage Graphite's wildcard syntax, so that fewer target values would be generated, while keeping the number of response values.

This alone reduced the time spent in traffic data retrieval by 50%. Along the way, I fixed several other code smells.

Then I discovered that most of the time in the view function was actually spent in fetching interface data from PostgreSQL, not waiting for Graphite. The view spent 2/3 of its time fetching data from PostgreSQL, and only 1/3 talking to Graphite, which is just ridiculous. As it turns out, it fetched all interface data *thrice*, in a massively-redundant fashion. With test data from the customer, a few milliseconds were spent fetching the initial set of interfaces from PostgreSQL. Then, 5 seconds were spent fetching each interface again, using individual SELECT queries. Then, 5 seconds was spent waiting for a Graphite request, and then, an additional 5 seconds were spent yet agan fetching each interface with single SELECT queries. So, for my third and final act:

3. I changed the code to only use the data fetched by the initial PostgreSQL query.

I really wish we had better code review processes back in the day, and therefore humbly present this for peer review this time over.