### PR TITLE
Run Django development server as a separate docker compose service

### DIFF
--- a/doc/hacking/using-docker.rst
+++ b/doc/hacking/using-docker.rst
@@ -40,8 +40,9 @@ Using the container(s)
 The default Docker Compose setup will expose the NAV web frontend on
 http://localhost/ and the Graphite-web frontend on http://localhost:8000 .
 
-You can access the inside of the NAV container (to control NAV daemons, adjust
-the running config, or whatever) by running a bash shell inside it, like so::
+You can access the inside of the NAV container (to control NAV daemons using
+the ``nav`` command, adjust the running config, or whatever) by running a bash
+shell inside it, like so::
 
   docker-compose exec nav /bin/bash
 
@@ -49,7 +50,7 @@ the running config, or whatever) by running a bash shell inside it, like so::
 Controlling processes inside the nav container
 ----------------------------------------------
 
-The main ``nav`` container uses :program:`supervisord` to controll multiple
+The main ``nav`` container uses :program:`supervisord` to control multiple
 processes. While the ``nav`` command can be used to control individual NAV
 services, :program:`supervisorctl` can be used to control other processes used
 within the development environment:
@@ -62,21 +63,23 @@ nav
   This is a one-time supervisor task to start all of NAV when the container
   starts.
 
-python-watcher
-  This is a process that monitors the :file:`python/` subdirectory for changes,
-  and restarts the web server if anything changes.
-
 sass-watcher
   This is a process that monitors the :file:`python/nav/web/sass/` subdirectory
   for changes, and re-runs ``python setup.py build_sass`` (i.e. rebuilding all
   the SASS-based stylesheets) on changes.
 
-web
-  This is a simple Django development web server (``django runserver``),
-  serving the NAV web interface.
+The individual logs of these program are typically found inside the ``nav``
+container in the :file:`/var/log/supervisor/` directory. The NAV process logs
+themselves are placed inside the :file:`/tmp/` directory inside the ``nav``
+container.
 
-The individual process logs are typically found inside the ``nav`` container in
-the :file:`/var/log/supervisor/` directory.
+Controlling log levels
+----------------------
+
+The log levels of various parts of NAV are controlled through the config file
+:file:`/etc/nav/logging.conf` inside the containers. Please be aware that the
+``nav`` and ``web`` containers do not share a configuration volume, so you may
+need to make adjustments in either container, depending on your needs.
 
 
 Happy hacking!

--- a/doc/hacking/using-docker.rst
+++ b/doc/hacking/using-docker.rst
@@ -37,14 +37,68 @@ command to build and run everything::
 Using the container(s)
 ----------------------
 
-The default Docker Compose setup will expose the NAV web frontend on
-http://localhost/ and the Graphite-web frontend on http://localhost:8000 .
+The Docker Compose specificiation creates these containers (called "services"
+in Docker Compose lingo):
 
-You can access the inside of the NAV container (to control NAV daemons using
-the ``nav`` command, adjust the running config, or whatever) by running a bash
-shell inside it, like so::
+nav
+  This container runs the NAV backend processes and cron jobs. It also runs the
+  "sass-watcher" job, which will watch *.scss files for modifications and
+  recompile NAV's CSS when changes do occur.
+
+web
+  This container runs the Django development server to serve NAV's web-based
+  user interface. By default, Docker Compose will expose this web service on
+  port 80 on the host system, i.e. at http://localhost/
+
+postgres
+  This runs a bog standard Postgres image from the Docker Hub, to serve as
+  NAV's main data store.
+
+graphite
+  This runs both carbon-cache backend and a graphite-web frontend, for NAV's
+  storage and retrieval of time-series data. By default, Docker Compose will
+  expose the web service on port 8000 on the host system,
+  i.e. http://localhost:8000/
+
+docbuild
+  This container will watch the :file:`doc/` directory for changes and initiate
+  a rebuild of the NAV documentation whenever the documentation source files
+  are modified. The built documentation should normally be browseable via the web
+  service at http://localhost/doc/
+
+Accessing internals of running containers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If need be, you can access the internals of the running containers (to control
+NAV daemons using the ``nav`` command, adjust the running config, or whatever)
+by running a bash shell inside the container, like so (for the ``nav``
+container)::
 
   docker-compose exec nav /bin/bash
+
+Manually restarting the web server
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To manually restart the web server, all you need is::
+
+  docker-compose restart web
+
+Rebuilding the NAV code from scratch
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A complete rebuild of the NAV code can be initiated by::
+
+  docker-compose restart nav
+
+Rebuilding the containers
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you are switching between branches, though, you may need to rebuild the
+images the containers are based on (as different development branches may have
+different requirements, and therefore different Dockerfiles). Stop the existing
+containers and run this::
+
+  docker-compose build
 
 
 Controlling processes inside the nav container
@@ -82,10 +136,41 @@ The log levels of various parts of NAV are controlled through the config file
 need to make adjustments in either container, depending on your needs.
 
 
+Overriding the compose services
+-------------------------------
+
+If you need to override certain aspects of the Docker Compose service
+definitions for your own purposes during development, you can usually do so
+without patching the :file:`docker-compose.yml` file. You can "patch" the
+definitions via `Docker Compose's override mechanism`_: Simply add a
+:file:`docker-compose.override.yml` to the top-level source directory.
+
+Preventing NAV backend services from starting at container startup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can add the environment variable ``NONAVSTART=1`` to prevent the backend
+daemons from being started at the ``nav`` container startup time (allowing for
+complete manual control of daemons, by entering the container using ``exec``,
+as documented above). This can be done by adding something akin to this:
+
+.. code-block:: yaml
+   :caption: docker-compose.override.yml
+
+   version: '2'
+   services:
+     nav:
+       environment:
+         - NONAVSTART=1
+
+The same technique can be used to insert your own environment into the ``web``
+container.
+
+
 Happy hacking!
 
 
-.. [*] See http://docs.docker.io/installation/#installation.
-.. _homepage: http://docker.io
-.. _documentation: http://docs.docker.io
+.. [*] See https://docs.docker.com/install/
+.. _homepage: https://docker.com
+.. _documentation: https://docs.docker.com/
 .. _Docker Compose: https://docs.docker.com/compose/gettingstarted/
+.. _Docker Compose's override mechanism: https://docs.docker.com/compose/extends/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,14 +24,24 @@ services:
       - PGHOST=postgres
       - PGDATABASE=nav
       - PGUSER=postgres
-    ports:
-      - "80:80"
     volumes:
       - .:/source
     depends_on:
       - postgres
+
+  web:
+    build: .
+    command: ["/source/tools/docker/web.sh"]
+    ports:
+      - "80:80"
+    volumes_from:
+      - nav
+    depends_on:
+      - nav
+
   postgres:
     image: "postgres:9.4"
+
   graphite:
     build: ./tools/docker/graphite
     ports:

--- a/tools/docker/run.sh
+++ b/tools/docker/run.sh
@@ -6,9 +6,6 @@ set -e
 mydir=$(dirname $0)
 "$mydir/build.sh"
 
-mkdir -p /var/run/apache2
-rm -f /var/run/apache2/*.pid
-
 "$mydir/syncdb.sh" || exit
 
 # Start supervisor to control the rest of the runtime

--- a/tools/docker/source-watch.sh
+++ b/tools/docker/source-watch.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-# ensures Apache restarts the WSGI process on changes to /source/python
-#
-while inotifywait -e modify -e move -e create -e delete -r --exclude \# /source/python
-do
-  supervisorctl restart web
-done

--- a/tools/docker/supervisord.conf
+++ b/tools/docker/supervisord.conf
@@ -13,14 +13,6 @@ command = /source/tools/docker/nav-start.sh
 autorestart = false
 startsecs = 0
 
-[program:web]
-command=django-admin runserver 0.0.0.0:80
-redirect_stderr=true
-stdout_logfile = /var/log/supervisor/%(program_name)s.log
-autorestart = true
-stopasgroup = true
-stopsignal = QUIT
-
 [program:sass-watcher]
 user = nav
 command = /source/tools/docker/sass-watch.sh

--- a/tools/docker/supervisord.conf
+++ b/tools/docker/supervisord.conf
@@ -19,11 +19,3 @@ command = /source/tools/docker/sass-watch.sh
 stdout_logfile = /var/log/supervisor/%(program_name)s.log
 redirect_stderr=true
 autorestart = true
-
-[program:python-watcher]
-user = nav
-command = /source/tools/docker/source-watch.sh
-stdout_logfile = /var/log/supervisor/%(program_name)s.log
-redirect_stderr=true
-autorestart = true
-

--- a/tools/docker/web.sh
+++ b/tools/docker/web.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+# Ensure latest NAV code is built
+mydir=$(dirname $0)
+"$mydir/build.sh"
+cd /source
+
+
+exec django-admin runserver 0.0.0.0:80


### PR DESCRIPTION
To improve process isolation, and to enable having the log output of the development server more up-front when using Docker Compose, this PR moves the development server out of the nav service container and into a dedicated web container.