### PR TITLE
Refactor installation documentation.

### DIFF
--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -14,6 +14,7 @@ NAV documentation contents
 
     overview
     intro/install
+    howto/integrating-graphite-with-nav
     intro/getting-started
     intro/getting-organized
     howto/debugging-topology

--- a/doc/howto/generic-install-from-source.rst
+++ b/doc/howto/generic-install-from-source.rst
@@ -1,0 +1,197 @@
+=================================
+ Installing NAV from source code
+=================================
+
+This is a generic guide to installing NAV from source code on a \*NIX flavored
+operating system. The specifics of how to install NAV's dependencies, such as
+PostgreSQL_ or Graphite_ will be entirely up to you and your choice of OS.
+
+
+Dependencies
+============
+
+This section specifies what software packages are needed to build and run NAV.
+Be aware that many of these packages have dependencies of their own.
+
+Build requirements
+------------------
+
+To build NAV, you need at least the following:
+
+ * Python >= 3.5.0
+ * Sphinx >= 1.0 (for building this documentation)
+
+Runtime requirements
+--------------------
+
+To run NAV, these software packages are required:
+
+ * Apache2 + mod_wsgi (or, really, any web server that supports the WSGI interface)
+ * PostgreSQL >= 9.4 (With the ``hstore`` extension available)
+ * Graphite_
+ * Python >= 3.5.0
+ * nbtscan = 1.5.1
+ * dhcping (only needed if using DHCP service monitor)
+
+PostgreSQL and Graphite are services that do not necessarily need to run on
+the same server as NAV.
+
+The required Python modules can be installed either from your OS package
+manager, or from the Python Package Index (PyPI_) using the regular ``setup.py``
+method described below. The packages can also be installed from PyPI_ in a
+separate step, using the pip_ tool and the provided requirements files::
+
+  pip install -r requirements.txt
+
+*However*, some of the required modules are C extensions that will require the
+presence of some C libraries to be correctly built (unless PyPI provides binary
+wheels for your platform). These include the ``psycopg2`` driver and the
+``python-ldap`` and ``Pillow`` modules).
+
+The current Python requirements are as follows:
+
+.. literalinclude:: ../../requirements/django111.txt
+   :language: text
+
+.. literalinclude:: ../../requirements/base.txt
+   :language: text
+
+.. _PostgreSQL: https://www.postgresql.org/
+.. _Graphite: http://graphiteapp.org/
+.. _pip: https://pip.pypa.io/en/stable/
+.. _PyPi: https://pypi.org/
+
+Recommended add-ons
+-------------------
+
+If you want to connect a mobile phone to your NAV server and enable SMS alerts
+in alert profiles, you will need to install :program:`Gammu` and the Python
+:mod:`gammu` module.  The SMS daemon can use plugins to dispatch text
+messages through other means, but using Gammu as an SMS dispatcher is the
+default.
+
+
+Installing NAV
+==============
+
+To build and install NAV and all its Python dependencies::
+
+  pip install -r requirements.txt .
+
+This will build and install NAV in the default system-wide directories for your
+system. If you wish to customize the install locations, please consult the
+output of ``python setup.py install --help``.
+
+
+.. _initializing-the-configuration-files:
+
+Initializing the configuration
+------------------------------
+
+NAV will look for its configuration files in various locations on your file
+system. These locations can be listed by running::
+
+  nav config path
+
+To install a set of pristine NAV configuration files into one of these locations,
+e.g. in :file:`/etc/nav`, run::
+
+  nav config install /etc/nav
+
+To verify that NAV can find its main configuration file, run::
+
+  nav config where
+
+
+Initializing the database
+-------------------------
+
+Before NAV can run, the database schema must be installed in your PostgreSQL
+server.  NAV can create a database user and a database schema for you.
+
+Choose a password for your NAV database user and set this in the ``userpw_nav``
+in the :file:`db.conf` config file. As the ``postgres`` superuser, run the following
+command::
+
+  navsyncdb -c
+
+This will attempt to create a new database user, a new database and initialize
+it with NAV's schema.
+
+
+Configuring the web interface
+-----------------------------
+
+NAV's web interface is implemented using the Django framework, and can be
+served in any web server environment supported by Django (chiefly, any
+environment that supports *WSGI*). This guide is primarily concerned with
+Apache 2.
+
+An example configuration file for Apache2 is provided the configuration
+directory, :file:`apache/apache.conf.example`. This configuration uses
+``mod_wsgi`` to serve the NAV web application, and can be modified to suit your
+installation paths. Once complete, it can be included in your virtualhost
+config, which needn't contain much more than this:
+
+.. code-block:: apacheconf
+
+  ServerName nav.example.org
+  ServerAdmin webmaster@example.org
+
+  Include /path/to/your/nav/apache.conf
+
+.. important:: You should always protect your NAV web site using SSL!
+
+Installing static resources
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You want your web server to be able to serve all of NAV's static resources. You
+can install all of them by issuing the following command:
+
+.. code-block:: console
+
+  # django-admin collectstatic --settings=nav.django.settings
+  You have requested to collect static files at the destination
+  location as specified in your settings:
+
+      /usr/share/nav/www/static
+
+  This will overwrite existing files!
+  Are you sure you want to do this?
+
+  Type 'yes' to continue, or 'no' to cancel:
+
+In this example, type :kbd:`yes`, hit :kbd:`Enter`, and ensure your web server's
+document root points to :file:`/usr/share/nav/www`, because that is where the
+:file:`static` directory is located. If that doesn't suit you, you will at
+least need an Alias to point the ``/static`` URL to the :file:`static`
+directory.
+
+Users and privileges
+--------------------
+
+Apart from the ``pping`` and ``snmptrapd`` daemons, no NAV processes should
+ever be run as ``root``. You should create a non-privileged system user and
+group, and ensure the ``NAV_USER`` option in :file:`nav.conf` is set
+accordingly. Also make sure this user has permissions to write to the directories
+configured in ``PID_DIR``, ``LOG_DIR`` and ``UPLOAD_DIR``.
+
+.. note:: The ``pping`` and ``snmptrapd`` daemons must be started as ``root``
+          to be able to create privileged communication sockets. Both daemons
+          will drop privileges and run as the configured non-privileged user as
+          soon as the sockets have been acquired.
+
+Building the documentation
+--------------------------
+
+If you wish, this HTML documentation can be built separately using this step::
+
+  python setup.py build_sphinx
+
+The resulting files will typically be placed in :file:`build/sphinx/html/`.
+
+If you want to serve this documentation on your NAV web server, you should copy
+the :file:`html` directory to a suitable location and make sure that location is served
+as ``/doc`` on the web server.  If using the example Apache configuration
+(:file:`apache.conf.example`), there is a define named ``documentation_path``,
+which can be set to point to this file system location.

--- a/doc/howto/installing-graphite-on-debian.rst
+++ b/doc/howto/installing-graphite-on-debian.rst
@@ -12,6 +12,9 @@ installation, dedicated to NAV, on a **Debian 9 (Stretch)** or **Debian 10
              graphs </faq/graph_gaps>`, which you will need to resolve
              manually after-the-fact.
 
+A more `generic and up-to-date installation guide for Graphite
+<https://graphite.readthedocs.io/en/latest/install.html>`_ can be found in the
+Graphite project's own documentation.
 
 Getting Graphite
 ================

--- a/doc/howto/integrating-graphite-with-nav.rst
+++ b/doc/howto/integrating-graphite-with-nav.rst
@@ -1,0 +1,87 @@
+.. _integrating-graphite-with-nav:
+
+Integrating Graphite with NAV
+-----------------------------
+
+.. highlight:: ini
+
+NAV uses Graphite_ to store and retrieve/graph time-series data. Installing
+Graphite itself is out of scope for this guide, but assuming you already have *a
+complete installation of Graphite*, you need to change some configuration
+options in both Graphite and NAV to ensure your time-series data is stored and
+retrieved properly:
+
+1. NAV needs to know the details of *where to send data*.
+2. NAV needs to know the details of *how to retrieve time-series data* from
+   :program:`graphite-web` (Graphite's front-end web service for retrieving stored
+   data)
+3. :program:`carbon-cache` (Graphite's backend component for receiving and
+   storing time series data) needs to know **how** it should store data
+   received from NAV.
+
+Configuring NAV
+~~~~~~~~~~~~~~~
+
+NAV must be configured with the IP address and port of your Graphite
+installation's Carbon backend, and the URL to the Graphite-web frontend used
+for graphing. These settings can be configured in the :file:`graphite.conf`
+configuration file.
+
+.. note:: NAV requires the Carbon backend's UDP listener to be enabled, as it
+          will only transmit metrics over UDP.
+
+For a simple, local Graphite installation, you may not need to touch this
+configuration file at all, but at its simplest it looks like this::
+
+  [carbon]
+  host = 127.0.0.1
+  port = 2003
+
+  [graphiteweb]
+  base = http://localhost:8000/
+
+
+Configuring Graphite
+~~~~~~~~~~~~~~~~~~~~
+
+You will need to make some configuration changes to :program:`carbon-cache`
+before letting NAV send data to Graphite:
+
+1. First and foremost, you will need to enable the UDP listener in the
+   configuration file :file:`carbon.conf`.
+
+   For performance reasons, Carbon will also limit the number of new Whisper
+   files that can be created per minute. This number is fairly low by default,
+   and when starting NAV for the first time, it may send a ton of new metrics
+   very fast. If the limit is set to 50, it will take a long time before all
+   the metrics are created. You might want to increase the
+   ``MAX_CREATES_PER_MINUTE`` option, or *temporarily* set it to ``inf``.
+
+2. You should add the suggested *storage-schema* configurations for the
+   various ``nav`` prefixes listed in :file:`etc/graphite/storage-schemas.conf`:
+
+   .. literalinclude:: ../../python/nav/etc/graphite/storage-schemas.conf
+
+   The highest precision retention archives are the most important ones here,
+   as their data point interval must correspond with the collection intervals
+   of various NAV processes. Other than that, the retention periods and the
+   precision of any other archive can be freely experimented with.
+
+   Remember, these schemas apply to new Whisper files as they are created. You
+   should not start NAV until the schemas have been configured, otherwise the
+   Whisper files will be created with the global Graphite defaults, and your
+   data may be munged or inaccurate, and your graphs will be spotty.
+
+3. You should add the suggested *storage-aggregation* configurations listed in
+   the file :file:`etc/graphite/storage-aggregation.conf`:
+
+   .. literalinclude:: ../../python/nav/etc/graphite/storage-aggregation.conf
+
+   These will ensure that time-series data sent to Graphite by NAV will be
+   aggregated properly when Graphite rolls them into lower-precision archives.
+
+Ensure :program:`carbon-cache` is restarted to make these changes take effect,
+before adding devices to monitor in your NAV installation.
+
+.. _PostgreSQL: https://www.postgresql.org/
+.. _Graphite: http://graphiteapp.org/

--- a/doc/howto/manual-install-on-debian.rst
+++ b/doc/howto/manual-install-on-debian.rst
@@ -194,9 +194,10 @@ You should now be able to browse the NAV web interface.
 11. Installing and configuring Graphite
 =======================================
 
-NAV uses Graphite_ to store and retrieve time-series data. See the :doc:`how-to
-guide for installing Graphite for use with NAV on a Debian system
-</howto/installing-graphite-on-debian>`.
+NAV uses Graphite_ to store and retrieve time-series data. If you do not
+already have a Graphite installation you wish to integrate with NAV, here is a
+:doc:`separate guide on how to install and use Graphite with NAV on your Debian
+system </howto/installing-graphite-on-debian>`.
 
 .. _Graphite: http://graphite.readthedocs.org/
 

--- a/doc/intro/getting-started.rst
+++ b/doc/intro/getting-started.rst
@@ -15,7 +15,8 @@ Minimal configuration
 If installing from source, you should have installed a copy of the default set
 of NAV configuration files to a global directory, typically :file:`/etc/nav/`,
 :ref:`as documented in the installation guide
-<initializing-the-configuration-files>`.
+<initializing-the-configuration-files>`. The pre-packaged installation options
+should already have done this for you.
 
 Most of the configuration files are documented with comments, so if you want to
 get advanced you can check each config file to see if there are any defaults
@@ -61,7 +62,15 @@ you will also want to change the directory paths used by NAV to store various
 state files, log files and files uploaded through the web interface:
 ``PID_DIR``, ``LOG_DIR`` and ``UPLOAD_DIR``.
 
-  
+
+.. warning:: **Before adding stuff to monitor into your NAV**, you need to
+             ensure you have :ref:`properly integrated your Graphite
+             installation with your NAV installation
+             <integrating-graphite-with-nav>`, or you *will* have issues with
+             :doc:`blank areas in your graphs </faq/graph_gaps>`, which you
+             will need to resolve manually after-the-fact.
+
+
 
 Starting NAV
 ============

--- a/doc/intro/install.rst
+++ b/doc/intro/install.rst
@@ -4,266 +4,99 @@
 
 .. highlight:: sh
 
-NAV releases official Debian packages. We recommend using these if you can. If
-you can't, or won't, please read on.
-
-Install from source on
-======================
-
-See :doc:`/howto/manual-install-on-debian` for more complete, Debian-centric
-guide to installation of a full NAV system from source.
+There are two main options for installing NAV: Either from source code, or from
+a pre-packaged version. Some of these options will require manually installing
+and/or configuring 3rd party software that NAV depends on, mainly PostgreSQL_
+and Graphite_.
 
 
-Dependencies
-============
+Installing a pre-packaged version of NAV
+========================================
 
-This section specifies what software packages are needed to build and run NAV.
-Be aware that many of these packages have dependencies of their own.
+There are mainly two official types of "pre-packaged" NAV versions you can use:
 
-Build requirements
-------------------
+1. A virtual appliance.
+2. A Debian package.
 
-To build NAV, you need at least the following:
+Installing NAV as a virtual appliance
+-------------------------------------
 
- * Python >= 3.5.0
- * Sphinx >= 1.0 (for building this documentation)
+We provide a virtual appliance in the Open Virtualization Format. `Open
+Virtualization Format`_ (OVF) is an open standard for packaging and distributing
+virtual appliances or, more generally, software to be run in virtual
+machines.
 
-Runtime requirements
---------------------
+Our virtual appliance is based on Debian GNU/Linux and our published Debian
+Package, mentioned below. This appliance can be imported into virtualization
+software like e.g. Virtualbox or VMWare.
 
-To run NAV, these software packages are required:
+The appliance is useful for quickly evaluating the NAV software, without the
+hassle of installing and maintaining a full OS for the purpose.  The appliance
+is, however, *not necessarily* suited for production use without modifications
+(such as increasing the storage space and other resources made available to
+the VM) or proper sysadmin practices.
 
- * Apache2 + mod_wsgi (or, really, any web server that supports the WSGI interface)
- * PostgreSQL >= 9.4 (With the ``hstore`` extension available)
- * Graphite_
- * Python >= 3.5.0
- * nbtscan = 1.5.1
- * dhcping (only needed if using DHCP service monitor)
+`There is a separate guide for installing the virtual appliance on the official
+NAV web site <https://nav.uninett.no/install-instructions/#ovf>`_ .
 
-PostgreSQL and Graphite are services that do not necessarily need to run on
-the same server as NAV.
+.. _`Open Virtualization Format`: https://en.wikipedia.org/wiki/Open_Virtualization_Format
 
-The required Python modules can be installed either from your OS package
-manager, or from the Python Package Index (PyPI_) using the regular ``setup.py``
-method described below. The packages can also be installed from PyPI_ in a
-separate step, using the pip_ tool and the provided requirements files::
+Installing NAV from a Debian Package
+------------------------------------
 
-  pip install -r requirements.txt
+If you are familiar with the `Debian GNU/Linux operating system
+<https://www.debian.org>`_, you can install NAV from a Debian Package. Debian
+is our primary choice of server operating system, so we always make sure to
+provide an official Debianized NAV package.
 
-*However*, some of the required modules are C extensions that will require the
-presence of some C libraries to be correctly built (unless PyPI provides binary
-wheels for your platform). These include the ``psycopg2`` driver and the
-``python-ldap`` and ``Pillow`` modules).
+Using the Debian package will save you from the hassle of installing and
+upgrading either NAV or its dependencies from source code. You can even
+configure your Debian to automatically keep up-to-date with the latest security
+patches from the Debian team.
 
-The current Python requirements are as follows:
+This is normally our recommended option for regular NAV users.
 
-.. literalinclude:: ../../requirements/django111.txt
-   :language: text
+`Instructions for installing the Debian package is available on the official
+NAV web site <https://nav.uninett.no/install-instructions/#debian>`_.
 
-.. literalinclude:: ../../requirements/base.txt
-   :language: text
+After installing the Debian package, you will need to :ref:`integrate Graphite
+with NAV <integrating-graphite-with-nav>`, before starting to use NAV to
+monitor your devices.
 
+
+Installing NAV using Docker Compose
+-----------------------------------
+
+There is also a third, still experimental, way of installing a pre-packaged
+NAV: `Docker Compose`_. Like with the Virtual Appliance, this offers a quick
+way to get started with NAV, without the up-front hassle of installing and
+configuring a full operating system for the purpose.
+
+Using Docker Compose, NAV's components and dependencies will run in individual
+ready-to-use containers. You can run NAV directly from your workstation for
+evaluation, on a server with other containers, or more easily scale out to
+multiple servers, if need be.
+
+The containerized version of NAV is available from a separate GitHub
+repository: https://github.com/Uninett/nav-container/
+
+.. _`Docker Compose`: https://docs.docker.com/compose/
+
+
+Installing NAV from source code
+===============================
+
+If you're the hacker type, or just want to run NAV on your own preferred choice
+of \*NIX flavored operating system, you'll want to build and install NAV from
+source code.
+
+For you, we provide two guides:
+
+1. :doc:`A generic guide to installation from source
+   </howto/generic-install-from-source>`.
+2. :doc:`A step-by-step, detailed guide on installing NAV from source on a
+   Debian GNU/Linux operating system </howto/manual-install-on-debian>`.
+
+
+.. _PostgreSQL: https://www.postgresql.org/	      
 .. _Graphite: http://graphiteapp.org/
-.. _pip: https://pip.pypa.io/en/stable/
-.. _PyPi: https://pypi.org/
-
-Recommended add-ons
--------------------
-
-If you want to connect a mobile phone to your NAV server and enable SMS alerts
-in alert profiles, you will need to install :program:`Gammu` and the Python
-:mod:`gammu` module.  The SMS daemon can use plugins to dispatch text
-messages through other means, but using Gammu as an SMS dispatcher is the
-default.
-
-
-Installing NAV
-==============
-
-To build and install NAV and all its Python dependencies::
-
-  pip install -r requirements.txt .
-
-This will build and install NAV in the default system-wide directories for your
-system. If you wish to customize the install locations, please consult the
-output of ``python setup.py install --help``.
-
-
-.. _initializing-the-configuration-files:
-
-Initializing the configuration
-------------------------------
-
-NAV will look for its configuration files in various locations on your file
-system. These locations can be listed by running::
-
-  nav config path
-
-To install a set of pristine NAV configuration files into one of these locations,
-e.g. in :file:`/etc/nav`, run::
-
-  nav config install /etc/nav
-
-To verify that NAV can find its main configuration file, run::
-
-  nav config where
-
-
-Initializing the database
--------------------------
-
-Before NAV can run, the database schema must be installed in your PostgreSQL
-server.  NAV can create a database user and a database schema for you.
-
-Choose a password for your NAV database user and set this in the ``userpw_nav``
-in the :file:`db.conf` config file. As the ``postgres`` superuser, run the following
-command::
-
-  navsyncdb -c
-
-This will attempt to create a new database user, a new database and initialize
-it with NAV's schema.
-
-
-Configuring the web interface
------------------------------
-
-NAV's web interface is implemented using the Django framework, and can be
-served in any web server environment supported by Django (chiefly, any
-environment that supports *WSGI*). This guide is primarily concerned with
-Apache 2.
-
-An example configuration file for Apache2 is provided the configuration
-directory, :file:`apache/apache.conf.example`. This configuration uses
-``mod_wsgi`` to serve the NAV web application, and can be modified to suit your
-installation paths. Once complete, it can be included in your virtualhost
-config, which needn't contain much more than this:
-
-.. code-block:: apacheconf
-
-  ServerName nav.example.org
-  ServerAdmin webmaster@example.org
-
-  Include /path/to/your/nav/apache.conf
-
-.. important:: You should always protect your NAV web site using SSL!
-
-Installing static resources
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You want your web server to be able to serve all of NAV's static resources. You
-can install all of them by issuing the following command:
-
-.. code-block:: console
-
-  # django-admin collectstatic --settings=nav.django.settings
-  You have requested to collect static files at the destination
-  location as specified in your settings:
-
-      /usr/share/nav/www/static
-
-  This will overwrite existing files!
-  Are you sure you want to do this?
-
-  Type 'yes' to continue, or 'no' to cancel:
-
-In this example, type :kbd:`yes`, hit :kbd:`Enter`, and ensure your web server's
-document root points to :file:`/usr/share/nav/www`, because that is where the
-:file:`static` directory is located. If that doesn't suit you, you will at
-least need an Alias to point the ``/static`` URL to the :file:`static`
-directory.
-
-Users and privileges
---------------------
-
-Apart from the ``pping`` and ``snmptrapd`` daemons, no NAV processes should
-ever be run as ``root``. You should create a non-privileged system user and
-group, and ensure the ``NAV_USER`` option in :file:`nav.conf` is set
-accordingly. Also make sure this user has permissions to write to the directories
-configured in ``PID_DIR``, ``LOG_DIR`` and ``UPLOAD_DIR``.
-
-.. note:: The ``pping`` and ``snmptrapd`` daemons must be started as ``root``
-          to be able to create privileged communication sockets. Both daemons
-          will drop privileges and run as the configured non-privileged user as
-          soon as the sockets have been acquired.
-
-Building the documentation
---------------------------
-
-If you wish, this HTML documentation can be built separately using this step::
-
-  python setup.py build_sphinx
-
-The resulting files will typically be placed in :file:`build/sphinx/html/`.
-
-If you want to serve this documentation on your NAV web server, you should copy
-the :file:`html` directory to a suitable location and make sure that location is served
-as ``/doc`` on the web server.  If using the example Apache configuration
-(:file:`apache.conf.example`), there is a define named ``documentation_path``,
-which can be set to point to this file system location.
-
-
-.. _integrating-graphite-with-nav:
-
-Integrating Graphite with NAV
------------------------------
-
-.. highlight:: ini
-
-NAV uses Graphite to store and retrieve/graph time-series data. NAV must be
-configured with the IP address and port of your Graphite installation's Carbon
-backend, and the URL to the Graphite-web frontend used for graphing. These
-settings can be configured in the :file:`graphite.conf` configuration file.
-
-.. note:: NAV requires the Carbon backend's UDP listener to be enabled, as it
-          will only transmit metrics over UDP.
-
-For a simple, local Graphite installation, you may not need to touch this
-configuration file at all, but at its simplest it looks like this::
-
-  [carbon]
-  host = 127.0.0.1
-  port = 2003
-
-  [graphiteweb]
-  base = http://localhost:8000/
-
-
-Configuring Graphite
-~~~~~~~~~~~~~~~~~~~~
-
-Installing Graphite_ itself is out of scope for this guide, but you will need
-to configure some options before letting NAV send data to Graphite.
-
-1. First and foremost, you will need to enable the UDP listener in the
-   configuration file :file:`carbon.conf`.
-
-   For performance reasons, Carbon will also limit the number of new Whisper
-   files that can be created per minute. This number is fairly low by default,
-   and when starting NAV for the first time, it may send a ton of new metrics
-   very fast. If the limit is set to 50, it will take a long time before all
-   the metrics are created. You might want to increase the
-   ``MAX_CREATES_PER_MINUTE`` option, or temporarily set it to ``inf``.
-
-2. You should add the suggested *storage-schema* configurations for the
-   various ``nav`` prefixes listed in :file:`etc/graphite/storage-schemas.conf`:
-
-   .. literalinclude:: ../../python/nav/etc/graphite/storage-schemas.conf
-
-   The highest precision retention archives are the most important ones here,
-   as their data point interval must correspond with the collection intervals
-   of various NAV processes. Other than that, the retention periods and the
-   precision of any other archive can be freely experimented with.
-
-   Remember, these schemas apply to new Whisper files as they are created. You
-   should not start NAV until the schemas have been configured, otherwise the
-   Whisper files will be created with the global Graphite defaults, and your
-   data may be munged or inaccurate, and your graphs will be spotty.
-
-3. You should add the suggested *storage-aggregation* configurations listed in
-   the file :file:`etc/graphite/storage-aggregation.conf`:
-
-   .. literalinclude:: ../../python/nav/etc/graphite/storage-aggregation.conf
-
-   These will ensure that time-series data sent to Graphite by NAV will be
-   aggregated properly when Graphite rolls them into lower-precision archives.

--- a/doc/intro/install.rst
+++ b/doc/intro/install.rst
@@ -25,7 +25,7 @@ Build requirements
 
 To build NAV, you need at least the following:
 
- * Python >= 2.7.0 < 3
+ * Python >= 3.5.0
  * Sphinx >= 1.0 (for building this documentation)
 
 Runtime requirements
@@ -36,7 +36,7 @@ To run NAV, these software packages are required:
  * Apache2 + mod_wsgi (or, really, any web server that supports the WSGI interface)
  * PostgreSQL >= 9.4 (With the ``hstore`` extension available)
  * Graphite_
- * Python >= 2.7.0
+ * Python >= 3.5.0
  * nbtscan = 1.5.1
  * dhcping (only needed if using DHCP service monitor)
 


### PR DESCRIPTION
In reference to #2001, and to previous internal developer discussions, the installation docs need to be brushed up. Most people install NAV from pre-packaged versions, not from source code, so the official docs should present all the various installation options.

A potential further improvement might be to move the contents of https://nav.uninett.no/install-instructions/ into the Sphinx-based documentation also.