### PR TITLE
Remove external link redundancies in docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,6 +17,7 @@ import sys, os
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.join(os.path.abspath('..'), 'python'))
+sys.path.insert(0, os.path.abspath("exts"))
 
 from nav import buildconf
 from nav import bootstrap
@@ -26,7 +27,7 @@ bootstrap.bootstrap_django('doc')
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.todo', 'sphinx.ext.ifconfig']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.todo', 'sphinx.ext.ifconfig', 'xref']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -264,6 +265,12 @@ latex_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 #intersphinx_mapping = {'http://docs.python.org/': None}
 
+
+# External links definitions
+xref_links = {
+    "Graphite": ("Graphite", "https://graphiteapp.org"),
+    "PostgreSQL": ("PostgreSQL", "https://www.postgresql.org"),
+}
 
 def setup(app):
     app.add_stylesheet("custom.css")

--- a/doc/exts/xref.py
+++ b/doc/exts/xref.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+from docutils import nodes
+
+from sphinx.util import caption_ref_re
+
+
+def xref(typ, rawtext, text, lineno, inliner, options={}, content=[]):
+
+    title = target = text
+    titleistarget = True
+    # look if explicit title and target are given with `foo <bar>` syntax
+    brace = text.find('<')
+    if brace != -1:
+        titleistarget = False
+        m = caption_ref_re.match(text)
+        if m:
+            target = m.group(2)
+            title = m.group(1)
+        else:
+            # fallback: everything after '<' is the target
+            target = text[brace+1:]
+            title = text[:brace]
+
+    link = xref.links[target]
+
+    if brace != -1:
+        pnode = nodes.reference(target, title, refuri=link[1])
+    else:
+        pnode = nodes.reference(target, link[0], refuri=link[1])
+
+    return [pnode], []
+
+
+def get_refs(app):
+
+    xref.links = app.config.xref_links
+
+
+def setup(app):
+
+    app.add_config_value('xref_links', {}, True)
+    app.add_role('xref', xref)
+    app.connect("builder-inited", get_refs)

--- a/doc/howto/generic-install-from-source.rst
+++ b/doc/howto/generic-install-from-source.rst
@@ -4,7 +4,7 @@
 
 This is a generic guide to installing NAV from source code on a \*NIX flavored
 operating system. The specifics of how to install NAV's dependencies, such as
-PostgreSQL_ or :xref:`Graphite` will be entirely up to you and your choice of OS.
+:xref:`PostgreSQL` or :xref:`Graphite` will be entirely up to you and your choice of OS.
 
 
 Dependencies
@@ -56,7 +56,6 @@ The current Python requirements are as follows:
 .. literalinclude:: ../../requirements/base.txt
    :language: text
 
-.. _PostgreSQL: https://www.postgresql.org/
 .. _pip: https://pip.pypa.io/en/stable/
 .. _PyPi: https://pypi.org/
 

--- a/doc/howto/generic-install-from-source.rst
+++ b/doc/howto/generic-install-from-source.rst
@@ -4,7 +4,7 @@
 
 This is a generic guide to installing NAV from source code on a \*NIX flavored
 operating system. The specifics of how to install NAV's dependencies, such as
-PostgreSQL_ or Graphite_ will be entirely up to you and your choice of OS.
+PostgreSQL_ or :xref:`Graphite` will be entirely up to you and your choice of OS.
 
 
 Dependencies
@@ -28,7 +28,7 @@ To run NAV, these software packages are required:
 
  * Apache2 + mod_wsgi (or, really, any web server that supports the WSGI interface)
  * PostgreSQL >= 9.4 (With the ``hstore`` extension available)
- * Graphite_
+ * :xref:`Graphite`
  * Python >= 3.5.0
  * nbtscan = 1.5.1
  * dhcping (only needed if using DHCP service monitor)
@@ -57,7 +57,6 @@ The current Python requirements are as follows:
    :language: text
 
 .. _PostgreSQL: https://www.postgresql.org/
-.. _Graphite: http://graphiteapp.org/
 .. _pip: https://pip.pypa.io/en/stable/
 .. _PyPi: https://pypi.org/
 

--- a/doc/howto/integrating-graphite-with-nav.rst
+++ b/doc/howto/integrating-graphite-with-nav.rst
@@ -5,7 +5,7 @@ Integrating Graphite with NAV
 
 .. highlight:: ini
 
-NAV uses Graphite_ to store and retrieve/graph time-series data. Installing
+NAV uses :xref:`Graphite` to store and retrieve/graph time-series data. Installing
 Graphite itself is out of scope for this guide, but assuming you already have *a
 complete installation of Graphite*, you need to change some configuration
 options in both Graphite and NAV to ensure your time-series data is stored and
@@ -84,4 +84,3 @@ Ensure :program:`carbon-cache` is restarted to make these changes take effect,
 before adding devices to monitor in your NAV installation.
 
 .. _PostgreSQL: https://www.postgresql.org/
-.. _Graphite: http://graphiteapp.org/

--- a/doc/howto/manual-install-on-debian.rst
+++ b/doc/howto/manual-install-on-debian.rst
@@ -194,12 +194,11 @@ You should now be able to browse the NAV web interface.
 11. Installing and configuring Graphite
 =======================================
 
-NAV uses Graphite_ to store and retrieve time-series data. If you do not
+NAV uses :xref:`Graphite` to store and retrieve time-series data. If you do not
 already have a Graphite installation you wish to integrate with NAV, here is a
 :doc:`separate guide on how to install and use Graphite with NAV on your Debian
 system </howto/installing-graphite-on-debian>`.
 
-.. _Graphite: http://graphite.readthedocs.org/
 
 Start using NAV
 ===============

--- a/doc/intro/install.rst
+++ b/doc/intro/install.rst
@@ -6,7 +6,7 @@
 
 There are two main options for installing NAV: Either from source code, or from
 a pre-packaged version. Some of these options will require manually installing
-and/or configuring 3rd party software that NAV depends on, mainly PostgreSQL_
+and/or configuring 3rd party software that NAV depends on, mainly :xref:`PostgreSQL`
 and :xref:`Graphite`.
 
 
@@ -97,5 +97,3 @@ For you, we provide two guides:
 2. :doc:`A step-by-step, detailed guide on installing NAV from source on a
    Debian GNU/Linux operating system </howto/manual-install-on-debian>`.
 
-
-.. _PostgreSQL: https://www.postgresql.org/	      

--- a/doc/intro/install.rst
+++ b/doc/intro/install.rst
@@ -7,7 +7,7 @@
 There are two main options for installing NAV: Either from source code, or from
 a pre-packaged version. Some of these options will require manually installing
 and/or configuring 3rd party software that NAV depends on, mainly PostgreSQL_
-and Graphite_.
+and :xref:`Graphite`.
 
 
 Installing a pre-packaged version of NAV
@@ -99,4 +99,3 @@ For you, we provide two guides:
 
 
 .. _PostgreSQL: https://www.postgresql.org/	      
-.. _Graphite: http://graphiteapp.org/


### PR DESCRIPTION
Implements a Sphinx extension to define external links in the configuration, so we don't need to update lots of doc pages when the external link changes.
