### PR TITLE
Export stream of serialized alerts from the event engine

### DIFF
--- a/NOTES.rst
+++ b/NOTES.rst
@@ -137,6 +137,15 @@ NAV now supports external authentication by honoring the `REMOTE_USER` HTTP
 header / environment variable. See the :doc:`reference documentation for
 external web authentication </reference/web_authentication>` for details.
 
+Exporting a continuous stream of NAV alerts to third party software
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :program:`Event Engine` has gained support for starting an external program
+and feeding it a continuous stream of JSON-formatted descriptions of every
+alert it generates. This can be used to aggregate alerts into third party
+software. More details are available in the :doc:`Event Engine reference guide
+</reference/eventengine>`.
+
 
 NAV 4.9
 =======

--- a/doc/reference/backend-processes.rst
+++ b/doc/reference/backend-processes.rst
@@ -107,6 +107,8 @@ Also, the Event Engine examines the network topology to correlate events from
 passes through another device currently known to be down, a ``boxShadow``
 alert will be posted instead of a ``boxDown`` alert.
 
+:Reference:
+  :doc:`Event Engine reference guide <eventengine>`
 :Dependencies:
   The various monitors need to post events on the *event queue*, targeted at
   ``eventEngine``, in order for the Event Engine to have anything to do.

--- a/doc/reference/eventengine.rst
+++ b/doc/reference/eventengine.rst
@@ -1,0 +1,221 @@
+============
+Event Engine
+============
+
+Introduction
+============
+
+The :program:`Event Engine` is the backend process used by NAV to process the
+*event queue*. Whenever a NAV subsystem posts an event to the queue, the
+:program:`Event Engine` will pick it up and decide what do to with it.
+
+Typically, the :program:`Event Engine` will generate an alert from the event,
+or it may ignore the event entirely, depending on the circumstances. In some
+cases, it will delay the alert for a grace period, while waiting for another
+corresponding event to resolve the pending problem.
+
+
+Plugins
+=======
+
+Most of the work of the :program:`Event Engine` is done by event handler
+plugins from the :py:mod:`nav.eventengine.plugins` namespace. Each event picked
+from the queue will be offered to each of the plugins, until one of them
+decides to handle the event. If no plugins wanted to handle the event, the
+:program:`Event Engine` will perform a very simple default routine to translate
+the event directly into an alert (possibly using alert hints given in the event
+itself).
+
+
+Configuration
+=============
+
+The operation of the :program:`Event Engine` can be customized using
+configuration options in :file:`eventengine.conf`. Most of the configuration
+concerns itself with configuring the grace periods (timeouts) for various types
+of alerts. The default configuration looks somewhat like this:
+
+.. literalinclude:: ../../python/nav/etc/eventengine.conf
+   :language: ini
+
+
+Exporting alerts from NAV into other systems
+============================================
+
+The :program:`Event Engine` can be made to export a stream of alerts. By
+setting the ``script`` option in the ``[export]`` section of
+:file:`eventengine.conf` to the path of an executable program or script, the
+:program:`Event Engine` will start that program and feed a continuous stream of
+JSON blobs. describing the alerts it generates, to that programs ``STDIN``.
+
+Alert JSON format
+-----------------
+
+The :program:`Event Engine` will export each alert as a discrete JSON
+structure. The receiving script will therefore need to be able to parse the
+beginning and end of each such object as it arrives. Each object will be
+separated by a newline, but no guarantees are made that the JSON blobs
+themselves will not also contain newlines.
+
+.. tip::
+
+   Here is a `Stack Overflow comment describing how Python's existing JSON library
+   can be used to decode arbitrarily big strings of "stacked" JSON
+   <https://stackoverflow.com/questions/27907633/multiple-json-objects-in-one-file-extract-by-python/50384432#50384432>`_,
+   such as is the case with the the alert export stream.
+
+
+An exported alert may look like this as JSON:
+
+.. code-block:: json
+
+   {
+      "id" : 212310,
+      "history" : 196179,
+      "time" : "2019-11-05T10:03:10.235877",
+      "message" : "box down example-sw.example.org 10.0.1.42",
+      "source" : "pping",
+      "state" : "s",
+      "on_maintenance" : false,
+      "netbox" : 138,
+      "device_groups" : null,
+      "device" : null,
+      "subid" : "",
+      "subject_type" : "Netbox",
+      "subject" : "example-sw.example.org",
+      "subject_url" : "/ipdevinfo/example-sw.example.org/",
+      "alert_details_url" : "/api/alert/196179/",
+      "netbox_history_url" : "/devicehistory/history/%3Fnetbox=138",
+      "event_history_url" : "/devicehistory/history/?eventtype=e_boxState",
+      "event_type" : {
+         "description" : "Tells us whether a network-unit is down or up.",
+         "id" : "boxState"
+      },
+      "alert_type" : {
+         "description" : "Box declared down.",
+         "name" : "boxDown"
+      },
+      "severity" : 50,
+      "value" : 100
+   }
+
+Attributes explained
+~~~~~~~~~~~~~~~~~~~~
+
+These are the attributes present in the JSON blob describing an alert:
+
+``id``
+  The internal integer ID of this alert in NAV. This number is volatile, as the
+  alert object disappears from NAV as soon as the :program:`Alert Engine` has
+  completed its processing of the alert.
+
+``history``
+  The internal integer ID of NAV's corresponding alert history entry. I.e., if
+  this alert created a new problem state in NAV, this will be a new ID. If this
+  alert resolves or otherwise concerns an existing state in NAV, this will
+  refer to the pre-existing history ID.
+
+  E.g. if a ``boxDown`` alert is issued for an IP device, and later, a
+  ``boxUp`` alert is issued for the same IP device, both of these alerts will
+  refer to the same alert history entry.
+
+``time``
+  This is the timestamp of the alert, in ISO8601 format. Usually, this
+  corresponds to the timestamp of the originating event. E.g., for ``boxState``
+  type alerts, this corresponds to the exact timestamp the :program:`pping`
+  program reported it could no longer receive ICMP echo replies from a device.
+  
+``message``
+  This is a short, human-readable description of what the alert is all about.
+  
+``source``
+  This is a reference to the NAV subsystem that postged the original event that
+  caused this alert.
+  
+``state``
+  This is NAV's internal moniker for the state represented by this alert:
+  
+  ``x``
+    This is a stateless alert (e.g. a generic warning or point-in-time event)
+  ``s``
+    This alert starts a new state in the alert history table.
+  ``e``
+    This alert ends (resolves) an existing state in the alert history table.
+
+``on_maintenance``
+  A boolean that tells you whether the subject of this alert is currently on
+  active maintenance, according to NAV's schedule. This would typically be
+  used to withhold notifications about alerts that occur during a known
+  maintenance period for a device.
+  
+``netbox``
+  A database primary key to the IP device this alert is associated with.
+  
+``device_groups``
+  A list of NAV device groups that the associated IP device is a member of.
+  
+``device``
+  A database primary key to the physical device this alert is associated with.
+  
+``subid``
+  If this alert's subject is a sub-component of the IP device referenced in the
+  ``netbox`` attribute, this will be some internal sub-ID of this
+  component. This reference ID can be interpreted differently, depending on the
+  alert type, which is what NAV does when the ``subject`` attribute described
+  below is composed.
+  
+``subject``
+  An object that describes the alert's actual subject (or object, if you will,
+  since NAV's terminology is grammatically challenged).
+
+``subject_type``
+  NAV's internal model name of the subject's data type. This would typically be
+  things like ``Netbox``, ``Interface``, ``Module``, ``GatewayPeerSession``
+  etc.
+
+  A ``subject_type`` value combined with the ``subid`` value can be used as a
+  unique identifier of a NAV component by a 3rd party tool.
+
+``subject_url``
+  A relative canonical URI to a NAV web page (meant for human consumption)
+  describing the alert's subject.
+  
+``alert_details_url``
+  A relative canonical URI to NAV's REST API, where the details of the alert
+  state entry can be retrieved.
+
+``netbox_history_url``
+  A relative canonical URI to a NAV web page (meant for human consumption)
+  detailing the recent alert history of this alert's associated IP device.
+
+``event_history_url``
+  A relative canonical URI to a NAV web page (meant for human consumption)
+  detailing the recent history of alerts of the same event type (e.g. all the
+  recent alerts of the ``boxState`` category, if this is a ``boxDown`` alert).
+
+``event_type``
+  A sub-structure describing the event category of this alert:
+
+  ``id``
+    The event category id of this alert.
+  ``description``
+    A description of said event category.
+
+``alert_type``
+  A sub-structure describing the alert type of this alert.
+
+  ``id``
+    The event type id of this alert.
+  ``description``
+    A description of said alert type.
+
+``severity``
+  The severity of this alert. This is usually an integer in the range *0-100*,
+  but at the moment, this carries no specific meaning in NAV.
+  
+``value``
+  The alert value. This is usually an integer in the range *0-100*, but at the
+  moment, this carries no specific meaning in NAV.
+
+
+

--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -12,6 +12,7 @@ This section contains reference material for end-users.
 
    arnold
    cabling_and_patch
+   eventengine
    event-templates
    geomap
    ipam

--- a/python/nav/etc/eventengine.conf
+++ b/python/nav/etc/eventengine.conf
@@ -1,4 +1,8 @@
 # NAV eventengine configuration
+[export]
+# If set, the script option will point to a program that will receive a
+# continuous stream of JSON serialized alert objects on its STDIN.
+;script = /path/to/event/receiver/script
 
 [timeouts]
 #

--- a/python/nav/eventengine/alerts.py
+++ b/python/nav/eventengine/alerts.py
@@ -28,6 +28,7 @@ from nav.models.fields import INFINITY
 
 import nav.config
 from . import unresolved
+from . import export
 
 ALERT_TEMPLATE_DIR = nav.config.find_configfile('alertmsg')
 _logger = logging.getLogger(__name__)
@@ -133,6 +134,8 @@ class AlertGenerator(dict):
         alert.history = history
         alert.save()
         self._post_alert_messages(alert)
+        if export.exporter:
+            export.exporter.export(alert)
         return alert
 
     def post_alert_history(self):

--- a/python/nav/eventengine/engine.py
+++ b/python/nav/eventengine/engine.py
@@ -224,7 +224,7 @@ class EventEngine(object):
                 self._logger.debug('%s is on maintenance, only posting to '
                                    'alert history for %s event',
                                    event.netbox, event.event_type)
-                alert.post_alert_history()
+                alert.post(post_alert=False)
             else:
                 self._logger.debug('Posting %s event', event.event_type)
                 alert.post()

--- a/python/nav/eventengine/export.py
+++ b/python/nav/eventengine/export.py
@@ -1,0 +1,93 @@
+#
+# Copyright (C) 2019 UNINETT
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.  You should have received a copy of the GNU General Public License
+# along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Alert stream export functionality"""
+import logging
+import json
+
+from django.core.serializers.json import DjangoJSONEncoder
+
+try:
+    import subprocess32 as subprocess
+except ImportError:
+    import subprocess
+from django.utils import six
+
+from nav.web.api.v1.alert_serializers import AlertQueueSerializer
+
+try:
+    exporter
+except NameError:
+    """A singleton, normally instantiated by the event engine as it starts"""
+    exporter = None
+
+_logger = logging.getLogger(__name__)
+
+
+class StreamExporter(object):
+    """Exports a stream of alert objects over a pipe to a specific script"""
+
+    def __init__(self, command):
+        self.command = command
+        self._process = None
+        self.run()
+
+    def run(self):
+        """Runs the subprocess that will receive the alert stream on its STDIN"""
+        self._process = subprocess.Popen(
+            [self.command], stdin=subprocess.PIPE, stdout=subprocess.DEVNULL
+        )
+
+    def is_ok(self):
+        """Verifies that the subprocess is running, and attempts to restart it if
+        it's dead.
+
+        :returns: True if the subprocess is running, False if it wasn't running and
+                  couldn't be restarted.
+
+        """
+        if self._process.poll() is not None:
+            _logger.info(
+                "restarting dead export script (retcode=%s) %r",
+                self._process.returncode,
+                self.command,
+            )
+            try:
+                self.run()
+            except Exception as error:
+                _logger.error("Cannot restart dead export script: %s", error)
+                return False
+
+        return True
+
+    def export(self, alert):
+        """Serializes and exports an event or alert to the export script.
+
+        :type alert: nav.models.event.AlertQueue
+
+        """
+        _logger.debug("exporting %r", alert)
+        serializer = AlertQueueSerializer(alert)
+        data = json.dumps(serializer.data, cls=DjangoJSONEncoder)
+        self._send_string(data + "\n")
+
+    def _send_string(self, string):
+        if self.is_ok():
+            self._process.stdin.write(
+                string
+                if not isinstance(string, six.text_type)
+                else string.encode("utf-8")
+            )
+            self._process.stdin.flush()

--- a/python/nav/eventengine/plugins/aggregatelinkstate.py
+++ b/python/nav/eventengine/plugins/aggregatelinkstate.py
@@ -46,10 +46,7 @@ class AggregateLinkStateHandler(EventHandler):
                 return self._ignore("Got aggregateLinkState end event, but the "
                                     "interface still appears to be degraded.")
 
-        if self._box_is_on_maintenance():
-            alert.post_alert_history()
-        else:
-            alert.post()
+        alert.post(post_alert=not self._box_is_on_maintenance())
 
         event.delete()
 
@@ -60,7 +57,7 @@ class AggregateLinkStateHandler(EventHandler):
         self._logger.debug("%s: The unresolved AlertHist entry is %r",
                            interface, vars(existing_alert))
         # Post just an alertq entry, but don't touch alerthist
-        alert.post_alert(history=existing_alert)
+        alert.post(set_state=existing_alert)
         self.event.delete()
 
     def _ignore(self, msg):

--- a/python/nav/eventengine/plugins/delayedstate.py
+++ b/python/nav/eventengine/plugins/delayedstate.py
@@ -121,10 +121,7 @@ class DelayedStateHandler(EventHandler):
 
             if is_unresolved:
                 alert = self._get_up_alert()
-                if self._box_is_on_maintenance():
-                    alert.post_alert_history()
-                else:
-                    alert.post()
+                alert.post(post_alert=not self._box_is_on_maintenance())
 
             if waiting_plugin:
                 self._logger.info("ignoring transient down state for %s",
@@ -184,10 +181,7 @@ class DelayedStateHandler(EventHandler):
         if alert:
             self._logger.info("%s: Posting %s alert", self.get_target(),
                               alert.alert_type)
-            if self._box_is_on_maintenance():
-                alert.post_alert_history()
-            else:
-                alert.post()
+            alert.post(post_alert=not self._box_is_on_maintenance())
         else:
             self._logger.error("could not find a down alert, doing nothing (%r)", alert)
 

--- a/python/nav/eventengine/plugins/servicestate.py
+++ b/python/nav/eventengine/plugins/servicestate.py
@@ -37,10 +37,7 @@ class ServiceStateHandler(EventHandler):
 
         self._populate_alert(alert)
 
-        if self._box_is_on_maintenance():
-            alert.post_alert_history()
-        else:
-            alert.post()
+        alert.post(post_alert=not self._box_is_on_maintenance())
 
         event.delete()
 

--- a/python/nav/web/api/v1/alert_serializers.py
+++ b/python/nav/web/api/v1/alert_serializers.py
@@ -136,7 +136,7 @@ class AlertSerializerBase(serializers.ModelSerializer):
         """Returns all the device groups for the netbox if any"""
         try:
             netbox = obj.netbox
-            return netbox.groups.values_list('id', flat=True)
+            return netbox.groups.values_list('id', flat=True) or None
         except Exception:
             pass
 


### PR DESCRIPTION
This implements basic functionality into eventengine to start an external process and feed a stream of serialized alert objects it has generated into that process' STDIN.

This can be used to integrate 3rd party software (such as an alert aggregator console) with the NAV event/alert system (as is identified as a requirement in the CNaaS project)

Further work:
- [x] Add sensible error handling to export process restart function. If the export script keeps failing, that should not interrupt the operation of the event engine itself. Processing events internally is still more important than a working export to 3rd party.
- [x] Figure out what to do about alerts that are withheld due to maintenance. These are not exported at the moment. A 3rd party tool may still be interested in these alerts. Should these always be exported, or should there be a config switch for it?
- [x] Fix broken serialization of event details uri
- [x] Further design of the serialization format to be meaningful outside a web context (specifically with regard to event subjects)
- [x] Document the changes.
