### PR TITLE
Add more database stats to Watchdog's "NAV by the numbers"

### DIFF
--- a/python/nav/web/static/js/src/watchdog.js
+++ b/python/nav/web/static/js/src/watchdog.js
@@ -13,6 +13,7 @@ require([], function () {
         var arpElement = document.getElementById('arp-count'),
             camElement = document.getElementById('cam-count'),
             netboxElement = document.getElementById('netbox-count'),
+            dbSizeElement = document.getElementById('db-size');
             activeAddressesElement = document.getElementById('active-addresses'),
             serialNumbers = document.getElementById('serial-numbers');
 
@@ -25,6 +26,10 @@ require([], function () {
             if (data.oldest_cam) {
                 camElement.innerHTML += ' <em>(Since ' + data.oldest_cam + ')</em>'
             }
+        });
+
+        doRequest(dbSizeElement, '/watchdog/db_size/', function(data) {
+            dbSizeElement.innerHTML = data.size;
         });
 
         doRequest(netboxElement, '/api/netbox', function(data) {

--- a/python/nav/web/static/js/src/watchdog.js
+++ b/python/nav/web/static/js/src/watchdog.js
@@ -18,7 +18,13 @@ require([], function () {
 
         doRequest(arpElement, '/watchdog/cam_and_arp', function(data) {
             arpElement.innerHTML = '~' + intComma(data.arp);
+            if (data.oldest_arp) {
+                arpElement.innerHTML += ' <em>(Since ' + data.oldest_arp + ')</em>'
+            }
             camElement.innerHTML = '~' + intComma(data.cam);
+            if (data.oldest_cam) {
+                camElement.innerHTML += ' <em>(Since ' + data.oldest_cam + ')</em>'
+            }
         });
 
         doRequest(netboxElement, '/api/netbox', function(data) {

--- a/python/nav/web/templates/watchdog/frag_overview.html
+++ b/python/nav/web/templates/watchdog/frag_overview.html
@@ -1,4 +1,4 @@
-<table class="vertitable"">
+<table class="vertitable">
   <tbody>
     <tr>
       <th title="A regular count of the IP Devices">IP Devices</th>
@@ -21,6 +21,10 @@
                  and version 6 can be seen after the main number.">
         Active IPs (v4/v6)</th>
       <td><span id="active-addresses">Fetching...</span></td>
+    </tr>
+    <tr>
+      <th title="The on-disk size of the NAV PostgreSQL database">Database size</th>
+      <td><span id="db-size">Fetching...</span></td>
     </tr>
   </tbody>
 </table>

--- a/python/nav/web/watchdog/urls.py
+++ b/python/nav/web/watchdog/urls.py
@@ -27,5 +27,7 @@ urlpatterns = [
     url(r'^serial_numbers', views.get_serial_numbers,
         name='watchdog-serial-numbers'),
     url(r'^cam_and_arp', views.get_cam_and_arp,
-        name='watchdog-cam-and-arp')
+        name='watchdog-cam-and-arp'),
+    url(r'^db_size', views.get_database_size,
+        name='watchdog-db-size'),
 ]

--- a/python/nav/web/watchdog/views.py
+++ b/python/nav/web/watchdog/views.py
@@ -53,10 +53,14 @@ def get_active_addresses(_):
 def get_cam_and_arp(_request):
     """Get cam and arp numbers"""
     cursor = connection.cursor()
-    return JsonResponse({
-        'cam': get_cam(cursor),
-        'arp': get_arp(cursor)
-    })
+    return JsonResponse(
+        {
+            "cam": get_cam(cursor),
+            "arp": get_arp(cursor),
+            "oldest_cam": get_oldest_cam_date(cursor),
+            "oldest_arp": get_oldest_arp_date(cursor),
+        }
+    )
 
 
 def get_cam(cursor):
@@ -68,6 +72,20 @@ def get_cam(cursor):
     return row[0]
 
 
+def get_oldest_cam_date(cursor):
+    """Returns the date of the oldest closed CAM record"""
+    query = """SELECT start_time::DATE
+                FROM
+                 (SELECT start_time
+                  FROM cam
+                  WHERE end_time < 'infinity'
+                  ORDER BY start_time ASC
+                  LIMIT 1) AS foo"""
+    cursor.execute(query)
+    row = cursor.fetchone()
+    return row[0] if row else None
+
+
 def get_arp(cursor):
     """Gets number of arp records"""
     query = """SELECT n_live_tup
@@ -76,6 +94,20 @@ def get_arp(cursor):
     cursor.execute(query)
     row = cursor.fetchone()
     return row[0]
+
+
+def get_oldest_arp_date(cursor):
+    """Returns the date of the oldest closed ARP record"""
+    query = """SELECT start_time::DATE
+                FROM
+                 (SELECT start_time
+                  FROM arp
+                  WHERE end_time < 'infinity'
+                  ORDER BY start_time ASC
+                  LIMIT 1) AS foo"""
+    cursor.execute(query)
+    row = cursor.fetchone()
+    return row[0] if row else None
 
 
 def get_serial_numbers(_):

--- a/python/nav/web/watchdog/views.py
+++ b/python/nav/web/watchdog/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 Uninett AS
+# Copyright (C) 2014, 2019 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #
@@ -26,28 +26,26 @@ from nav.watchdog.util import get_statuses
 
 def render_index(request):
     """Controller for WatchDog index"""
-    navpath = [('Home', '/'), ('WatchDog', )]
+    navpath = [("Home", "/"), ("WatchDog",)]
 
     context = {
-        'navpath': navpath,
-        'title': create_title(navpath),
-        'tests': get_statuses()
+        "navpath": navpath,
+        "title": create_title(navpath),
+        "tests": get_statuses(),
     }
 
-    return render(request, 'watchdog/base.html', context)
+    return render(request, "watchdog/base.html", context)
 
 
 def get_active_addresses(_):
     """Get active addresses on the network"""
     active = Arp.objects.filter(end_time=INFINITY)
     num_active = active.count()
-    num_active_ipv6 = active.extra(where=['family(ip)=6']).count()
-    num_active_ipv4 = active.extra(where=['family(ip)=4']).count()
-    return JsonResponse({
-        'active': num_active,
-        'ipv6': num_active_ipv6,
-        'ipv4': num_active_ipv4
-    })
+    num_active_ipv6 = active.extra(where=["family(ip)=6"]).count()
+    num_active_ipv4 = active.extra(where=["family(ip)=4"]).count()
+    return JsonResponse(
+        {"active": num_active, "ipv6": num_active_ipv6, "ipv4": num_active_ipv4}
+    )
 
 
 def get_cam_and_arp(_request):
@@ -112,4 +110,4 @@ def get_oldest_start_time_date(cursor, table):
 
 def get_serial_numbers(_):
     """Get number of distinct serial numbers in NAV"""
-    return JsonResponse({'count': Device.objects.distinct('serial').count()})
+    return JsonResponse({"count": Device.objects.distinct("serial").count()})

--- a/python/nav/web/watchdog/views.py
+++ b/python/nav/web/watchdog/views.py
@@ -61,6 +61,17 @@ def get_cam_and_arp(_request):
     )
 
 
+def get_database_size(_request):
+    """Gets the size of the PostgreSQL database"""
+    cursor = connection.cursor()
+    return JsonResponse({"size": get_postgres_db_size(cursor)})
+
+
+#
+# Helper functions
+#
+
+
 def get_cam(cursor):
     """Gets number of cam records"""
     return get_tuple_count_estimate(cursor, "cam")
@@ -104,6 +115,14 @@ def get_oldest_start_time_date(cursor, table):
                   ORDER BY start_time ASC
                   LIMIT 1) AS foo"""
     cursor.execute(query.format(table=table))
+    row = cursor.fetchone()
+    return row[0] if row else None
+
+
+def get_postgres_db_size(cursor):
+    """Returns the size of the PostgreSQL database as a pretty string"""
+    query = """SELECT pg_size_pretty( pg_database_size( current_database() ) )"""
+    cursor.execute(query)
     row = cursor.fetchone()
     return row[0] if row else None
 


### PR DESCRIPTION
Adds these elements to the "NAV by the numbers" info box in the Watchdog tool:

- The date of the oldest, closed ARP record
- The date of the oldest, closed CAM record
- A "pretty-printed" on-disk size estimate of the underlying PostgreSQL database.