### PR TITLE
Do not use internal state in snmpcheck plugin

### DIFF
--- a/python/nav/models/sql/changes/sc.05.00.0090.sql
+++ b/python/nav/models/sql/changes/sc.05.00.0090.sql
@@ -1,0 +1,2 @@
+-- the snmpcheck plugin no longer keeps internal state here
+DELETE FROM netboxinfo WHERE key='status' AND var='snmpstate';

--- a/tests/unittests/ipdevpoll/plugins_snmpcheck_test.py
+++ b/tests/unittests/ipdevpoll/plugins_snmpcheck_test.py
@@ -18,7 +18,7 @@ def plugin():
 
 @pytest.mark.twisted
 @pytest_twisted.inlineCallbacks
-def test_stays_up(plugin):
+def test_should_not_mark_as_up_when_already_up(plugin):
     plugin._currently_down = Mock(return_value=False)
     plugin._currently_down.__name__ = '_currently_down'
     plugin.agent.walk.return_value = defer.succeed(True)
@@ -45,7 +45,7 @@ def test_should_always_mark_as_down_when_down(plugin):
 
 @pytest.mark.twisted
 @pytest_twisted.inlineCallbacks
-def test_going_down(plugin):
+def test_should_mark_as_down_when_transitioning_from_up_to_down(plugin):
     plugin._currently_down = Mock(return_value=False)
     plugin._currently_down.__name__ = '_currently_down'
     plugin.agent.walk.return_value = defer.succeed(False)
@@ -59,7 +59,7 @@ def test_going_down(plugin):
 
 @pytest.mark.twisted
 @pytest_twisted.inlineCallbacks
-def test_going_up(plugin):
+def test_should_mark_as_up_when_transitioning_from_down_to_up(plugin):
     plugin._currently_down = Mock(return_value=True)
     plugin._currently_down.__name__ = '_currently_down'
     plugin.agent.walk.return_value = defer.succeed(True)
@@ -72,7 +72,7 @@ def test_going_up(plugin):
 
 @pytest.mark.twisted
 @pytest_twisted.inlineCallbacks
-def test_timeout(plugin):
+def test_do_check_should_report_false_on_timeout(plugin):
     plugin.agent.walk.return_value = defer.fail(defer.TimeoutError())
     res = yield plugin._do_check()
     assert res is False

--- a/tests/unittests/ipdevpoll/plugins_snmpcheck_test.py
+++ b/tests/unittests/ipdevpoll/plugins_snmpcheck_test.py
@@ -31,15 +31,16 @@ def test_stays_up(plugin):
 
 @pytest.mark.twisted
 @pytest_twisted.inlineCallbacks
-def test_stays_down(plugin):
+def test_should_always_mark_as_down_when_down(plugin):
     plugin._currently_down = Mock(return_value=True)
     plugin._currently_down.__name__ = '_currently_down'
     plugin.agent.walk.return_value = defer.succeed(False)
     plugin._mark_as_up = Mock()
     plugin._mark_as_down = Mock()
-    yield plugin.handle()
+    with pytest.raises(SuggestedReschedule):
+        yield plugin.handle()
     plugin._mark_as_up.assert_not_called()
-    plugin._mark_as_down.assert_not_called()
+    plugin._mark_as_down.assert_called()
 
 
 @pytest.mark.twisted


### PR DESCRIPTION
Because:
- The internal persisted state of the plugin may become out-of-sync with the official state in the alerthist table, at which point the snmpcheck plugin may stop sending the relevant alerts.

A more sane approach is to always send down-events if a device isn't responding - event engine will ignore the duplicates. In the normal case, when a device keeps responding, we only need to post UP events if there is an actual down-state to resolve in alerthist.

This was all supposed to have been fixed in #1782, but there were still corner cases if the eventengine processing malfunctions, which might cause an snmpAgentState alert to never be resolved.