### PR TITLE
Fix faulty handling of exception message

### DIFF
--- a/python/nav/web/seeddb/page/netbox/forms.py
+++ b/python/nav/web/seeddb/page/netbox/forms.py
@@ -188,7 +188,7 @@ class NetboxModelForm(forms.ModelForm):
             try:
                 self._check_existing_ip(ip)
             except IPExistsException as ex:
-                self._errors['ip'] = self.error_class(ex.message)
+                self._errors['ip'] = self.error_class(str(ex))
                 del cleaned_data['ip']
 
         if cat and cat.req_mgmt and not profiles:


### PR DESCRIPTION
The old way is correct for Python 2 but does not work in Python 3
because the signature of Exception.__init__ has changed.

The way that works for python 3 also works for python 2, so the old code
was more complex than necessary.