### PR TITLE
Log wrong type for `parse_dateandtime_tc()` value

### DIFF
--- a/python/nav/mibs/entity_mib.py
+++ b/python/nav/mibs/entity_mib.py
@@ -277,7 +277,7 @@ class EntityTable(dict):
     def _parse_mfg_date(self):
         for entity in self.values():
             mfg_date = entity.get('entPhysicalMfgDate')
-            if isinstance(mfg_date, six.string_types):
+            if mfg_date:
                 mfg_date = parse_dateandtime_tc(mfg_date)
                 entity['entPhysicalMfgDate'] = mfg_date
 
@@ -377,6 +377,9 @@ def parse_dateandtime_tc(value):
     except struct.error as err:
         _logger.debug("could not parse %r as DateAndTime TC: %s",
                       value, err)
+        return
+    except TypeError as err:
+        _logger.debug("value \"%s\" wrong type: %s", value, err)
         return
 
     microseconds = deciseconds * 100000

--- a/python/nav/mibs/entity_mib.py
+++ b/python/nav/mibs/entity_mib.py
@@ -382,7 +382,7 @@ def parse_dateandtime_tc(value):
                       value, err)
         return
     except TypeError as err:
-        _logger.debug("value \"%s\" wrong type: %s", value, err)
+        _logger.debug("value %r wrong type: %s", value, err)
         return
 
     microseconds = deciseconds * 100000

--- a/python/nav/mibs/entity_mib.py
+++ b/python/nav/mibs/entity_mib.py
@@ -20,6 +20,7 @@ from operator import itemgetter
 import logging
 from datetime import datetime
 import struct
+import sys
 
 from django.utils import six
 from django.utils.six import iteritems
@@ -268,7 +269,9 @@ class EntityTable(dict):
 
     def clean(self):
         """Cleans the table data"""
-        self._clean_unicode()
+
+        if sys.version_info[0] == 2:  # Python 2 only
+            self._clean_unicode()
         self._parse_mfg_date()
         self._strip_whitespace()
         self._fix_broken_chassis_relative_positions()

--- a/tests/unittests/ipdevpoll/mibs_test.py
+++ b/tests/unittests/ipdevpoll/mibs_test.py
@@ -229,6 +229,11 @@ def test_zero_dateandtime_parses_properly():
     assert parsed is None
 
 
+def test_non_bytes_dateandtime_should_not_be_parsed():
+    parsed = parse_dateandtime_tc(u'\xdf\x07\x05\x0e\x0c\x1e*\x05+\x02\x00')
+    assert parsed is None
+
+
 def test_crazy_dateandtime_should_not_crash():
     assert parse_dateandtime_tc(b"FOOBAR") is None
 


### PR DESCRIPTION
Fixes #2016 and makes for safer code overall.