### PR TITLE
Ignore lldpRemTable results with broken row indexes

### DIFF
--- a/python/nav/mibs/lldp_mib.py
+++ b/python/nav/mibs/lldp_mib.py
@@ -87,6 +87,10 @@ class LLDPMib(mibretriever.MibRetriever):
         translateable into an ifIndex via the lldpLocPortTable.
 
         """
+        if self._is_remote_table_index_broken(remote_table):
+            self._logger.warning("lldpRemTable has broken row indexes on this device")
+            returnValue([])
+
         remotes = remote_table.values()
         local_ports = yield self._retrieve_local_ports()
 
@@ -134,6 +138,11 @@ class LLDPMib(mibretriever.MibRetriever):
             remote[0] = lookup.get(local_portnum, local_portnum)
 
         returnValue(remotes)
+
+    @staticmethod
+    def _is_remote_table_index_broken(remote_table):
+        """Returns True if an lldpRemTable response has a broken row index"""
+        return any(len(row[0]) != 3 for row in remote_table.values())
 
     @inlineCallbacks
     def _retrieve_local_ports(self):

--- a/tests/unittests/mibs/lldp_mib_test.py
+++ b/tests/unittests/mibs/lldp_mib_test.py
@@ -1,0 +1,33 @@
+import pytest
+from nav.mibs.lldp_mib import LLDPMib
+
+
+def test_broken_remote_table_result_should_be_detected(
+    table_with_too_short_index, table_with_too_long_index
+):
+    assert LLDPMib._is_remote_table_index_broken(table_with_too_short_index)
+    assert LLDPMib._is_remote_table_index_broken(table_with_too_long_index)
+
+
+def test_ok_remote_table_result_should_be_detected(ok_remote_table):
+    assert not LLDPMib._is_remote_table_index_broken(ok_remote_table)
+
+
+#
+# Fixtures go here
+#
+
+
+@pytest.fixture
+def table_with_too_short_index():
+    return {index: {0: index} for index in ((1000,), (1002,))}
+
+
+@pytest.fixture
+def table_with_too_long_index():
+    return {index: {0: index} for index in ((0, 1000, 2, 3), (0, 1002, 2, 3))}
+
+
+@pytest.fixture
+def ok_remote_table():
+    return {index: {0: index} for index in ((0, 1000, 2), (0, 1002, 2))}


### PR DESCRIPTION
Fixes #2015 by ignoring the `LLDP-MIB::lldpRemTable` response from broken agents.