### PR TITLE
Add a view to force a 500 error.

### DIFF
--- a/doc/hacking/hacking.rst
+++ b/doc/hacking/hacking.rst
@@ -445,6 +445,14 @@ See https://docs.djangoproject.com/en/1.8/topics/serialization/
    <https://docs.djangoproject.com/en/dev/ref/django-admin/#dumpdata-appname-appname-appname-model>`_
    to create fixtures.
 
+Force the custom Django 500 error handler to run
+------------------------------------------------
+
+If working on the custom Django 500 error handler view,
+:py:func:`nav.django.views.custom_500`, a 500 error can be produced
+intentionally by browsing the URI ``/500/`` on your NAV installation. This view
+will by default only be available when logged in as a NAV administrator.
+
 .. _GitHub: https://github.com/Uninett/nav
 __ Github_
 .. _RequireJS: http://requirejs.org/

--- a/python/nav/django/urls.py
+++ b/python/nav/django/urls.py
@@ -25,6 +25,7 @@ from nav.config import find_config_dir
 from nav.web import refresh_session
 from nav.web.webfront.urls import urlpatterns
 from nav.web.styleguide import styleguide_index
+from nav.django.views import force_500
 
 _logger = logging.getLogger(__name__)
 
@@ -63,6 +64,7 @@ urlpatterns += [
     url(r'^refresh_session/', refresh_session, name='refresh-session'),
     url(r'^auditlog/', include('nav.auditlog.urls')),
     url(r'^interfaces/', include('nav.web.interface_browser.urls')),
+    url(r'^500/', force_500),
 ]
 
 # Load local url-config

--- a/python/nav/django/views.py
+++ b/python/nav/django/views.py
@@ -34,3 +34,11 @@ def custom_500(request):
         'value': value,
         'traceback': traceback.format_exception(type, value, tb)
         }, request=request))
+
+
+def force_500(request):
+    """View that throws an exception just to test/showcase the currently active 500
+    error handler
+    """
+    raise Exception("This error was thrown on purpose, please ignore")
+


### PR DESCRIPTION
Because:
- We need some way to test our 500 error handling.