### PR TITLE
Share a configuration volume between nav and web dev containers

### DIFF
--- a/doc/hacking/using-docker.rst
+++ b/doc/hacking/using-docker.rst
@@ -127,13 +127,17 @@ container in the :file:`/var/log/supervisor/` directory. The NAV process logs
 themselves are placed inside the :file:`/tmp/` directory inside the ``nav``
 container.
 
-Controlling log levels
-----------------------
+Controlling log levels and configuration
+----------------------------------------
 
 The log levels of various parts of NAV are controlled through the config file
-:file:`/etc/nav/logging.conf` inside the containers. Please be aware that the
-``nav`` and ``web`` containers do not share a configuration volume, so you may
-need to make adjustments in either container, depending on your needs.
+:file:`/etc/nav/logging.conf` inside the containers.
+
+The ``nav`` and ``web`` containers share a common configuration volume named
+``nav_config``. This volume should persist even between rebuilds of the
+containers themselves. If you want NAV to install a completely new set of
+config files from scratch, you may need to manually trash this volume using the
+``-v`` option to the :kbd:`docker-compose down` command.
 
 
 Overriding the compose services

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - PGUSER=postgres
     volumes:
       - .:/source
+      - nav_config:/etc/nav
     depends_on:
       - postgres
 
@@ -61,3 +62,7 @@ services:
   # mydevice.mydomain:
   #   << : *forwarder
   #   command: /snmp_forward.sh mydevice.mydomain myvk
+
+volumes:
+  nav_config:
+    driver: local

--- a/tools/docker/build.sh
+++ b/tools/docker/build.sh
@@ -12,7 +12,7 @@ sudo -u nav python3 setup.py build
 python3 setup.py develop
 sudo -u nav python3 setup.py build_sass
 
-if [[ ! -d "/etc/nav" ]]; then
+if [[ ! -f "/etc/nav/nav.conf" ]]; then
     echo "Copying initial NAV config files into this container"
     nav config install --verbose /etc/nav
     chown -R nav:nav /etc/nav


### PR DESCRIPTION
Because:
- It gets tedious to have two separate sets of config files to relate to when developing.
