### PR TITLE
Ensure internal snmp agent check state stays in sync with global snmpAgentState

### DIFF
--- a/python/nav/ipdevpoll/plugins/snmpcheck.py
+++ b/python/nav/ipdevpoll/plugins/snmpcheck.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011, 2012, 2016 Uninett AS
+# Copyright (C) 2011, 2012, 2016, 2019 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #
@@ -21,7 +21,7 @@ from twisted.internet.defer import returnValue
 from django.db import transaction
 
 from nav.event2 import EventFactory
-from nav.models import manage
+from nav.models import manage, event
 from nav.ipdevpoll import Plugin, db
 from nav.ipdevpoll.jobs import SuggestedReschedule
 
@@ -104,9 +104,16 @@ class SnmpCheck(Plugin):
 
     @transaction.atomic()
     def _currently_down(self):
-        return manage.NetboxInfo.objects.filter(
+        internally_down = manage.NetboxInfo.objects.filter(
             netbox=self.netbox.id,
             key=INFO_KEY_NAME,
             variable=INFO_VARIABLE_NAME,
-            value="down"
+            value="down",
         ).exists()
+        globally_down = (
+            event.AlertHistory.objects.unresolved("snmpAgentState")
+            .filter(netbox=self.netbox.id)
+            .exists()
+        )
+
+        return internally_down or globally_down

--- a/python/nav/ipdevpoll/plugins/snmpcheck.py
+++ b/python/nav/ipdevpoll/plugins/snmpcheck.py
@@ -56,7 +56,8 @@ class SnmpCheck(Plugin):
 
         if is_ok and was_down:
             yield self._mark_as_up()
-        elif not is_ok and not was_down:
+        elif not is_ok:
+            # Always send down events; eventengine will ignore any duplicates
             yield self._mark_as_down()
             raise SuggestedReschedule(delay=60)
 

--- a/tests/integration/ipdevpoll/plugins/snmpcheck_test.py
+++ b/tests/integration/ipdevpoll/plugins/snmpcheck_test.py
@@ -1,4 +1,5 @@
 from mock import Mock
+from datetime import datetime
 
 import pytest
 import pytest_twisted
@@ -6,7 +7,8 @@ from twisted.internet import defer
 
 from nav.ipdevpoll.jobs import JobHandler, SuggestedReschedule
 from nav.ipdevpoll.plugins import snmpcheck, plugin_registry
-from nav.models.event import EventQueue
+from nav.models.event import EventQueue, AlertHistory
+from nav.models.fields import INFINITY
 
 
 @pytest.mark.twisted
@@ -32,7 +34,8 @@ def test_short_outage(localhost, db):
         event_type='snmpAgentState',
         netbox_id=localhost.pk,
         state=EventQueue.STATE_START).count() == 1
-    yield job.run()
+    with pytest.raises(SuggestedReschedule):
+        yield job.run()
     assert localhost.info_set.filter(
         key=snmpcheck.INFO_KEY_NAME,
         variable=snmpcheck.INFO_VARIABLE_NAME,
@@ -42,8 +45,20 @@ def test_short_outage(localhost, db):
         target_id='eventEngine',
         event_type='snmpAgentState',
         netbox_id=localhost.pk,
-        state=EventQueue.STATE_START).count() == 1
+        state=EventQueue.STATE_START).count() == 2
 
+    # now fake an AlertHist entry from event engine
+    AlertHistory(
+        source_id='ipdevpoll',
+        event_type_id='snmpAgentState',
+        netbox_id=localhost.pk,
+        start_time=datetime.now(),
+        end_time=INFINITY,
+        value=100,
+        severity=50,
+    ).save()
+
+    # and make sure snmpcheck tries to resolve it when the box is up
     agent.walk.return_value = defer.succeed(True)
     yield job.run()
     assert localhost.info_set.filter(

--- a/tests/unittests/ipdevpoll/plugins_snmpcheck_test.py
+++ b/tests/unittests/ipdevpoll/plugins_snmpcheck_test.py
@@ -18,7 +18,7 @@ def plugin():
 
 @pytest.mark.twisted
 @pytest_twisted.inlineCallbacks
-def test_stays_up(plugin):
+def test_should_not_mark_as_up_when_already_up(plugin):
     plugin._currently_down = Mock(return_value=False)
     plugin._currently_down.__name__ = '_currently_down'
     plugin.agent.walk.return_value = defer.succeed(True)
@@ -44,7 +44,7 @@ def test_stays_down(plugin):
 
 @pytest.mark.twisted
 @pytest_twisted.inlineCallbacks
-def test_going_down(plugin):
+def test_should_mark_as_down_when_transitioning_from_up_to_down(plugin):
     plugin._currently_down = Mock(return_value=False)
     plugin._currently_down.__name__ = '_currently_down'
     plugin.agent.walk.return_value = defer.succeed(False)
@@ -58,7 +58,7 @@ def test_going_down(plugin):
 
 @pytest.mark.twisted
 @pytest_twisted.inlineCallbacks
-def test_going_up(plugin):
+def test_should_mark_as_up_when_transitioning_from_down_to_up(plugin):
     plugin._currently_down = Mock(return_value=True)
     plugin._currently_down.__name__ = '_currently_down'
     plugin.agent.walk.return_value = defer.succeed(True)
@@ -71,7 +71,7 @@ def test_going_up(plugin):
 
 @pytest.mark.twisted
 @pytest_twisted.inlineCallbacks
-def test_timeout(plugin):
+def test_do_check_should_report_false_on_timeout(plugin):
     plugin.agent.walk.return_value = defer.fail(defer.TimeoutError())
     res = yield plugin._do_check()
     assert res is False

--- a/tests/unittests/ipdevpoll/plugins_snmpcheck_test.py
+++ b/tests/unittests/ipdevpoll/plugins_snmpcheck_test.py
@@ -31,15 +31,16 @@ def test_should_not_mark_as_up_when_already_up(plugin):
 
 @pytest.mark.twisted
 @pytest_twisted.inlineCallbacks
-def test_stays_down(plugin):
+def test_should_keep_sending_down_events_when_down(plugin):
     plugin._currently_down = Mock(return_value=True)
     plugin._currently_down.__name__ = '_currently_down'
     plugin.agent.walk.return_value = defer.succeed(False)
     plugin._mark_as_up = Mock()
     plugin._mark_as_down = Mock()
-    yield plugin.handle()
+    with pytest.raises(SuggestedReschedule):
+        yield plugin.handle()
     plugin._mark_as_up.assert_not_called()
-    plugin._mark_as_down.assert_not_called()
+    plugin._mark_as_down.assert_called()
 
 
 @pytest.mark.twisted


### PR DESCRIPTION
Because:
- The internal persisted state of the plugin may become out-of-sync with the official state in the alerthist table, at which point the snmpcheck plugin may stop sending the relevant alerts.

A more sane approach is to always send down-events if a device isn't responding - event engine will ignore the duplicates. In the normal case, when a device keeps responding, we only need to post UP events if there is an actual down-state to resolve in alerthist.

This was all supposed to have been fixed in #1782, but there were still corner cases if the eventengine processing malfunctions, which might cause an snmpAgentState alert to never be resolved.

This is a second stab at this fix, after realizing #2010 didn't cut it. The main difference is that this PR keeps the internal state, but uses a combination of both internal and global NAV state to decide whether an snmp agent is down.