### PR TITLE
Fix PortAdmin crash on invalid IP search

### DIFF
--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -109,7 +109,7 @@ def search(query):
     netbox_filters = [
         Q(sysname__icontains=query),
     ]
-    if is_valid_ip(query):
+    if is_valid_ip(query, use_socket_lib=True):
         netbox_filters.append(Q(ip=query))
     netboxes = Netbox.objects.filter(
         reduce(OR, netbox_filters)).order_by('sysname')


### PR DESCRIPTION
Because:
- Searching for a partial IP address causes a DataError

Using `IPy` to validate IP addresses can validate incomplete addresses. `IPy.IP` can deal with these. PostgreSQL, however, cannot. PortAdmin will generate a SQL statement comparing the raw query against an `INET` type field, which crashes.

Sample traceback:

```pytb
Internal Server Error: /portadmin/
Traceback (most recent call last):
  File "/opt/venvs/nav/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/venvs/nav/local/lib/python2.7/site-packages/nav/web/portadmin/views.py", line 95, in index
    if len(netboxes) == 1 and not interfaces:
  File "/opt/venvs/nav/local/lib/python2.7/site-packages/django/db/models/query.py", line 144, in __len__
    self._fetch_all()
  File "/opt/venvs/nav/local/lib/python2.7/site-packages/django/db/models/query.py", line 965, in _fetch_all
    self._result_cache = list(self.iterator())
  File "/opt/venvs/nav/local/lib/python2.7/site-packages/django/db/models/query.py", line 238, in iterator
    results = compiler.execute_sql()
  File "/opt/venvs/nav/local/lib/python2.7/site-packages/django/db/models/sql/compiler.py", line 840, in execute_sql
    cursor.execute(sql, params)
  File "/opt/venvs/nav/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "/opt/venvs/nav/local/lib/python2.7/site-packages/django/db/utils.py", line 98, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/opt/venvs/nav/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
DataError: invalid input syntax for type inet: "10.0"
LINE 1: ...::text) LIKE UPPER('%10.0%') OR "netbox"."ip" = '10.0'::...
```