### PR TITLE
Replace SNMP community columns in SeedDB netbox listing with management profile lists

### DIFF
--- a/python/nav/django/templatetags/info.py
+++ b/python/nav/django/templatetags/info.py
@@ -162,3 +162,9 @@ def get_value(something, key):
 def sortdict(dictionary, reverse=False):
     """Returns a list of sorted dictionary items"""
     return sorted(dictionary.items(), reverse=bool(reverse))
+
+
+@register.filter
+def is_list(value):
+    """Returns True if the value is a list"""
+    return isinstance(value, list)

--- a/python/nav/web/seeddb/page/netbox/__init__.py
+++ b/python/nav/web/seeddb/page/netbox/__init__.py
@@ -17,6 +17,7 @@
 """Controllers for the netbox part of seedDB"""
 import datetime
 from django.db import transaction
+from django.contrib.postgres.aggregates import ArrayAgg
 
 from nav.models.manage import Netbox
 from nav.bulkparse import NetboxBulkParser
@@ -57,24 +58,17 @@ def netbox_list(request):
     info = NetboxInfo()
     query = (
         Netbox.objects.select_related("room", "category", "type", "organization")
+        .prefetch_related("profiles")
+        .annotate(profile=ArrayAgg("profiles__name"))
     )
     filter_form = NetboxFilterForm(request.GET)
-    value_list = (
-        'sysname', 'room', 'ip', 'category', 'organization', 'read_only',
-        'read_write', 'snmp_version', 'type__name')
+    value_list = ('sysname', 'room', 'ip', 'category', 'organization', 'profile',
+                  'type__name')
     return render_list(request, query, value_list, 'seeddb-netbox-edit',
                        edit_url_attr='pk',
                        filter_form=filter_form,
                        template='seeddb/list_netbox.html',
-                       extra_context=info.template_context,
-                       censor_list=create_index_list(
-                           value_list,
-                           ['read_only', 'read_write']))
-
-
-def create_index_list(value_list, values_to_index):
-    """Create a zero-based index list for the listvalues in value_list"""
-    return [value_list.index(x) for x in values_to_index]
+                       extra_context=info.template_context)
 
 
 def netbox_delete(request):

--- a/python/nav/web/seeddb/page/netbox/__init__.py
+++ b/python/nav/web/seeddb/page/netbox/__init__.py
@@ -55,7 +55,9 @@ def netbox(request):
 def netbox_list(request):
     """Controller for showing all netboxes"""
     info = NetboxInfo()
-    query = Netbox.objects.all()
+    query = (
+        Netbox.objects.select_related("room", "category", "type", "organization")
+    )
     filter_form = NetboxFilterForm(request.GET)
     value_list = (
         'sysname', 'room', 'ip', 'category', 'organization', 'read_only',

--- a/python/nav/web/seeddb/utils/list.py
+++ b/python/nav/web/seeddb/utils/list.py
@@ -31,7 +31,7 @@ from nav.django.utils import get_verbose_name
 def render_list(request, queryset, value_list, edit_url=None,
                 edit_url_attr='pk', filter_form=None,
                 template='seeddb/list.html', extra_context=None,
-                censor_list=None, add_descriptions=False):
+                add_descriptions=False):
     """Renders a Seed DB list.
 
     Parameters:
@@ -46,7 +46,6 @@ def render_list(request, queryset, value_list, edit_url=None,
      - template: Path to the template used.
      - extra_context: A dictionary containing all additional context that
                       should be used in the template.
-     - censor_list: list of value headers to censor
     """
 
     if not extra_context:
@@ -69,7 +68,6 @@ def render_list(request, queryset, value_list, edit_url=None,
         'labels': labels,
         'filter_form': filter_form,
         'sub_active': {'list': True},
-        'censor_list': censor_list
     }
 
     # Update extra_context with context.

--- a/python/nav/web/templates/seeddb/list.html
+++ b/python/nav/web/templates/seeddb/list.html
@@ -61,11 +61,7 @@
                         {{ element }}
                       {% endif %}
                     {% else %}
-                      {% if element and forloop.counter0 in censor_list %}
-                        ******
-                      {% else %}
                         {{ element|default_if_none:"" }}
-                      {% endif %}
                     {% endif %}
                   </td>
                 {% endfor %}

--- a/python/nav/web/templates/seeddb/list_netbox.html
+++ b/python/nav/web/templates/seeddb/list_netbox.html
@@ -1,5 +1,6 @@
 {% extends "seeddb/list.html" %}
 {% load crispy_forms_tags %}
+{% load info %}
 
 {% block row %}
 
@@ -24,6 +25,8 @@
       {% else %}
         {% if element and forloop.counter0 in censor_list %}
           ******
+        {% elif element|is_list %}
+            <span title="{{ element|join:", " }}">{{ element|join:", "|truncatechars:30}}</span>
         {% else %}
           {{ element|default_if_none:"" }}
         {% endif %}

--- a/python/nav/web/templates/seeddb/list_netbox.html
+++ b/python/nav/web/templates/seeddb/list_netbox.html
@@ -23,9 +23,7 @@
           {% endif %}
 
       {% else %}
-        {% if element and forloop.counter0 in censor_list %}
-          ******
-        {% elif element|is_list %}
+        {% if element|is_list %}
             <span title="{{ element|join:", " }}">{{ element|join:", "|truncatechars:30}}</span>
         {% else %}
           {{ element|default_if_none:"" }}


### PR DESCRIPTION
This implements both a replacement column for the SeedDB netbox list, but also improves the performance of the SeedDB netbox list page, by reducing the number of SQL queries from approximately **6+(5*N)** to **7** (which on a test data set of 259 netboxes amounts to a reduction **factor of 368**!)