### PR TITLE
Fix broken natural sort implementation on Python 3 

### DIFF
--- a/python/nav/natsort.py
+++ b/python/nav/natsort.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007 Uninett AS
+# Copyright (C) 2007, 2019 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #
@@ -24,17 +24,58 @@ An example of how to naturally sort a directory listing:
   foo = os.listdir('/path/to/bar')
   foo.sort(key=natsort.split)
 """
+import sys
 import re
+from functools import total_ordering
+
+if sys.version_info.major == 2:
+    _string_types = basestring,
+else:
+    _string_types = str,
 
 _split_pattern = re.compile(r'(\d+|\D+)')
 
 
 def split(string):
     """Split a string into digit- and non-digit components."""
-    def intcast(n):
-        if n.isdigit():
-            return int(n)
-        else:
-            return n
+    return [ComparableThing(x) for x in _split_pattern.findall(string)]
 
-    return [intcast(x) for x in _split_pattern.findall(string)]
+
+@total_ordering
+class ComparableThing(object):
+    """Wrapper class for comparing both strings and integers.
+
+    This exists to impose a stable sort order for strings split by natsort.split, even
+    on Python 3, which doesn't want to compare objects of different types.
+
+    """
+
+    def __init__(self, value):
+        if isinstance(value, _string_types) and value.isdigit():
+            self.value = int(value)
+        else:
+            self.value = value
+
+    def __eq__(self, other):
+        if isinstance(other, ComparableThing):
+            return self.value == other.value
+        return self.value == other
+
+    def __lt__(self, other):
+        if not isinstance(other, ComparableThing):
+            return self.value < other
+
+        if isinstance(self.value, int) and not isinstance(other.value, int):
+            return True
+        if isinstance(self.value, _string_types) and not isinstance(
+            other.value, _string_types
+        ):
+            return False
+
+        return self.value < other.value
+
+    def __repr__(self):
+        return repr(self.value)
+
+    def __str__(self):
+        return str(self.value)

--- a/python/nav/natsort.py
+++ b/python/nav/natsort.py
@@ -29,9 +29,9 @@ import re
 from functools import total_ordering
 
 if sys.version_info.major == 2:
-    _string_types = basestring,
+    _string_types = basestring,  # Python 2
 else:
-    _string_types = str,
+    _string_types = str,         # Python 3
 
 _split_pattern = re.compile(r'(\d+|\D+)')
 

--- a/tests/unittests/natsort_test.py
+++ b/tests/unittests/natsort_test.py
@@ -1,0 +1,29 @@
+import pytest
+from random import shuffle
+
+from nav import natsort
+
+
+@pytest.mark.parametrize(
+    "string,expected",
+    [("abc123def", ["abc", 123, "def"]),
+     ("123", [123]),
+     ("foo-123", ["foo-", 123]),
+     ("bar", ["bar"])],
+)
+def test_natsort_split_should_split_correctly(string, expected):
+    assert natsort.split(string) == expected
+
+
+def test_natsort_splits_can_be_sorted():
+    expected = [
+        "1 January 1970",
+        "1 January 2020",
+        "10 January 1970",
+        "Tenth of January 1986",
+    ]
+    data = list(expected)
+    for i in range(5):
+        shuffle(data)
+        result = sorted(data, key=natsort.split)
+        assert result == expected


### PR DESCRIPTION
Depending on the data set of any given NAV installation, multiple subsystems may break when using the `nav.natsort` library to sort strings in "natural" order, as Python 3 will not permit comparisons between integers and strings: A feature of Python 2 that `nav.natsort.split()` relies heavily on.


A traceback example from Portadmin:

```pytb
Traceback:

File "/opt/venvs/nav/lib/python3.5/site-packages/django/core/handlers/exception.py" in inner
  41.             response = get_response(request)

File "/opt/venvs/nav/lib/python3.5/site-packages/django/core/handlers/base.py" in _get_response
  187.                 response = self.process_exception_by_middleware(e, request)

File "/opt/venvs/nav/lib/python3.5/site-packages/django/core/handlers/base.py" in _get_response
  185.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/opt/venvs/nav/lib/python3.5/site-packages/nav/web/portadmin/views.py" in search_by_sysname
  128.     return search_by_kwargs(request, sysname=sysname)

File "/opt/venvs/nav/lib/python3.5/site-packages/nav/web/portadmin/views.py" in search_by_kwargs
  146.         interfaces = netbox.get_swports_sorted()

File "/opt/venvs/nav/lib/python3.5/site-packages/nav/models/manage.py" in get_swports_sorted
  386.         return Interface.sort_ports_by_ifname(ports)

File "/opt/venvs/nav/lib/python3.5/site-packages/nav/models/manage.py" in sort_ports_by_ifname
  1847.         return sorted(ports, key=lambda p: nav.natsort.split(p.ifname))

Exception Type: TypeError at /portadmin/sysname=example-sw.example.org
Exception Value: unorderable types: str() < int()
```

This PR fixes the issue by implementing a value wrapper class that compare strings and integers using the same ordering rules as Python 2.