### PR TITLE
Switch to correct drf method

### DIFF
--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -20,7 +20,6 @@ import logging
 
 from IPy import IP
 from django.http import HttpResponse, JsonResponse
-from django.template import RequestContext
 from django.db.models import Q
 from django.db.models.fields.related import ManyToOneRel as _RelatedObject
 from django.db.models.fields import FieldDoesNotExist
@@ -879,16 +878,15 @@ class AlertFragmentRenderer(TemplateHTMLRenderer):
     """
     media_type = 'text/x-nav-html'
 
-    def resolve_context(self, data, request, _response):
+    def get_template_context(self, data, renderer_context):
         """Populate the context used for rendering the template
 
-        :type request: rest_framework.request.Request
-        :type _response: rest_framework.request.Response
         :param dict data: The serialized alert
+        :param dict renderer_context: Existing context
         """
 
         if 'id' not in data:
-            return RequestContext(request, data)
+            return data
 
         # Put the alert object in the context
         data['alert'] = event.AlertHistory.objects.get(pk=data['id'])
@@ -899,7 +897,7 @@ class AlertFragmentRenderer(TemplateHTMLRenderer):
             data.update({
                 'netbox': manage.Netbox.objects.get(pk=netboxid)
             })
-        return RequestContext(request, data)
+        return data
 
 
 class AlertHistoryViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
`AlertHistoryViewSet`, if the action is `retrieve`, adds the renderer `AlertFragmentRenderer`.

`AlertFragmentRenderer` adds to the context if `id` is in the serialized alert. It swaps out a netbox-id with a netbox, and adds the alert belonging to the id.

As of drf 3.6, the old method `resolve_context` is deprecated in favor of `get_template_context`. The former returns a `RequestContext` while the latter returns a `dict`.

There seems to be no tests covering `AlertHistoryViewSet.retrieve`, the closest seems to be `test_alert_should_be_visible_in_api'.

Fixes #2045 