### PR TITLE
Make navclean work properly on Python 3

### DIFF
--- a/bin/navclean
+++ b/bin/navclean
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# -*- testargs: --arp -*-
 #
 # Copyright (C) 2017 Uninett AS
 #

--- a/python/nav/db/__init__.py
+++ b/python/nav/db/__init__.py
@@ -27,6 +27,8 @@ import time
 import psycopg2
 import psycopg2.extensions
 
+from django.utils import six
+
 import nav
 from nav import config
 
@@ -84,7 +86,8 @@ def escape(string):
 
     """
     quoted = psycopg2.extensions.QuotedString(string)
-    return quoted.getquoted()
+    result = quoted.getquoted()
+    return result if isinstance(result, six.text_type) else result.decode("utf-8")
 
 
 def get_connection_parameters(script_name='default', database='nav'):


### PR DESCRIPTION
Fixes #2044 

`nav.db.escape()` still sucks.
