### PR TITLE
Support MAC address device IDs from CDP records

### DIFF
--- a/python/nav/ipdevpoll/neighbor.py
+++ b/python/nav/ipdevpoll/neighbor.py
@@ -129,6 +129,11 @@ class Neighbor(object):
     def _identify_interfaces(self):
         raise NotImplementedError
 
+    def _netbox_from_mac(self, mac):
+        mac_map = get_netbox_macs()
+        if mac in mac_map:
+            return self._netbox_query(Q(id=mac_map[mac]))
+
     def _netbox_from_ip(self, ip):
         """Tries to find a Netbox from NAV's database based on an IP address.
 

--- a/python/nav/ipdevpoll/plugins/lldp.py
+++ b/python/nav/ipdevpoll/plugins/lldp.py
@@ -23,7 +23,7 @@ from twisted.internet import defer
 from nav.models import manage
 from nav.mibs import lldp_mib
 from nav.ipdevpoll import Plugin, shadows
-from nav.ipdevpoll.neighbor import Neighbor, get_netbox_macs
+from nav.ipdevpoll.neighbor import Neighbor
 from nav.ipdevpoll.db import run_in_thread
 from nav.ipdevpoll.timestamps import TimestampChecker
 
@@ -203,11 +203,6 @@ class LLDPNeighbor(Neighbor):
             return netbox
         else:
             return self._netbox_from_sysname(chassid)
-
-    def _netbox_from_mac(self, mac):
-        mac_map = get_netbox_macs()
-        if mac in mac_map:
-            return self._netbox_query(Q(id=mac_map[mac]))
 
     def _identify_interfaces(self):
         portid = self.record.port_id

--- a/python/nav/macaddress.py
+++ b/python/nav/macaddress.py
@@ -286,4 +286,7 @@ def _int_to_delimited_hexstring(mac_addr, delim, step):
 
 def octets_to_hexstring(octets):
     """Converts an octet string to a printable hexadecimal string"""
-    return ''.join("%02x" % byte for byte in six.iterbytes(octets))
+    if isinstance(octets, six.binary_type):
+        return ''.join("%02x" % byte for byte in six.iterbytes(octets))
+    else:
+        return ''.join("%02x" % ord(byte) for byte in six.iterbytes(octets))


### PR DESCRIPTION
Discovered and fixed while researching #2047, Cisco devices will oftentimes not return a sysname in a CDP record's deviceid field, but rather a 6-octet binary MAC address string. NAV uses the deviceid string to attempt to look up a sysname from the NAV database.

This:
1. Makes no sense if the deviceid is a MAC address. It could be looked up as MAC address instead.
2. Will crash if the MAC address string contains NUL bytes, which it often does, since the database layer will not support queries containing NUL bytes.

Typically, the problem is seen as the ipdevpoll `topo` job crashes and logs this:

> Job 'topo' for example-sw.example.org aborted: Job aborted due to plugin failure (cause=ValueError('A string literal cannot contain NUL (0x00) characters.',))

Since CDP records do not contain any hints as to what type of data deviceid represents (in opposition to LLDP), we need to "guess" by looking at the contents of the string.