### PR TITLE
[BUG] Navlets crash/appear blank if their config is stored as legacy pickles

### DIFF
--- a/python/nav/models/fields.py
+++ b/python/nav/models/fields.py
@@ -82,9 +82,11 @@ class DictAsJsonField(models.TextField):
             if isinstance(value, dict):
                 return value
             try:
-                if isinstance(value, six.binary_type):
-                    value = six.text_type(value, encoding='utf-8')
-                return json.loads(value)
+                return json.loads(
+                    six.text_type(value, encoding="utf-8")
+                    if isinstance(value, six.binary_type)
+                    else value
+                )
             except ValueError:
                 try:
                     return pickle.loads(value)

--- a/tests/unittests/models/fields_test.py
+++ b/tests/unittests/models/fields_test.py
@@ -123,7 +123,7 @@ class TestDictAsJsonField(object):
     def test_to_python_pickle(self):
         field = DictAsJsonField()
         orig_value = 2
-        value = pickle.dumps(orig_value)
+        value = pickle.dumps(orig_value, protocol=1)
         result = field.to_python(value)
         assert result == orig_value
 


### PR DESCRIPTION
Under Python 3, users with navlets whose config is stored in legacy pickle formats may experience failure to load these navlets in the NAV dashboard.

This is due to a crash bug where the pickle value is fed to `pickle.loads()` as a `str` object, rather than a `bytes`-like object.

**Traceback**
```pytb
Traceback:  

File "/usr/lib/python3.5/json/decoder.py" in raw_decode
  355.             obj, end = self.scan_once(s, idx)
  
    
      During handling of the above exception (0), another exception occurred:
    
  

File "/opt/venvs/nav/lib/python3.5/site-packages/nav/models/fields.py" in to_python
  87.                 return json.loads(value)

File "/usr/lib/python3.5/json/__init__.py" in loads
  319.         return _default_decoder.decode(s)

File "/usr/lib/python3.5/json/decoder.py" in decode
  339.         obj, end = self.raw_decode(s, idx=_w(s, 0).end())

File "/usr/lib/python3.5/json/decoder.py" in raw_decode
  357.             raise JSONDecodeError("Expecting value", s, err.value) from None
  
    
      During handling of the above exception (Expecting value: line 1 column 1 (char 0)), another exception occurred:
    
  

File "/opt/venvs/nav/lib/python3.5/site-packages/django/core/handlers/exception.py" in inner
  41.             response = get_response(request)

File "/opt/venvs/nav/lib/python3.5/site-packages/django/core/handlers/base.py" in _get_response
  187.                 response = self.process_exception_by_middleware(e, request)

File "/opt/venvs/nav/lib/python3.5/site-packages/django/core/handlers/base.py" in _get_response
  185.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/opt/venvs/nav/lib/python3.5/site-packages/nav/web/navlets/__init__.py" in get_user_navlets
  208.     for usernavlet in usernavlets:

File "/opt/venvs/nav/lib/python3.5/site-packages/django/db/models/query.py" in __iter__
  250.         self._fetch_all()

File "/opt/venvs/nav/lib/python3.5/site-packages/django/db/models/query.py" in _fetch_all
  1121.             self._result_cache = list(self._iterable_class(self))

File "/opt/venvs/nav/lib/python3.5/site-packages/django/db/models/query.py" in __iter__
  62.         for row in compiler.results_iter(results):

File "/opt/venvs/nav/lib/python3.5/site-packages/django/db/models/sql/compiler.py" in results_iter
  847.                     row = self.apply_converters(row, converters)

File "/opt/venvs/nav/lib/python3.5/site-packages/django/db/models/sql/compiler.py" in apply_converters
  832.                 value = converter(value, expression, self.connection, self.query.context)

File "/opt/venvs/nav/lib/python3.5/site-packages/nav/models/fields.py" in from_db_value
  78.         return self.to_python(value)

File "/opt/venvs/nav/lib/python3.5/site-packages/nav/models/fields.py" in to_python
  90.                     return pickle.loads(value)

Exception Type: TypeError at /navlets/get-user-navlets/303/
Exception Value: a bytes-like object is required, not 'str'
```