### PR TITLE
Make servicemon run on Python 3

### DIFF
--- a/python/nav/statemon/RunQueue.py
+++ b/python/nav/statemon/RunQueue.py
@@ -140,8 +140,10 @@ class _RunQueue(object):
     def _start_worker_if_needed(self):
         # This is quite dirty, but I really need to know how many
         # threads are waiting for checkers.
-        # pylint: disable=protected-access, no-member
-        num_waiters = len(self.await_work._Condition__waiters)
+        waiters = getattr(self.await_work, "_waiters", None)
+        if waiters is None:  # Likely on Python 2
+            waiters = getattr(self.await_work, "_Condition__waiters")
+        num_waiters = len(waiters)
         _logger.debug("Number of workers: %i Waiting workers: %i",
                       len(self.workers), num_waiters)
         if num_waiters > 0:

--- a/python/nav/statemon/RunQueue.py
+++ b/python/nav/statemon/RunQueue.py
@@ -141,7 +141,8 @@ class _RunQueue(object):
         # This is quite dirty, but I really need to know how many
         # threads are waiting for checkers.
         waiters = getattr(self.await_work, "_waiters", None)
-        if waiters is None:  # Likely on Python 2
+        # Next two lines exist only for compat with Python 2 (Python < 3)
+        if waiters is None:
             waiters = getattr(self.await_work, "_Condition__waiters")
         num_waiters = len(waiters)
         _logger.debug("Number of workers: %i Waiting workers: %i",

--- a/python/nav/statemon/checker/MysqlChecker.py
+++ b/python/nav/statemon/checker/MysqlChecker.py
@@ -69,7 +69,7 @@ class MysqlConnection(object):
     def __init__(self, addr, timeout=None):
         host, _port = addr
         sock = socket.create_connection(addr, timeout)
-        self.file = sock.makefile('r+')
+        self.file = sock.makefile('rw')
 
         self.seqno = 0
 

--- a/python/nav/statemon/checker/SshChecker.py
+++ b/python/nav/statemon/checker/SshChecker.py
@@ -39,7 +39,7 @@ class SshChecker(AbstractChecker):
         try:
             sock = socket.create_connection((hostname, port),
                                             self.timeout)
-            stream = sock.makefile('r+')
+            stream = sock.makefile('rw')
             version = stream.readline().strip()
             protocol, major = version.split('-')[:2]
             stream.write("%s-%s-%s" % (protocol, major, "NAV_Servicemon"))

--- a/python/nav/statemon/checkermap.py
+++ b/python/nav/statemon/checkermap.py
@@ -44,6 +44,8 @@ def get(checker):
         return
     if checker not in checkers:
         parsedir()
+        # apparently, the following is required for proper plugin imports on Python 3
+        importlib.import_module("nav.statemon.checker")
     module_name = class_name = checkers.get(checker.lower(), '')
     if not module_name:
         return


### PR DESCRIPTION
Servicemon will not load any plugins when running on Python 3.

This fixes two problems with Python 3 compatibility in the servicemon engine itself, and two minor issues in individual Servicemon plugins.
