### PR TITLE
Increase the max number of shown alerts in Status page to 1000 and provide feedback spinner when loading data

### DIFF
--- a/python/nav/web/static/js/src/status2/views.js
+++ b/python/nav/web/static/js/src/status2/views.js
@@ -152,7 +152,7 @@ define([
             this.alertBox.addClass('hidden');
             this.collection.url = NAV.urls.status2_api_alerthistory + '?' + this.$('form').serialize();
             console.log(this.collection.url);
-            var request = this.collection.fetch({ reset: true });
+            var request = this.collection.fetch({ reset: true, data: {page_size: 1000} });
             request.done(function () {
                 console.log('data fetched');
                 // Reflow for foundation to enable dropdown content

--- a/python/nav/web/static/js/src/status2/views.js
+++ b/python/nav/web/static/js/src/status2/views.js
@@ -1,4 +1,5 @@
 define([
+    'libs/spin.min',
     'status/collections',
     'libs-amd/text!resources/status2/event_template.hbs',
     'moment',
@@ -6,10 +7,12 @@ define([
     'status/handlebars-helpers',
     'libs/backbone',
     'libs/backbone-eventbroker'
-], function (Collections, EventTemplate, moment, Handlebars) {
+], function (Spinner, Collections, EventTemplate, moment, Handlebars) {
 
     // This collection contains all the event-models that are to be cleared/acknowledged etc.
     var alertsToChange = new Collections.ChangeCollection();
+
+    var spinner = new Spinner({position: 'relative', top: '0.5em', left: '-1em', scale: 0.5});
 
     /** The main view containing the panel and the results list */
     var StatusView = Backbone.View.extend({
@@ -86,6 +89,14 @@ define([
 
     });
 
+    function startSpinner() {
+        spinner.spin();
+        $('#fetch-spinner').append(spinner.el);
+    }
+
+    function stopSpinner() {
+        spinner.stop();
+    }
 
     /** The main panel for filtering events */
     var PanelView = Backbone.View.extend({
@@ -146,15 +157,16 @@ define([
         },
 
         fetchData: function () {
-            /* TODO: Inform user that we are trying to fetch data */
             var self = this;
             console.log('Fetching data...');
+            startSpinner();
             this.alertBox.addClass('hidden');
             this.collection.url = NAV.urls.status2_api_alerthistory + '?' + this.$('form').serialize();
             console.log(this.collection.url);
             var request = this.collection.fetch({ reset: true, data: {page_size: 1000} });
             request.done(function () {
                 console.log('data fetched');
+                stopSpinner();
                 // Reflow for foundation to enable dropdown content
                 $(document).foundation('dropdown', 'reflow');
             });

--- a/python/nav/web/templates/status2/status.html
+++ b/python/nav/web/templates/status2/status.html
@@ -43,7 +43,7 @@
     {# Table displaying filtered events #}
 
     <table id="events-list" class="listtable hover expand tablesorter expandable">
-      <caption>Events<span class="last-changed pull-right"></span></caption>
+        <caption>Events<span class="pull-right"><span id="fetch-spinner"></span><span class="last-changed"></span></span></caption>
       <thead>
         <tr>
           <th>


### PR DESCRIPTION
The Status page will currently only show a maximum of 100 active alerts, since it does not take into account the API paging mechanism.

Ideally, the status page would also include paging, but implementing that seems to have a much larger scope than just artificially increasing the limit to 1000, which is what this PR does.

Implementing paging in the status page (which is based on Backbone, and not on datatables) seems to entail upgrading the Backbone version for all of NAV, and including backbone.paginator into the mix. Understanding Backbone at all is a plus.