### PR TITLE
Run test suite on Python 3.5 and 3.7

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,42 +1,40 @@
 # Full integration test image for NAV
 #
-FROM mbrekkevold/debian-gosu:stretch
+FROM mbrekkevold/ubuntu-gosu:bionic
 
-ENV DISTRO stretch
+ENV DISTRO buster
 ENV DISPLAY :99
 ENV ADMINPASSWORD omicronpersei8
+ENV DEBIAN_FRONTEND noninteractive
 
 ### Installing packages
 RUN apt-get update && \
-    apt-get -y install --no-install-recommends \
-      curl git \
-      python python-dev python-pip build-essential \
-      python3 python3-dev python3-pip
+    apt-get install -y software-properties-common
 
-RUN echo "\n\
-\
-deb-src http://security.debian.org/ $DISTRO/updates main\n\
-deb-src http://deb.debian.org/debian $DISTRO main contrib non-free\n\
-deb-src http://deb.debian.org/debian $DISTRO-updates main contrib non-free\n\
-\
-deb http://dl.google.com/linux/chrome/deb/ stable main\n\
-\
-" > /etc/apt/sources.list.d/pkg-sources.list
+RUN add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get -y install --no-install-recommends \
+      curl git build-essential \
+      python3.5 python3.5-dev \
+      python3.7 python3.7-dev \
+      python3-pip
+
+RUN echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
 RUN apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys A040830F7FAC5991 1397BC53640DB551
 
 RUN apt-get update && \
     apt-get -y --no-install-recommends build-dep \
-	python-psycopg2 python-lxml python-imaging python-ldap
+	python3-psycopg2 python3-lxml python3-pil python3-ldap
 
 RUN apt-get update && \
     apt-get -y --no-install-recommends install \
 	libsnmp30 \
 	cron \
-	python-cairo \
+	libjpeg62 \
 	postgresql postgresql-contrib postgresql-client \
 	libxml2-dev libxslt1-dev \
 	libwww-perl \
-	firefox-esr xvfb \
+	firefox xvfb \
 	imagemagick \
 	x11vnc google-chrome-stable cloc \
 	cmake nbtscan python-gammu
@@ -73,7 +71,7 @@ RUN cd /tmp && \
     mv chromedriver /usr/local/bin/
 
 # Install our primary test runner
-RUN pip install tox snmpsim
+RUN python3.5 -m pip install tox snmpsim
 
 # Add a build user
 RUN adduser --system --group --home=/source --shell=/bin/bash build && \

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,10 +1,10 @@
 astroid==2.2.4  ; python_version > '3'
 gunicorn==19.7.1
-lxml==4.0.0
+lxml==4.4.2
 mock==2.0.0
 pylint==2.3.1  ; python_version > '3'
 pylint-django==2.0.6  ; python_version > '3'
-pytest==4.6.5
+pytest==5.3.3
 pytest-cov==2.7.1
 pytest-selenium==1.17.0
 pytest-twisted==1.12

--- a/tests/unittests/netmap/multidigraph_to_undirect_test.py
+++ b/tests/unittests/netmap/multidigraph_to_undirect_test.py
@@ -36,17 +36,12 @@ class Layer2MultiGraphToUndirectTests(TopologyLayer2TestCase):
 
     def test_edges_length_of_netmap_graph_is_reduced_properly(self):
         # one LINE between A and B.
-        # one LINE between B and C
+        # one LINE between A and C
         # one line between C and D
         self.assertEqual(3, len(self.netmap_graph.edges()))
-        self.assertEqual(
-            [
-                (self.a, self.b),
-                (self.a, self.c),
-                (self.c, self.d)
-            ],
-            list(self.netmap_graph.edges())
-        )
+        self.assertIn((self.a, self.b), self.netmap_graph.edges())
+        self.assertIn((self.a, self.c), self.netmap_graph.edges())
+        self.assertIn((self.c, self.d), self.netmap_graph.edges())
 
     def test_layer2_create_directional_metadata_from_nav_graph(self):
         self.netmap_graph = build_netmap_layer2_graph (
@@ -57,14 +52,9 @@ class Layer2MultiGraphToUndirectTests(TopologyLayer2TestCase):
 
         # should be the same as
         #  test_edges_length_of_netmap_graph_is_reduced_properly
-        self.assertEqual(
-            [
-                (self.a, self.b),
-                (self.a, self.c),
-                (self.c, self.d)
-            ],
-            list(self.netmap_graph.edges())
-        )
+        self.assertIn((self.a, self.b), self.netmap_graph.edges())
+        self.assertIn((self.a, self.c), self.netmap_graph.edges())
+        self.assertIn((self.c, self.d), self.netmap_graph.edges())
 
         self.assertEqual(2,
                          len(self.netmap_graph.get_edge_data(

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # based on tests/docker/Dockerfile
 
 [tox]
-envlist = {unit,integration,functional}-{py35,py27}-django111, javascript, docs
+envlist = {unit,integration,functional}-py35-django111, javascript, docs
 skipsdist = True
 
 [tox:jenkins]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # based on tests/docker/Dockerfile
 
 [tox]
-envlist = {unit,integration,functional}-py35-django111, javascript, docs
+envlist = {unit,integration,functional}-{py35,py37}-django111, javascript, docs
 skipsdist = True
 basepython = python3.5
 

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,6 @@ commands =
 
 [testenv:docs]
 description = Just build the Sphinx documentation
-usedevelop=True
 deps = pip-tools
 setenv =
     PYTHONPATH = {toxinidir}/python:{toxinidir}/tests

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@
 [tox]
 envlist = {unit,integration,functional}-py35-django111, javascript, docs
 skipsdist = True
+basepython = python3.5
 
 [tox:jenkins]
 toxworkdir = /source/.tox
@@ -64,7 +65,6 @@ commands =
          /sbin/start-stop-daemon --stop --quiet --pidfile /var/tmp/xvfb.pid
 
 [testenv:pylint]
-basepython = python3.5
 deps = pip-tools
 description = PyLint run on default environment
 setenv =
@@ -92,4 +92,4 @@ commands =
          pip-sync {envdir}/requirements.txt
 
          python setup.py build_sphinx
-         sh -c "cd doc; python -c 'import conf; print conf.version' > {toxinidir}/reports/doc_version"
+         sh -c "cd doc; python -c 'import conf; print(conf.version)' > {toxinidir}/reports/doc_version"


### PR DESCRIPTION
We no longer need to run the test suite on Python 2.7 for NAV 5.1, but we *do* want to be able to run the suite on multiple Python 3 versions.

Debian isn't well suited for that; however, we can utilize the deadsnakes PPA to have multiple Python versions installed on an Ubuntu system.

This PR attempts to replace the CI container with a Ubuntu Bionic image, utilizing deadsnakes PPA to test on both Python 3.5 and 3.7 (and potentially other versions, once we get this to work).
