### PR TITLE
Ensure ifAlias values are treated as strings

### DIFF
--- a/python/nav/portadmin/snmputils.py
+++ b/python/nav/portadmin/snmputils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2015 Uninett AS
+# Copyright (C) 2011-2015, 2020 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #
@@ -22,6 +22,7 @@ from django.utils import six
 from django.utils.encoding import python_2_unicode_compatible
 
 from nav import Snmp
+from nav.Snmp import safestring
 from nav.errors import NoNetboxTypeError
 from nav.Snmp.errors import (SnmpError, UnsupportedSnmpVersionError,
                              NoSuchObjectError)
@@ -218,11 +219,13 @@ class SNMPHandler(object):
 
     def get_if_alias(self, if_index):
         """ Get alias on a specific interface """
-        return self._query_netbox(self.IF_ALIAS_OID, if_index)
+        return safestring(self._query_netbox(self.IF_ALIAS_OID, if_index))
 
     def get_all_if_alias(self):
         """Get all aliases for all interfaces."""
-        return self._bulkwalk(self.IF_ALIAS_OID)
+        return [
+            (oid, safestring(value)) for oid, value in self._bulkwalk(self.IF_ALIAS_OID)
+        ]
 
     def set_if_alias(self, if_index, if_alias):
         """Set alias on a specific interface."""

--- a/tests/unittests/portadmin/portadmin_test.py
+++ b/tests/unittests/portadmin/portadmin_test.py
@@ -91,9 +91,11 @@ class PortadminResponseTest(unittest.TestCase):
         self.snmpReadOnlyHandler = self.handler._get_read_only_handle()
         # replace get-method on Snmp-object with a mock-method
         # for getting all IfAlias
-        self.snmpReadOnlyHandler.bulkwalk = Mock(return_value=['hjalmar', 'snorre', 'bjarne'])
+        walkdata = [('.1', b'hjalmar'), ('.2', b'snorre'), ('.3', b'bjarne')]
+        expected = [('.1', 'hjalmar'), ('.2', 'snorre'), ('.3', 'bjarne')]
+        self.snmpReadOnlyHandler.bulkwalk = Mock(return_value=walkdata)
         self.assertEqual(self.handler.get_all_if_alias(),
-                         ['hjalmar', 'snorre', 'bjarne'],
+                         expected,
                          "getAllIfAlias failed.")
 
     def test_set_ifalias_hp(self):
@@ -159,9 +161,11 @@ class PortadminResponseTest(unittest.TestCase):
         self.snmpReadOnlyHandler = self.handler._get_read_only_handle()
         # replace get-method on Snmp-object with a mock-method
         # for getting all IfAlias
-        self.snmpReadOnlyHandler.bulkwalk = Mock(return_value=['jomar', 'knut', 'hjallis'])
+        walkdata = [('.1', b'jomar'), ('.2', b'knut'), ('.3', b'hjallis')]
+        expected = [('.1', 'jomar'), ('.2', 'knut'), ('.3', 'hjallis')]
+        self.snmpReadOnlyHandler.bulkwalk = Mock(return_value=walkdata)
         self.assertEqual(self.handler.get_all_if_alias(),
-                         ['jomar', 'knut', 'hjallis'], "getAllIfAlias failed.")
+                         expected, "getAllIfAlias failed.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Because:
- Under Python 3, the strings retrieved using SNMP will actually be bytes objects.
- Whereas most of the other SNMP data PortAdmin works with is either integers or actual bytestrings, the aliases are human-readable (and human-configured) text.

Although SNMP is only defined for ASCII, some devices let you enter non-ASCII data as port aliases. Rarely through SNMP, but often through the CLI. This patch uses the existing safestring implementation to ensure the retrieved ifAlias values are decoded using one of the "supported" encodings.

Patch tested on affected customer installs.

Fixes #2093