### PR TITLE
Reduce the size of ipdevinfo's Graphite request to get the latest sensor data

### DIFF
--- a/python/nav/web/ipdevinfo/views.py
+++ b/python/nav/web/ipdevinfo/views.py
@@ -305,8 +305,7 @@ def ipdev_details(request, name=None, addr=None, netbox_id=None):
             metric = {
                 'id': metric_id,
                 'sensor': sensor,
-                'graphite_data_url': Graph(
-                    magic_targets=[metric_id], format='json'),
+                'graphite_data_url': sensor.get_graph(format='json'),
             }
             sensor_metrics.append(metric)
         find_rules(sensor_metrics)

--- a/python/nav/web/static/js/src/ipdevinfo.js
+++ b/python/nav/web/static/js/src/ipdevinfo.js
@@ -55,10 +55,20 @@ require([
         });
     }
 
+    function commonPrefix(array){
+        var arr = array.concat().sort(),
+            a1 = arr[0], a2 = arr[arr.length-1], len = a1.length, i = 0;
+        while (i<len && a1.charAt(i) === a2.charAt(i)) i++;
+        return a1.substring(0, i);
+    }
+
     function getSensorData(metricMap, updateFunc) {
         var url = NAV.graphiteRenderUrl;
+        // under the assumption that all sensors on a single device have a
+        // common parent node in the metric tree:
+        var target = commonPrefix(_.keys(metricMap)) + '*';
         var data = $.param({
-            target: _.keys(metricMap),
+            target: target,
             format: 'json',
             from: '-5min',
             until: 'now'


### PR DESCRIPTION
Fixes #2092 - but also reduces the number of ipdevinfo SQL queries generated to get `Sensor` objects.