### PR TITLE
Improve ipdevpoll worker pool logging

### DIFF
--- a/python/nav/ipdevpoll/pool.py
+++ b/python/nav/ipdevpoll/pool.py
@@ -17,6 +17,7 @@
 from __future__ import print_function
 import os
 import sys
+import logging
 
 from twisted.protocols import amp
 from twisted.internet import reactor, protocol
@@ -26,7 +27,6 @@ import twisted.internet.endpoints
 
 from django.utils import six
 
-from nav.ipdevpoll import ContextLogger
 from . import control, jobs
 
 
@@ -72,7 +72,7 @@ class Job(amp.Command):
 class JobHandler(amp.CommandLocator):
     """Resolve actions for jobs received over AMP"""
 
-    _logger = ContextLogger()
+    _logger = logging.getLogger(__name__ + '.jobhandler')
 
     def __init__(self):
         super(JobHandler, self).__init__()
@@ -132,8 +132,6 @@ class JobHandler(amp.CommandLocator):
 class ProcessAMP(amp.AMP):
     """Modify AMP protocol to allow running over process pipes"""
 
-    _logger = ContextLogger()
-
     def __init__(self, is_worker, **kwargs):
         super(ProcessAMP, self).__init__(**kwargs)
         self.is_worker = is_worker
@@ -182,7 +180,7 @@ class Worker(object):
     """This class holds information about one worker process as seen from
     the worker pool"""
 
-    _logger = ContextLogger()
+    _logger = logging.getLogger(__name__ + '.worker')
 
     def __init__(self, pool, threadpoolsize, max_jobs):
         self.active_jobs = 0
@@ -243,7 +241,7 @@ class WorkerPool(object):
     """This class represent a pool of worker processes to which jobs can
     be scheduled"""
 
-    _logger = ContextLogger()
+    _logger = logging.getLogger(__name__ + '.workerpool')
 
     def __init__(self, workers, max_jobs, threadpoolsize=None):
         twisted.internet.endpoints.log = HackLog

--- a/python/nav/ipdevpoll/pool.py
+++ b/python/nav/ipdevpoll/pool.py
@@ -193,6 +193,18 @@ class Worker(object):
         self.max_jobs = max_jobs
         self.started_at = None
 
+    def __repr__(self):
+        return (
+            "<Worker pid={pid} ready={ready} active={active} max={max} "
+            "total={total} started_at={started_at}>"
+        ).format(
+            pid=self.pid,
+            ready=not self.done(),
+            active=self.active_jobs,
+            max=self.max_concurrent_jobs,
+            total=self.total_jobs,
+            started_at=self.started_at,
+        )
 
     @inlineCallbacks
     def start(self):

--- a/python/nav/ipdevpoll/pool.py
+++ b/python/nav/ipdevpoll/pool.py
@@ -340,3 +340,4 @@ class HackLog(object):
         if six.PY3 and isinstance(data, six.binary_type):
             data = data.decode("utf-8")
         sys.stderr.write(data)
+        sys.stderr.flush()

--- a/python/nav/ipdevpoll/pool.py
+++ b/python/nav/ipdevpoll/pool.py
@@ -15,6 +15,8 @@
 #
 """Handle sending jobs to worker processes."""
 from __future__ import print_function
+
+import datetime
 import os
 import sys
 import logging
@@ -189,6 +191,8 @@ class Worker(object):
         self.pool = pool
         self.threadpoolsize = threadpoolsize
         self.max_jobs = max_jobs
+        self.started_at = None
+
 
     @inlineCallbacks
     def start(self):
@@ -202,6 +206,7 @@ class Worker(object):
                                               locator=JobHandler())
         self.process = yield endpoint.connect(factory)
         self.process.lost_handler = self._worker_died
+        self.started_at = datetime.datetime.now()
         returnValue(self)
 
     @property

--- a/python/nav/ipdevpoll/pool.py
+++ b/python/nav/ipdevpoll/pool.py
@@ -204,6 +204,15 @@ class Worker(object):
         self.process.lost_handler = self._worker_died
         returnValue(self)
 
+    @property
+    def pid(self):
+        try:
+            if not getattr(self, '_pid', None):
+                self._pid = self.process.transport._process.pid
+        except AttributeError:
+            return None
+        return getattr(self, '_pid', None)
+
     def done(self):
         return self.max_jobs and (self.total_jobs >= self.max_jobs)
 


### PR DESCRIPTION
I'm working on debugging a potential problem in NAV 5.0 where ipdevpoll workers sometimes just freeze, leaving jobs "running" indefinitely.

The (debug) log output from the ipdevpoll multiprocess pool module leaves a lot to be desired. This PR seeks to improve these logs to aid in the debugging of the issue.

Especially sad was the buffered log output from worker processes. I suspect this might even be part of the cause of frozen workers.
