### PR TITLE
Refactor portadmin configuration parsing bits

### DIFF
--- a/python/nav/portadmin/config.py
+++ b/python/nav/portadmin/config.py
@@ -1,0 +1,116 @@
+#
+# Copyright (C) 2011-2015, 2017, 2019 UNINETT
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.  You should have received a copy of the GNU General Public License
+# along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Tools to handle PortAdmin configuration database/file"""
+import configparser
+from os.path import join
+
+from nav.config import find_configfile
+from nav.portadmin.vlan import FantasyVlan
+
+CONFIGFILE = find_configfile(join("portadmin", "portadmin.conf")) or ''
+
+
+def is_vlan_authorization_enabled():
+    """Check config to see if authorization is to be done"""
+    # TODO: It is very inefficient to reread config for every option
+    config = read_config()
+    if config.has_option("authorization", "vlan_auth"):
+        return config.getboolean("authorization", "vlan_auth")
+
+    return False
+
+
+def is_write_mem_enabled():
+    """Checks if write mem is turned on or off. Default is on"""
+    # TODO: It is very inefficient to reread config for every option
+    config = read_config()
+    if config.has_option("general", "write_mem"):
+        return config.getboolean("general", "write_mem")
+
+    return True
+
+
+def is_restart_interface_enabled():
+    """Checks if restart interface is turned on or off. Default is on"""
+    # TODO: It is very inefficient to reread config for every option
+    config = read_config()
+    if config.has_option("general", "restart_interface"):
+        return config.getboolean("general", "restart_interface")
+
+    return True
+
+
+def dot1x_external_url():
+    """Returns url for external config of dot1x for a interface"""
+    config = read_config()
+    section = 'dot1x'
+    option = 'port_url_template'
+    return config[section].get(option, None)
+
+
+def get_ifaliasformat(config=None):
+    """Get format for ifalias defined in config file"""
+    if config is None:
+        config = read_config()
+    section = "ifaliasformat"
+    option = "format"
+    if config.has_section(section) and config.has_option(section, option):
+        return config.get(section, option)
+
+
+def find_default_vlan(include_netident=False):
+    """Check config to see if a default vlan is set
+
+    :rtype: FantasyVlan
+    """
+    defaultvlan = ""
+    netident = ""
+
+    # TODO: It is very inefficient to reread config for every option
+    config = read_config()
+    if config.has_section("defaultvlan"):
+        if config.has_option("defaultvlan", "vlan"):
+            defaultvlan = config.getint("defaultvlan", "vlan")
+        if config.has_option("defaultvlan", "netident"):
+            netident = config.get("defaultvlan", "netident")
+
+    if defaultvlan:
+        if include_netident:
+            return FantasyVlan(defaultvlan, netident)
+        else:
+            return FantasyVlan(defaultvlan)
+
+
+def fetch_voice_vlans(config=None):
+    """Fetch the voice vlans (if any) from the config file"""
+    if config is None:
+        config = read_config()
+    if config.has_section("general"):
+        if config.has_option("general", "voice_vlans"):
+            try:
+                return [int(v) for v in
+                        config.get("general", "voice_vlans").split(',')]
+            except ValueError:
+                pass
+    return []
+
+
+def read_config():
+    """Read the config"""
+    config = configparser.ConfigParser()
+    config.read(CONFIGFILE)
+
+    return config

--- a/python/nav/web/portadmin/utils.py
+++ b/python/nav/web/portadmin/utils.py
@@ -25,7 +25,7 @@ from nav.django.utils import is_admin
 from nav.portadmin.config import (
     is_vlan_authorization_enabled,
     dot1x_external_url,
-    read_config,
+    get_ifaliasformat,
     find_default_vlan)
 from nav.portadmin.management import ManagementFactory
 from nav.portadmin.vlan import FantasyVlan
@@ -171,13 +171,11 @@ def find_vlans_in_org(org):
 
 def check_format_on_ifalias(ifalias):
     """Verify that format on ifalias is correct if it is defined in config"""
-    section = "ifaliasformat"
-    option = "format"
-    config = read_config()
     if not ifalias:
         return True
-    elif config.has_section(section) and config.has_option(section, option):
-        ifalias_format = re.compile(config.get(section, option))
+    ifalias_format = get_ifaliasformat()
+    if ifalias_format:
+        ifalias_format = re.compile(ifalias_format)
         if ifalias_format.match(ifalias):
             return True
         else:

--- a/python/nav/web/portadmin/utils.py
+++ b/python/nav/web/portadmin/utils.py
@@ -16,20 +16,21 @@
 """Util functions for the PortAdmin"""
 from __future__ import unicode_literals
 import re
-import configparser
 import logging
 from operator import attrgetter
-from os.path import join
 
 from django.template import loader
 
-from nav.config import find_configfile
 from nav.django.utils import is_admin
+from nav.portadmin.config import (
+    is_vlan_authorization_enabled,
+    dot1x_external_url,
+    read_config,
+    find_default_vlan)
 from nav.portadmin.management import ManagementFactory
 from nav.portadmin.vlan import FantasyVlan
 from nav.enterprise.ids import VENDOR_ID_CISCOSYSTEMS
 
-CONFIGFILE = find_configfile(join("portadmin", "portadmin.conf")) or ''
 
 _logger = logging.getLogger("nav.web.portadmin")
 
@@ -109,44 +110,6 @@ def find_allowed_vlans_for_user_on_netbox(account, netbox, factory=None):
     return sorted(allowed_vlans, key=attrgetter('vlan'))
 
 
-def is_vlan_authorization_enabled():
-    """Check config to see if authorization is to be done"""
-    # TODO: It is very inefficient to reread config for every option
-    config = read_config()
-    if config.has_option("authorization", "vlan_auth"):
-        return config.getboolean("authorization", "vlan_auth")
-
-    return False
-
-
-def is_write_mem_enabled():
-    """Checks if write mem is turned on or off. Default is on"""
-    # TODO: It is very inefficient to reread config for every option
-    config = read_config()
-    if config.has_option("general", "write_mem"):
-        return config.getboolean("general", "write_mem")
-
-    return True
-
-
-def is_restart_interface_enabled():
-    """Checks if restart interface is turned on or off. Default is on"""
-    # TODO: It is very inefficient to reread config for every option
-    config = read_config()
-    if config.has_option("general", "restart_interface"):
-        return config.getboolean("general", "restart_interface")
-
-    return True
-
-
-def dot1x_external_url():
-    """Returns url for external config of dot1x for a interface"""
-    config = read_config()
-    section = 'dot1x'
-    option = 'port_url_template'
-    return config[section].get(option, None)
-
-
 def find_vlans_on_netbox(netbox, factory=None):
     """Find all the vlans on this netbox
 
@@ -172,51 +135,6 @@ def find_allowed_vlans_for_user(account):
         allowed_vlans.append(defaultvlan)
 
     return allowed_vlans
-
-
-def find_default_vlan(include_netident=False):
-    """Check config to see if a default vlan is set
-
-    :rtype: FantasyVlan
-    """
-    defaultvlan = ""
-    netident = ""
-
-    # TODO: It is very inefficient to reread config for every option
-    config = read_config()
-    if config.has_section("defaultvlan"):
-        if config.has_option("defaultvlan", "vlan"):
-            defaultvlan = config.getint("defaultvlan", "vlan")
-        if config.has_option("defaultvlan", "netident"):
-            netident = config.get("defaultvlan", "netident")
-
-    if defaultvlan:
-        if include_netident:
-            return FantasyVlan(defaultvlan, netident)
-        else:
-            return FantasyVlan(defaultvlan)
-
-
-def fetch_voice_vlans(config=None):
-    """Fetch the voice vlans (if any) from the config file"""
-    if config is None:
-        config = read_config()
-    if config.has_section("general"):
-        if config.has_option("general", "voice_vlans"):
-            try:
-                return [int(v) for v in
-                        config.get("general", "voice_vlans").split(',')]
-            except ValueError:
-                pass
-    return []
-
-
-def read_config():
-    """Read the config"""
-    config = configparser.ConfigParser()
-    config.read(CONFIGFILE)
-
-    return config
 
 
 def set_editable_on_interfaces(netbox, interfaces, vlans):
@@ -267,16 +185,6 @@ def check_format_on_ifalias(ifalias):
             return False
     else:
         return True
-
-
-def get_ifaliasformat(config=None):
-    """Get format for ifalias defined in config file"""
-    if config is None:
-        config = read_config()
-    section = "ifaliasformat"
-    option = "format"
-    if config.has_section(section) and config.has_option(section, option):
-        return config.get(section, option)
 
 
 def get_aliastemplate():

--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -36,18 +36,22 @@ from nav.web.utils import create_title
 from nav.models.manage import Netbox, Interface
 from nav.web.portadmin.utils import (get_and_populate_livedata,
                                      find_and_populate_allowed_vlans,
-                                     get_aliastemplate, get_ifaliasformat,
-                                     save_to_database,
+                                     get_aliastemplate, save_to_database,
                                      check_format_on_ifalias,
                                      find_allowed_vlans_for_user_on_netbox,
                                      find_allowed_vlans_for_user,
-                                     filter_vlans, fetch_voice_vlans,
-                                     should_check_access_rights,
+                                     filter_vlans, should_check_access_rights,
                                      mark_detained_interfaces,
-                                     read_config, is_cisco,
+                                     is_cisco,
                                      add_dot1x_info,
-                                     is_restart_interface_enabled,
-                                     is_write_mem_enabled, get_trunk_edit)
+                                     get_trunk_edit)
+from nav.portadmin.config import (
+    is_write_mem_enabled,
+    is_restart_interface_enabled,
+    read_config,
+    get_ifaliasformat,
+    fetch_voice_vlans,
+)
 from nav.Snmp.errors import SnmpError, TimeOutException
 from nav.portadmin.snmp.base import SNMPHandler
 from nav.portadmin.management import ManagementFactory


### PR DESCRIPTION
Because:
- portadmin is weirdly split into the `nav.portadmin` and `nav.web.portadmin` packages.
- Config parsing code was kept in the `nav.web.portadmin` package, but will soon be needed also in `nav.portadmin`.
- It's, IMHO, best to coalesce everything config-parsing related into a module of its own.
- There may be import cycles if `nav.portadmin` modules begin importing stuff from the `nav.web.portadmin` package.