### PR TITLE
[BUG] Latitude/Longitude is displayed weirdly in the SeedDB room list

### DIFF
--- a/python/nav/web/seeddb/utils/list.py
+++ b/python/nav/web/seeddb/utils/list.py
@@ -113,6 +113,9 @@ def _process_objects(queryset, value_list, edit_url=None, edit_url_attr=None):
             if attr in datakeys:
                 for key in datakeys[attr]:
                     yield value.get(key, None)
+            elif isinstance(value, tuple):
+                # this only normally happens with tuples of Decimal values in Rooms
+                yield ", ".join(str(v) for v in value)
             else:
                 yield value
 


### PR DESCRIPTION
**Describe the bug**
The SeedDB room listing would display geographical coordinates like e.g. `(Decimal('63.414868887417'), Decimal('10.4065664274869'))`, which is just confusing to the end-user (this looks like a simple `repr()` of the internal storage format, which is a tuple of Decimal objects).

A more natural display value would be just `63.414868887417, 10.4065664274869`.

This PR sets out to do just that.

**Environment (please complete the following information):**
 - NAV version installed: 5.0.4