### PR TITLE
Factor out unnecessary dict conversion function

### DIFF
--- a/python/nav/web/portadmin/utils.py
+++ b/python/nav/web/portadmin/utils.py
@@ -38,32 +38,14 @@ _logger = logging.getLogger("nav.web.portadmin")
 def get_and_populate_livedata(netbox, interfaces):
     """Fetch live data from netbox"""
     handler = ManagementFactory.get_instance(netbox)
-    live_ifaliases = create_dict_from_tuplelist(handler.get_all_if_alias())
-    live_vlans = create_dict_from_tuplelist(handler.get_all_vlans())
+    live_ifaliases = handler.get_all_if_alias()
+    live_vlans = handler.get_all_vlans()
     live_operstatus = dict(handler.get_netbox_oper_status())
     live_adminstatus = dict(handler.get_netbox_admin_status())
     update_interfaces_with_snmpdata(interfaces, live_ifaliases, live_vlans,
                                     live_operstatus, live_adminstatus)
 
     return handler
-
-
-def create_dict_from_tuplelist(tuplelist):
-    """
-    The input is a list from a snmp bulkwalk or walk.
-    Extract ifindex from oid and use that as key in the dict.
-    """
-    pattern = re.compile(r"(\d+)$")
-    result = []
-    # Extract ifindex from oid
-    for key, value in tuplelist:
-        match_object = pattern.search(key)
-        if match_object:
-            ifindex = int(match_object.groups()[0])
-            result.append((ifindex, value))
-
-    # Create dict from modified list
-    return dict(result)
 
 
 def update_interfaces_with_snmpdata(interfaces, ifalias, vlans, operstatus,

--- a/tests/unittests/portadmin/portadmin_test.py
+++ b/tests/unittests/portadmin/portadmin_test.py
@@ -93,7 +93,7 @@ class PortadminResponseTest(unittest.TestCase):
         # replace get-method on Snmp-object with a mock-method
         # for getting all IfAlias
         walkdata = [('.1', b'hjalmar'), ('.2', b'snorre'), ('.3', b'bjarne')]
-        expected = [('.1', 'hjalmar'), ('.2', 'snorre'), ('.3', 'bjarne')]
+        expected = {1: 'hjalmar', 2: 'snorre', 3: 'bjarne'}
         self.snmpReadOnlyHandler.bulkwalk = Mock(return_value=walkdata)
         self.assertEqual(self.handler.get_all_if_alias(),
                          expected,
@@ -163,7 +163,7 @@ class PortadminResponseTest(unittest.TestCase):
         # replace get-method on Snmp-object with a mock-method
         # for getting all IfAlias
         walkdata = [('.1', b'jomar'), ('.2', b'knut'), ('.3', b'hjallis')]
-        expected = [('.1', 'jomar'), ('.2', 'knut'), ('.3', 'hjallis')]
+        expected = {1: 'jomar', 2: 'knut', 3: 'hjallis'}
         self.snmpReadOnlyHandler.bulkwalk = Mock(return_value=walkdata)
         self.assertEqual(self.handler.get_all_if_alias(),
                          expected, "getAllIfAlias failed.")


### PR DESCRIPTION
Because:
- The ugly `create_dict_from_tuplelist()` function was only ever used to convert the output of `get_all_vlans()` and `get_all_if_alias()` to dicts.
- The `get_all_vlans()` and `get_all_if_alias()` methods were only ever used by `get_and_populate_livedata()`, so it made sense to change the API to just return the desired dicts in the first place.