### PR TITLE
Use nav.config.NAVConfigParser for PortAdmin configuration

### DIFF
--- a/python/nav/portadmin/config.py
+++ b/python/nav/portadmin/config.py
@@ -14,103 +14,96 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Tools to handle PortAdmin configuration database/file"""
-import configparser
 from os.path import join
 
-from nav.config import find_configfile
+from nav.config import NAVConfigParser
 from nav.portadmin.vlan import FantasyVlan
 
-CONFIGFILE = find_configfile(join("portadmin", "portadmin.conf")) or ''
+
+class PortAdminConfig(NAVConfigParser):
+    """"PortAdmin config parser"""
+
+    DEFAULT_CONFIG_FILES = (join("portadmin", "portadmin.conf"),)
+    DEFAULT_CONFIG = """
+[general]
+cisco_voice_vlans = false
+cisco_voice_cdp = false
+restart_interface = on
+write_mem = on
+timeout = 3
+retries = 3
+trunk_edit = true
+
+[authorization]
+vlan_auth = off
+
+[defaultvlan]
+[ifaliasformat]
+
+[dot1x]
+enabled = false
+"""
+
+    def is_vlan_authorization_enabled(self):
+        """Check config to see if authorization is to be done"""
+        return self.getboolean("authorization", "vlan_auth")
+
+    def is_write_mem_enabled(self):
+        """Checks if write mem is turned on or off. Default is on"""
+        return self.getboolean("general", "write_mem")
+
+    def is_restart_interface_enabled(self):
+        """Checks if restart interface is turned on or off. Default is on"""
+        return self.getboolean("general", "restart_interface")
+
+    def get_dot1x_external_url(self):
+        """Returns url for external config of dot1x for a interface"""
+        return self.get("dot1x", "port_url_template", fallback=None)
+
+    def get_ifaliasformat(self):
+        """Get format for ifalias defined in config file"""
+        return self.get("ifaliasformat", "format", fallback=None)
+
+    def find_default_vlan(self, include_netident=False):
+        """Check config to see if a default vlan is set
+
+        :rtype: FantasyVlan
+        """
+        defaultvlan = self.getint("defaultvlan", "vlan", fallback=None)
+        netident = self.get("defaultvlan", "netident", fallback="")
+
+        if defaultvlan:
+            if include_netident:
+                return FantasyVlan(defaultvlan, netident)
+            else:
+                return FantasyVlan(defaultvlan)
+
+    def fetch_voice_vlans(self):
+        """Fetch the voice vlans (if any) from the config file"""
+        voice_vlans = self.get("general", "voice_vlans", fallback="")
+        try:
+            return [int(v) for v in voice_vlans.split(",")]
+        except ValueError:
+            return []
+
+    def get_trunk_edit(self):
+        """Gets config option for trunk edit
+
+        Default is to allow trunk edit
+        """
+        return self.getboolean("general", "trunk_edit", fallback=True)
+
+    def is_dot1x_enabled(self):
+        """Checks if dot1x config option is true"""
+        self.getboolean("dot1x", "enabled", fallback=False)
+
+    def is_cisco_voice_enabled(self):
+        """Checks if the Cisco config option is enabled"""
+        return self.getboolean("general", "cisco_voice_vlan", fallback=False)
+
+    def is_cisco_voice_cdp_enabled(self):
+        """Checks if the CDP config option is enabled"""
+        return self.getboolean("general", "cisco_voice_cdp", fallback=False)
 
 
-def is_vlan_authorization_enabled():
-    """Check config to see if authorization is to be done"""
-    # TODO: It is very inefficient to reread config for every option
-    config = read_config()
-    if config.has_option("authorization", "vlan_auth"):
-        return config.getboolean("authorization", "vlan_auth")
-
-    return False
-
-
-def is_write_mem_enabled():
-    """Checks if write mem is turned on or off. Default is on"""
-    # TODO: It is very inefficient to reread config for every option
-    config = read_config()
-    if config.has_option("general", "write_mem"):
-        return config.getboolean("general", "write_mem")
-
-    return True
-
-
-def is_restart_interface_enabled():
-    """Checks if restart interface is turned on or off. Default is on"""
-    # TODO: It is very inefficient to reread config for every option
-    config = read_config()
-    if config.has_option("general", "restart_interface"):
-        return config.getboolean("general", "restart_interface")
-
-    return True
-
-
-def dot1x_external_url():
-    """Returns url for external config of dot1x for a interface"""
-    config = read_config()
-    section = 'dot1x'
-    option = 'port_url_template'
-    return config[section].get(option, None)
-
-
-def get_ifaliasformat(config=None):
-    """Get format for ifalias defined in config file"""
-    if config is None:
-        config = read_config()
-    section = "ifaliasformat"
-    option = "format"
-    if config.has_section(section) and config.has_option(section, option):
-        return config.get(section, option)
-
-
-def find_default_vlan(include_netident=False):
-    """Check config to see if a default vlan is set
-
-    :rtype: FantasyVlan
-    """
-    defaultvlan = ""
-    netident = ""
-
-    # TODO: It is very inefficient to reread config for every option
-    config = read_config()
-    if config.has_section("defaultvlan"):
-        if config.has_option("defaultvlan", "vlan"):
-            defaultvlan = config.getint("defaultvlan", "vlan")
-        if config.has_option("defaultvlan", "netident"):
-            netident = config.get("defaultvlan", "netident")
-
-    if defaultvlan:
-        if include_netident:
-            return FantasyVlan(defaultvlan, netident)
-        else:
-            return FantasyVlan(defaultvlan)
-
-
-def fetch_voice_vlans(config=None):
-    """Fetch the voice vlans (if any) from the config file"""
-    if config is None:
-        config = read_config()
-    if config.has_section("general"):
-        if config.has_option("general", "voice_vlans"):
-            try:
-                return [int(v) for v in
-                        config.get("general", "voice_vlans").split(',')]
-            except ValueError:
-                pass
-    return []
-
-
-def read_config():
-    """Read the config"""
-    config = configparser.ConfigParser()
-    config.read(CONFIGFILE)
-
-    return config
+CONFIG = PortAdminConfig()


### PR DESCRIPTION
This refactors all configuration parsing/access in PortAdmin to use the more standardized `nav.config.NAVConfigParser`, which also offers a way to document default values more clearly.

Because:
- Config access was still all over the place in the PortAdmin code.
- Config access contained lots of redundant code.
- Almost every config access function would read the complete config file over again, just to get a single option.
- It's best to have a single pattern for parsing config files in NAV, and `nav.config.NAVConfigParser` is it.

For the end-user, these changes have only a single implication: _Any config changes to portadmin.conf will now require a restart of the web/wsgi server to take effect._