### PR TITLE
Extract an interface from PortAdmin's SNMPHandler class

### DIFF
--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -14,10 +14,8 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Interface definition for PortAdmin management handlers"""
-from django.utils.encoding import python_2_unicode_compatible
 
 
-@python_2_unicode_compatible
 class ManagementHandler:
     """Defines a common interface for all types of PortAdmin management handlers.
 

--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -1,0 +1,204 @@
+#
+# Copyright (C) 2011-2015, 2020 UNINETT
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.  You should have received a copy of the GNU General Public License
+# along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Interface definition for PortAdmin management handlers"""
+from django.utils.encoding import python_2_unicode_compatible
+
+
+@python_2_unicode_compatible
+class ManagementHandler:
+    """Defines a common interface for all types of PortAdmin management handlers.
+
+    This defines the set of methods that a handler class may be expected by PortAdmin
+    to provide, regardless of the underlying management protocol implemented by such
+    a class.
+    """
+    def __init__(self, netbox, **kwargs):
+        self.netbox = netbox
+
+    def __str__(self):
+        # TODO: This was copied from SNMPHandler and doesn't make much sense
+        return self.netbox.type.vendor.id
+
+    def test_read(self):
+        """Test if read works"""
+        raise NotImplementedError
+
+    def test_write(self):
+        """Test if write works"""
+        raise NotImplementedError
+
+    def get_if_alias(self, if_index):
+        """Get alias on a specific interface"""
+        raise NotImplementedError
+
+    def get_all_if_alias(self):
+        """Get all aliases for all interfaces.
+
+        :returns: A dict describing {ifIndex: ifAlias}
+        """
+        raise NotImplementedError
+
+    def set_if_alias(self, if_index, if_alias):
+        """Set alias on a specific interface."""
+        raise NotImplementedError
+
+    def get_vlan(self, interface):
+        """Get vlan on a specific interface."""
+        raise NotImplementedError
+
+    def get_all_vlans(self):
+        """Retrieves the untagged VLAN value for every interface.
+
+        :returns: A dict describing {ifIndex: VLAN_TAG}
+        """
+        raise NotImplementedError
+
+    def set_vlan(self, interface, vlan):
+        """Set a new vlan on the given interface and remove the previous vlan"""
+        raise NotImplementedError
+
+    def set_native_vlan(self, interface, vlan):
+        """Set native vlan on a trunk interface"""
+        raise NotImplementedError
+
+    def set_if_up(self, if_index):
+        """Set interface.to up"""
+        raise NotImplementedError
+
+    def set_if_down(self, if_index):
+        """Set interface.to down"""
+        raise NotImplementedError
+
+    def restart_if(self, if_index, wait=5):
+        """Take interface down and up.
+
+        :param wait: number of seconds to wait between down and up.
+        """
+        raise NotImplementedError
+
+    def write_mem(self):
+        """Do a write memory on netbox if available"""
+        raise NotImplementedError
+
+    def get_if_admin_status(self, if_index):
+        """Query administrative status for a given interface."""
+        raise NotImplementedError
+
+    def get_if_oper_status(self, if_index):
+        """Query operational status of a given interface."""
+        raise NotImplementedError
+
+    def get_netbox_admin_status(self):
+        """Walk all ports and get their administration status."""
+        raise NotImplementedError
+
+    def get_netbox_oper_status(self):
+        """Walk all ports and get their operational status."""
+        raise NotImplementedError
+
+    def get_netbox_vlans(self):
+        """Create Fantasyvlans for all vlans on this netbox"""
+        raise NotImplementedError
+
+    def get_available_vlans(self):
+        """Get available vlans from the box
+
+        This is similar to the terminal command "show vlans"
+        """
+        raise NotImplementedError
+
+    def set_voice_vlan(self, interface, voice_vlan):
+        """Activate voice vlan on this interface
+
+        Use set_trunk to make sure the interface is put in trunk mode
+        """
+        raise NotImplementedError
+
+    def get_cisco_voice_vlans(self):
+        """Should not be implemented on anything else than Cisco"""
+        raise NotImplementedError
+
+    def set_cisco_voice_vlan(self, interface, voice_vlan):
+        """Should not be implemented on anything else than Cisco"""
+        raise NotImplementedError
+
+    def enable_cisco_cdp(self, interface):
+        """Should not be implemented on anything else than Cisco"""
+        raise NotImplementedError
+
+    def disable_cisco_voice_vlan(self, interface):
+        """Should not be implemented on anything else than Cisco"""
+        raise NotImplementedError
+
+    def disable_cisco_cdp(self, interface):
+        """Should not be implemented on anything else than Cisco"""
+        raise NotImplementedError
+
+    def get_native_and_trunked_vlans(self, interface):
+        """Get the trunked vlans on this interface
+
+        For each available vlan, fetch list of interfaces that forward this
+        vlan. If the interface index is in this list, add the vlan to the
+        return list.
+
+        :returns: (native vlan, list_of_trunked_vlans)
+        :rtype: tuple
+        """
+        raise NotImplementedError
+
+    def get_native_vlan(self, interface):
+        raise NotImplementedError
+
+    def set_trunk_vlans(self, interface, vlans):
+        """Trunk the vlans on interface
+
+        Egress_Ports includes native vlan. Be sure to not alter that.
+
+        Get all available vlans. For each available vlan fetch list of
+        interfaces that forward this vlan. Set or remove the interface from
+        this list based on if it is in the vlans list.
+
+        """
+        raise NotImplementedError
+
+    def set_access(self, interface, access_vlan):
+        """Set this port in access mode and set access vlan
+
+        Means - remove all vlans except access vlan from this interface
+        """
+        raise NotImplementedError
+
+    def set_trunk(self, interface, native_vlan, trunk_vlans):
+        """Set this port in trunk mode and set native vlan"""
+        raise NotImplementedError
+
+    def is_dot1x_enabled(self, interface):
+        """Returns a boolean indicating whether 802.1X is enabled on the given
+        interface.
+        """
+        raise NotImplementedError
+
+    def get_dot1x_enabled_interfaces(self):
+        """Fetches a dict mapping ifindex to enabled state
+
+        :returns: dict[ifindex, is_enabled]
+        :rtype: dict[int, bool]
+        """
+        raise NotImplementedError
+
+    def is_port_access_control_enabled(self):
+        """Returns state of port access control"""
+        raise NotImplementedError

--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -26,10 +26,6 @@ class ManagementHandler:
     def __init__(self, netbox, **kwargs):
         self.netbox = netbox
 
-    def __str__(self):
-        # TODO: This was copied from SNMPHandler and doesn't make much sense
-        return self.netbox.type.vendor.id
-
     def test_read(self):
         """Test if read works"""
         raise NotImplementedError

--- a/python/nav/portadmin/snmp/base.py
+++ b/python/nav/portadmin/snmp/base.py
@@ -285,6 +285,7 @@ class SNMPHandler(ManagementHandler):
     @staticmethod
     def _get_last_number(oid):
         """Get the last index for an OID."""
+        # TODO: This method is superfluous, use nav.oids.OID objects instead
         if not (isinstance(oid, six.string_types)):
             raise TypeError('Illegal value for oid')
         splits = oid.split('.')
@@ -376,6 +377,7 @@ class SNMPHandler(ManagementHandler):
 
     @staticmethod
     def _extract_index_from_oid(oid):
+        # TODO: This method is also superfluous, use nav.oids.OID objects instead
         return int(oid.split('.')[-1])
 
     def get_native_and_trunked_vlans(self, interface):

--- a/python/nav/portadmin/snmp/base.py
+++ b/python/nav/portadmin/snmp/base.py
@@ -319,26 +319,6 @@ class SNMPHandler(ManagementHandler):
     def set_voice_vlan(self, interface, voice_vlan):
         self.set_trunk(interface, interface.vlan, [voice_vlan])
 
-    def get_cisco_voice_vlans(self):
-        """Should not be implemented on anything else than Cisco"""
-        raise NotImplementedError
-
-    def set_cisco_voice_vlan(self, interface, voice_vlan):
-        """Should not be implemented on anything else than Cisco"""
-        raise NotImplementedError
-
-    def enable_cisco_cdp(self, interface):
-        """Should not be implemented on anything else than Cisco"""
-        raise NotImplementedError
-
-    def disable_cisco_voice_vlan(self, interface):
-        """Should not be implemented on anything else than Cisco"""
-        raise NotImplementedError
-
-    def disable_cisco_cdp(self, interface):
-        """Should not be implemented on anything else than Cisco"""
-        raise NotImplementedError
-
     @staticmethod
     def _extract_index_from_oid(oid):
         # TODO: This method is also superfluous, use nav.oids.OID objects instead

--- a/python/nav/portadmin/snmp/base.py
+++ b/python/nav/portadmin/snmp/base.py
@@ -18,7 +18,6 @@ from operator import attrgetter
 import logging
 
 from django.utils import six
-from django.utils.encoding import python_2_unicode_compatible
 
 from nav import Snmp
 from nav.Snmp import safestring, OID
@@ -26,6 +25,7 @@ from nav.Snmp.errors import UnsupportedSnmpVersionError, SnmpError, NoSuchObject
 from nav.bitvector import BitVector
 
 from nav.models.manage import Vlan, SwPortAllowedVlan
+from nav.portadmin.handlers import ManagementHandler
 from nav.portadmin.vlan import FantasyVlan
 from nav.smidumps import get_mib
 
@@ -33,8 +33,7 @@ from nav.smidumps import get_mib
 _logger = logging.getLogger(__name__)
 
 
-@python_2_unicode_compatible
-class SNMPHandler(object):
+class SNMPHandler(ManagementHandler):
     """A basic class for SNMP-read and -write to switches."""
     VENDOR = None
 
@@ -66,18 +65,13 @@ class SNMPHandler(object):
     # Port Access Control in a System.
     dot1xPaeSystemAuthControl = '1.0.8802.1.1.1.1.1.1.0'
 
-    netbox = None
-
     def __init__(self, netbox, **kwargs):
-        self.netbox = netbox
+        super().__init__(netbox, **kwargs)
         self.read_only_handle = None
         self.read_write_handle = None
         self.available_vlans = None
         self.timeout = kwargs.get('timeout', 3)
         self.retries = kwargs.get('retries', 3)
-
-    def __str__(self):
-        return self.netbox.type.vendor.id
 
     def _bulkwalk(self, oid):
         """Walk all branches for the given oid."""

--- a/python/nav/portadmin/snmp/base.py
+++ b/python/nav/portadmin/snmp/base.py
@@ -423,20 +423,6 @@ class SNMPHandler(ManagementHandler):
         allowedvlan.set_allowed_vlans(trunk_vlans)
         allowedvlan.save()
 
-    @staticmethod
-    def _find_vlans_for_interface(interface):
-        """Find vland for the given interface."""
-        interface_vlans = interface.swportvlan_set.all()
-        vlans = []
-        if interface_vlans:
-            for swportvlan in interface_vlans:
-                vlan = swportvlan.vlan
-                if vlan.vlan:
-                    vlans.append(FantasyVlan(vlan.vlan, vlan.net_ident))
-        elif interface.vlan:
-            vlans = [FantasyVlan(vlan=interface.vlan)]
-        return vlans
-
     def is_dot1x_enabled(self, interfaces):
         """Explicitly returns None as we do not know on a SNMP-generic basis"""
         return None

--- a/tests/unittests/portadmin/portadmin_test.py
+++ b/tests/unittests/portadmin/portadmin_test.py
@@ -59,8 +59,7 @@ class PortadminResponseTest(unittest.TestCase):
         self.handler = ManagementFactory.get_instance(self.netboxHP)
         self.assertNotEqual(self.handler, None,
                             'Could not get handler-object')
-        self.assertEqual(six.text_type(self.handler),  u'hp',
-                          'Wrong handler-type')
+        self.assertIsInstance(self.handler, HP, msg='Wrong handler-type')
 
     def test_get_ifalias_hp(self):
         self.handler = ManagementFactory.get_instance(self.netboxHP)
@@ -118,8 +117,7 @@ class PortadminResponseTest(unittest.TestCase):
         #  cisco-netbox
         self.handler = ManagementFactory.get_instance(self.netboxCisco)
         self.assertNotEqual(self.handler, None, 'Could not get handler-object')
-        self.assertEqual(six.text_type(self.handler),  u'cisco', 'Wrong handler-type')
-        self.assertEqual(type(self.handler), Cisco, 'Wrong handler-type')
+        self.assertIsInstance(self.handler, Cisco, 'Wrong handler-type')
 
     def test_get_ifalias_cisco(self):
         self.handler = ManagementFactory.get_instance(self.netboxCisco)

--- a/tests/unittests/portadmin/portadmin_test.py
+++ b/tests/unittests/portadmin/portadmin_test.py
@@ -110,18 +110,6 @@ class PortadminResponseTest(unittest.TestCase):
         self.assertEqual(self.handler.set_if_alias(1, 'punkt1'), None,
                          'setIfAlias failed')
 
-    def test_get_vlans(self):
-        handler = ManagementFactory.get_instance(self.netboxHP)
-
-        interface = Mock()
-        swportvlan1 = Mock(vlan=Mock(vlan=1))
-        swportvlan2 = Mock(vlan=Mock(vlan=2))
-
-        interface.swportvlan_set.all.return_value = [swportvlan1, swportvlan2]
-
-        self.assertEqual(sorted(handler._find_vlans_for_interface(interface)),
-                         [FantasyVlan(1), FantasyVlan(2)])
-
     ####################################################################
     #  CISCO-netbox
 


### PR DESCRIPTION
Up until now, the `SNMPHandler` class was a base class for generic SNMP operations used by PortAdmin. 

To avoid redundancies when we write support for multiple protocols, it's best to define a common interface of the operations that must/should be supported by any implementing class. This PR sets out to do exactly that, without breaking any of the existing functionality.

Some code cleanup along the way. More will probably come in other PRs.