### PR TITLE
Drop support for legacy status preference pickles

### DIFF
--- a/python/nav/web/status2/views.py
+++ b/python/nav/web/status2/views.py
@@ -46,7 +46,11 @@ class StatusView(View):
                 data = base64.b64decode(preferences)
                 return pickle.loads(data)
             except Exception:  # maybe an old, none-base64 pickle
-                return pickle.loads(preferences)
+                _logger.exception(
+                    "Ignoring potential legacy status preferences for user %s",
+                    self.request.account.login,
+                )
+                return self.set_default_parameters({})
 
     @staticmethod
     def set_default_parameters(parameters):


### PR DESCRIPTION
Because:
- Status filter preferences aren't critical and can be easily re-created by the
  users who still have them.
- Unpickling the preferences string as a fallback will crash on Python 3, since
  the unpickler requires a bytes object. Keeping support would require encoding
  the string as e.g. UTF-8, but why do we want to keep doing this ourselves?