### PR TITLE
ipdevpoll and pping device filtering based on groups

### DIFF
--- a/bin/pping.py
+++ b/bin/pping.py
@@ -94,7 +94,9 @@ class Pinger(object):
         internal data structures.
         """
         _logger.debug("Getting hosts from database...")
-        hosts = self.db.hosts_to_ping()
+        netbox_included_groups = self.config.get("groups_included", "").split()
+        netbox_excluded_groups = self.config.get("groups_excluded", "").split()
+        hosts = self.db.hosts_to_ping(netbox_included_groups, netbox_excluded_groups)
         netboxmap = {}
         self.ip_to_netboxid = {}
         for host in hosts:

--- a/doc/reference/ipdevpoll.rst
+++ b/doc/reference/ipdevpoll.rst
@@ -117,6 +117,17 @@ Section [prefix]
   database, even if they are collected from a device's interfaces.
 
 
+Section [netbox_filters]
+------------------------
+
+``groups_included``
+  Allows you to specify the devices that WILL be handled by this instance of
+  ipdevpoll using a space separated list of group ids.
+
+``groups_excluded``
+  Allows you to specify the devices that WON'T be handled by this instance of
+  ipdevpoll using a space separated list of group ids.
+
 Section [linkstate]
 -------------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,12 +23,27 @@ services:
       - NONAVSTART=0  # Set to 1 to disable startup of NAV backend processes when container starts
       - PGHOST=postgres
       - PGDATABASE=nav
-      - PGUSER=postgres
+      - PGUSER=postgre
     volumes:
       - .:/source
       - nav_config:/etc/nav
     depends_on:
       - postgres
+
+# Uncomment if you want a second container for group restricted backend services
+#  slave:
+#    build: .
+#    environment:
+#      - NONAVSTART=0  # Set to 1 to disable startup of NAV backend processes when container starts
+#      - PGHOST=postgres
+#      - PGDATABASE=nav
+#      - PGUSER=postgres
+#      - NONAVSTART=1
+#    volumes:
+#      - .:/source
+#      - slave_nav_config:/etc/nav
+#    depends_on:
+#      - postgres
 
   web:
     build: .
@@ -42,6 +57,8 @@ services:
 
   postgres:
     image: "postgres:9.4"
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
 
   graphite:
     build: ./tools/docker/graphite
@@ -66,3 +83,6 @@ services:
 volumes:
   nav_config:
     driver: local
+# Uncomment if you want a second container for group restricted backend services
+#  slave_nav_config:
+#    driver: local

--- a/python/nav/etc/ipdevpoll.conf
+++ b/python/nav/etc/ipdevpoll.conf
@@ -6,6 +6,10 @@
 #
 logfile = ipdevpoll.log
 
+[netbox_filters]
+#groups_included=
+#groups_excluded=
+
 #
 # The maximum number of concurrent jobs within a single ipdevpoll process. It
 # may be necessary to adjust this if you keep running out of available file

--- a/python/nav/etc/pping.conf
+++ b/python/nav/etc/pping.conf
@@ -22,3 +22,11 @@ delay = 2
 
 # Location of the logfile, defaults to ./pping.log
 logfile = pping.log
+
+# Space separated group ids containing the netboxes
+# this ppinger will handle. Empty to include all.
+#groups_included =
+
+# Space separated group ids containing the netboxes
+# this ppinger will not handle. Empty to exclude none.
+#groups_excluded =

--- a/python/nav/ipdevpoll/config.py
+++ b/python/nav/ipdevpoll/config.py
@@ -33,6 +33,10 @@ class IpdevpollConfig(NAVConfigParser):
 logfile = ipdevpolld.log
 max_concurrent_jobs = 500
 
+[netbox_filters]
+groups_included=
+groups_excluded=
+
 [snmp]
 timeout = 1.5
 max-repetitions = 10
@@ -103,6 +107,18 @@ def get_jobs(config=None):
 def get_job_sections(config):
     """Find all job sections in a config file"""
     return [s for s in config.sections() if s.startswith(JOB_PREFIX)]
+
+
+def get_netbox_filter(section, config=None):
+    """Get the requested netbox filter as list"""
+    if config is None:
+        config = ipdevpoll_conf
+
+    netbox_filters = ipdevpoll_conf.get('netbox_filters',section)
+
+    if netbox_filters:
+        return netbox_filters.split()
+    return []
 
 
 # this is a data container class, mr. pylint!

--- a/python/nav/ipdevpoll/dataloader.py
+++ b/python/nav/ipdevpoll/dataloader.py
@@ -40,6 +40,7 @@ import django.db
 from nav.models import manage, event
 from nav import ipdevpoll
 from nav.ipdevpoll.db import django_debug_cleanup, run_in_thread
+from nav.ipdevpoll.config import get_netbox_filter
 from . import storage
 
 
@@ -101,6 +102,15 @@ class NetboxLoader(dict):
         self._logger.debug("These netboxes have active snmpAgentStates: %r",
                            snmp_down)
         queryset = manage.Netbox.objects.filter(deleted_at__isnull=True)
+
+        filter_groups_included = get_netbox_filter('groups_included')
+        if len(filter_groups_included):
+            queryset = queryset.filter(groups__id__in=filter_groups_included)
+
+        filter_groups_excluded = get_netbox_filter('groups_excluded')
+        if len(filter_groups_excluded):
+            queryset = queryset.exclude(groups__id__in=filter_groups_excluded)
+
         queryset = list(queryset.select_related(*related))
         for netbox in queryset:
             netbox.snmp_up = netbox.id not in snmp_down


### PR DESCRIPTION
ipdevpoll and pping can now be filtered to include or exclude specifc groups of devices.

Documentation has been created to explain the configuration.
Easiest setup is using the new "slave" docker container which is commented out by default.
After uncommenting and starting the docker containers, you can connect to the main nav container and secondary slave container and change the ipdevpoll and pping configs using the new "groups_included" and "groups_excluded" config variables.