### PR TITLE
Euthanize unresponsive ipdevpoll workers

### DIFF
--- a/python/nav/ipdevpoll/config.py
+++ b/python/nav/ipdevpoll/config.py
@@ -37,6 +37,11 @@ max_concurrent_jobs = 500
 timeout = 1.5
 max-repetitions = 10
 
+[multiprocess]
+ping_workers = true
+ping_interval = 30
+ping_timeout = 10
+
 [plugins]
 
 [jobs]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,8 +8,7 @@ IPy==1.00
 py2-ipaddress==3.4.1 ; python_version < '3'
 pyaml
 
-twisted>=14.0.1,<18 ; python_version < '3'
-twisted>=16.6.0,<18 ; python_version >= '3'
+twisted>=16.6.0,<18
 
 networkx>=2.2,<2.3
 Pillow==3.3.2


### PR DESCRIPTION
Since the cause of #2105 still has not been found, I'm taking the time to produce a potential workaround (which may still be useful if the cause of #2105 is found):

This PR implements a `Ping` command to the ipdevpoll worker AMP protocol, and uses this to regularly ping all running workers. Any worker who is not known to be done, and does not respond to a  ping request will be euthanized using a `SIGTERM` signal. The existing ipdevpoll scheduler will automatically reschedule the jobs that are lost/frozen as a consequence.

Please see comments in individual commits for various rationales.


