### PR TITLE
Prevent ipdevinfo from crashing on weird device names

### DIFF
--- a/python/nav/util.py
+++ b/python/nav/util.py
@@ -91,6 +91,9 @@ def _is_valid_ip_socket(ip):
             return False
         else:
             return True
+    except UnicodeError:
+        # Definitely not an IP address!
+        return False
     else:
         return True
 

--- a/python/nav/web/ipdevinfo/host_information.py
+++ b/python/nav/web/ipdevinfo/host_information.py
@@ -51,7 +51,12 @@ def _get_host_info(host):
     if is_valid_ip(host):
         addresses = list(reverse_lookup([host]))
     else:
-        addresses = forward_lookup(host) or []
+        try:
+            addresses = forward_lookup(host) or []
+        except UnicodeError:
+            # Probably just some invalid string that cannot be represented using IDNA
+            # encoding. Let's just pretend it never happened (i.e. we can't look it up)
+            addresses = []
         if addresses:
             addresses = list(reverse_lookup(addresses))
 

--- a/python/nav/web/ipdevinfo/host_information.py
+++ b/python/nav/web/ipdevinfo/host_information.py
@@ -48,7 +48,7 @@ def reverse_lookup(addresses):
 
 def _get_host_info(host):
     """Returns a dictionary containing DNS information about the host"""
-    if is_valid_ip(host):
+    if is_valid_ip(host, use_socket_lib=True):
         addresses = list(reverse_lookup([host]))
     else:
         try:

--- a/python/nav/web/ipdevinfo/views.py
+++ b/python/nav/web/ipdevinfo/views.py
@@ -142,7 +142,7 @@ def ipdev_details(request, name=None, addr=None, netbox_id=None):
 
         if name:
             try:
-                if is_valid_ip(name):
+                if is_valid_ip(name, use_socket_lib=True):
                     netbox = netboxes.get(Q(sysname=name) | Q(ip=name))
                 else:
                     netbox = netboxes.get(sysname=name)

--- a/tests/integration/web/ipdevinfo_test.py
+++ b/tests/integration/web/ipdevinfo_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function
 
 from django.urls import reverse
@@ -37,6 +38,18 @@ def test_get_module_view(netbox, perspective):
     result = get_module_view(module, perspective='swportstatus', netbox=netbox)
     assert result['object'] == module
     assert 'ports' in result
+
+
+@pytest.mark.parametrize("badname", [
+    "02.44.02",  # Looks like an IP address
+    "\x01\x9e$ü\x86",  # Cannot be encoded using IDNA for DNS lookups
+])
+def test_bad_name_should_not_crash_ipdevinfo(client, badname):
+    """Tests "bad" device names to ensure they dont crash ipdevinfo lookup views"""
+    url = reverse("ipdevinfo-details-by-name", kwargs={"name": badname})
+    response = client.get(url)
+    assert response.status_code == 200
+    assert badname in smart_text(response.content)
 
 ###
 #

--- a/tests/integration/web/ipdevinfo_test.py
+++ b/tests/integration/web/ipdevinfo_test.py
@@ -42,7 +42,7 @@ def test_get_module_view(netbox, perspective):
 
 @pytest.mark.parametrize("badname", [
     "02.44.02",  # Looks like an IP address
-    "\x01\x9e$ü\x86",  # Cannot be encoded using IDNA for DNS lookups
+    u"\x01\x9e$ü\x86",  # Cannot be encoded using IDNA for DNS lookups
 ])
 def test_bad_name_should_not_crash_ipdevinfo(client, badname):
     """Tests "bad" device names to ensure they dont crash ipdevinfo lookup views"""


### PR DESCRIPTION
The ipdevinfo view `ipdev-details-by-name` will crash if fed certain device name in the URL.

Mostly, users will not enter the URL manually, but get there from clicking on various links from the UI. Two examples of crashing URLs came from the same customer data set:

LLDP/CDP neighbor records sometimes contains device identifiers that 
1. Look like binary garbage
2. Or, could be parsed as valid (although they aren't) valid IP addresses by  `IPy.IP`.

The ipdevinfo "Neighbors" tab, if the "unrecognized neighbors" checkbox is checked, will happily generated ipdevinfo device links from broken neighbor names.

This PR implements tests and fixes for both cases.
