### PR TITLE
Warn about user accounts that have issues with their passwords

### DIFF
--- a/python/nav/web/sass/nav/useradmin.scss
+++ b/python/nav/web/sass/nav/useradmin.scss
@@ -1,0 +1,7 @@
+/* Custom global styles */
+@import '../navsettings';
+
+/* Useradmin local styles */
+.fa.warning {
+  color: $warning-color;
+}

--- a/python/nav/web/templates/useradmin/account_list.html
+++ b/python/nav/web/templates/useradmin/account_list.html
@@ -26,7 +26,7 @@
           <tr>
             <th>Login</th>
             <th>Name</th>
-            <th>External</th>
+            <th>Status</th>
             <th># of groups</th>
           </tr>
         </thead>
@@ -37,7 +37,19 @@
                 <a href="{% url 'useradmin-account_detail' account.id %}">{{ account.login }}</a>
               </td>
               <td>{{ account.name }}</td>
-              <td>{{ account.ext_sync|default_if_none:"" }}</td>
+              <td>
+                  {% if account.ext_sync %}<span class="label info" data-tooltip title="This account is managed externally via {{ account.ext_sync }}">{{ account.ext_sync }}</span>{% endif %}
+
+                  {% if account.locked %}
+                      <i class="fa fa-lock warning" data-tooltip title="This account is locked: It cannot be used to log in."></i>
+                  {% elif account.has_plaintext_password %}
+                      <i class="fa fa-warning warning" data-tooltip title="This account uses an insecure plaintext password. It should be reset."></i>
+                  {% elif account.has_old_style_password_hash %}
+                      <i class="fa fa-warning warning" data-tooltip title="This account has a password using an old style insecure hashing method. Its password has probably not been changed in years - or, in the case of an LDAP user, they might not have logged in in years."></i>
+                  {% elif account.has_deprecated_password_hash_method %}
+                      <i class="fa fa-warning warning" data-tooltip title="This account has a password hashed with an older, deprecated method. Its password has probably not been changed in a long time - or, in the case of an LDAP user, they might not have logged in in a long time."></i>
+                  {% endif %}
+              </td>
               <td>{{ account.accountgroup_set.all|length }}</td>
             </tr>
           {% endfor %}

--- a/python/nav/web/templates/useradmin/base.html
+++ b/python/nav/web/templates/useradmin/base.html
@@ -4,6 +4,8 @@
 {% block base_header_title %}NAV - User Administration{% endblock %}
 
 {% block base_header_additional_head %}
+    <link rel="stylesheet" href="{{ STATIC_URL }}css/nav/useradmin.css" />
+
   <style>
    .long-listing {
        border: 1px solid lightgray;

--- a/python/nav/web/useradmin/views.py
+++ b/python/nav/web/useradmin/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008, 2011 Uninett AS
+# Copyright (C) 2008, 2011, 2020 Uninett AS
 #
 # This file is part of Network Administration Visualized (NAV).
 #
@@ -82,11 +82,13 @@ def account_detail(request, account_id=None):
         elif 'submit_sudo' in request.POST:
             return sudo_to_user(request)
 
-    active = {'account_detail': True} if account else {'account_new': True}
-    auditlog_api_parameters = {
-        'object_model': 'account',
-        'object_pk': account.pk
-    } if account else {}
+    if account:
+        active = {"account_detail": True}
+        auditlog_api_parameters = {"object_model": "account", "object_pk": account.pk}
+        add_warnings_for_account(account, request)
+    else:
+        active = {"account_new": True}
+        auditlog_api_parameters = {}
 
     context = {
         'auditlog_api_parameters': auditlog_api_parameters,

--- a/python/nav/web/useradmin/views.py
+++ b/python/nav/web/useradmin/views.py
@@ -100,6 +100,51 @@ def account_detail(request, account_id=None):
     return render(request, 'useradmin/account_detail.html', context)
 
 
+def add_warnings_for_account(account, request):
+    """Adds session warning messages about issues with an Account's configuration
+
+    :type account: Account
+    :type request: HttpRequest
+    """
+    if account.id == Account.DEFAULT_ACCOUNT:
+        if account.locked:
+            messages.warning(
+                request,
+                "This account represents all non-logged in users. Be wary of making "
+                "changes to it.",
+            )
+        else:
+            messages.warning(
+                request,
+                "This account represents all non-logged in users, but has been UNLOCKED"
+                " so it can be used to log in. Please LOCK this account immediately",
+            )
+    else:
+        if account.locked:
+            messages.warning(request, "This account is locked and cannot log in.")
+
+    if not account.locked and account.has_plaintext_password():
+        messages.warning(
+            request,
+            "This account's password is stored in plain text. Its password should be "
+            "changed immediately, or the account disabled.",
+        )
+    if account.has_old_style_password_hash():
+        messages.warning(
+            request,
+            "This account's password is stored using an outdated and INSECURE hashing "
+            "method. The user has either not logged in or not changed its password in "
+            "years. Its password should be changed or the account disabled.",
+        )
+    if account.has_deprecated_password_hash_method():
+        messages.warning(
+            request,
+            "This account's password is stored using an older hash method. The user "
+            "has either not logged in or not changed its password in a long time. Its "
+            "password should be changed or the account disabled.",
+        )
+
+
 def save_account(request, account_form, old_account):
     """Save an account based on post data"""
     account = account_form.save(commit=False)


### PR DESCRIPTION
This adds the following warnings about password issues in the Useradmin tool:

* Locked accounts
* Accounts with plaintext passwords
* Accounts with insecure password hashes
* Accounts with deprecated password hash methods
* Warnings about tampering with the `default` account.

These warnings are added as small icons (with tooltips) to the account list, and as session warning messages to the "edit account" page.

Methods for testing the password issues are added to the `Account` model class, and can be reused for scripting checks.