### PR TITLE
Implement NAPALM management profiles and connectivity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 # be world-readable!
 #
 #
-FROM mbrekkevold/navbase-debian:stretch
+FROM mbrekkevold/navbase-debian:buster
 
 #### Install various build and runtime requirements as Debian packages ####
 

--- a/doc/howto/generic-install-from-source.rst
+++ b/doc/howto/generic-install-from-source.rst
@@ -18,7 +18,7 @@ Build requirements
 
 To build NAV, you need at least the following:
 
- * Python >= 3.5.0
+ * Python >= 3.7.0
  * Sphinx >= 1.0 (for building this documentation)
 
 Runtime requirements
@@ -29,7 +29,7 @@ To run NAV, these software packages are required:
  * Apache2 + mod_wsgi (or, really, any web server that supports the WSGI interface)
  * PostgreSQL >= 9.4 (With the ``hstore`` extension available)
  * :xref:`Graphite`
- * Python >= 3.5.0
+ * Python >= 3.7.0
  * nbtscan = 1.5.1
  * dhcping (only needed if using DHCP service monitor)
 

--- a/doc/howto/manual-install-on-debian.rst
+++ b/doc/howto/manual-install-on-debian.rst
@@ -160,7 +160,7 @@ Copy the file :file:`/etc/nav/apache/apache.conf.example` to
 * ``documentation_path`` is where Sphinx put the docs, in
   ``$SOURCE_CODE_DIRECTORY/build/sphinx/html/``.
 * ``nav_uploads_path`` is the upload path you created in step 8.
-* ``nav_python_base`` should be :file:`/usr/local/lib/python3.5/dist-packages` (or wherever the ``nav`` Python module was installed)
+* ``nav_python_base`` should be :file:`/usr/local/lib/python3.7/dist-packages` (or wherever the ``nav`` Python module was installed)
 
 We suggest creating a new Apache site config:
 Inside a ``VirtualHost``-directive, add:

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -101,8 +101,10 @@ class ManagementProfile(models.Model):
 
     PROTOCOL_DEBUG = 0
     PROTOCOL_SNMP = 1
+    PROTOCOL_NAPALM = 2
     PROTOCOL_CHOICES = [
         (PROTOCOL_SNMP, "SNMP"),
+        (PROTOCOL_NAPALM, "NAPALM"),
     ]
     if settings.DEBUG:
         PROTOCOL_CHOICES.insert(0, (PROTOCOL_DEBUG, 'debug'))

--- a/python/nav/napalm.py
+++ b/python/nav/napalm.py
@@ -1,0 +1,80 @@
+#
+# Copyright (C) 2020 Uninett AS
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.  You should have received a copy of the GNU General Public
+# License along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""This module contains NAPALM connectivity interfaces for NAV"""
+import weakref
+from tempfile import NamedTemporaryFile
+from typing import TypeVar, Type
+import logging
+import napalm
+from napalm.base import NetworkDriver
+
+from nav.models import manage
+
+
+Host = TypeVar("Host", str, manage.Netbox)
+_logger = logging.getLogger(__name__)
+
+
+def connect(host: Host, profile: manage.ManagementProfile) -> NetworkDriver:
+    """Opens and returns a NAPALM connection"""
+    driver = get_driver(profile)
+    config = profile.configuration
+    hostname = host if not isinstance(host, manage.Netbox) else host.ip
+    optional_args = {"config_lock": True, "lock_disable": True}
+    key_file = _write_key_to_temporary_file(config, optional_args)
+
+    try:
+        device = driver(
+            hostname=hostname,
+            username=config.get("username"),
+            password=config.get("password"),
+            optional_args=optional_args,
+        )
+        # Let temporary file live as long as the device connection exists
+        if key_file:
+            weakref.finalize(device, key_file.close)
+        device.open()
+        return device
+    except Exception:
+        # but remove it immediately if device was never created
+        if key_file:
+            key_file.close()
+        raise
+
+
+def _write_key_to_temporary_file(config: dict, optional_args: dict):
+    if config.get("private_key"):
+        key_file = NamedTemporaryFile(mode="w+")
+        key_file.write(config["private_key"])
+        key_file.flush()
+        optional_args["key_file"] = key_file.name
+        return key_file
+
+
+def get_driver(
+    profile: manage.ManagementProfile,
+) -> Type[napalm.base.base.NetworkDriver]:
+    """Returns a NAPALM NetworkDriver based on a management profile config"""
+    if profile.protocol != profile.PROTOCOL_NAPALM:
+        raise NapalmError("Management profile is not a NAPALM profile")
+    driver = profile.configuration.get("driver")
+    if not driver:
+        raise NapalmError("Management profile has no configured driver")
+    return napalm.get_network_driver(driver)
+
+
+class NapalmError(Exception):
+    """Raised when there is a problem with NAPALM management profiles"""

--- a/python/nav/web/seeddb/page/management_profile/forms.py
+++ b/python/nav/web/seeddb/page/management_profile/forms.py
@@ -90,6 +90,49 @@ class SnmpForm(ProtocolSpecificMixIn, forms.ModelForm):
     )
 
 
+class NapalmForm(ProtocolSpecificMixIn, forms.ModelForm):
+    PROTOCOL = ManagementProfile.PROTOCOL_NAPALM
+    PROTOCOL_NAME = PROTOCOL_CHOICES.get(PROTOCOL)
+
+    class Meta(object):
+        model = ManagementProfile
+        configuration_fields = [
+            "driver",
+            "username",
+            "password",
+            "private_key",
+            "use_keys",
+            "alternate_port",
+        ]
+        fields = []
+
+    driver = forms.ChoiceField(
+        choices=(("JunOS", "JunOS"),),
+        initial="JunOS",
+        help_text="Which NAPALM driver to use",
+    )
+    username = forms.CharField(required=True, help_text="User name to use for login")
+    password = forms.CharField(
+        required=False,
+        widget=forms.PasswordInput(render_value=True),
+        help_text="Password to use for login",
+    )
+    private_key = forms.CharField(
+        required=False,
+        widget=forms.Textarea(),
+        help_text="SSH private key to use for login",
+    )
+    use_keys = forms.BooleanField(
+        required=False, help_text="Check to try the available keys in ~/.ssh/"
+    )
+    alternate_port = forms.IntegerField(
+        required=False,
+        help_text="Alternate port (default port value varies with vendor)",
+        min_value=1,
+        max_value=65535,
+    )
+
+
 FORM_MAPPING = {
     form_class.PROTOCOL: form_class
     for form_class in ProtocolSpecificMixIn.__subclasses__()

--- a/python/nav/web/seeddb/page/netbox/edit.py
+++ b/python/nav/web/seeddb/page/netbox/edit.py
@@ -137,6 +137,8 @@ def get_read_only_variables(request):
     for profile in profiles:
         if profile.is_snmp:
             response = get_snmp_read_only_variables(ip_address, profile)
+        elif profile.protocol == profile.PROTOCOL_NAPALM:
+            response = test_napalm_connectivity(ip_address, profile)
         else:
             response = None
 
@@ -217,6 +219,14 @@ def check_snmp_version(ip, profile):
         return False
     else:
         return True
+
+
+def test_napalm_connectivity(ip_address: str, profile: ManagementProfile) -> dict:
+    """Tests connectivity of a NAPALM profile and returns a status dictionary"""
+    return {
+        "status": False,
+        "error_message": "Can't test NAPALM profiles just yet",
+    }
 
 
 def get_sysname(ip_address):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,3 +26,5 @@ pynetsnmp-2==0.1.5
 
 # libsass for compiling scss files to css using distutils/setuptools
 libsass==0.15.1
+
+napalm==3.0.1

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ build.sub_commands = [('build_sass', None)] + build.sub_commands
 
 setup(
     setup_requires=['libsass', 'setuptools_scm'],
-    python_requires=">=2.7",
+    python_requires=">=3.7",
     use_scm_version=True,
 
     name="nav",

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -15,8 +15,8 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get -y install --no-install-recommends \
       curl git build-essential \
-      python3.5 python3.5-dev \
       python3.7 python3.7-dev \
+      python3.8 python3.8-dev \
       python3-pip
 
 RUN echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
@@ -41,10 +41,8 @@ RUN apt-get update && \
 
 
 # Now install NodeJS and NPM for Javascript testing needs -
-# Which incidentally includes Python2.7, so we need some selection magic
 RUN curl -sL https://deb.nodesource.com/setup_8.x  | bash - && \
-    apt-get install -y --no-install-recommends nodejs && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python2.7 2
+    apt-get install -y --no-install-recommends nodejs
 
 # Build and install libtidy5
 RUN cd /tmp && \
@@ -71,7 +69,7 @@ RUN cd /tmp && \
     mv chromedriver /usr/local/bin/
 
 # Install our primary test runner
-RUN python3.5 -m pip install tox snmpsim 'virtualenv<20.0.0'
+RUN python3.7 -m pip install tox snmpsim 'virtualenv<20.0.0'
 
 # Add a build user
 RUN adduser --system --group --home=/source --shell=/bin/bash build && \

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,9 @@
 # based on tests/docker/Dockerfile
 
 [tox]
-envlist = {unit,integration,functional}-py{35,37}-django{111,22}, javascript, docs
+envlist = {unit,integration,functional}-py{37,38}-django{111,22}, javascript, docs
 skipsdist = True
-basepython = python3.5
+basepython = python3.7
 
 [tox:jenkins]
 toxworkdir = /source/.tox


### PR DESCRIPTION
This implements [NAPALM](https://napalm.readthedocs.io/) as a new type of available management protocol in NAV.

NAPALM provides us with management connectivity on multiple vendor platforms where the SNMP operations we need are not available.

Initially, we need management of ports on Juniper switches in PortAdmin. Much of what we need here can be implemented by using Juniper's PyEZ library directly, and many of the operations we need are not actually available in the standard NAPALM API - however, we plan to improve our support for other platforms than JunOS in the future, so we might as well go for NAPALM.

Several of NAPALM's drivers, including the one for JunOS, will use NETCONF under the hood - so the connectivity details we need for NETCONF access are about the same as those put into NAPALM profiles by this PR.