### PR TITLE
Implement LLDP remote table caching and processing

### DIFF
--- a/python/nav/ipdevpoll/plugins/lldp.py
+++ b/python/nav/ipdevpoll/plugins/lldp.py
@@ -13,7 +13,7 @@
 # more details.  You should have received a copy of the GNU General Public
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
-"ipdevpoll plugin to collect LLDP neighbors"
+"""ipdevpoll plugin to collect LLDP neighbors"""
 from pprint import pformat
 
 from django.db.models import Q
@@ -32,6 +32,7 @@ SOURCE = 'lldp'
 INFO_KEY_LLDP_INFO = "lldp"
 INFO_VAR_CHASSIS_ID = "chassis_id"
 INFO_VAR_CHASSIS_MAC = "chassis_mac"
+INFO_VAR_REMOTES_CACHE = "remotes_cache"
 
 
 class LLDP(Plugin):
@@ -94,15 +95,25 @@ class LLDP(Plugin):
 
     @defer.inlineCallbacks
     def _get_cached_remote_table(self):
-        """Placeholder for retrieving a cached version of the remote neighbor table"""
-        yield None
-        defer.returnValue(None)
+        """Retrieves a cached version of the remote neighbor table"""
+        value = yield run_in_thread(
+            manage.NetboxInfo.cache_get,
+            self.netbox,
+            INFO_KEY_LLDP_INFO,
+            INFO_VAR_REMOTES_CACHE
+        )
+        defer.returnValue(value)
 
     @defer.inlineCallbacks
     def _save_cached_remote_table(self, remote_table):
-        """Placeholder for caching a copy of the remote neighbor table"""
-        yield None
-        defer.returnValue(None)
+        """Saves a cached copy of the remote neighbor table"""
+        yield run_in_thread(
+            manage.NetboxInfo.cache_set,
+            self.netbox,
+            INFO_KEY_LLDP_INFO,
+            INFO_VAR_REMOTES_CACHE,
+            remote_table
+        )
 
     @defer.inlineCallbacks
     def _get_chassis_id(self, mib):

--- a/python/nav/ipdevpoll/plugins/lldp.py
+++ b/python/nav/ipdevpoll/plugins/lldp.py
@@ -61,8 +61,8 @@ class LLDP(Plugin):
     @defer.inlineCallbacks
     def handle(self):
         mib = lldp_mib.LLDPMib(self.agent)
-        stampcheck = yield self._stampcheck(mib)
         need_to_collect = yield stampcheck.is_changed()
+        stampcheck = yield self._get_stampcheck(mib)
         if need_to_collect:
             self._logger.debug("collecting LLDP remote table")
             self.remote = yield mib.get_remote_table()
@@ -104,9 +104,11 @@ class LLDP(Plugin):
             info.variable = INFO_VAR_CHASSIS_MAC
 
     @defer.inlineCallbacks
-    def _stampcheck(self, mib):
-        stampcheck = TimestampChecker(self.agent, self.containers,
-                                      INFO_VAR_NAME)
+    def _get_stampcheck(self, mib):
+        """Retrieves the last change timestamp of the LLDP remote table, returning a
+        TimestampChecker instance reflecting it.
+        """
+        stampcheck = TimestampChecker(self.agent, self.containers, INFO_VAR_NAME)
         yield stampcheck.load()
         yield stampcheck.collect([mib.get_remote_last_change()])
 

--- a/python/nav/ipdevpoll/plugins/lldp.py
+++ b/python/nav/ipdevpoll/plugins/lldp.py
@@ -80,6 +80,18 @@ class LLDP(Plugin):
         stampcheck.save()
 
     @defer.inlineCallbacks
+    def _get_cached_remote_table(self):
+        """Placeholder for retrieving a cached version of the remote neighbor table"""
+        yield None
+        defer.returnValue(None)
+
+    @defer.inlineCallbacks
+    def _save_cached_remote_table(self, remote_table):
+        """Placeholder for caching a copy of the remote neighbor table"""
+        yield None
+        defer.returnValue(None)
+
+    @defer.inlineCallbacks
     def _get_chassis_id(self, mib):
         chassis_id_subtype = yield mib.get_next("lldpLocChassisIdSubtype",
                                                 translate_result=True)


### PR DESCRIPTION
Fixes #2106 .

This ensures the LLDP remote table contents can be cached in the NAV db, and that neighbor identification processing is always run at the end of the LLDP plugin, regardless of whether a cached table was available or a new table was retrieved.