### PR TITLE
Implement CDP neighbor table caching and processing

### DIFF
--- a/python/nav/ipdevpoll/plugins/cdp.py
+++ b/python/nav/ipdevpoll/plugins/cdp.py
@@ -58,7 +58,7 @@ class CDP(Plugin):
     @defer.inlineCallbacks
     def handle(self):
         cdp = CiscoCDPMib(self.agent)
-        stampcheck = yield self._stampcheck(cdp)
+        stampcheck = yield self._get_stampcheck(cdp)
         need_to_collect = yield stampcheck.is_changed()
         if need_to_collect:
             self._logger.debug("collecting CDP cache table")
@@ -78,9 +78,8 @@ class CDP(Plugin):
         stampcheck.save()
 
     @defer.inlineCallbacks
-    def _stampcheck(self, mib):
-        stampcheck = TimestampChecker(self.agent, self.containers,
-                                      INFO_VAR_NAME)
+    def _get_stampcheck(self, mib):
+        stampcheck = TimestampChecker(self.agent, self.containers, INFO_VAR_NAME)
         yield stampcheck.load()
         yield stampcheck.collect([mib.get_neighbors_last_change()])
 

--- a/python/nav/ipdevpoll/plugins/cdp.py
+++ b/python/nav/ipdevpoll/plugins/cdp.py
@@ -40,7 +40,7 @@ class CDP(Plugin):
     device.
 
     """
-    cache = None
+    neighbors = None
 
     @classmethod
     @defer.inlineCallbacks
@@ -61,11 +61,11 @@ class CDP(Plugin):
         need_to_collect = yield stampcheck.is_changed()
         if need_to_collect:
             self._logger.debug("collecting CDP cache table")
-            cache = yield cdp.get_cdp_neighbors()
-            if cache:
-                self._logger.debug("found CDP cache data: %r", cache)
-                self.cache = cache
-                yield run_in_thread(self._process_cache)
+            neighbors = yield cdp.get_cdp_neighbors()
+            if neighbors:
+                self._logger.debug("found CDP cache data: %r", neighbors)
+                self.neighbors = neighbors
+                yield run_in_thread(self._process_neighbors)
 
             # Store sentinels to signal that CDP neighbors have been processed
             shadows.AdjacencyCandidate.sentinel(self.containers, SOURCE)
@@ -84,11 +84,11 @@ class CDP(Plugin):
 
         defer.returnValue(stampcheck)
 
-    def _process_cache(self):
+    def _process_neighbors(self):
         """
         Tries to synchronously identify CDP cache entries in NAV's database
         """
-        neighbors = [CDPNeighbor(cdp, self.netbox.ip) for cdp in self.cache]
+        neighbors = [CDPNeighbor(cdp, self.netbox.ip) for cdp in self.neighbors]
 
         self._process_identified(
             [n for n in neighbors if n.identified])

--- a/python/nav/ipdevpoll/plugins/cdp.py
+++ b/python/nav/ipdevpoll/plugins/cdp.py
@@ -41,7 +41,6 @@ class CDP(Plugin):
 
     """
     cache = None
-    neighbors = None
 
     @classmethod
     @defer.inlineCallbacks
@@ -95,8 +94,6 @@ class CDP(Plugin):
             [n for n in neighbors if n.identified])
         self._process_unidentified(
             [n.record for n in neighbors if not n.identified])
-
-        self.neighbors = neighbors
 
     def _process_identified(self, identified):
         for neigh in identified:


### PR DESCRIPTION
This mirrors #2192 and also fixes #2106 (the CDP part).

This ensures the CDP cache table contents can be cached in the NAV db, and that neighbor identification processing is always run at the end of the CDP plugin, regardless of whether a cached table was available or a new table was retrieved.

This depends on #2192, and will therefore stay in draft mode until #2192 is merged.