### PR TITLE
Save psu/fanState events in transactions

### DIFF
--- a/python/nav/ipdevpoll/plugins/psuwatch.py
+++ b/python/nav/ipdevpoll/plugins/psuwatch.py
@@ -21,6 +21,8 @@ import datetime
 
 from twisted.internet import defer
 
+from django.db import transaction
+
 from nav.event2 import EventFactory
 from nav.ipdevpoll import Plugin, db
 from nav.models.manage import PowerSupplyOrFan
@@ -135,4 +137,5 @@ class PowerSupplyOrFanStateWatcher(Plugin):
             varmap=varmap,
         )
         self._logger.debug("posting state change event for %s: %r", unit, event)
-        event.save()
+        with transaction.atomic():
+            event.save()


### PR DESCRIPTION
Fixes #2139 

An event's varmap is stored as multiple rows in an auxiliary table, and if `event.save()` isn't run inside a transaction, the complete event details may not have hit the database when eventengine reads the event queue.

The event engine does not have a specific plugin for `psuState` or `fanState` events, and is entirely dependent on the `alerttype` variable in the event's varmap to pick the correct alert type and matching alert message template.

Instrumenting the varmap saving code with a `time.sleep(1)` between each variable saved quickly revealed the problem and made it reproducible.

This PR ensures everything takes place inside a transaction.

