### PR TITLE
Netbox reference is not passed to customization template for the ipdevinfo "What if" tab

### DIFF
--- a/python/nav/web/ipdevinfo/views.py
+++ b/python/nav/web/ipdevinfo/views.py
@@ -737,6 +737,7 @@ def render_affected(request, netboxid):
         request,
         'ipdevinfo/frag-affected.html',
         {
+            'netbox': netbox,
             'unreachable': unreachable,
             'affected': affected,
             'services': services,


### PR DESCRIPTION
The documentation [mentions how to add custom information to ipdevinfo's "What if" tab](https://nav.uninett.no/doc/5.0/hacking/web-interface-customization.html#adding-custom-information-to-the-ipdevinfo-what-if-tab), however the provided example will not work, because the `netbox` variable is never passed into the template.

This PR fixes that problem.