### PR TITLE
Cleanup and update requirements for upcoming NAV 5.1

### DIFF
--- a/NOTES.rst
+++ b/NOTES.rst
@@ -17,9 +17,18 @@ Backwards incompatible changes
 Dependency changes
 ------------------
 
-The Python library :mod:`Pillow` requirement has been moved to version 8.0 (In
-reality, NAV is compatible with all versions from 3 through 8, as only the
-thumbnail API call is used, but the latest version is recommended due to
+NAV 5.1 moves to Django 2.2, resulting in several changes in version
+dependencies of related libraries:
+
+* :mod:`Django`>=2.2,<2.3
+* :mod:`django-filter`>=2
+* :mod:`django-crispy-forms`>=1.7,<1.8
+* :mod:`crispy-forms-foundation`>=0.7,<0.8
+* :mod:`djangorestframework`>=3.9,<3.10
+
+Also, the Python library :mod:`Pillow` requirement has been moved to version
+8.0 (In reality, NAV is compatible with all versions from 3 through 8, as only
+the thumbnail API call is used, but the latest version is recommended due to
 reported security vulnerabilities in the older versions).
 
 

--- a/NOTES.rst
+++ b/NOTES.rst
@@ -14,6 +14,15 @@ NAV 5.1 (unreleased)
 Backwards incompatible changes
 ------------------------------
 
+Dependency changes
+------------------
+
+The Python library :mod:`Pillow` requirement has been moved to version 8.0 (In
+reality, NAV is compatible with all versions from 3 through 8, as only the
+thumbnail API call is used, but the latest version is recommended due to
+reported security vulnerabilities in the older versions).
+
+
 Changed configuration files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--r requirements/django111.txt
+-r requirements/django22.txt
 -r requirements/base.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,10 +2,8 @@
 # Dockerfile
 
 asciitree==0.3.3  # optional, for naventity
-configparser==3.5.0 ; python_version < '3'
 psycopg2==2.8.4  # requires libpq to build
 IPy==1.00
-py2-ipaddress==3.4.1 ; python_version < '3'
 pyaml
 
 twisted>=16.6.0,<18

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ pyaml
 twisted>=16.6.0,<18
 
 networkx>=2.2,<2.3
-Pillow==3.3.2
+Pillow>3.3.2,<8.1
 pyrad==2.1
 python-ldap==3.0.0 # optional for LDAP authentication, requires libldap (OpenLDAP) to build
 sphinx>=1.8.0

--- a/requirements/django111.txt
+++ b/requirements/django111.txt
@@ -1,5 +1,0 @@
-Django>=1.11,<2.0
-django-filter>=1.1,<1.2
-django-crispy-forms>=1.7,<1.8
-crispy-forms-foundation>=0.6,<0.7
-djangorestframework>=3.5,<3.7

--- a/requirements/django20.txt
+++ b/requirements/django20.txt
@@ -1,5 +1,0 @@
-Django>=2.0,<2.1
-django-filter>=2
-django-crispy-forms>=1.7,<1.8
-crispy-forms-foundation>=0.7,<0.8
-djangorestframework>=3.8,<3.9

--- a/requirements/django21.txt
+++ b/requirements/django21.txt
@@ -1,5 +1,0 @@
-Django>=2.1,<2.2
-django-filter>=2
-django-crispy-forms>=1.7,<1.8
-crispy-forms-foundation>=0.7,<0.8
-djangorestframework>=3.9,<3.10

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # based on tests/docker/Dockerfile
 
 [tox]
-envlist = {unit,integration,functional}-py{37,38}-django{111,22}, javascript, docs
+envlist = {unit,integration,functional}-py{37,38}-django22, javascript, docs
 skipsdist = True
 basepython = python3.7
 
@@ -21,9 +21,6 @@ setenv =
     BUILDDIR = {envdir}
     CHROME_BIN = /usr/bin/google-chrome
     DJANGO_SETTINGS_MODULE = nav.django.settings
-    django111: DJANGO_VER=111
-    django20: DJANGO_VER=20
-    django21: DJANGO_VER=21
     django22: DJANGO_VER=22
     django30: DJANGO_VER=30
 passenv = WORKSPACE DISPLAY
@@ -77,7 +74,7 @@ setenv =
        LC_ALL=C.UTF-8
        LANG=C.UTF-8
 commands_pre =
-         pip-compile --output-file {envdir}/requirements.txt tests/requirements.txt requirements/base.txt requirements/django111.txt
+         pip-compile --output-file {envdir}/requirements.txt tests/requirements.txt requirements/base.txt requirements/django22.txt
          pip-sync {envdir}/requirements.txt
 commands =
          {toxinidir}/tests/docker/scripts/pylint.sh python/nav --jobs=4 --rcfile=python/pylint.rc --disable=I,similarities --load-plugins pylint_django --output-format=parseable
@@ -92,7 +89,7 @@ setenv =
     LANG=C.UTF-8
 whitelist_externals = /bin/sh
 commands_pre =
-         pip-compile --output-file {envdir}/requirements.txt tests/requirements.txt requirements/base.txt requirements/django111.txt
+         pip-compile --output-file {envdir}/requirements.txt tests/requirements.txt requirements/base.txt requirements/django22.txt
          pip-sync {envdir}/requirements.txt
 commands =
          python setup.py build_sphinx


### PR DESCRIPTION
The master branch still targeted all the old requirements of NAV 5.0 - these needed an update to be inline with our goals for the 5.1 release and beyond. 

Mainly, this is about dropping support for Python 2 and moving on to newer Django versions (Django 2.2 LTS this time around, some Django 3 version later).
