### PR TITLE
Fix broken JSON output from Netmap index page

### DIFF
--- a/python/nav/web/netmap/views.py
+++ b/python/nav/web/netmap/views.py
@@ -14,10 +14,10 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Netmap views"""
+import json
+
 from django.db.models import Q
 from django.views.generic import TemplateView, ListView
-
-from rest_framework.renderers import JSONRenderer
 
 from nav.django.utils import get_account
 from nav.models.profiles import (
@@ -58,14 +58,14 @@ class IndexView(DefaultNetmapViewMixin, TemplateView):
                 'owner',
             )
 
-        netmap_views_json = JSONRenderer().render(
+        netmap_views_json = json.dumps(
             NetmapViewSerializer(netmap_views, many=True).data
         )
 
         categories = list(Category.objects.values_list('id', flat=True))
         categories.append('ELINK')
 
-        rooms_locations = JSONRenderer().render(
+        rooms_locations = json.dumps(
             list(Room.objects.values_list('id', flat=True)) +
             list(Location.objects.values_list('id', flat=True))
         )

--- a/tests/functional/netmap_test.py
+++ b/tests/functional/netmap_test.py
@@ -1,0 +1,13 @@
+"""Selenium tests for netmap"""
+
+
+def test_netmap_index_should_not_have_syntax_errors(selenium, base_url):
+    selenium.get("{}/netmap/".format(base_url))
+    log = selenium.get_log("browser")
+    syntax_errors = [
+        line
+        for line in log
+        if "syntaxerror" in line.get("message", "").lower()
+        and line.get("source") == "javascript"
+    ]
+    assert not syntax_errors


### PR DESCRIPTION
The Netmap index page outputs a Javascript snippet with config variables for the Netmap JS application. Part of this configuration dictionary contains JSON-serialized data from the NAV backend, but in NAV 5.1 the serialized string has become broken, i.e. invalid JSON.

Apparently, the backend serializer used comes from Django Rest Framework, and now outputs bytes rather than strings. bytes objects are rendered by the Django template as a `repr()` of the object, which is NOT valid JSON (i.e. prefixed with a `b'`, etc.).

The data structure is not complicated, so this PR just switches to use Python's built in json serializer.

Fixes #2221.