### PR TITLE
Ignore export errors in eventengine

### DIFF
--- a/python/nav/eventengine/alerts.py
+++ b/python/nav/eventengine/alerts.py
@@ -143,7 +143,11 @@ class AlertGenerator(dict):
             if not alert:
                 alert = self.make_alert()
                 alert.history = history
-            export.exporter.export(alert)
+            try:
+                export.exporter.export(alert)
+            except Exception:
+                # we don't want to derail everything internally if external export fails
+                _logger.exception("Ignoring unhandled exception on alert export")
 
     def _post_alert(self, history=None):
         """Generates and posts an alert on the alert queue only"""


### PR DESCRIPTION
Export to an external script should be considered secondary, and any errors should not have an impact of the further internal processing of  the event.

Fixes #2225