### PR TITLE
Edit existing alert messages in case of dupes

### DIFF
--- a/python/nav/eventengine/alerts.py
+++ b/python/nav/eventengine/alerts.py
@@ -166,14 +166,16 @@ class AlertGenerator(dict):
     def _post_alert_messages(self, obj):
         msg_class = obj.messages.model
         for details, text in self._make_messages():
-            msg = msg_class(type=details.msgtype,
-                            language=details.language,
-                            message=text)
-            if hasattr(msg_class, 'alert_queue'):
-                msg.alert_queue = obj
-            elif hasattr(msg_class, 'alert_history'):
-                msg.alert_history = obj
-                msg.state = self.state
+            kwargs = {"type": details.msgtype, "language": details.language}
+            if hasattr(msg_class, "alert_queue"):
+                kwargs["alert_queue"] = obj
+            elif hasattr(msg_class, "alert_history"):
+                kwargs["alert_history"] = obj
+                kwargs["state"] = self.state
+
+            msg, _created = msg_class.objects.get_or_create(
+                **kwargs, defaults={"message": text},
+            )
             msg.save()
 
     def _make_messages(self):


### PR DESCRIPTION
Because:

- If, for some reason, an AlertQueue or AlertHistory object already has a message that matches the uniqueness criteria of the one we are trying to post, then we should not hard fail, but optionally edit the existing message (though this code does not change existing messages).
- Hard fails are bad during event processing, as you might get into a situation where an alert is never closed.

This situation would normally never happen, as processing of each event in the queue will run fully inside a transaction, for example preventing the end messages from being persisted to the database if updating the end_time of the alerthist entry fails. Yet, this seems to have happened on at least one customer install - so this attemps to take precautions against that situation occurring again.

Fixes #2224