### PR TITLE
Allow big AS numbers in BGP peering sessions

### DIFF
--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -2166,8 +2166,8 @@ class GatewayPeerSession(models.Model):
     protocol = models.IntegerField(choices=PROTOCOL_CHOICES)
     peer = models.GenericIPAddressField()
     state = VarcharField()
-    local_as = models.IntegerField(null=True)
-    remote_as = models.IntegerField(null=True)
+    local_as = models.BigIntegerField(null=True)
+    remote_as = models.BigIntegerField(null=True)
     adminstatus = VarcharField()
 
     class Meta(object):

--- a/python/nav/models/sql/changes/sc.05.01.0001.sql
+++ b/python/nav/models/sql/changes/sc.05.01.0001.sql
@@ -1,0 +1,5 @@
+-- Make it so AS numbers can be really big,
+ALTER TABLE peersession
+  ALTER COLUMN local_as TYPE BIGINT,
+  ALTER COLUMN remote_as TYPE BIGINT
+;


### PR DESCRIPTION
Because:

- RFC 6793 extends the BGP protocol to allow for 4-byte (unsigned) AS numbers, as opposed to the old 2-byte numbers.
- The BGP peering session table in PostgreSQL uses INT data types to store the AS numbers, but these are signed, and will therefore only allow a maximum AS of 2,147,483,647, not 4,294,967,295 as the new standard specifies.

Fixes #2216