### PR TITLE
[BUG] EventEngine alert export crashes on any alert from a device that is a member of a device group

### DIFF
--- a/python/nav/web/api/v1/alert_serializers.py
+++ b/python/nav/web/api/v1/alert_serializers.py
@@ -136,7 +136,8 @@ class AlertSerializerBase(serializers.ModelSerializer):
         """Returns all the device groups for the netbox if any"""
         try:
             netbox = obj.netbox
-            return netbox.groups.values_list('id', flat=True) or None
+            values = netbox.groups.values_list('id', flat=True)
+            return list(values) if values else None
         except Exception:
             pass
 


### PR DESCRIPTION
**Describe the bug**
Enabling an export script in `eventengine.conf` (as one would do to export alerts to Argus) causes the eventengine to sometimes fail to process alerts due to a serialization error.

Apparently, Django 2.2 changes the behavior of `QuerySet.values_list()`, so that it no longer returns a `list`, but a `ValuesListQuerySet` object. NAV's serializer definitions for alerts uses a call to `values_list` to generate a list of Device Groups that a device is a member of. If the result is an empty QuerySet, everything is just peachy. If, however, the alert comes from a device that is a member of any device group, `json.dumps` will be asked to dump a `ValuesListQuerySet` instead of a `None` value, which it can't, and a `TypeError` is raised.

**To Reproduce**
Steps to reproduce the behavior:
1. Set `export=/bin/cat` in `eventengine.conf`
2. `nav restart eventengine`
3. Use `tools/eventgenerators/boxstate.py` to inject a fake boxDown event for a device that is a member of any device group
4. See error in `eventengine.log`


**Expected behavior**

Serialization should be able to produce a list of device group names, as it did in NAV 5.0.

**Traceback**

```pytb
Traceback (most recent call last):
  File "/opt/venvs/nav/lib/python3.7/site-packages/nav/eventengine/engine.py", line 189, in load_new_events
    self.handle_event(event)
  File "/usr/lib/python3.7/contextlib.py", line 74, in inner
    return func(*args, **kwds)
  File "/opt/venvs/nav/lib/python3.7/site-packages/nav/eventengine/engine.py", line 255, in handle_event
    self._post_generic_alert(event)
  File "/opt/venvs/nav/lib/python3.7/site-packages/nav/eventengine/engine.py", line 230, in _post_generic_alert
    alert.post()
  File "/opt/venvs/nav/lib/python3.7/site-packages/nav/eventengine/alerts.py", line 146, in post
    export.exporter.export(alert)
  File "/opt/venvs/nav/lib/python3.7/site-packages/nav/eventengine/export.py", line 83, in export
    data = json.dumps(serializer.data, cls=DjangoJSONEncoder)
  File "/usr/lib/python3.7/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/lib/python3.7/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.7/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/opt/venvs/nav/lib/python3.7/site-packages/django/core/serializers/json.py", line 124, in default
    return super(DjangoJSONEncoder, self).default(o)
  File "/usr/lib/python3.7/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type QuerySet is not JSON serializable
```

**Environment (please complete the following information):**
 - NAV version installed: 5.1.0
