### PR TITLE
Fix formatting of small and negative numbers in Rickshaw graphs

### DIFF
--- a/python/nav/web/static/js/src/plugins/rickshaw-utils.js
+++ b/python/nav/web/static/js/src/plugins/rickshaw-utils.js
@@ -86,7 +86,6 @@ define([], function () {
         else if (value <= 0.0000001) { return convert(value, 1/1000000000 ) + space + "n"; }
         else if (value <= 0.0001) { return convert(value, 1/1000000 ) + space + "µ"; }
         else if (value <= 0.01) { return convert(value, 1/1000) + space + "m"; }
-        else if (value <= 1) { return value.toFixed(3); }  // This is inconsistent
         else { return value.toFixed(precision); }
     }
 

--- a/python/nav/web/static/js/src/plugins/rickshaw-utils.js
+++ b/python/nav/web/static/js/src/plugins/rickshaw-utils.js
@@ -82,7 +82,9 @@ define([], function () {
         else if (value >= 1000000000) { return convert(value, 1000000000) + space + "G"; }
         else if (value >= 1000000) { return convert(value, 1000000) + space + "M"; }
         else if (value >= 1000) { return convert(value, 1000) + space + "k"; }
-        else if (value <= 0.000001) { return convert(value, 1/1000000 ) + space + "µ"; }
+        else if (value <= 0.0000000001) { return convert(value, 1/1000000000000 ) + space + "p"; }
+        else if (value <= 0.0000001) { return convert(value, 1/1000000000 ) + space + "n"; }
+        else if (value <= 0.0001) { return convert(value, 1/1000000 ) + space + "µ"; }
         else if (value <= 0.01) { return convert(value, 1/1000) + space + "m"; }
         else if (value <= 1) { return value.toFixed(3); }  // This is inconsistent
         else { return value.toFixed(precision); }

--- a/python/nav/web/static/js/src/plugins/rickshaw-utils.js
+++ b/python/nav/web/static/js/src/plugins/rickshaw-utils.js
@@ -78,14 +78,15 @@ define([], function () {
         };
 
         var value = Number(y);
-        if (value >= 1000000000000) { return convert(value, 1000000000000) + space + "T"; }
-        else if (value >= 1000000000) { return convert(value, 1000000000) + space + "G"; }
-        else if (value >= 1000000) { return convert(value, 1000000) + space + "M"; }
-        else if (value >= 1000) { return convert(value, 1000) + space + "k"; }
-        else if (value <= 0.0000000001) { return convert(value, 1/1000000000000 ) + space + "p"; }
-        else if (value <= 0.0000001) { return convert(value, 1/1000000000 ) + space + "n"; }
-        else if (value <= 0.0001) { return convert(value, 1/1000000 ) + space + "µ"; }
-        else if (value <= 0.01) { return convert(value, 1/1000) + space + "m"; }
+        var absvalue = Math.abs(value);
+        if (absvalue >= 1000000000000) { return convert(value, 1000000000000) + space + "T"; }
+        else if (absvalue >= 1000000000) { return convert(value, 1000000000) + space + "G"; }
+        else if (absvalue >= 1000000) { return convert(value, 1000000) + space + "M"; }
+        else if (absvalue >= 1000) { return convert(value, 1000) + space + "k"; }
+        else if (absvalue <= 0.0000000001) { return convert(value, 1/1000000000000 ) + space + "p"; }
+        else if (absvalue <= 0.0000001) { return convert(value, 1/1000000000 ) + space + "n"; }
+        else if (absvalue <= 0.0001) { return convert(value, 1/1000000 ) + space + "µ"; }
+        else if (absvalue <= 0.01) { return convert(value, 1/1000) + space + "m"; }
         else { return value.toFixed(precision); }
     }
 


### PR DESCRIPTION
A user who was recording error ratios in the nano-scale complained that the Rickshaw-based sensor graphs in NAV consistently showed any non-zero values as "0.00 µ"  (in the popup that appears when hovering above the graph line in these graphs).

It turns out, the number formatting code used in the popup does not support any scale below micro numbers. Additionally, it turned out it didn't support formatting negative numbers at all, which we also have in some sensors.

This PR fixes both issues (supporting formatting down to the pico scale, but no further until we have a practical use case)

The logic could also probably use some cleaning up, but I don't want to spend more time with Javascript than strictly necessary ;-)
