### PR TITLE
Fix broken serial numbers for Juniper, APC PowerNet and old HP devices

### DIFF
--- a/python/nav/mibs/hp_httpmanageable_mib.py
+++ b/python/nav/mibs/hp_httpmanageable_mib.py
@@ -27,4 +27,6 @@ class HPHTTPManageableMib(MibRetriever):
         """Tries to get a chassis serial number from old HP switches"""
         serial = yield self.get_next('hpHttpMgSerialNumber')
         if serial:
+            if isinstance(serial, bytes):
+                serial = serial.decode("utf-8")
             defer.returnValue(serial)

--- a/python/nav/mibs/juniper_mib.py
+++ b/python/nav/mibs/juniper_mib.py
@@ -53,6 +53,8 @@ class JuniperMib(MibRetriever):
         """Tries to get a serial number from a Juniper device"""
         serial = yield self.get_next("jnxBoxSerialNo")
         if serial:
+            if isinstance(serial, bytes):
+                serial = serial.decode("utf-8")
             defer.returnValue(serial)
 
     @defer.inlineCallbacks

--- a/python/nav/mibs/powernet_mib.py
+++ b/python/nav/mibs/powernet_mib.py
@@ -135,4 +135,6 @@ class PowerNetMib(UpsMib):
         for c in candidates:
             serial = yield self.get_next(c)
             if serial:
+                if isinstance(serial, bytes):
+                    serial = serial.decode("utf-8")
                 defer.returnValue(serial)


### PR DESCRIPTION
Due to the shift to Python 3, lots of collected serial numbers would now appear as `b'actual-serial-number'` in NAV, particularly for Juniper device, APC PDUs and older HP switches.

Table-based MIB object retrieval will compensate for this by recognizing retrieved columns that have a syntax equivalent to `DisplayString`, converting these bytestrings on the fly to Python strings.

However, the methods used to retrieve serial numbers for these devices/vendors used a more low-level SNMP call, which is not imbued with MIB object syntax knowledge, and hence did not attempt to translate the result values to actual strings.
