### PR TITLE
Drastically improve page load times on maintenance edit form

### DIFF
--- a/python/nav/web/devicehistory/views.py
+++ b/python/nav/web/devicehistory/views.py
@@ -36,14 +36,14 @@ from nav.web.devicehistory.forms import DeviceHistoryViewFilter
 DEVICEQUICKSELECT_VIEW_HISTORY_KWARGS = {
     'button': 'View %s history',
     'module': True,
-    'netbox_label': '%(sysname)s [%(ip)s - %(device__serial)s]',
+    'netbox_label': '%(sysname)s [%(ip)s - %(chassis_serial)s]',
 }
 DEVICEQUICKSELECT_POST_ERROR_KWARGS = {
     'button': 'Add %s error event',
     'location': False,
     'room': False,
     'module': True,
-    'netbox_label': '%(sysname)s [%(ip)s - %(device__serial)s]',
+    'netbox_label': '%(sysname)s [%(ip)s - %(chassis_serial)s]',
 }
 
 

--- a/python/nav/web/quickselect.py
+++ b/python/nav/web/quickselect.py
@@ -58,14 +58,9 @@ class QuickSelect(object):
             raise TypeError('__init__() got an unexpected keyword argument '
                             '%s' % key)
 
-        # 'Dirtier than your mother' hack to add the serial to our values.
-        netboxes = Netbox.objects.order_by('sysname')
-        self.netbox_set = [netbox for netbox in netboxes.values()]
-        for index, netbox in enumerate(netboxes):
-            serial = netbox.device.serial if netbox.device else None
-            self.netbox_set[index]['device__serial'] = serial
-
-        # Rest of the queryset we need
+        self.netbox_set = (
+            Netbox.objects.with_chassis_serials().order_by('sysname').values()
+        )
         self.location_set = Location.objects.order_by(('id')).values()
         self.service_set = Service.objects.order_by('handler').values()
         self.module_set = Module.objects.order_by('module_number').values()

--- a/tests/integration/models/netbox_test.py
+++ b/tests/integration/models/netbox_test.py
@@ -1,6 +1,12 @@
 import pytest
 
-from nav.models.manage import ManagementProfile, NetboxProfile
+from nav.models.manage import (
+    ManagementProfile,
+    NetboxProfile,
+    NetboxEntity,
+    Netbox,
+    Device,
+)
 
 
 def test_get_snmp_config_should_pick_highest_available_snmp_version(
@@ -26,6 +32,25 @@ def test_get_snmp_config_should_pick_highest_available_snmp_version(
         localhost._get_snmp_config(variable="community")
         == wanted_profile.configuration["community"]
     )
+
+
+def test_netbox_should_be_annotated_with_chassis_serial(db, localhost):
+    """Mainly, this verifies that regressions haven't rendered the raw SQL used to
+    annotate netboxes with serial numbers incompatible with the current schema.
+    """
+    for index, serial in enumerate(["first", "second"]):
+        device = Device(serial=serial)
+        device.save()
+        chassis = NetboxEntity(
+            netbox=localhost,
+            device=device,
+            index=index,
+            physical_class=NetboxEntity.CLASS_CHASSIS
+        )
+        chassis.save()
+
+    netbox = Netbox.objects.with_chassis_serials().filter(id=localhost.id)[0]
+    assert netbox.chassis_serial == "first"
 
 
 @pytest.fixture


### PR DESCRIPTION
The (ancient) QuickSelect component will by default populate itself with a list of all netboxes in the database upon initialization. It also tries to annotate each of these netbox records with a device serial number.

However, due to schema changes that took place years ago by now, this leads to N(netbox) auxiliary queries against the NetboxEntity and Device models, which can become horribly inefficient as N grows.

This PR implements serial number annotations as a new method in the `NetboxQuerySet` manager, and makes QuickSelect use this new method. This should alleviate some of the performance issues described in #2251

It seems I'm too lazy to figure out how to accomplish this using pure Django ORM acrobatics, so this is implemented partially using raw SQL, so tests are included to ensure this SQL works as intended on the current schema.