### PR TITLE
Work around buggy ifSpeed/ifHighSpeed implementations in IF-MIB

### DIFF
--- a/python/nav/etc/ipdevpoll.conf
+++ b/python/nav/etc/ipdevpoll.conf
@@ -207,6 +207,11 @@ filter = topology
 # Whether to generate alerts for internal BGP sessions
 #alert_ibgp = yes
 
+[interfaces]
+# Work around broken SNMP agents that return incorrect IF-MIB::ifSpeed values,
+# but correct IF-MIB::ifHighSpeed values
+#always_use_ifhighspeed = false
+
 [staticroutes]
 # Temporary SNMP throttle-delay to use during collection of routing tables
 # using the staticroutes plugins. Value is a number of seconds between requests.

--- a/python/nav/ipdevpoll/__init__.py
+++ b/python/nav/ipdevpoll/__init__.py
@@ -21,6 +21,7 @@ Packages:
 
 """
 from nav.models import manage
+from nav.ipdevpoll.config import IpdevpollConfig
 from .log import ContextLogger, ContextFormatter
 
 
@@ -34,7 +35,7 @@ class Plugin(object):
     _logger = ContextLogger()
     RESTRICT_TO_VENDORS = []
 
-    def __init__(self, netbox, agent, containers, config=None):
+    def __init__(self, netbox, agent, containers, config:IpdevpollConfig = None):
         """
 
         :type netbox: nav.ipdevpoll.shadows.Netbox

--- a/python/nav/ipdevpoll/config.py
+++ b/python/nav/ipdevpoll/config.py
@@ -60,6 +60,9 @@ filter = topology
 [bgp]
 alert_ibgp = yes
 
+[interfaces]
+always_use_ifhighspeed = false
+
 [sensors]
 loadmodules = nav.mibs.*
 

--- a/python/nav/ipdevpoll/plugins/interfaces.py
+++ b/python/nav/ipdevpoll/plugins/interfaces.py
@@ -114,7 +114,7 @@ class Interfaces(Plugin):
         return interface
 
     @staticmethod
-    def _extract_interface_speed(speed, highspeed):
+    def _extract_interface_speed(speed, highspeed, always_use_highspeed=False):
         """Determines the interface speed from a combination of ifSpeed and ifHighSpeed
         values.
 
@@ -122,7 +122,13 @@ class Interfaces(Plugin):
         ifSpeed value is maxed out. However, some devices, like Cisco SG350X-24T
         running 2.5.5.47 firmware, have an incorrect implementation that causes
         ifSpeed=ifHighSpeed.
+
+        Yet other buggy implementations even have no discernable correlation between
+        the two values, and only their ifHighSpeed value can be trusted.
         """
+        if always_use_highspeed and isinstance(highspeed, int):
+            return float(highspeed)
+
         if isinstance(speed, int):
             if 4294967295 > speed != highspeed:
                 return speed / 1000000.0

--- a/python/nav/ipdevpoll/plugins/interfaces.py
+++ b/python/nav/ipdevpoll/plugins/interfaces.py
@@ -119,10 +119,12 @@ class Interfaces(Plugin):
         values.
 
         The IF-MIB spec says to use the ifHighSpeed value if the 32-bit unsigned
-        ifSpeed value is maxed out.
+        ifSpeed value is maxed out. However, some devices, like Cisco SG350X-24T
+        running 2.5.5.47 firmware, have an incorrect implementation that causes
+        ifSpeed=ifHighSpeed.
         """
         if isinstance(speed, int):
-            if speed < 4294967295:
+            if 4294967295 > speed != highspeed:
                 return speed / 1000000.0
             elif isinstance(highspeed, int):
                 return float(highspeed)

--- a/python/nav/ipdevpoll/plugins/interfaces.py
+++ b/python/nav/ipdevpoll/plugins/interfaces.py
@@ -92,7 +92,13 @@ class Interfaces(Plugin):
         interface.ifdescr = row['ifDescr']
         interface.iftype = row['ifType']
 
-        speed = self._extract_interface_speed(row["ifSpeed"], row["ifHighSpeed"])
+        speed = self._extract_interface_speed(
+            row["ifSpeed"],
+            row["ifHighSpeed"],
+            always_use_highspeed=self.config.getboolean(
+                "interfaces", "always_use_ifhighspeed"
+            ),
+        )
         if speed is not None:
             interface.speed = interface.speed
 

--- a/tests/unittests/ipdevpoll/interfaces_test.py
+++ b/tests/unittests/ipdevpoll/interfaces_test.py
@@ -40,3 +40,7 @@ class TestExtractInterfaceSpeed:
         assert Interfaces._extract_interface_speed(1073741824, 0) == pytest.approx(
             1073.741824
         )
+
+    def test_should_use_highspeed_value_when_equal_to_speed(self):
+        """Tests the behavior when agent implementation is buggy"""
+        assert Interfaces._extract_interface_speed(1000, 1000) == pytest.approx(1000.0)

--- a/tests/unittests/ipdevpoll/interfaces_test.py
+++ b/tests/unittests/ipdevpoll/interfaces_test.py
@@ -2,6 +2,8 @@ from unittest import TestCase
 from mock import Mock
 from django.utils import six
 
+import pytest
+
 from nav.ipdevpoll.storage import ContainerRepository
 from nav.ipdevpoll.plugins.interfaces import Interfaces
 
@@ -26,3 +28,15 @@ class EncodingTests(TestCase):
 
         interface = plugin._convert_row_to_container(netbox, 1, row)
         self.assertTrue(isinstance(interface.ifalias, six.text_type))
+
+
+class TestExtractInterfaceSpeed:
+    def test_should_use_highspeed_value_when_speed_is_maxed_out(self):
+        assert Interfaces._extract_interface_speed(4294967295, 10000) == pytest.approx(
+            10000.0
+        )
+
+    def test_should_use_speed_value_when_not_maxed_out(self):
+        assert Interfaces._extract_interface_speed(1073741824, 0) == pytest.approx(
+            1073.741824
+        )

--- a/tests/unittests/ipdevpoll/interfaces_test.py
+++ b/tests/unittests/ipdevpoll/interfaces_test.py
@@ -44,3 +44,8 @@ class TestExtractInterfaceSpeed:
     def test_should_use_highspeed_value_when_equal_to_speed(self):
         """Tests the behavior when agent implementation is buggy"""
         assert Interfaces._extract_interface_speed(1000, 1000) == pytest.approx(1000.0)
+
+    def test_should_return_highspeed_when_flag_is_set(self):
+        assert Interfaces._extract_interface_speed(
+            69, 42, always_use_highspeed=True
+        ) == pytest.approx(42.0)

--- a/tests/unittests/ipdevpoll/interfaces_test.py
+++ b/tests/unittests/ipdevpoll/interfaces_test.py
@@ -4,6 +4,7 @@ from django.utils import six
 
 import pytest
 
+from nav.ipdevpoll import IpdevpollConfig
 from nav.ipdevpoll.storage import ContainerRepository
 from nav.ipdevpoll.plugins.interfaces import Interfaces
 
@@ -13,7 +14,7 @@ class EncodingTests(TestCase):
         netbox = Mock('Netbox')
         agent = Mock('AgentProxy')
         containers = ContainerRepository()
-        plugin = Interfaces(netbox, agent, containers)
+        plugin = Interfaces(netbox, agent, containers, FakeConfig())
 
         row = {
             'ifDescr': 'GigabitEthernet0/1',
@@ -49,3 +50,10 @@ class TestExtractInterfaceSpeed:
         assert Interfaces._extract_interface_speed(
             69, 42, always_use_highspeed=True
         ) == pytest.approx(42.0)
+
+
+class FakeConfig(IpdevpollConfig):
+    """Represents the default ipdevpoll config, but prevents the parent from attempting
+    a read from the file system
+    """
+    DEFAULT_CONFIG_FILES = []


### PR DESCRIPTION
This closes #2240 by

- Refactoring the `ifSpeed`/`ifHighSpeed` logic to a unit-testable function
- Implementing tests
- Working around vendor issues by using `ifHighSpeed` if `ifSpeed=ifHighSpeed`.