### PR TITLE
Use enterprise IDs to identify Cisco equipment

### DIFF
--- a/python/nav/ipdevpoll/plugins/poe.py
+++ b/python/nav/ipdevpoll/plugins/poe.py
@@ -21,6 +21,7 @@ from nav.mibs.power_ethernet_mib import PowerEthernetMib
 from nav.mibs.cisco_power_ethernet_ext_mib import CiscoPowerEthernetExtMib
 from nav.mibs.entity_mib import EntityMib
 
+from nav.enterprise.ids import VENDOR_ID_CISCOSYSTEMS
 from nav.ipdevpoll import Plugin
 from nav.ipdevpoll import shadows
 
@@ -41,7 +42,7 @@ class Poe(Plugin):
             returnValue(None)
 
         poemib = PowerEthernetMib(self.agent)
-        if self.netbox.type and self.netbox.type.vendor.id == 'cisco':
+        if self._is_cisco():
             cisco_mib = CiscoPowerEthernetExtMib(self.agent)
             port_phy_index = yield cisco_mib.retrieve_column(
                 "cpeExtPsePortEntPhyIndex")
@@ -60,6 +61,12 @@ class Poe(Plugin):
         ports = yield poemib.get_ports_table()
         self._process_ports(ports, port_ifindices)
         self._log_invalid_portgroups()
+
+    def _is_cisco(self):
+        return (
+            self.netbox.type
+            and self.netbox.type.get_enterprise_id() == VENDOR_ID_CISCOSYSTEMS
+        )
 
     def _process_groups(self, groups, phy_indices):
         netbox = self.containers.factory(None, shadows.Netbox)

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -41,7 +41,6 @@ from django.contrib.postgres.fields import JSONField
 from nav import util
 from nav.adapters import HStoreField
 from nav.bitvector import BitVector
-from nav.enterprise.ids import VENDOR_ID_CISCOSYSTEMS
 from nav.metrics.data import get_netboxes_availability
 from nav.metrics.graphs import get_simple_graph_url, Graph
 from nav.metrics.names import get_all_leaves_below
@@ -755,6 +754,7 @@ class NetboxEntity(models.Model):
 
     def _get_applicable_software_revision(self):
         """Gets an aggregated software revision for this entity"""
+        from nav.enterprise.ids import VENDOR_ID_CISCOSYSTEMS
         if self.netbox.type.get_enterprise_id() == VENDOR_ID_CISCOSYSTEMS:
             return self._get_cisco_sup_software_version()
 

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -41,6 +41,7 @@ from django.contrib.postgres.fields import JSONField
 from nav import util
 from nav.adapters import HStoreField
 from nav.bitvector import BitVector
+from nav.enterprise.ids import VENDOR_ID_CISCOSYSTEMS
 from nav.metrics.data import get_netboxes_availability
 from nav.metrics.graphs import get_simple_graph_url, Graph
 from nav.metrics.names import get_all_leaves_below
@@ -754,7 +755,7 @@ class NetboxEntity(models.Model):
 
     def _get_applicable_software_revision(self):
         """Gets an aggregated software revision for this entity"""
-        if self.netbox.type.vendor.id == 'cisco':
+        if self.netbox.type.get_enterprise_id() == VENDOR_ID_CISCOSYSTEMS:
             return self._get_cisco_sup_software_version()
 
     def _get_cisco_sup_software_version(self):


### PR DESCRIPTION
- Vendor names can be changed by users in SeedDB.
- The correct way to identify a vendor for SNMP purposes is to use the enterprise ID as derived from the sysObjectID.

Fixes #2264