### PR TITLE
Update Graphite docker container to Debian Buster

### DIFF
--- a/tools/docker/graphite/Dockerfile
+++ b/tools/docker/graphite/Dockerfile
@@ -1,16 +1,37 @@
-FROM mbrekkevold/navbase-debian:stretch
+FROM debian:buster
+
+#### Prepare the OS base setup ###
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN echo 'deb-src http://deb.debian.org/debian buster main' >> /etc/apt/sources.list.d/srcpkg.list && \
+    echo 'deb-src http://security.debian.org/debian-security buster/updates main' >> /etc/apt/sources.list.d/srcpkg.list && \
+    echo 'deb-src http://deb.debian.org/debian buster-updates main' >> /etc/apt/sources.list.d/srcpkg.list
+
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install \
+            locales \
+            sudo python3-dev python3-pip python3-virtualenv build-essential supervisor \
+	    debian-keyring debian-archive-keyring ca-certificates
+
+ARG TIMEZONE=Europe/Oslo
+ARG LOCALE=en_US.UTF-8
+ARG ENCODING=UTF-8
+RUN echo "${LOCALE} ${ENCODING}" > /etc/locale.gen && locale-gen ${LOCALE} && update-locale LANG=${LOCALE} LC_ALL=${LOCALE}
+ENV LANG ${LOCALE}
+ENV LC_ALL ${LOCALE}
+RUN echo "${TIMEZONE}" > /etc/timezone && cp /usr/share/zoneinfo/${TIMEZONE} /etc/localtime
 
 RUN apt-get update \
    && apt-get -y install \
-      python-dev python-pip gpg build-essential \
-      libcairo2-dev libffi-dev
+      libcairo2-dev libffi-dev python3-setuptools gnupg
 
 RUN adduser --system --group --no-create-home --home=/opt/graphite --shell=/bin/bash graphite
 
 ENV PYTHONPATH =/opt/graphite/lib/:/opt/graphite/webapp/
-RUN pip install --no-binary=:all: whisper
-RUN pip install --no-binary=:all: carbon
-RUN pip install --no-binary=:all: graphite-web
+RUN pip3 install --no-binary=:all: whisper
+RUN pip3 install --no-binary=:all: carbon
+RUN pip3 install --no-binary=:all: graphite-web
 
 ADD carbon.conf /opt/graphite/conf/
 ADD supervisord.conf /etc/supervisor/conf.d/graphite.conf


### PR DESCRIPTION
Because:
- The Graphite image used for the docker-compose based development environment would no longer build from scratch.
- The problem seems to be that the image still ran on Python 2 on Debian Stretch, but some of Graphite's Python dependencies would no longer run on Python 2.

This re-uses the basic OS setup from the top-level Dockerfile used for NAV.
