### PR TITLE
PortAdmin SNMP error handling is broken in several ways

### DIFF
--- a/python/nav/portadmin/snmp/base.py
+++ b/python/nav/portadmin/snmp/base.py
@@ -14,6 +14,7 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 import time
+from functools import wraps
 from operator import attrgetter
 import logging
 from typing import Dict, Sequence, List, Any
@@ -43,6 +44,28 @@ from nav.smidumps import get_mib
 
 
 _logger = logging.getLogger(__name__)
+
+
+def translate_protocol_errors(func):
+    """Decorator that translates SNMPErrors into PortAdmin ProtocolErrors.
+
+    The PortAdmin API will handle ProtocolErrors gracefully, but other exceptions
+    will bleed through and be handled by Django's 500 handler.
+    """
+
+    @wraps(func)
+    def _wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except SnmpError as error:
+            logmsg = "An SnmpError was raised:"
+            if args and isinstance(args[0], SNMPHandler):
+                sysname = args[0].netbox.sysname
+                logmsg = f"{sysname}: {logmsg}"
+            _logger.exception(logmsg)
+            raise ProtocolError(error)
+
+    return _wrapper
 
 
 class SNMPHandler(ManagementHandler):

--- a/python/nav/portadmin/snmp/dell.py
+++ b/python/nav/portadmin/snmp/dell.py
@@ -16,7 +16,7 @@
 """Dell specific PortAdmin SNMP handling"""
 import logging
 
-from nav.portadmin.snmp.base import SNMPHandler
+from nav.portadmin.snmp.base import SNMPHandler, translate_protocol_errors
 from nav.smidumps import get_mib
 from nav.enterprise.ids import VENDOR_ID_DELL_INC
 
@@ -47,12 +47,14 @@ class Dell(SNMPHandler):
     def __init__(self, netbox, **kwargs):
         super(Dell, self).__init__(netbox, **kwargs)
 
+    @translate_protocol_errors
     def commit_configuration(self):
         """Use DNOS-SWITCHING-MIB agentSaveConfig to write to memory.
         Write configuration into non-volatile memory."""
         handle = self._get_read_write_handle()
         return handle.set(self.WRITE_MEM_OID, 'i', 1)
 
+    @translate_protocol_errors
     def set_vlan(self, interface, vlan):
         baseport = interface.baseport
         try:
@@ -68,6 +70,7 @@ class Dell(SNMPHandler):
 
         self._set_netbox_value(self.VlAN_OID, baseport, "i", vlan)
 
+    @translate_protocol_errors
     def set_access(self, interface, access_vlan):
         self._set_swport_mode(interface, self.PORT_MODE_ACCESS)
         self.set_vlan(interface, access_vlan)
@@ -75,6 +78,7 @@ class Dell(SNMPHandler):
         interface.trunk = False
         interface.save()
 
+    @translate_protocol_errors
     def set_trunk(self, interface, native_vlan, trunk_vlans):
         self._set_swport_mode(interface, self.PORT_MODE_TRUNK)
         self.set_trunk_vlans(interface, trunk_vlans)
@@ -87,11 +91,13 @@ class Dell(SNMPHandler):
         baseport = interface.baseport
         self._set_netbox_value(self.PORT_MODE_OID, baseport, 'i', mode)
 
+    @translate_protocol_errors
     def get_interface_native_vlan(self, interface):
         # FIXME This override is potentially only applicable for trunk ports
         baseport = interface.baseport
         return self._query_netbox(self.NATIVE_VLAN_ID, baseport)
 
+    @translate_protocol_errors
     def set_native_vlan(self, interface, vlan):
         """Set native vlan on a trunk interface"""
         baseport = interface.baseport

--- a/python/nav/portadmin/snmp/h3c.py
+++ b/python/nav/portadmin/snmp/h3c.py
@@ -16,7 +16,7 @@
 """H3C specific PortAdmin SNMP handling"""
 from nav import Snmp
 from nav.oids import OID
-from nav.portadmin.snmp.base import SNMPHandler
+from nav.portadmin.snmp.base import SNMPHandler, translate_protocol_errors
 from nav.enterprise.ids import VENDOR_ID_H3C
 
 
@@ -30,6 +30,7 @@ class H3C(SNMPHandler):
     def __init__(self, netbox, **kwargs):
         super(H3C, self).__init__(netbox, **kwargs)
 
+    @translate_protocol_errors
     def commit_configuration(self):
         """Use hh3c-config-man-mib to save running config to startup"""
 

--- a/python/nav/portadmin/snmp/hp.py
+++ b/python/nav/portadmin/snmp/hp.py
@@ -15,7 +15,7 @@
 #
 """Hewlett-Packard specific PortAdmin SNMP handling"""
 from nav.oids import OID
-from nav.portadmin.snmp.base import SNMPHandler
+from nav.portadmin.snmp.base import SNMPHandler, translate_protocol_errors
 from nav.enterprise.ids import VENDOR_ID_HEWLETT_PACKARD
 
 
@@ -30,11 +30,13 @@ class HP(SNMPHandler):
     def __init__(self, netbox, **kwargs):
         super(HP, self).__init__(netbox, **kwargs)
 
+    @translate_protocol_errors
     def is_dot1x_enabled(self, interface):
         """Returns True or False based on state of dot1x"""
         return int(self._query_netbox(
             self.dot1xPortAuth, interface.ifindex)) == 1
 
+    @translate_protocol_errors
     def get_dot1x_enabled_interfaces(self):
         names = self._get_interface_names()
         return {


### PR DESCRIPTION
Handling of various SNMP errors that can occur is pretty broken in many places in PortAdmin, up to NAV 5.1.3.

Requests against SNMP agents may time out, agents may not accept specific configuration values in some running modes, and so forth. Most of the `SNMPHandler` classes in PortAdmin will not handle these errors, letting them bleed through to the PortAdmin API views. Even worse, the Cisco SNMP handler seems to log and ignore many SNMPErrors, which results in success reports to the end user, even in the face of total failure.

The API views, however, are only equipped to give proper JSON error responses for "official" PortAdmin exception classes. Most of the `SNMPError`s would fall in to the `ProtocolError`. Anything outside the expected will bleed through to the Django 500 handler which:

1. Presents the user with a non-specific "Failed" error in the UI
2. Mails a huge traceback report to the site admin - which is rather pointless, since the underlying error does not represent a problem in NAV code.


This PR sets out to remedy these things, by translating SNMPErrors into ProtocolErrors, among other things.
