### PR TITLE
Disable the PortAdmin "Enable" checkbox for interfaces that aren't editable

### DIFF
--- a/python/nav/web/templates/portadmin/portlist.html
+++ b/python/nav/web/templates/portadmin/portlist.html
@@ -62,7 +62,10 @@
             <img src="{{ STATIC_URL }}images/toolbox/arnold.png" width="24" height="24" title="Detained in Arnold">
           </a>
         {% else %}
-          <input type="checkbox" class="ifadminstatus" data-orig="{{ interface.ifadminstatus }}" {% if interface.ifadminstatus == 1 %}checked{% endif %}>
+          <input type="checkbox" class="ifadminstatus" data-orig="{{ interface.ifadminstatus }}"
+                 {% if interface.ifadminstatus == 1 %}checked{% endif %}
+                 {% if not interface.iseditable %}disabled{% endif %}
+          >
         {% endif %}
       </div>
       <div class="medium-1 small-6 column portadmin-status">


### PR DESCRIPTION
This ensures the form checkbox to shutdown or enable an interface in PortAdmin
is *disabled* when the interface is mark as non-editable, just as all the other form components in that row are.

**Because:**
- When an interface was non-editable, the UI would still allow the user to check/uncheck the "Enable" checkbox, and thus marking the interface row as a config change to be committed. Yet, since the interface is non-editable, there was no Save-button to actually commit the changes. This is only good for confusing users...


**Screenshot**
![Screenshot 2021-06-03 at 14 14 37](https://user-images.githubusercontent.com/100995/120643174-1c9a6e80-c476-11eb-816f-d39d75521b20.png)
The checkbox is still checked, to show that the interface is in fact enabled, but can no longer be changed by the user, just as none of the attributes on that row can.
