### PR TITLE
Add config option to disallow editing of uplinks and downlinks in PortAdmin

### DIFF
--- a/doc/reference/portadmin.rst
+++ b/doc/reference/portadmin.rst
@@ -140,8 +140,9 @@ See above.
 The Config File
 ===============
 
-The way in which PortAdmin operates can be configured through
-:file:`portadmin.conf`. Some of the options that can be set in this file are:
+PortAdmin's operational aspects can be modified through the configuration file
+:file:`portadmin.conf`. All available configuration options are documented in
+the example config file. Some of the options that can be set in this file are:
 
 **voice_vlans**
     Voice VLANs are the VLANs you use for IP telephone traffic. If
@@ -160,6 +161,16 @@ The way in which PortAdmin operates can be configured through
     If using Cisco Voice VLANs, set this option to ``true`` to explicitly
     enable CDP on a port when its voice vlan is configured (and consequently,
     disable CDP when voice vlan is de-configured). The default is ``false``.
+
+**trunk_edit**
+    When set to ``false``, editing the configuration of trunk ports is
+    disabled. The default value is ``true``.
+
+**link_edit**
+    When set to ``false``, editing the configuration of any port that has been
+    found to be an uplink or downlink is disabled. This could be useful to
+    prevent accidental misconfigurations that can cause a switch to become
+    non-reachable. The default value is ``true``.
 
 **vlan_auth**
     If you want to limit what users can do in PortAdmin you activate

--- a/python/nav/etc/portadmin/portadmin.conf
+++ b/python/nav/etc/portadmin/portadmin.conf
@@ -40,6 +40,12 @@
 # create, remove and edit trunks on interfaces.
 # trunk_edit = true
 
+# Allow editing uplinks/downlinks. If this is set to false, PortAdmin will not
+# allow editing any access port that is known to be an uplink or downlink in
+# the topology. This will take precedence over trunk_edit when a trunks is an
+# uplink
+# link_edit = true
+
 [authorization]
 # Authorization options
 

--- a/python/nav/portadmin/config.py
+++ b/python/nav/portadmin/config.py
@@ -33,6 +33,7 @@ commit = on
 timeout = 3
 retries = 3
 trunk_edit = true
+link_edit = true
 
 [authorization]
 vlan_auth = off
@@ -92,6 +93,10 @@ enabled = false
         Default is to allow trunk edit
         """
         return self.getboolean("general", "trunk_edit", fallback=True)
+
+    def get_link_edit(self):
+        """Gets config option for link edit"""
+        return self.getboolean("general", "link_edit", fallback=True)
 
     def is_dot1x_enabled(self):
         """Checks if dot1x config option is true"""

--- a/python/nav/web/portadmin/utils.py
+++ b/python/nav/web/portadmin/utils.py
@@ -132,12 +132,17 @@ def set_editable_flag_on_interfaces(
     list, indicating whether the PortAdmin UI should allow edits to it or not.
 
     An interface will be considered "editable" only if its native vlan matches one of
-    the vlan tags from `vlans`.
+    the vlan tags from `vlans`. An interface may be considered non-editable if it is
+    an uplink, depending on how portadmin is configured.
     """
     vlan_tags = {vlan.vlan for vlan in vlans}
 
     for interface in interfaces:
-        interface.iseditable = interface.vlan in vlan_tags
+        vlan_is_acceptable = interface.vlan in vlan_tags
+        is_link = bool(interface.to_netbox)
+        refuse_link_edit = not CONFIG.get_link_edit() and is_link
+
+        interface.iseditable = vlan_is_acceptable and not refuse_link_edit
 
 
 def intersect(list_a, list_b):

--- a/python/nav/web/templates/portadmin/portlist.html
+++ b/python/nav/web/templates/portadmin/portlist.html
@@ -93,7 +93,7 @@
           {% endif %}
         {% else %}
           {% if interface.trunk and not interface.voice_activated %}
-            {% if trunk_edit %}
+            {% if trunk_edit and interface.iseditable %}
               <a href="{% url 'portadmin-render-trunk-edit' interface.id %}">
                 Trunk
               </a>


### PR DESCRIPTION
This was requested by SUNET.

There is already a config option to prevent trunk port editing, but not all uplinks are trunks - and sometimes you want to be able to edit trunks to client devices but still prevent messing about with uplinks.