### PR TITLE
Document the event and alert type hierarchy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dummy clean bigclean
+.PHONY: dummy clean bigclean doc .FORCE
 
 dummy:
 	@echo "'make' is no longer used for deployment. See 'doc/intro/install.rst'"
@@ -14,3 +14,10 @@ testclean: clean
 	-rm *.stats
 	-rm python/nav/web/static/js/package-lock.json
 	-rm -rf .tox
+
+doc: doc/reference/alerttypes.rst
+
+doc/reference/alerttypes.rst: .FORCE
+	python3 doc/exts/alerttypes.py > $@
+
+.FORCE:

--- a/doc/exts/alerttypes.py
+++ b/doc/exts/alerttypes.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 Uninett AS
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.  You should have received a copy of the GNU General Public
+# License along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""This is not really a Sphinx extension, but a tool to autogenerate the reference
+documentation for NAV's event- and alert type hierarchy.
+
+It should only be necessary to re-run this in the event of changes to the supported
+event/alert types, or in the templates used to generate this doc.
+"""
+import os
+
+from jinja2 import FileSystemLoader, Environment  # Jinja is a sub-dependency of Sphinx
+
+from nav.bootstrap import bootstrap_django
+
+bootstrap_django(__name__)
+
+
+from nav.models.event import EventType, AlertType
+
+
+def main():
+    env = Environment(loader=FileSystemLoader(os.path.dirname(__file__)))
+    template = env.get_template('alerttypes.rst.j2')
+
+    types = [
+        (eventtype, AlertType.objects.filter(event_type=eventtype))
+        for eventtype in EventType.objects.all()
+    ]
+    print(template.render(types=types))
+
+
+if __name__ == '__main__':
+    main()

--- a/doc/exts/alerttypes.rst.j2
+++ b/doc/exts/alerttypes.rst.j2
@@ -1,0 +1,41 @@
+Event- and alert type hierarchy
+===============================
+
+NAV events and alerts are organized into a type hierarchy. While NAV's backend
+monitoring processes usually generate events, the :program:`Event Engine` is
+responsible for deciding what to do with those events. In most cases, events
+are translated into a corresponding alert by the :program:`Event Engine`.
+
+Most alerts are *stateful*, i.e. they can be viewed as an incident that has a
+start time and an end time. If the end time is set to an infinite value, the
+alert is considered unresolved (also known as *open*).
+
+Some alert types indicate the beginning of a new alert state, while some alert
+types indicate the closure of an existing alert state. E.g. for ``boxState``
+alerts, a ``boxDown`` alert indicates that a new stateful incident has occured:
+A device is no longer responsive. On the other hand, a ``boxUp`` alert will
+cause an existing ``boxState``-type alert to be resolved.
+
+
+All legal event- and alert-types are registered in the NAV database (and can
+thus be extended, even by the user, if need be). The following are the event-
+and alert types that come pre-defined with NAV:
+
+
+{% for event, alerts in types %}
+*{{ event.id }}* events
+{{ '-' * event.id|length }}---------
+{{ event.description }}
+
+.. list-table:: Alerts associated with {{ event.id }} events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+{% for alert in alerts %}   * - ``{{ alert.name }}``
+     - {{ alert.description }}
+{% endfor %}
+
+
+{% endfor %}

--- a/doc/hacking/release-procedure.rst
+++ b/doc/hacking/release-procedure.rst
@@ -34,6 +34,25 @@ Getting the code
     git clone -b 4.8.x git@github.com:UNINETT/nav.git
     cd nav
 
+Ensure generated docs are up to date
+------------------------------------
+
+Some documentation source files need to be built using a running PostgreSQL
+database. If any changes have been made to the default event- and
+alert-hierarchies provided by NAV, these documentation source files need to be
+updated and checked into Git.
+
+If you have a full dev environment running (such as the environment defined by
+:file:`docker-compose.yml`), use the following to generate new docs and verify
+whether they have changed::
+
+    make doc
+    git status
+
+If you see files under the :file:`doc` directory were changed, these changes
+need to be checked into Git to ensure the documentation is up to date for the
+new release.
+
 
 Updating changelog and release notes
 ------------------------------------

--- a/doc/reference/alerttypes.rst
+++ b/doc/reference/alerttypes.rst
@@ -1,0 +1,373 @@
+Event- and alert type hierarchy
+===============================
+
+NAV events and alerts are organized into a type hierarchy. While NAV's backend
+monitoring processes usually generate events, the :program:`Event Engine` is
+responsible for deciding what to do with those events. In most cases, events
+are translated into a corresponding alert by the :program:`Event Engine`.
+
+Most alerts are *stateful*, i.e. they can be viewed as an incident that has a
+start time and an end time. If the end time is set to an infinite value, the
+alert is considered unresolved (also known as *open*).
+
+Some alert types indicate the beginning of a new alert state, while some alert
+types indicate the closure of an existing alert state. E.g. for ``boxState``
+alerts, a ``boxDown`` alert indicates that a new stateful incident has occured:
+A device is no longer responsive. On the other hand, a ``boxUp`` alert will
+cause an existing ``boxState``-type alert to be resolved.
+
+
+All legal event- and alert-types are registered in the NAV database (and can
+thus be extended, even by the user, if need be). The following are the event-
+and alert types that come pre-defined with NAV:
+
+
+
+*boxState* events
+-----------------
+Tells us whether a network-unit is down or up.
+
+.. list-table:: Alerts associated with boxState events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+   * - ``boxDownWarning``
+     - Warning sent before declaring the box down.
+   * - ``boxShadowWarning``
+     - Warning sent before declaring the box in shadow.
+   * - ``boxDown``
+     - Box declared down.
+   * - ``boxUp``
+     - Box declared up.
+   * - ``boxShadow``
+     - Box declared down, but is in shadow.
+   * - ``boxSunny``
+     - Box declared up from a previous shadow state.
+
+
+
+
+*serviceState* events
+---------------------
+Tells us whether a service on a server is up or down.
+
+.. list-table:: Alerts associated with serviceState events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+   * - ``httpDown``
+     - http service not responding.
+   * - ``httpUp``
+     - http service responding.
+
+
+
+
+*moduleState* events
+--------------------
+Tells us whether a module in a device is working or not.
+
+.. list-table:: Alerts associated with moduleState events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+   * - ``moduleDownWarning``
+     - Warning sent before declaring the module down.
+   * - ``moduleDown``
+     - Module declared down.
+   * - ``moduleUp``
+     - Module declared up.
+
+
+
+
+*thresholdState* events
+-----------------------
+Tells us whether the load has passed a certain threshold.
+
+.. list-table:: Alerts associated with thresholdState events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+   * - ``exceededThreshold``
+     - Threshold exceeded.
+   * - ``belowThreshold``
+     - Value below threshold.
+
+
+
+
+*linkState* events
+------------------
+Tells us whether a link is up or down.
+
+.. list-table:: Alerts associated with linkState events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+
+
+
+
+*boxRestart* events
+-------------------
+Tells us that a network-unit has done a restart
+
+.. list-table:: Alerts associated with boxRestart events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+   * - ``coldStart``
+     - The IP device has coldstarted
+   * - ``warmStart``
+     - The IP device has warmstarted
+
+
+
+
+*info* events
+-------------
+Basic information
+
+.. list-table:: Alerts associated with info events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+   * - ``dnsMismatch``
+     - Mismatch between sysname and dnsname.
+   * - ``serialChanged``
+     - Serial number for the device has changed.
+   * - ``macWarning``
+     - Mac appeared on port
+
+
+
+
+*notification* events
+---------------------
+Notification event, typically between NAV systems
+
+.. list-table:: Alerts associated with notification events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+
+
+
+
+*deviceActive* events
+---------------------
+Lifetime event for a device
+
+.. list-table:: Alerts associated with deviceActive events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+
+
+
+
+*deviceState* events
+--------------------
+Registers the state of a device
+
+.. list-table:: Alerts associated with deviceState events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+   * - ``deviceInIPOperation``
+     - The device is now in operation with an active IP address
+   * - ``deviceInStack``
+     - The device is now in operation as a chassis module
+   * - ``deviceRMA``
+     - RMA event for device.
+
+
+
+
+*deviceNotice* events
+---------------------
+Registers a notice on a device
+
+.. list-table:: Alerts associated with deviceNotice events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+   * - ``deviceError``
+     - Error situation on device.
+   * - ``deviceSwUpgrade``
+     - Software upgrade on device.
+   * - ``deviceHwUpgrade``
+     - Hardware upgrade on device.
+
+
+
+
+*maintenanceState* events
+-------------------------
+Tells us if something is set on maintenance
+
+.. list-table:: Alerts associated with maintenanceState events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+   * - ``onMaintenance``
+     - Box put on maintenance.
+   * - ``offMaintenance``
+     - Box taken off maintenance.
+
+
+
+
+*apState* events
+----------------
+Tells us whether an access point has disassociated or associated from the controller
+
+.. list-table:: Alerts associated with apState events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+   * - ``apUp``
+     - AP associated with controller
+   * - ``apDown``
+     - AP disassociated from controller
+
+
+
+
+*snmpAgentState* events
+-----------------------
+Tells us whether the SNMP agent on a device is down or up.
+
+.. list-table:: Alerts associated with snmpAgentState events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+   * - ``snmpAgentDown``
+     - SNMP agent is down or unreachable due to misconfiguration.
+   * - ``snmpAgentUp``
+     - SNMP agent is up.
+
+
+
+
+*chassisState* events
+---------------------
+The state of this chassis has changed
+
+.. list-table:: Alerts associated with chassisState events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+   * - ``chassisDown``
+     - This chassis is no longer visible in the stack
+   * - ``chassisUp``
+     - This chassis is visible in the stack again
+
+
+
+
+*aggregateLinkState* events
+---------------------------
+The state of this aggregated link changed
+
+.. list-table:: Alerts associated with aggregateLinkState events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+   * - ``linkDegraded``
+     - This aggregate link has been degraded
+   * - ``linkRestored``
+     - This aggregate link has been restored
+
+
+
+
+*psuState* events
+-----------------
+Reports state changes in power supply units
+
+.. list-table:: Alerts associated with psuState events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+   * - ``psuNotOK``
+     - A PSU has entered a non-OK state
+   * - ``psuOK``
+     - A PSU has returned to an OK state
+
+
+
+
+*fanState* events
+-----------------
+Reports state changes in fan units
+
+.. list-table:: Alerts associated with fanState events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+   * - ``fanNotOK``
+     - A fan unit has entered a non-OK state
+   * - ``fanOK``
+     - A fan unit has returned to an OK state
+
+
+
+
+*bgpState* events
+-----------------
+The state of this BGP peering session changed
+
+.. list-table:: Alerts associated with bgpState events
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Alert type name
+     - Description
+   * - ``bgpDown``
+     - This BGP peering session is down
+   * - ``bgpEstablished``
+     - This BGP peering session has been established
+   * - ``bgpAdmDown``
+     - This BGP peering session is administratively down
+
+
+
+

--- a/doc/reference/eventengine.rst
+++ b/doc/reference/eventengine.rst
@@ -146,6 +146,13 @@ severity value will ever exceed the valid range of 1-5.
                A good practice would be to always quote your values, as that
                will work as intended in all cases.
 
+Available ``event_type`` and ``alert_type`` values
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Two of the available alert attributes that can be matched against in severity
+rules are ``event_type`` and ``alert_type``. See the :doc:`event- and
+alert-type reference documentation <alerttypes>` for a detailed list of
+available type names to match.
 
 Exporting alerts from NAV into other systems
 ============================================

--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -15,6 +15,7 @@ This section contains reference material for end-users.
    cabling_and_patch
    eventengine
    event-templates
+   alerttypes
    geomap
    ipam
    ipdevpoll


### PR DESCRIPTION
The only complete "documentation" of NAV's event and alert type hierarchy exists in the SQL schema definitions (and [this once-generated Wiki page](https://nav.uninett.no/wiki/nav-ref:navref_230221:alerttypes?s[]=boxdownwarning) ).

This information needs to be out there in the Sphinx-based user documentation, as part of the reference material. The simplest way to get it there is to just generate this documentation source text as necessary, when the event and alert type hierarchy changes (which is a rare event).

This PR sets out to do that.

A more viable solution for the future might be to actually define the hierarchy as Python code and use that to both seed the initial SQL database *and* to generate documentation. Why? Because the generator introduced in this PR needs access to an operational PostgreSQL database with the NAV schema - which usually requires a fully integrated NAV environment.