### PR TITLE
Support renamed RPC command on JunOS>=20

### DIFF
--- a/python/nav/junos/nav_views.yml
+++ b/python/nav/junos/nav_views.yml
@@ -96,6 +96,14 @@ ElsEthernetSwitchingInterfaceTable:
     key: l2iff-interface-handle
     view: ElsEthernetSwitchingInterfaceView
 
+ElsEthernetSwitchingInterfaceTableJunOS20:
+    rpc: get-ethernet-switching-interface-details
+    args:
+        detail: True
+    item: l2ng-l2ald-iff-interface-entry
+    key: l2iff-interface-handle
+    view: ElsEthernetSwitchingInterfaceView
+
 ElsEthernetSwitchingInterfaceView:
     fields:
         ifname: l2iff-interface-name


### PR DESCRIPTION
Fixes #2298

- JunOS changed the name of the `get-ethernet-switching-interface-information` command to `get-ethernet-switching-details` in JunOS 20, although their output is exactly the same.
- The old command will crash with an RpcError if the switch is running on JunOS >= 20, and we still need to support older versions.
