### PR TITLE
Upgrade feedparser dependency

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ networkx>=2.2,<2.3
 Pillow>3.3.2,<8.1
 pyrad==2.1
 sphinx==3.3.1
-feedparser>=5.2.1,<5.3
+feedparser==6.0.8
 markdown==2.5.1
 dnspython==1.15.0
 


### PR DESCRIPTION
ReadTheDocs seems to be unable to successfully install the feedparser dependency during doc builds. This PR tries to upgrade the dependency, to see if it still works for us and satisfies RTD as well.

The actual error in RTD is during the installation of the feedparser package:

>    error in feedparser setup command: use_2to3 is invalid.