### PR TITLE
Add Sphinx autodoc of central ORM models

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -33,6 +33,7 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.todo',
     'sphinx.ext.ifconfig',
+    'sphinxcontrib_django',
     'xref',
 ]
 
@@ -260,7 +261,10 @@ latex_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-# intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {
+    'http://docs.python.org/': None,
+    'https://docs.djangoproject.com/en/2.2': 'https://docs.djangoproject.com/en/2.2/_objects',
+}
 
 
 # External links definitions

--- a/doc/reference/models-event.rst
+++ b/doc/reference/models-event.rst
@@ -1,0 +1,63 @@
+Central data models of NAV's event/alert subsystems
+===================================================
+
+EventQueue
+----------
+.. autoclass:: nav.models.event.EventQueue
+   :members:
+   :undoc-members:
+
+EventQueueVar
+-------------
+.. autoclass:: nav.models.event.EventQueueVar
+   :members:
+   :undoc-members:
+
+AlertQueue
+----------
+.. autoclass:: nav.models.event.AlertQueue
+   :members:
+   :undoc-members:
+
+AlertQueueVariable
+------------------
+.. autoclass:: nav.models.event.AlertQueueVariable
+   :members:
+   :undoc-members:
+
+AlertHistory
+------------
+.. autoclass:: nav.models.event.AlertHistory
+   :members:
+   :undoc-members:
+
+AlertHistoryVariable
+--------------------
+.. autoclass:: nav.models.event.AlertHistoryVariable
+   :members:
+   :undoc-members:
+
+AlertHistoryMessage
+--------------------
+.. autoclass:: nav.models.event.AlertHistoryMessage
+   :members:
+   :undoc-members:
+
+EventMixIn
+----------
+.. autoclass:: nav.models.event.EventMixIn
+   :members:
+   :undoc-members:
+
+EventType
+---------
+.. autoclass:: nav.models.event.EventType
+   :members:
+   :undoc-members:
+
+AlertType
+---------
+.. autoclass:: nav.models.event.AlertType
+   :members:
+   :undoc-members:
+

--- a/doc/reference/models-manage.rst
+++ b/doc/reference/models-manage.rst
@@ -1,0 +1,44 @@
+Central data models of NAV's management subsystems
+==================================================
+
+Netbox
+------
+.. autoclass:: nav.models.manage.Netbox
+   :members:
+   :undoc-members:
+
+NetboxType
+----------
+.. autoclass:: nav.models.manage.NetboxType
+   :members:
+   :undoc-members:
+
+Category
+--------
+.. autoclass:: nav.models.manage.Category
+   :members:
+   :undoc-members:
+
+Interface
+---------
+.. autoclass:: nav.models.manage.Interface
+   :members:
+   :undoc-members:
+
+Room
+----
+.. autoclass:: nav.models.manage.Room
+   :members:
+   :undoc-members:
+
+Location
+--------
+.. autoclass:: nav.models.manage.Location
+   :members:
+   :undoc-members:
+
+Organization
+------------
+.. autoclass:: nav.models.manage.Organization
+   :members:
+   :undoc-members:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,6 +12,8 @@ networkx>=2.2,<2.3
 Pillow>3.3.2,<8.1
 pyrad==2.1
 sphinx==3.3.1
+sphinxcontrib-django
+
 feedparser==6.0.8
 markdown==2.5.1
 dnspython==1.15.0


### PR DESCRIPTION
We've added several features that lets users configure hyperlinks, templates or severity values based on matching the values of various data model objects in NAV.

In order for users to be able to figure which models and attributes are available to use, and what they mean, *without* requiring them to read NAV's source code, we should use Sphinx' autodoc features to document these models.

This PR introduces the `sphinxcontrib-django` dependency, which improves the autodoc output of Django models, and adds autodoc reference sections for some of the central NAV models, so they can be  properly cross-referenced by other documentation sections.
