### PR TITLE
Fix crash when using nav.event.Event to post events to the queue

### DIFF
--- a/python/nav/event.py
+++ b/python/nav/event.py
@@ -24,6 +24,8 @@ from nav.errors import GeneralException
 
 from nav.models.event import EventType, AlertType
 
+DEFAULT_SEVERITY = 3
+
 
 class Event(dict):
     """Represents a single event on or off the queue.
@@ -44,7 +46,7 @@ class Event(dict):
         eventtypeid=None,
         state=None,
         value=None,
-        severity=None,
+        severity=DEFAULT_SEVERITY,
     ):
         super(Event, self).__init__()
         self.eventqid = None

--- a/tests/integration/event_test.py
+++ b/tests/integration/event_test.py
@@ -1,0 +1,15 @@
+from nav.event import Event
+from nav.models.event import EventQueue
+
+
+class TestEvent:
+    def test_should_post_simple_event_without_error(self, localhost_using_legacy_db):
+        event = Event(
+            source='ipdevpoll',
+            target='eventEngine',
+            netboxid=localhost_using_legacy_db,
+            eventtypeid='snmpAgentState',
+            state=EventQueue.STATE_START,
+        )
+
+        assert event.post()


### PR DESCRIPTION
Fixes #2310 

See individual commits for detailed comments