### PR TITLE
Include all ethernet interface types used in the wild in the room interface listing

### DIFF
--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -1750,6 +1750,16 @@ class Interface(models.Model):
         (DUPLEX_HALF, 'half duplex'),
     )
 
+    # These are the subset of IF-MIB::ifType values NAV considers to be
+    # ethernet interfaces. See section 3.2.4 of RFC 3635 for the full list of
+    # ifType values:
+    ETHERNET_INTERFACE_TYPES = (
+        6,  # ethernetCsmacd
+        62,  # fastEther
+        69,  # fastEtherFX
+        117,  # gigabitEthernet
+    )
+
     id = models.AutoField(db_column='interfaceid', primary_key=True)
     netbox = models.ForeignKey('Netbox', on_delete=models.CASCADE, db_column='netboxid')
     module = models.ForeignKey(

--- a/python/nav/web/info/room/views.py
+++ b/python/nav/web/info/room/views.py
@@ -217,7 +217,7 @@ def render_netboxes(request, roomid):
     # Filter interfaces on iftype and add fast last_cam lookup
     for netbox in netboxes:
         netbox.interfaces = (
-            netbox.interface_set.filter(iftype=6)
+            netbox.interface_set.filter(iftype__in=Interface.ETHERNET_INTERFACE_TYPES)
             .order_by("ifindex")
             .extra(select=cam_query)
         )


### PR DESCRIPTION
- Although RFC 3635 specifies that implementations MUST use `ifType=ethernetCsmacd(6)` for all ethernet-like interface types, many fielded implementations have incorrectly used other values that were never reserved by the IETF.
- D-Link is one such vendor, where interfaces would not be listed in the room interface list because of this.

Fixes #2280

Replaces #2283, which was accidentally closed beyond recovery when the old stable branch was removed