### PR TITLE
Properly upgrade to Django 2.2

### DIFF
--- a/bin/smsd.py
+++ b/bin/smsd.py
@@ -29,7 +29,7 @@ import socket
 import sys
 import time
 
-from django.utils.encoding import smart_text
+from nav.compatibility import smart_str
 
 import nav.config
 import nav.daemon
@@ -431,8 +431,8 @@ def backoffaction(error, retrylimitaction):
         for index, msg in enumerate(msgs):
             error_message += u'\n%s: "%s" --> %s' % (
                 index + 1,
-                smart_text(msg['msg']),
-                smart_text(msg['name']),
+                smart_str(msg['msg']),
+                smart_str(msg['name']),
             )
 
         error_message += u"\nError message: %s" % error

--- a/python/nav/alertengine/base.py
+++ b/python/nav/alertengine/base.py
@@ -23,8 +23,8 @@ import logging
 from datetime import datetime, timedelta
 
 from django.db import transaction, reset_queries
-from django.utils.lru_cache import lru_cache
 
+from nav.compatibility import lru_cache
 from nav.models.profiles import (
     Account,
     AccountAlertQueue,

--- a/python/nav/auditlog/models.py
+++ b/python/nav/auditlog/models.py
@@ -17,10 +17,10 @@
 from __future__ import unicode_literals, absolute_import
 
 import logging
+from nav.compatibility import force_str
 
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.encoding import force_text
 from django.utils.timezone import now as utcnow
 
 from nav.models.fields import VarcharField, LegacyGenericForeignKey
@@ -99,8 +99,8 @@ class LogEntry(models.Model):
         self.target_pk = target.pk if target else None
         self.timestamp = utcnow()
         self.subsystem = subsystem if subsystem else None
-        self.before = force_text(before)
-        self.after = force_text(after)
+        self.before = force_str(before)
+        self.after = force_str(after)
         self.save()
         return self
 

--- a/python/nav/auditlog/utils.py
+++ b/python/nav/auditlog/utils.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from django.utils.encoding import force_text
+from nav.compatibility import force_str
 from django.db.models import Q
 
 from . import find_modelname
@@ -26,7 +26,7 @@ def get_auditlog_entries(
     if pks is None:
         pks = []
     if queryset is not None and queryset.exists():
-        qs_pks = set(force_text(o.pk) for o in queryset)
+        qs_pks = set(force_str(o.pk) for o in queryset)
         if qs_pks:
             if pks:
                 pks = qs_pks.intersection(pks)

--- a/python/nav/compatibility.py
+++ b/python/nav/compatibility.py
@@ -6,12 +6,12 @@
 # s/nav.compatibility \(import \w+_str\)/django.utils.encoding \1/
 try:
     from django.utils.encoding import force_str
-except ImoprtError:
+except ImportError:
     from django.utils.encoding import force_text as force_str
 
 try:
     from django.utils.encoding import smart_str
-except ImoprtError:
+except ImportError:
     from django.utils.encoding import smart_text as smart_str
 
 # lru_cache isn't used that much but one application of sed is faster

--- a/python/nav/compatibility.py
+++ b/python/nav/compatibility.py
@@ -1,0 +1,25 @@
+# Django 2.2 has only *_text, Django 3.2 has both *_text and *_str,
+# Django 4.0 has only *_str. These are imported so many places that
+# it is better to do it once, hence this file
+
+# When no longer supporting 2.2:
+# s/nav.compatibility \(import \w+_str\)/django.utils.encoding \1/
+try:
+    from django.utils.encoding import force_str
+except ImoprtError:
+    from django.utils.encoding import force_text as force_str
+
+try:
+    from django.utils.encoding import smart_str
+except ImoprtError:
+    from django.utils.encoding import smart_text as smart_str
+
+# lru_cache isn't used that much but one application of sed is faster
+# than changing a block into a line three times.
+
+# When no longer supporting 2.2:
+# s/nav.compatibility import lru_cache/functools import lru_cache/
+try:
+    from functools import lru_cache
+except ImportError:
+    from django.utils.lru_cache import lru_cache

--- a/python/nav/django/utils.py
+++ b/python/nav/django/utils.py
@@ -16,7 +16,7 @@
 #
 
 """Utility methods for django used in NAV"""
-from django.db.models.fields import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist
 from django.urls import reverse
 from django.utils.http import urlencode
 

--- a/python/nav/metrics/lookup.py
+++ b/python/nav/metrics/lookup.py
@@ -17,8 +17,9 @@
 
 import re
 
-from django.utils.lru_cache import lru_cache
+from nav.compatibility import lru_cache
 from django.utils.six import iteritems
+
 from nav.models.manage import Netbox, Interface, Prefix, Sensor
 
 

--- a/python/nav/mibs/cisco_process_mib.py
+++ b/python/nav/mibs/cisco_process_mib.py
@@ -16,7 +16,7 @@
 from django.utils.six import itervalues, iteritems
 from twisted.internet import defer
 
-from django.utils.encoding import smart_text
+from nav.compatibility import smart_str
 
 from nav.smidumps import get_mib
 from nav.mibs import mibretriever
@@ -62,7 +62,7 @@ class CiscoProcessMib(mibretriever.MibRetriever):
         names = yield self.agent_proxy.get(oids)
         self._logger.debug("cpu name result: %r", names)
         names = {
-            OID(oid)[-1]: smart_text(value) for oid, value in names.items() if value
+            OID(oid)[-1]: smart_str(value) for oid, value in names.items() if value
         }
         defer.returnValue(names)
 

--- a/python/nav/mibs/itw_mib.py
+++ b/python/nav/mibs/itw_mib.py
@@ -21,7 +21,7 @@ A class that tries to retrieve all sensors from WeatherGoose I.
 Uses the vendor-specifica IT-WATCHDOGS-MIB to detect and collect
 sensor-information.
 """
-from django.utils.encoding import smart_text
+from nav.compatibility import smart_str
 from django.utils.six import itervalues
 from twisted.internet import defer
 
@@ -346,7 +346,7 @@ class BaseITWatchDogsMib(mibretriever.MibRetriever):
         if not sensor_oid or not base_oid or not serial or not desc:
             return {}
         oid = OID(base_oid) + OID(sensor_oid)
-        internal_name = smart_text(serial) + desc
+        internal_name = smart_str(serial) + desc
         res = {
             'oid': oid,
             'unit_of_measurement': u_o_m,

--- a/python/nav/web/api/v1/alert_serializers.py
+++ b/python/nav/web/api/v1/alert_serializers.py
@@ -17,7 +17,7 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.template.defaultfilters import urlize
 from django.urls import reverse
-from django.utils.encoding import force_text
+from nav.compatibility import force_str
 from django.utils.html import strip_tags
 from rest_framework import serializers
 
@@ -91,7 +91,7 @@ class AlertSerializerBase(serializers.ModelSerializer):
     @staticmethod
     def get_subject(obj):
         """Return textual description of object"""
-        return force_text(obj.get_subject())
+        return force_str(obj.get_subject())
 
     @staticmethod
     def get_subject_url(obj):

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -22,7 +22,7 @@ from IPy import IP
 from django.http import HttpResponse, JsonResponse
 from django.db.models import Q
 from django.db.models.fields.related import ManyToOneRel as _RelatedObject
-from django.db.models.fields import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist
 import iso8601
 
 from django_filters.rest_framework import DjangoFilterBackend, FilterSet

--- a/python/nav/web/ipdevinfo/host_information.py
+++ b/python/nav/web/ipdevinfo/host_information.py
@@ -17,8 +17,8 @@
 
 
 import IPy
-from django.utils.lru_cache import lru_cache
 from nav import asyncdns
+from nav.compatibility import lru_cache
 
 from nav.util import is_valid_ip
 

--- a/python/nav/web/seeddb/utils/list.py
+++ b/python/nav/web/seeddb/utils/list.py
@@ -21,7 +21,7 @@ from functools import reduce
 
 from django.db.models import Model
 from django.shortcuts import render
-from django.db.models.fields import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist
 from django.urls import reverse
 from django.utils.six import iteritems
 

--- a/python/nav/web/useradmin/forms.py
+++ b/python/nav/web/useradmin/forms.py
@@ -18,7 +18,7 @@
 from datetime import date, timedelta
 
 from django import forms
-from django.utils.encoding import force_text
+from nav.compatibility import force_str
 
 from crispy_forms.helper import FormHelper
 from crispy_forms_foundation.layout import (
@@ -300,7 +300,7 @@ class TokenForm(forms.ModelForm):
     def clean_endpoints(self):
         """Convert endpoints from list to dictionary"""
         endpoints = self.cleaned_data.get('endpoints')
-        return {x: force_text(self.available_endpoints.get(x)) for x in endpoints}
+        return {x: force_str(self.available_endpoints.get(x)) for x in endpoints}
 
     class Meta(object):
         model = APIToken

--- a/tests/integration/api_test.py
+++ b/tests/integration/api_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
-from django.utils.encoding import force_text
+from nav.compatibility import force_str
 
 from datetime import datetime, timedelta
 import json
@@ -12,7 +12,7 @@ from nav.models.fields import INFINITY
 from nav.web.api.v1.views import get_endpoints
 
 
-ENDPOINTS = {name: force_text(url) for name, url in get_endpoints().items()}
+ENDPOINTS = {name: force_str(url) for name, url in get_endpoints().items()}
 
 
 # Data for writable endpoints
@@ -333,7 +333,7 @@ def create_token_endpoint(token, name):
 def get(api_client, endpoint, id=None):
     endpoint = ENDPOINTS[endpoint]
     if id:
-        endpoint = endpoint + force_text(id) + '/'
+        endpoint = endpoint + force_str(id) + '/'
     return api_client.get(endpoint)
 
 
@@ -345,13 +345,13 @@ def create(api_client, endpoint, data):
 def update(api_client, endpoint, id, data):
     """Sends a patch request to endpoint with data"""
     return api_client.patch(
-        ENDPOINTS[endpoint] + force_text(id) + '/', data, format='json'
+        ENDPOINTS[endpoint] + force_str(id) + '/', data, format='json'
     )
 
 
 def delete(api_client, endpoint, id):
     """Sends a delete request to endpoint"""
-    return api_client.delete(ENDPOINTS[endpoint] + force_text(id) + '/')
+    return api_client.delete(ENDPOINTS[endpoint] + force_str(id) + '/')
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/api_test.py
+++ b/tests/integration/api_test.py
@@ -40,23 +40,6 @@ TEST_DATA = {
 }
 
 
-# Django newer than 1.9 can send a response that lacks the Content-Type header,
-# like for a delete. The __repr__ in django 1.9 and 1.10 directly looks up the
-# Content-Type header, leading to a KeyError. Therefore, don't print()
-# responses, which depends on __repr__.
-#
-# See django bug #27640. Fixed in Django 1.11
-def print_response(response):
-    print(
-        '<%(cls)s status_code=%(status_code)d%(content_type)s>'
-        % {
-            'cls': response.__class__.__name__,
-            'status_code': response.status_code,
-            'content_type': response._headers.get('Content-Type', ''),
-        }
-    )
-
-
 # Generic tests
 
 
@@ -85,10 +68,10 @@ def test_delete(db, api_client, token, endpoint):
     response_delete = delete(api_client, endpoint, res.get('id'))
     response_get = get(api_client, endpoint, res.get('id'))
 
-    print_response(response_delete)
+    print(response_delete)
     assert response_delete.status_code == 204
 
-    print_response(response_get)
+    print(response_get)
     assert response_get.status_code == 404
 
 
@@ -96,7 +79,7 @@ def test_delete(db, api_client, token, endpoint):
 def test_create(db, api_client, token, endpoint):
     create_token_endpoint(token, endpoint)
     response = create(api_client, endpoint, TEST_DATA.get(endpoint))
-    print_response(response)
+    print(response)
     assert response.status_code == 201
 
 
@@ -126,12 +109,12 @@ def test_update_org_on_account(db, api_client, token):
     create_token_endpoint(token, endpoint)
     data = {"organizations": ["myorg"]}
     response = update(api_client, endpoint, 1, data)
-    print_response(response)
+    print(response)
     assert response.status_code == 200
 
     data = {"organizations": []}
     response = update(api_client, endpoint, 1, data)
-    print_response(response)
+    print(response)
     assert response.status_code == 200
 
 
@@ -141,7 +124,7 @@ def test_update_group_on_org(db, api_client, token):
     # Only admin group
     data = {"accountgroups": [1]}
     response = update(api_client, endpoint, 1, data)
-    print_response(response)
+    print(response)
     assert response.status_code == 200
 
 
@@ -155,7 +138,7 @@ def test_update_netbox(db, api_client, token):
     res = json.loads(response_create.content.decode('utf-8'))
     data = {'categoryid': 'GW'}
     response_update = update(api_client, endpoint, res['id'], data)
-    print_response(response_update)
+    print(response_update)
     assert response_update.status_code == 200
 
 
@@ -168,7 +151,7 @@ def test_delete_netbox(db, api_client, token):
     response_get = get(api_client, endpoint, json_create['id'])
     json_get = json.loads(response_get.content.decode('utf-8'))
 
-    print_response(response_delete)
+    print(response_delete)
     print(json_get['deleted_at'])
 
     assert response_delete.status_code == 204
@@ -181,7 +164,7 @@ def test_delete_netbox(db, api_client, token):
 def test_get_wrong_room(db, api_client, token):
     create_token_endpoint(token, 'room')
     response = api_client.get('{}blapp/'.format(ENDPOINTS['room']))
-    print_response(response)
+    print(response)
     assert response.status_code == 404
 
 
@@ -190,7 +173,7 @@ def test_get_new_room(db, api_client, token):
     create_token_endpoint(token, endpoint)
     create(api_client, endpoint, TEST_DATA.get(endpoint))
     response = api_client.get('/api/1/room/blapp/')
-    print_response(response)
+    print(response)
     assert response.status_code == 200
 
 
@@ -198,7 +181,7 @@ def test_patch_room_not_found(db, api_client, token):
     create_token_endpoint(token, 'room')
     data = {'location': 'mylocation'}
     response = api_client.patch('/api/1/room/blapp/', data, format='json')
-    print_response(response)
+    print(response)
     assert response.status_code == 404
 
 
@@ -208,7 +191,7 @@ def test_patch_room_wrong_location(db, api_client, token):
     create(api_client, endpoint, TEST_DATA.get(endpoint))
     data = {'location': 'mylocatio'}
     response = api_client.patch('/api/1/room/blapp/', data, format='json')
-    print_response(response)
+    print(response)
     assert response.status_code == 400
 
 
@@ -219,7 +202,7 @@ def test_patch_room(db, api_client, token):
     data = {'location': 'mylocation'}
     response = api_client.patch('/api/1/room/blapp/', data, format='json')
 
-    print_response(response)
+    print(response)
     assert response.status_code == 200
 
 
@@ -229,7 +212,7 @@ def test_delete_room_wrong_room(db, api_client, token):
     create(api_client, endpoint, TEST_DATA.get(endpoint))
     response = api_client.delete('/api/1/room/blap/')
 
-    print_response(response)
+    print(response)
     assert response.status_code == 404
 
 
@@ -240,7 +223,7 @@ def test_validate_vlan(db, api_client, token):
     testdata.update({'net_type': 'core'})
     response = create(api_client, endpoint, testdata)
 
-    print_response(response)
+    print(response)
     assert response.status_code == 400
 
 
@@ -260,7 +243,7 @@ def test_create_prefix(db, api_client, token):
     testdata = prepare_prefix_test(db, api_client, token)
     response = create(api_client, endpoint, testdata)
 
-    print_response(response)
+    print(response)
     assert response.status_code == 201
 
 
@@ -293,7 +276,7 @@ def test_update_prefix_remove_usage(db, api_client, token, serializer_models):
 def test_nonexistent_alert_should_give_404(db, api_client, token):
     create_token_endpoint(token, 'alert')
     response = api_client.get('{}9999/'.format(ENDPOINTS['alert']))
-    print_response(response)
+    print(response)
     assert response.status_code == 404
 
 
@@ -301,7 +284,7 @@ def test_alert_should_be_visible_in_api(db, api_client, token, serializer_models
     create_token_endpoint(token, 'alert')
     alert = AlertHistory.objects.all()[0]
     response = api_client.get('{url}{id}/'.format(url=ENDPOINTS['alert'], id=alert.id))
-    print_response(response)
+    print(response)
     assert response.status_code == 200
     content = response.content.decode('utf-8')
     # Simple string tests, but they might just as well parse the JSON structure

--- a/tests/integration/web/alertprofiles_test.py
+++ b/tests/integration/web/alertprofiles_test.py
@@ -7,7 +7,7 @@ import pytest
 
 from django.test.client import RequestFactory
 from django.urls import reverse
-from django.utils.encoding import smart_text
+from nav.compatibility import smart_str
 
 from nav.models.profiles import AlertProfile, Account, AlertPreference
 from nav.web.alertprofiles.views import set_active_profile
@@ -46,7 +46,7 @@ def test_alertprofiles_view(client, view):
     """Simple GET tests for various non-modifying alertprofiles views"""
     url = reverse(view)
     response = client.get(url)
-    assert "admin" in smart_text(response.content)
+    assert "admin" in smart_str(response.content)
 
 
 def test_alertprofiles_save_profile(db, client):
@@ -66,7 +66,7 @@ def test_alertprofiles_save_profile(db, client):
 
     assert response.status_code == 200
     print(response.content)
-    assert "Saved profile" in smart_text(response.content)
+    assert "Saved profile" in smart_str(response.content)
     assert AlertProfile.objects.filter(name=profile_name).count() > 0
 
 
@@ -94,8 +94,8 @@ def test_alertprofiles_remove_profile(db, client, activated_dummy_profile):
         },
     )
     assert response.status_code == 200
-    assert "Confirm deletion" in smart_text(response.content)
-    assert activated_dummy_profile.name in smart_text(response.content)
+    assert "Confirm deletion" in smart_str(response.content)
+    assert activated_dummy_profile.name in smart_str(response.content)
     assert AlertProfile.objects.filter(pk=activated_dummy_profile.pk).count() == 1
 
 
@@ -110,8 +110,8 @@ def test_alertprofiles_activate_profile(db, client, dummy_profile):
         },
     )
     assert response.status_code == 200
-    assert "Active profile set" in smart_text(response.content)
-    assert dummy_profile.name in smart_text(response.content)
+    assert "Active profile set" in smart_str(response.content)
+    assert dummy_profile.name in smart_str(response.content)
     preference = AlertPreference.objects.get(account=dummy_profile.account)
     assert preference.active_profile == dummy_profile
 
@@ -128,8 +128,8 @@ def test_alertprofiles_deactivate_profile(db, client, activated_dummy_profile):
     )
     assert response.status_code == 200
     print(type(response.content))
-    assert "was deactivated" in smart_text(response.content)
-    assert activated_dummy_profile.name in smart_text(response.content)
+    assert "was deactivated" in smart_str(response.content)
+    assert activated_dummy_profile.name in smart_str(response.content)
     preference = AlertPreference.objects.get(account=activated_dummy_profile.account)
     assert preference.active_profile is None
 

--- a/tests/integration/web/ipdevinfo_test.py
+++ b/tests/integration/web/ipdevinfo_test.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 
 from django.urls import reverse
-from django.utils.encoding import smart_text
+from nav.compatibility import smart_str
 
 from nav.models.manage import Netbox, Module, Interface, Device, NetboxProfile
 from nav.web.ipdevinfo.utils import get_module_view
@@ -13,7 +13,7 @@ import pytest
 def test_device_details_should_include_sysname(client, netbox):
     url = reverse('ipdevinfo-details-by-name', args=(netbox.sysname,))
     response = client.get(url)
-    assert netbox.sysname in smart_text(response.content)
+    assert netbox.sysname in smart_str(response.content)
 
 
 def test_port_search_should_match_case_insensitively(client, netbox):
@@ -27,7 +27,7 @@ def test_port_search_should_match_case_insensitively(client, netbox):
     )
     response = client.get(url)
     assert response.status_code == 200
-    assert ifc.ifdescr in smart_text(response.content)
+    assert ifc.ifdescr in smart_str(response.content)
 
 
 @pytest.mark.parametrize(
@@ -58,7 +58,7 @@ def test_bad_name_should_not_crash_ipdevinfo(client, badname):
     url = reverse("ipdevinfo-details-by-name", kwargs={"name": badname})
     response = client.get(url)
     assert response.status_code == 200
-    assert badname in smart_text(response.content)
+    assert badname in smart_str(response.content)
 
 
 ###


### PR DESCRIPTION
While the code currently runs on 2.2, it is not doing everything as 2.2 would prefer.

Merging this PR will improve code quality on 2.2 and prevent exceptions on 3.2.

A new module `nav.compatibility` is introduced, to do some conditional imports in a single location, similar to `six.moves`. When 2.2 is no longer supported this file can be removed after updating to the modern locations: `lru_cache` from `functools`, `force_str`/`smart_str` from `django.utils.encoding`.