### PR TITLE
Completely hide all attributes starting with "__"

### DIFF
--- a/python/nav/django/templatetags/info.py
+++ b/python/nav/django/templatetags/info.py
@@ -164,3 +164,10 @@ def sortdict(dictionary, reverse=False):
 def is_list(value):
     """Returns True if the value is a list"""
     return isinstance(value, list)
+
+
+@register.filter
+def dunderless(mapping):
+    """Returns a mapping with all elements of the input mapping except for ones whose key starts with dunder"""
+    mapping = {k: v for k, v in mapping.items() if not k.startswith('__')}
+    return mapping

--- a/python/nav/web/templates/ipdevinfo/frag-ipdevinfo.html
+++ b/python/nav/web/templates/ipdevinfo/frag-ipdevinfo.html
@@ -393,12 +393,13 @@
 
 
         {# Custom key value fields #}
-        {% if netbox.data %}
+        {% with dunderless_dict=netbox.data|dunderless %}
+        {% if dunderless_dict %}
           <table class="vertitable full-width">
             <caption>Custom data</caption>
 
             <tbody>
-              {% for key, value in netbox.data.items %}
+              {% for key, value in dunderless_dict.items %}
                 <tr>
                   <th>{{ key }}</th>
                   <td>{{ value|urlize }}</td>
@@ -408,6 +409,7 @@
 
           </table>
         {% endif %}
+        {% endwith %}
 
 
         {% with netbox.get_last_jobs as jobs %}


### PR DESCRIPTION
Closes #2274 by completely hiding attributes where key starts with double underscore.