### PR TITLE
Link SeeDB edit pages to detail views for locations, rooms, device groups, prefixes and vlans

### DIFF
--- a/python/nav/web/seeddb/page/location.py
+++ b/python/nav/web/seeddb/page/location.py
@@ -89,9 +89,16 @@ def location_edit(request, location_id=None, action='edit'):
         copy_url = None
 
     _title = 'Use this location as a template for creating a new location'
+    if location_id:
+        detail_page_url = reverse_lazy(
+            'location-info', kwargs={'locationid': location_id}
+        )
+    else:
+        detail_page_url = ""
     extra_context = {
         'copy_url': copy_url,
         'copy_title': _title,
+        'detail_page_url': detail_page_url,
     }
     extra_context.update(info.template_context)
     return render_edit(

--- a/python/nav/web/seeddb/page/netboxgroup.py
+++ b/python/nav/web/seeddb/page/netboxgroup.py
@@ -99,7 +99,17 @@ def netboxgroup_delete(request, object_id=None):
 
 
 def netboxgroup_edit(request, netboxgroup_id=None):
+    if netboxgroup_id:
+        detail_page_url = reverse_lazy(
+            'netbox-group-detail', kwargs={'groupid': netboxgroup_id}
+        )
+    else:
+        detail_page_url = ""
     info = NetboxGroupInfo()
+    extra_context = {
+        'detail_page_url': detail_page_url,
+    }
+    extra_context.update(info.template_context)
     return render_edit(
         request,
         NetboxGroup,
@@ -107,7 +117,7 @@ def netboxgroup_edit(request, netboxgroup_id=None):
         netboxgroup_id,
         'seeddb-netboxgroup-edit',
         template='seeddb/edit_device_group.html',
-        extra_context=info.template_context,
+        extra_context=extra_context,
     )
 
 

--- a/python/nav/web/seeddb/page/prefix.py
+++ b/python/nav/web/seeddb/page/prefix.py
@@ -35,7 +35,7 @@ from nav.web.seeddb import SeeddbInfo, reverse_lazy
 from nav.web.seeddb.constants import SEEDDB_EDITABLE_MODELS
 from nav.web.seeddb.page import view_switcher, not_implemented
 from nav.web.seeddb.utils.list import render_list
-from nav.web.seeddb.utils.edit import _get_object
+from nav.web.seeddb.utils.edit import _get_object, render_edit
 from nav.web.seeddb.utils.bulk import render_bulkimport
 from nav.web.seeddb.utils.delete import render_delete
 
@@ -169,10 +169,17 @@ def prefix_edit(request, prefix_id=None):
             'form': prefix_form,
             'vlan_form': vlan_form,
             'sub_active': prefix and {'edit': True} or {'add': True},
-            'detail_link': "",
         }
     )
-    return render(request, 'seeddb/edit_prefix.html', context)
+    return render_edit(
+        request,
+        Prefix,
+        PrefixForm,
+        prefix_id,
+        "seeddb-prefix-edit",
+        template="seeddb/edit_prefix.html",
+        extra_context=context,
+    )
 
 
 def get_prefix_and_vlan(prefix_id):

--- a/python/nav/web/seeddb/page/prefix.py
+++ b/python/nav/web/seeddb/page/prefix.py
@@ -162,6 +162,12 @@ def prefix_edit(request, prefix_id=None):
     else:
         prefix_form = PrefixForm(instance=prefix, initial=request.GET.dict())
         vlan_form = PrefixVlanForm(instance=vlan, initial=request.GET.dict())
+    if prefix_id:
+        detail_page_url = reverse_lazy(
+            'prefix-details', kwargs={'prefix_id': prefix_id}
+        )
+    else:
+        detail_page_url = ""
     context = info.template_context
     context.update(
         {
@@ -169,6 +175,7 @@ def prefix_edit(request, prefix_id=None):
             'form': prefix_form,
             'vlan_form': vlan_form,
             'sub_active': prefix and {'edit': True} or {'add': True},
+            'detail_page_url': detail_page_url,
         }
     )
     return render_edit(

--- a/python/nav/web/seeddb/page/prefix.py
+++ b/python/nav/web/seeddb/page/prefix.py
@@ -169,6 +169,7 @@ def prefix_edit(request, prefix_id=None):
             'form': prefix_form,
             'vlan_form': vlan_form,
             'sub_active': prefix and {'edit': True} or {'add': True},
+            'detail_link': "",
         }
     )
     return render(request, 'seeddb/edit_prefix.html', context)

--- a/python/nav/web/seeddb/page/room.py
+++ b/python/nav/web/seeddb/page/room.py
@@ -109,11 +109,16 @@ def room_edit(request, action='edit', room_id=None, lat=None, lon=None):
         for r in Room.objects.all()
         if r.position
     ]
+    if room_id:
+        detail_page_url = reverse_lazy('room-info', kwargs={'roomid': room_id})
+    else:
+        detail_page_url = ""
     extra_context = {
         'map': True,
         'roompositions': roompositions,
         'copy_url': copy_url,
         'copy_title': 'Use this room as a template for creating a new room',
+        'detail_page_url': detail_page_url,
     }
 
     extra_context.update(info.template_context)

--- a/python/nav/web/seeddb/page/vlan.py
+++ b/python/nav/web/seeddb/page/vlan.py
@@ -109,7 +109,15 @@ def vlan_list(request):
 
 
 def vlan_edit(request, vlan_id=None):
+    if vlan_id:
+        detail_page_url = reverse_lazy('vlan-details', kwargs={'vlanid': vlan_id})
+    else:
+        detail_page_url = ""
     info = VlanInfo()
+    extra_context = {
+        'detail_page_url': detail_page_url,
+    }
+    extra_context.update(info.template_context)
     return render_edit(
         request,
         Vlan,
@@ -117,5 +125,5 @@ def vlan_edit(request, vlan_id=None):
         vlan_id,
         'seeddb-vlan-edit',
         template='seeddb/edit_vlan.html',
-        extra_context=info.template_context,
+        extra_context=extra_context,
     )

--- a/python/nav/web/seeddb/utils/edit.py
+++ b/python/nav/web/seeddb/utils/edit.py
@@ -32,6 +32,7 @@ from django.urls import reverse, NoReverseMatch
 from django.utils import six
 
 from nav.web.message import new_message, Messages
+from nav.web.seeddb import reverse_lazy
 from nav.models.manage import Netbox, NetboxCategory, NetboxGroup
 
 _logger = logging.getLogger(__name__)
@@ -50,7 +51,6 @@ def render_edit(
     action='edit',
 ):
     """Handles editing for objects in seeddb."""
-
     if not extra_context:
         extra_context = {}
 
@@ -99,9 +99,29 @@ def render_edit(
     }
     if obj:
         if obj.pk:
+            if verbose_name == "room":
+                detail_link = reverse_lazy('room-info', kwargs={'roomid': obj.pk})
+            elif verbose_name == "location":
+                detail_link = reverse_lazy(
+                    'location-info', kwargs={'locationid': obj.pk}
+                )
+            elif verbose_name == "vlan":
+                detail_link = reverse_lazy('vlan-details', kwargs={'vlanid': obj.pk})
+            elif verbose_name == "device group":
+                detail_link = reverse_lazy(
+                    'netbox-group-detail', kwargs={'groupid': obj.pk}
+                )
+            elif verbose_name == "prefix":
+                detail_link = reverse_lazy(
+                    'prefix-details', kwargs={'prefix_id': obj.pk}
+                )
+            else:
+                detail_link = ""
             context.update(
                 {
-                    'title': 'Edit %s "%s"' % (verbose_name, obj),
+                    'title': 'Edit %s' % verbose_name,
+                    'detail_link_name': obj,
+                    'detail_link_url': detail_link,
                     'sub_active': {'edit': True},
                 }
             )

--- a/python/nav/web/seeddb/utils/edit.py
+++ b/python/nav/web/seeddb/utils/edit.py
@@ -32,7 +32,6 @@ from django.urls import reverse, NoReverseMatch
 from django.utils import six
 
 from nav.web.message import new_message, Messages
-from nav.web.seeddb import reverse_lazy
 from nav.models.manage import Netbox, NetboxCategory, NetboxGroup
 
 _logger = logging.getLogger(__name__)
@@ -99,29 +98,10 @@ def render_edit(
     }
     if obj:
         if obj.pk:
-            if verbose_name == "room":
-                detail_link = reverse_lazy('room-info', kwargs={'roomid': obj.pk})
-            elif verbose_name == "location":
-                detail_link = reverse_lazy(
-                    'location-info', kwargs={'locationid': obj.pk}
-                )
-            elif verbose_name == "vlan":
-                detail_link = reverse_lazy('vlan-details', kwargs={'vlanid': obj.pk})
-            elif verbose_name == "device group":
-                detail_link = reverse_lazy(
-                    'netbox-group-detail', kwargs={'groupid': obj.pk}
-                )
-            elif verbose_name == "prefix":
-                detail_link = reverse_lazy(
-                    'prefix-details', kwargs={'prefix_id': obj.pk}
-                )
-            else:
-                detail_link = ""
             context.update(
                 {
                     'title': 'Edit %s' % verbose_name,
-                    'detail_link_name': obj,
-                    'detail_link_url': detail_link,
+                    'detail_page_name': obj,
                     'sub_active': {'edit': True},
                 }
             )

--- a/python/nav/web/templates/seeddb/edit.html
+++ b/python/nav/web/templates/seeddb/edit.html
@@ -24,13 +24,13 @@
   <div class="row">
     <div class="small-12 column">
       <h4>{{ title }}
-        {% if detail_link_url %}
-          <a href="{{ detail_link_url }}"
+        {% if detail_page_url %}
+          <a href="{{ detail_page_url }}"
               title="See more information">
-              {{ detail_link_name }}
+              {{ detail_page_name }}
           </a>
         {% else %}
-          "{{ detail_link_name }}"
+          "{{ detail_page_name }}"
         {% endif %}
       </h4>
     </div>

--- a/python/nav/web/templates/seeddb/edit.html
+++ b/python/nav/web/templates/seeddb/edit.html
@@ -23,7 +23,16 @@
 
   <div class="row">
     <div class="small-12 column">
-      <h4>{{ title }}</h4>
+      <h4>{{ title }}
+        {% if detail_link_url %}
+          <a href="{{ detail_link_url }}"
+              title="See more information">
+              {{ detail_link_name }}
+          </a>
+        {% else %}
+          "{{ detail_link_name }}"
+        {% endif %}
+      </h4>
     </div>
 
     <div class="large-6 column{% if not map %} end{% endif %}">


### PR DESCRIPTION
Resolves #2245 

Also changes the SeedDB edit page for prefixes to the same style as rooms, locations, etc..