### PR TITLE
Remove "no access" message from login page during normal login

### DIFF
--- a/python/nav/web/auth.py
+++ b/python/nav/web/auth.py
@@ -210,9 +210,11 @@ def authenticate_remote_user(request):
 
 def get_login_url(request):
     """Calculate which login_url to use"""
-    default_new_url = '{0}?origin={1}&noaccess'.format(
-        LOGIN_URL, parse.quote(request.get_full_path())
-    )
+    path = parse.quote(request.get_full_path())
+    if path == "/":
+        default_new_url = LOGIN_URL
+    else:
+        default_new_url = '{0}?origin={1}&noaccess'.format(LOGIN_URL, path)
     remote_loginurl = get_remote_loginurl(request)
     return remote_loginurl if remote_loginurl else default_new_url
 


### PR DESCRIPTION
Currently when we click on the login button we are met with the messages "You need to log in to access this resource" and " After successfully logging in, you will be redirected to: /"
These are useful if the user tries to access other parts of nav, but not when logging in normally. 

This will fix that and we will be shown a message-free login in screen. 