### PR TITLE
Upgrade to dnspython 2.1

### DIFF
--- a/NOTES.rst
+++ b/NOTES.rst
@@ -28,7 +28,12 @@ Changed versions
 NAV 5.2 moved to a newer version of the Python module :mod:`feedparser`,
 because of Python 3 issues with the old version. The new requirement is:
 
-* :mod:`feedparser==6.0.8`
+* :mod:`feedparser`==6.0.8
+
+Due to recent dependency conflicts with Napalm, NAV also changed the version
+requirement for the :mod:`dnspython` module. This is the current requirement:
+
+* mod:`dnspython`<3.0.0,>=2.1.0
 
 
 Backwards incompatible changes

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ sphinxcontrib-django
 
 feedparser==6.0.8
 markdown==2.5.1
-dnspython==1.15.0
+dnspython<3.0.0,>=2.1.0
 
 # REST framework
 iso8601


### PR DESCRIPTION
This fixes a recently arisen dependency conflict:

* NAV depends on napalm==3.0.1 and dnspython==1.15.0
* Napalm depends on ciscoconfparse (not sure which version, but it's maybe not properly version locked)
* ciscoconfparse depends on dnspython<3.0.0,>=2.1.0

Only the DnsChecker handler for servicemon seems to require dnspython, so it's time to see if we can live with a newer dnspython.

Manual testing seems to indicate it works as before (there is no advance usage of the library).
