### PR TITLE
Upload coverage reports to CodeCov

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -81,6 +81,12 @@ jobs:
           path: |
             /tmp/pytest-of-runner
 
+      - name: "Upload coverage to Codecov"
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+
       - name: Upload test reports (${{ matrix.python-version }})
         if: always()
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This adds the action to the main testing workflow, but it may still need some tweaking