### PR TITLE
Increase test coverage for GammuDispatcher

### DIFF
--- a/python/nav/smsd/gammudispatcher.py
+++ b/python/nav/smsd/gammudispatcher.py
@@ -26,8 +26,6 @@ Depends on python-gammu.
 
 from nav.smsd.dispatcher import Dispatcher, PermanentDispatcherError, DispatcherError
 
-import six
-
 try:
     import gammu
 except ImportError as error:
@@ -97,16 +95,16 @@ class GammuDispatcher(Dispatcher):
                 % (error.args[0]['Where'], error.args[0]['Code'], error.args[0]['Text'])
             )
 
-        if isinstance(smsid, six.integer_types):
+        if isinstance(smsid, int):
             result = True
         else:
             result = False
 
-        return (sms, sent, ignored, result, smsid)
+        return sms, sent, ignored, result, smsid
 
 
 def decode_sms_to_unicode(sms):
-    if isinstance(sms, six.text_type):
+    if isinstance(sms, str):
         return sms
     else:
         return sms.decode('utf-8')

--- a/tests/unittests/smsd/gammudispatcher_test.py
+++ b/tests/unittests/smsd/gammudispatcher_test.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-
 # mock/patch/hack/workaround: gammudispatcher normally requires gammu to be
 # installed, but we're only testing functionality from the module that is not
 # dependent on this. If there is no gammu module, we fake it so we can import
@@ -10,22 +8,22 @@ except ImportError:
     import sys
 
     gammu = sys.modules['gammu'] = type(sys)('gammu')
-from nav.smsd.gammudispatcher import decode_sms_to_unicode
+from nav.smsd.gammudispatcher import decode_sms_to_unicode, GammuDispatcher
 
 
-class EncodingTests(TestCase):
-    def test_ascii_string_should_decode_to_equal_object(self):
+class TestThat_decode_sms_to_unicode:
+    def test_should_decode_ascii_bytes_to_comparable_string(self):
         sms = 'Hello'
         unicode_sms = decode_sms_to_unicode(sms)
-        self.assertEqual(sms, unicode_sms)
+        assert sms == unicode_sms
 
-    def test_unicode_object_should_be_decoded_to_equal_object(self):
+    def test_should_decode_string_to_comparable_string(self):
         sms = u'A m\xf8\xf8se once bit my sister'
         unicode_sms = decode_sms_to_unicode(sms)
-        self.assertEqual(sms, unicode_sms)
+        assert sms == unicode_sms
 
-    def test_utf_8_string_should_properly_decode(self):
+    def test_should_decode_utf8_string_properly(self):
         sms = b'A m\xc3\xb8\xc3\xb8se once bit my sister'
         unicode_sms = decode_sms_to_unicode(sms)
         expected = u'A m\xf8\xf8se once bit my sister'
-        self.assertEqual(unicode_sms, expected)
+        assert unicode_sms == expected

--- a/tests/unittests/smsd/gammudispatcher_test.py
+++ b/tests/unittests/smsd/gammudispatcher_test.py
@@ -2,16 +2,28 @@
 # installed, but we're only testing functionality from the module that is not
 # dependent on this. If there is no gammu module, we fake it so we can import
 # gammudispather without failures.
+import pytest
+from mock import Mock, patch
+
+from nav.smsd.dispatcher import PermanentDispatcherError, DispatcherError
+
 try:
     import gammu
 except ImportError:
     import sys
 
+    # Mock a minimum gammu module when one isn't present to patch
     gammu = sys.modules['gammu'] = type(sys)('gammu')
+    mock_statemachine = Mock(SendSMS=Mock(return_value=42))
+    gammu.StateMachine = Mock(return_value=mock_statemachine)
+    gammu.GSMError = Exception
+
 from nav.smsd.gammudispatcher import decode_sms_to_unicode, GammuDispatcher
 
+DUMMY_SENDSMS_ARGS = ("999999", ["Message 1", "Message 2"])
 
-class TestThat_decode_sms_to_unicode:
+
+class TestThatDecodeSmsToUnicode:
     def test_should_decode_ascii_bytes_to_comparable_string(self):
         sms = 'Hello'
         unicode_sms = decode_sms_to_unicode(sms)
@@ -27,3 +39,45 @@ class TestThat_decode_sms_to_unicode:
         unicode_sms = decode_sms_to_unicode(sms)
         expected = u'A m\xf8\xf8se once bit my sister'
         assert unicode_sms == expected
+
+
+class TestThatGammuDispatcher:
+    def test_can_be_initialized(self):
+        assert GammuDispatcher(None)
+
+    @patch('gammu.StateMachine', new=Mock())
+    def test_should_send_sms_without_error(self):
+        dispatcher = GammuDispatcher(None)
+        result = dispatcher.sendsms(*DUMMY_SENDSMS_ARGS)
+        assert result
+
+    def test_should_raise_permanent_error_when_gammu_cannot_read_config(self):
+        mocked_statemachine = Mock(ReadConfig=Mock(side_effect=IOError('Fake')))
+        with patch('gammu.StateMachine') as statemachine:
+            statemachine.return_value = mocked_statemachine
+            dispatcher = GammuDispatcher(None)
+            with pytest.raises(PermanentDispatcherError):
+                dispatcher.sendsms(*DUMMY_SENDSMS_ARGS)
+
+    def test_should_raise_permanent_error_when_gammu_errors_during_init(
+        self, mock_gsm_error
+    ):
+        mocked_statemachine = Mock(Init=Mock(side_effect=mock_gsm_error))
+        with patch('gammu.StateMachine') as statemachine:
+            statemachine.return_value = mocked_statemachine
+            dispatcher = GammuDispatcher(None)
+            with pytest.raises(PermanentDispatcherError):
+                dispatcher.sendsms(*DUMMY_SENDSMS_ARGS)
+
+    def test_should_raise_temporary_when_gammu_send_fails(self, mock_gsm_error):
+        mocked_statemachine = Mock(SendSMS=Mock(side_effect=mock_gsm_error))
+        with patch('gammu.StateMachine') as statemachine:
+            statemachine.return_value = mocked_statemachine
+            dispatcher = GammuDispatcher(None)
+            with pytest.raises(DispatcherError):
+                dispatcher.sendsms(*DUMMY_SENDSMS_ARGS)
+
+
+@pytest.fixture(scope='module')
+def mock_gsm_error():
+    return gammu.GSMError({"Where": Mock(), 'Code': 666, 'Text': Mock()})


### PR DESCRIPTION
Playing with using CodeCov for the NAV repo, I picked a module with low test coverage, with the goal of increasing its test coverage. I picked GammuDispatcher, the smsd dispatcher plugin that can dispatch SMS messages using the Gammu library.

This PR:
* Rewrites the existing tests to become pure pytest tests.
* Adds more tests for the actual GammuDispatcher plugin code
* Removes the GammuDispatcher's obsolete dependency on `six`, since NAV code is now Python 3-only.

The tests were designed to run even when then gammu library isn't present, but since the mock library's patch framework doesn't work well when the code to patch doesn't exist, the test module needs to mock the bare minimum of the gammu library if it isn't present.
