### PR TITLE
Use GitHub superlinter to validate Python code using Black and Flake8

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,58 @@
+---
+#################################
+#################################
+## Super Linter GitHub Actions ##
+#################################
+#################################
+name: Lint Code Base
+
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+
+#############################
+# Start the job on all push #
+#############################
+on:
+  push:
+    #branches-ignore: [master, main]
+    # Remove the line above to run when pushing to master
+  pull_request:
+    branches: [master, main]
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    # Name the Job
+    name: Lint Code Base
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    ##################
+    # Load all steps #
+    ##################
+    steps:
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_PYTHON: true
+          LINTER_RULES_PATH: /python
+          PYTHON_PYLINT_CONFIG_FILE: pylint.rc

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -54,5 +54,8 @@ jobs:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_PYTHON: true
-          LINTER_RULES_PATH: /python
-          PYTHON_PYLINT_CONFIG_FILE: pylint.rc
+          VALIDATE_PYTHON_ISORT: false
+          VALIDATE_PYTHON_MYPY: false
+          VALIDATE_PYTHON_PYLINT: false
+          LINTER_RULES_PATH: /
+          PYTHON_BLACK_CONFIG_FILE: pyproject.toml

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -59,3 +59,4 @@ jobs:
           VALIDATE_PYTHON_PYLINT: false
           LINTER_RULES_PATH: /
           PYTHON_BLACK_CONFIG_FILE: pyproject.toml
+          PYTHON_FLAKE8_CONFIG_FILE: tox.ini

--- a/tox.ini
+++ b/tox.ini
@@ -107,3 +107,10 @@ commands_pre =
 commands =
          python setup.py build_sphinx
          sh -c "cd doc; python -c 'import conf; print(conf.version)' > {toxinidir}/reports/doc_version"
+
+# The flake8 setup should mirror the setup in pre-commit
+[flake8]
+statistics = True
+count = True
+# Only check for critical problems that will prevent testing/running
+select = E9,F63,F7,F82


### PR DESCRIPTION
This adds GitHub superlinter to the GitHub actions workflow, mainly to verify that developers have actually installed the pre-commit hooks documented by the NAV hacker's guide: It validates all changed Python code using Black and Flake8.