### PR TITLE
log warning if DATABASES cannot be defined

### DIFF
--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -19,6 +19,7 @@
 import os
 import sys
 import copy
+import warnings
 
 import django
 from django.utils.log import DEFAULT_LOGGING
@@ -66,8 +67,8 @@ try:
             },
         }
     }
-except (IOError, OSError):
-    pass
+except (IOError, OSError) as e:
+    warnings.warn(f"Could not get connection parameters from db.conf: {e}")
 
 # URLs configuration
 ROOT_URLCONF = 'nav.django.urls'


### PR DESCRIPTION
Fixes #2341 

logs a warning if something goes wrong while defining DATABASES.

Struggled a bit as the warning never showed up in the log when refreshing the site. I think my PHP experiences
have infected my brain, as I guess I assumed all code would be rerun for each refresh.

But the warning shows up when starting up (with docker-compose up) or after making changes to the code.

![image](https://user-images.githubusercontent.com/31960753/154024405-ec5cf20c-db9a-4991-bda3-7c8656596c55.png)
This is shown in the log during docker-compose up when I cause an error to happen.

Is this something along the lines of what is wanted?