### PR TITLE
Document the name change from Uninett to Sikt

### DIFF
--- a/NOTES.rst
+++ b/NOTES.rst
@@ -11,6 +11,23 @@ please go to https://github.com/uninett/nav/milestones .
 NAV 5.3
 =======
 
+Changes in governance and code ownership
+----------------------------------------
+
+On January 1st 2022, Uninett, NSD and Unit (all entities owned by the Norwegian
+government) were merged into the new governmental agency *Sikt - Norwegian
+Agency for Shared Services in Education and Research*.
+
+This does not change our commitment to develop and provide NAV as free and open
+source software. We still have the same ownership and the same goals - we're
+just doing everything under a new name.
+
+In the coming year, references to Uninett, both in the NAV documentation, code
+and related web sites will slowly change into Sikt, but for some time going
+forward, there will be references to both names.  For more information about
+the new organization, we refer you to https://sikt.no/about-sikt
+
+
 Dependency changes
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ NAV is licensed under the *GNU GPL version 3*.  NAV includes software from third
 parties, which are either licensed under the GPL or compatible licenses.
 
 * Copyright 2002-2021 Uninett AS
+* Copyright 2022 Sikt
 
 See individual source files for more detailed copyright notices.
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,7 +51,7 @@ master_doc = 'contents'
 
 # General information about the project.
 project = u'NAV'
-copyright = u'2012-2021, Uninett AS'
+copyright = u'2012-2021 Uninett AS, 2022 Sikt'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -239,7 +239,7 @@ htmlhelp_basename = 'NAVdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ('index', 'NAV.tex', u'NAV Documentation', u'Uninett AS', 'manual'),
+    ('index', 'NAV.tex', u'NAV Documentation', u'Sikt', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/doc/hacking/hacking-with-pycharm.rst
+++ b/doc/hacking/hacking-with-pycharm.rst
@@ -7,15 +7,10 @@ a complete set of tools for productive development with the Python programming
 language. In addition, the IDE provides high-class capabilities for
 professional Web development with Django framework.
 
-JetBrains has kindly issued an open source license to the NAV development
-project.
-
-Obtaining a copy of the open source license
--------------------------------------------
-
-Active NAV developers may be eligible to receive a copy of the open source
-license. The license must be renewed annually. Contact nav-support@uninett.no
-for inquiries.
+JetBrains used to provide NAV developers with a free open source license to
+PyCharm, but their open source policy has since changed. Sikt is now left to
+pay an annual license subscription for a few PyCharm licenses, and these are
+reserved for Sikt employees.
 
 Configuring PyCharm for use with NAV
 ------------------------------------

--- a/doc/hacking/hacking.rst
+++ b/doc/hacking/hacking.rst
@@ -9,19 +9,18 @@ please read this first.
 Contributing to NAV
 ===================
 
-Originally, NAV was a closed source project, initiated by the
-Norwegian University of Science and Technology (NTNU), and eventually
-sponsored by Uninett on behalf of the Norwegian higher education
-community.  In 2004, however, NTNU and Uninett started distributing
-NAV under the *GNU General Public License*, making it a truly free
-software system.
+Originally, NAV was a closed source project, initiated by the Norwegian
+University of Science and Technology (NTNU), and eventually sponsored by Sikt
+(back then, known as *Uninett*) on behalf of the Norwegian higher education
+community.  In 2004, however, NTNU and Sikt started distributing NAV under the
+*GNU General Public License*, making it a truly free software system.
 
-While Uninett and NTNU are still the main contributors to NAV,
-developing NAV to support the needs of the Norwegian higher education
-community, contributions from third parties is highly appreciated.
+While Sikt is still the main contributor to NAV, developing NAV to support the
+needs of the Norwegian higher education community, contributions from third
+parties are highly appreciated.
 
 We communicate mainly through mailing lists, GitHub_, and the ``#nav`` IRC
-channel on *Libera.Chat*. At times, Uninett also arranges workshops and
+channel on *Libera.Chat*. At times, Sikt also arranges workshops and
 gatherings for its customers: Norwegian universities, university colleges and
 research institutions.
 
@@ -87,9 +86,9 @@ by the CLA assistant.
 Rationale
 ~~~~~~~~~
 
-NAV is a software project primarily made by Uninett AS. Uninett is a
-non-profit, government-owned limited company, who builds and operates
-Norway's national research and education network.
+NAV is a software project primarily made by Sikt. Sikt is a government agency
+that provides shared services in research and education in Norway, which
+includes operating Norway's national research and education network.
 
 Due to our experiences with FOSS license compatibility issues, and with
 switching the 20-year old NAV project explicitly from the GPLv2 to the
@@ -376,7 +375,7 @@ Push access
 -----------
 
 Push access to the official repositories is limited to developers
-employed or commissioned by Uninett.
+employed or commissioned by Sikt.
 
 Testing and Continuous Integration
 ==================================

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -50,3 +50,7 @@ In 2006, Uninett assumed the main responsibility of maintaining and developing
 the software further, and is continually doing so on behalf of its customers,
 the Norwegian universities and university colleges, and research network
 partners.
+
+On January 1st 2022, Uninett, NSD and Unit (all entities owned by the Norwegian
+government) were merged into the new governmental agency *Sikt - Norwegian
+Agency for Shared Services in Education and Research*.

--- a/doc/reference/smsd.rst
+++ b/doc/reference/smsd.rst
@@ -115,8 +115,8 @@ UninettMailDispatcher
 
 :description:
 
-	This dispatcher sends SMS via Uninett's `email-to-SMS` gateway.
-	Uninett's gateway only works internally, but this plugin can serve as
+	This dispatcher sends SMS via Sikt's (previously Uninett) `email-to-SMS` gateway.
+	Sikt's gateway only works internally, but this plugin can serve as
 	a proof-of-concept for someone implementing a similar service.  The
 	e-mail adress is configurable in ``smsd.conf``.
 
@@ -134,7 +134,7 @@ UninettMailDispatcher
 :cons:
 
 	Unless you have a similar email-to-SMS gatway, this only works for
-	Uninett.
+	Sikt.
 
 Extending
 =========


### PR DESCRIPTION
This PR just updates the docs and release notes to reflect the name change from Uninett to Sikt, which we need for the next NAV release.