### PR TITLE
Fix syntax warning (and likely broken logic)

### DIFF
--- a/python/nav/web/netmap/graph.py
+++ b/python/nav/web/netmap/graph.py
@@ -236,7 +236,7 @@ def get_layer3_traffic(location_or_room_id=None):
 
         gwport_prefixes = router_ports_prefix_map[prefix]
 
-        if gwport_prefixes and prefix.vlan.net_type.id is not 'elink':
+        if gwport_prefixes and prefix.vlan.net_type.id != 'elink':
 
             for gwport_prefix_a in gwport_prefixes:
                 for gwport_prefix_b in gwport_prefixes:


### PR DESCRIPTION
Newer Python versions issue a SyntaxWarning when this code is being run in the test suite. This code is old, and this logic is entirely broken, as suggested by the SyntaxWarning. Not exactly sure if or how this has affected production code, but it's been there for the last 8 years without raising any eyebrows :-P