### PR TITLE
Wrap RpcErrors in PortAdmin ProtocolErrors, for more user-friendly error reporting

### DIFF
--- a/python/nav/portadmin/napalm/juniper.py
+++ b/python/nav/portadmin/napalm/juniper.py
@@ -248,6 +248,7 @@ class Juniper(ManagementHandler):
         untagged = first_true(vlans, pred=lambda vlan: not vlan.tagged)
         return (untagged.tag if untagged else None), tagged
 
+    @wrap_unhandled_rpc_errors
     def set_interface_description(self, interface: manage.Interface, description: str):
         # never set description on units but on master interface
         master, _ = split_master_unit(interface.ifname)
@@ -260,9 +261,11 @@ class Juniper(ManagementHandler):
         config = template.render(context)
         self.device.load_merge_candidate(config=config)
 
+    @wrap_unhandled_rpc_errors
     def set_vlan(self, interface: manage.Interface, vlan: int):
         self.set_access(interface, vlan)
 
+    @wrap_unhandled_rpc_errors
     def set_access(self, interface: manage.Interface, access_vlan: int):
         master, unit = split_master_unit(interface.ifname)
         current = InterfaceConfigTable(self.device.device).get(master)[master]
@@ -290,6 +293,7 @@ class Juniper(ManagementHandler):
             pass
         interface.save()
 
+    @wrap_unhandled_rpc_errors
     def set_trunk(
         self, interface: manage.Interface, native_vlan: int, trunk_vlans: Sequence[int]
     ):
@@ -340,6 +344,7 @@ class Juniper(ManagementHandler):
         # and that operation will likely delay at least as much as the wait would have
         return super().cycle_interfaces(interfaces=interfaces, wait=0, commit=True)
 
+    @wrap_unhandled_rpc_errors
     def set_interface_down(self, interface: manage.Interface):
         # does not set oper on logical units, only on physical masters
         master, _unit = split_master_unit(interface.ifname)
@@ -349,6 +354,7 @@ class Juniper(ManagementHandler):
 
         self._save_interface_oper(interface, interface.OPER_DOWN)
 
+    @wrap_unhandled_rpc_errors
     def set_interface_up(self, interface: manage.Interface):
         # does not set oper on logical units, only on physical masters
         master, _unit = split_master_unit(interface.ifname)
@@ -368,6 +374,7 @@ class Juniper(ManagementHandler):
             )
             master_interface.update(ifoperstatus=ifoperstatus)
 
+    @wrap_unhandled_rpc_errors
     def commit_configuration(self):
         # Only take our sweet time to commit if there are pending changes
         if self.device.compare_config():

--- a/tests/unittests/portadmin/napalm/juniper_test.py
+++ b/tests/unittests/portadmin/napalm/juniper_test.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2022 Sikt AS
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.  You should have received a copy of the GNU General Public
+# License along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+import pytest
+
+from jnpr.junos.exception import RpcError
+
+from nav.portadmin.handlers import ProtocolError
+from nav.portadmin.napalm.juniper import wrap_unhandled_rpc_errors
+
+
+class TestWrapUnhandledRpcErrors:
+    def test_rpcerrors_should_become_protocolerrors(self):
+        @wrap_unhandled_rpc_errors
+        def wrapped_function():
+            raise RpcError("bogus")
+
+        with pytest.raises(ProtocolError):
+            wrapped_function()
+
+    def test_non_rpcerrors_should_pass_through(self):
+        @wrap_unhandled_rpc_errors
+        def wrapped_function():
+            raise TypeError("bogus")
+
+        with pytest.raises(TypeError):
+            wrapped_function()


### PR DESCRIPTION
This PR adds a wrapper function to translate an unhandled `RpcError` exception into a PortAdmin `ProtocolError`, and decorates all the config-changing methods of the Juniper Napalm/Netconf management handler with it.

A `ProtocolError` is handled  more gracefully by the interaction between backend and frontend, causing the UI to display a more friendly error to the end user.

Fixes #2362

### Screenshots
The config-saving feedback dialog now looks like this:

![Skjermbilde 2022-03-18 kl  15 25 34](https://user-images.githubusercontent.com/100995/159023342-d6a17169-61a8-450c-acf3-645596691b01.png)

The status of the changed row looks like this afterwards:

![Skjermbilde 2022-03-18 kl  15 25 54](https://user-images.githubusercontent.com/100995/159023417-67a94671-a9ec-4c47-a698-9b7b1bc8d013.png)

