### PR TITLE
Restrict CodeCov uploads to Uninett upstream repos

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -89,6 +89,7 @@ jobs:
             /tmp/pytest-of-runner
 
       - name: "Upload coverage to Codecov"
+        if: "github.repository_owner == 'Uninett'"
         uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
Forks will not have the necessary CodeCov token to upload coverage
results, causing this workflow to fail.