### PR TITLE
Migrate to django 3.2 for docs

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
--r ../requirements/django22.txt
+-r ../requirements/django32.txt
 -r ../requirements/base.txt


### PR DESCRIPTION
As noticed in #2396 nav runs on django 3.2, but the docs use django 2.2.
This changes it so that #2396 works.