### PR TITLE
Upgrade to napalm 3.4.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,4 +34,4 @@ pynetsnmp-2>=0.1.8,<0.2.0
 # libsass for compiling scss files to css using distutils/setuptools
 libsass==0.15.1
 
-napalm==3.0.1
+napalm==3.4.1


### PR DESCRIPTION
Closes #2381. 

The old version resulted it the warning
`DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working`
`from collections import Iterable`
Upgrading it to 3.4.1 fixes that and doesn't seem to influence anything else