### PR TITLE
Fix broken deserialization of Rack data

### DIFF
--- a/python/nav/models/rack.py
+++ b/python/nav/models/rack.py
@@ -59,7 +59,9 @@ class Rack(models.Model):
     room = models.ForeignKey(Room, on_delete=models.CASCADE, db_column='roomid')
     rackname = VarcharField(blank=True)
     ordering = models.IntegerField()
-    _configuration = VarcharField(default=None, db_column='configuration')
+    _configuration = models.JSONField(
+        default=None, db_column='configuration', encoder=RackEncoder
+    )
     __configuration = None
     item_counter = models.IntegerField(default=0, null=False, db_column='item_counter')
 
@@ -94,10 +96,6 @@ class Rack(models.Model):
             self.__configuration = self._configuration
 
         return self.__configuration
-
-    def save(self, *args, **kwargs):
-        self._configuration = json.dumps(self.configuration, cls=RackEncoder)
-        return super(Rack, self).save(*args, **kwargs)
 
     def _column(self, column):
         return self.configuration[column]

--- a/python/nav/models/rack.py
+++ b/python/nav/models/rack.py
@@ -40,6 +40,16 @@ class RackManager(models.Manager):
         return set(chain(*sensor_pks))
 
 
+class RackEncoder(json.JSONEncoder):
+    """JSON encoder for rack items"""
+
+    def default(self, obj):
+        if isinstance(obj, BaseRackItem):
+            return obj.to_json()
+        # Let the base class default method raise the TypeError
+        return json.JSONEncoder.default(self, obj)
+
+
 class Rack(models.Model):
     """A physical rack placed in a room."""
 
@@ -166,16 +176,6 @@ def rack_decoder(obj):
         if obj['__type__'] == 'SensorsSumRackItem':
             return SensorsSumRackItem(**obj)
     return obj
-
-
-class RackEncoder(json.JSONEncoder):
-    """TODO: Write doc"""
-
-    def default(self, obj):
-        if isinstance(obj, BaseRackItem):
-            return obj.to_json()
-        # Let the base class default method raise the TypeError
-        return json.JSONEncoder.default(self, obj)
 
 
 class BaseRackItem(object):

--- a/tests/integration/models/rack_test.py
+++ b/tests/integration/models/rack_test.py
@@ -1,0 +1,39 @@
+import pytest
+
+from nav.models.manage import Sensor
+from nav.models.rack import Rack, SensorRackItem
+
+
+class TestRack:
+    def test_that_rack_configuration_can_be_saved_without_error(self, test_rack):
+        test_rack.save()
+        assert test_rack.id
+
+    def test_that_rack_configuration_is_a_dict(self, test_rack):
+        test_rack.save()
+        rack = Rack.objects.get(id=test_rack.id)
+        print(repr(Rack._configuration))
+        assert isinstance(rack._configuration, dict)
+
+    def test_that_rack_configuration_can_be_loaded_without_error(self, test_rack):
+        test_rack.save()
+        rack = Rack.objects.get(id=test_rack.id)
+        assert rack.configuration
+
+
+@pytest.fixture
+def test_rack(test_sensor):
+    rack = Rack(room=test_sensor.netbox.room, rackname="Rack 1")
+    item = SensorRackItem(test_sensor)
+    rack.add_left_item(item)
+    return rack
+
+
+@pytest.fixture
+def test_sensor(localhost):
+    sensor = Sensor(
+        netbox=localhost, oid="1.2.3", unit_of_measurement=Sensor.UNIT_CELSIUS
+    )
+    sensor.save()
+    yield sensor
+    sensor.delete()


### PR DESCRIPTION
Since version 5.3.0, NAV has been unable to properly decode existing Rack item information from the database, due to changes in Django. This was only discovered this week by an internal NAV user who uses Rack definitions for environment monitoring of their server rooms.

The display configuration for a Rack is stored in the PostgreSQL database as a `JSONB` field. Older versions of Django would apparently allow such fields to be defined as text fields in the Django Model and then magically make them dicts when fetching from the database (but still requiring conversion magic during save).

This no longer works in Django 3 (introduced in NAV 5.3), where the text field is returned as a string, even when the underlying data is a JSONB field. The code tries to access the field as if it was a `dict` object, and crashes, as `dict` methods aren't generally available on `str` objects :wink:

This PR changes the field definition into a proper `JSONField`, and removes the unnecessary save-time magic. It also introduces regression tests to reveal the problem.