### PR TITLE
Create event when new device is discovered

### DIFF
--- a/doc/reference/alerttypes.rst
+++ b/doc/reference/alerttypes.rst
@@ -196,12 +196,19 @@ Registers the state of a device
    * - Alert type name
      - Description
    * - ``deviceInIPOperation``
-     - The device is now in operation with an active IP address
+     - The device is now in operation with an active IP address.
    * - ``deviceInStack``
-     - The device is now in operation as a chassis module
+     - The device is now in operation as a chassis module.
    * - ``deviceRMA``
      - RMA event for device.
-
+   * - ``deviceNewModule``
+     -  The device has been found as a module.
+   * - ``deviceNewChassis``
+     - The device has been found as a chassis.
+   * - ``deviceNewPsu``
+     - The device has been found as a power supply.
+   * - ``deviceNewFan``
+     - The device has been found as a fan.
 
 
 

--- a/python/nav/etc/alertmsg/deviceState/deviceNewChassis-email.txt
+++ b/python/nav/etc/alertmsg/deviceState/deviceNewChassis-email.txt
@@ -1,0 +1,2 @@
+Subject: Device has been found as a module
+Device {{ device.get_extended_description }} has been found on {{netbox}} as a chassis

--- a/python/nav/etc/alertmsg/deviceState/deviceNewChassis-sms.txt
+++ b/python/nav/etc/alertmsg/deviceState/deviceNewChassis-sms.txt
@@ -1,0 +1,1 @@
+Device {{ device.get_extended_description }} has been found on {{netbox}} as a chassis

--- a/python/nav/etc/alertmsg/deviceState/deviceNewFan-email.txt
+++ b/python/nav/etc/alertmsg/deviceState/deviceNewFan-email.txt
@@ -1,0 +1,2 @@
+Subject: Device has been found as a fan
+Device {{ device.get_extended_description }} has been found on {{netbox}} as a fan

--- a/python/nav/etc/alertmsg/deviceState/deviceNewFan-sms.txt
+++ b/python/nav/etc/alertmsg/deviceState/deviceNewFan-sms.txt
@@ -1,0 +1,1 @@
+Device {{ device.get_extended_description }} has been found on {{netbox}} as a fan

--- a/python/nav/etc/alertmsg/deviceState/deviceNewModule-email.txt
+++ b/python/nav/etc/alertmsg/deviceState/deviceNewModule-email.txt
@@ -1,0 +1,2 @@
+Subject: Device has been found as a module
+Device {{ device.get_extended_description }} has been found on {{netbox}} as a module

--- a/python/nav/etc/alertmsg/deviceState/deviceNewModule-sms.txt
+++ b/python/nav/etc/alertmsg/deviceState/deviceNewModule-sms.txt
@@ -1,0 +1,1 @@
+Device {{ device.get_extended_description }} has been found on {{netbox}} as a module

--- a/python/nav/etc/alertmsg/deviceState/deviceNewPsu-email.txt
+++ b/python/nav/etc/alertmsg/deviceState/deviceNewPsu-email.txt
@@ -1,0 +1,2 @@
+Subject: Device has been found as a power supply
+Device {{ device.get_extended_description }} has been found on {{netbox}} as a power supply

--- a/python/nav/etc/alertmsg/deviceState/deviceNewPsu-sms.txt
+++ b/python/nav/etc/alertmsg/deviceState/deviceNewPsu-sms.txt
@@ -1,0 +1,1 @@
+Device {{ device.get_extended_description }} has been found on {{netbox}} as a power supply

--- a/python/nav/ipdevpoll/shadows/__init__.py
+++ b/python/nav/ipdevpoll/shadows/__init__.py
@@ -794,6 +794,7 @@ class PowerSupplyOrFan(Shadow):
         if not self.is_new:
             return
         psufan = self.get_existing_model()
+        # Device not existing seems to be an issue exclusive to PowerSupplyOrFan objects
         try:
             if psufan.device.serial:
                 device_event.notify(

--- a/python/nav/ipdevpoll/shadows/__init__.py
+++ b/python/nav/ipdevpoll/shadows/__init__.py
@@ -54,6 +54,7 @@ ALERT_TYPE_MAPPING = {
     "software_version": "deviceSwUpgrade",
     "firmware_version": "deviceFwUpgrade",
 }
+device_event = EventFactory('ipdevpoll', 'eventEngine', 'deviceState')
 
 
 class NetboxType(Shadow):
@@ -113,6 +114,10 @@ class Module(Shadow):
     __lookups__ = [('netbox', 'device'), ('netbox', 'name')]
     event = EventFactory('ipdevpoll', 'eventEngine', 'moduleState')
 
+    def __init__(self, *args, **kwargs):
+        super(Module, self).__init__(*args, **kwargs)
+        self.is_new = None
+
     @classmethod
     def prepare_for_save(cls, containers):
         cls._resolve_actual_duplicate_names(containers)
@@ -148,6 +153,7 @@ class Module(Shadow):
         self._fix_binary_garbage()
         self._fix_missing_name()
         self._resolve_duplicate_names()
+        self.is_new = not self.get_existing_model()
 
     def _fix_binary_garbage(self):
         """Fixes string attributes that appear as binary garbage."""
@@ -238,9 +244,26 @@ class Module(Shadow):
             for module in reappeared_modules:
                 cls.event.end(module.device, module.netbox, module.id).save()
 
+    def cleanup(self, containers):
+        self._handle_new_module()
+
+    def _handle_new_module(self):
+        # If a module is also registered as a chassis, then avoid duplicate
+        # events and let NetboxEntity handle it. This should not really happen,
+        # but its possible if the standard MIBs detects something as a module
+        # and proprietary MIBs detect the same thing as a chassis.
+        module = self.get_existing_model()
+        if self.is_new and not module.get_entity().is_chassis():
+            device_event.notify(
+                device=module.device,
+                netbox=module.netbox,
+                alert_type='deviceNewModule',
+            ).save()
+
     @classmethod
     def cleanup_after_save(cls, containers):
         cls._handle_missing_modules(containers)
+        super(Module, cls).cleanup_after_save(containers)
 
 
 class Device(Shadow):
@@ -750,15 +773,37 @@ class PowerSupplyOrFan(Shadow):
     __shadowclass__ = manage.PowerSupplyOrFan
     __lookups__ = [('netbox', 'name')]
 
+    def __init__(self, *args, **kwargs):
+        super(PowerSupplyOrFan, self).__init__(*args, **kwargs)
+        self.is_new = None
+
     def prepare(self, containers):
-        existing = self.get_existing_model(containers)
+        self.is_new = not self.get_existing_model()
         # Set a default value of UNKNOWN if this is a new object
-        if not existing and self.up is None:
+        if self.is_new and self.up is None:
             self.up = manage.PowerSupplyOrFan.STATE_UNKNOWN
+
+    def cleanup(self, containers):
+        self._handle_new_psu_or_fan()
+
+    def _handle_new_psu_or_fan(self):
+        if self.is_new:
+            psufan = self.get_existing_model()
+            try:
+                device_event.notify(
+                    device=psufan.device,
+                    netbox=psufan.netbox,
+                    alert_type="deviceNewPsu" if psufan.is_psu() else "deviceNewFan",
+                ).save()
+            except manage.Device.DoesNotExist:
+                self._logger.debug(
+                    f"New PowerSupplyOrFan does not have a Device defined."
+                )
 
     @classmethod
     def cleanup_after_save(cls, containers):
         cls._delete_missing_psus_and_fans(containers)
+        super(PowerSupplyOrFan, cls).cleanup_after_save(containers)
 
     @classmethod
     def _delete_missing_psus_and_fans(cls, containers):

--- a/python/nav/ipdevpoll/shadows/__init__.py
+++ b/python/nav/ipdevpoll/shadows/__init__.py
@@ -248,16 +248,14 @@ class Module(Shadow):
         self._handle_new_module()
 
     def _handle_new_module(self):
+        if not self.is_new:
+            return
+        module = self.get_existing_model()
         # If a module is also registered as a chassis, then avoid duplicate
         # events and let NetboxEntity handle it. This should not really happen,
         # but its possible if the standard MIBs detects something as a module
         # and proprietary MIBs detect the same thing as a chassis.
-        module = self.get_existing_model()
-        if (
-            self.is_new
-            and not module.get_entity().is_chassis()
-            and module.device.serial
-        ):
+        if not module.get_entity().is_chassis() and module.device.serial:
             device_event.notify(
                 device=module.device,
                 netbox=module.netbox,

--- a/python/nav/ipdevpoll/shadows/entity.py
+++ b/python/nav/ipdevpoll/shadows/entity.py
@@ -242,7 +242,7 @@ class NetboxEntity(Shadow):
 
     def _handle_new_entity(self):
         entity = self.get_existing_model()
-        if self.is_new and entity.is_chassis():
+        if self.is_new and entity.is_chassis() and entity.device.serial:
             device_event.notify(
                 device=entity.device,
                 netbox=entity.netbox,

--- a/python/nav/ipdevpoll/shadows/entity.py
+++ b/python/nav/ipdevpoll/shadows/entity.py
@@ -241,8 +241,10 @@ class NetboxEntity(Shadow):
         self._handle_new_entity()
 
     def _handle_new_entity(self):
+        if not self.is_new:
+            return
         entity = self.get_existing_model()
-        if self.is_new and entity.is_chassis() and entity.device.serial:
+        if entity.is_chassis() and entity.device.serial:
             device_event.notify(
                 device=entity.device,
                 netbox=entity.netbox,

--- a/python/nav/ipdevpoll/shadows/entity.py
+++ b/python/nav/ipdevpoll/shadows/entity.py
@@ -32,6 +32,8 @@ from nav.models import manage
 from nav.event2 import EventFactory
 from .netbox import Netbox
 
+device_event = EventFactory('ipdevpoll', 'eventEngine', 'deviceState')
+
 chassis_event = EventFactory(
     'ipdevpoll', 'eventEngine', 'chassisState', 'chassisDown', 'chassisUp'
 )
@@ -70,6 +72,7 @@ class EntityManager(DefaultManager):
 
         self.existing = index.entities
         self.missing = self.existing.difference(self.matched)
+        super(EntityManager, self).prepare()
 
     def _delete_missing(self):
         if self.missing:
@@ -207,6 +210,7 @@ class NetboxEntity(Shadow):
 
     def __init__(self, *args, **kwargs):
         super(NetboxEntity, self).__init__(*args, **kwargs)
+        self.is_new = None
         if 'gone_since' not in kwargs:
             # make sure to reset the gone_since timestamp on created records
             self.gone_since = None
@@ -229,6 +233,21 @@ class NetboxEntity(Shadow):
         if entity and entity.gone_since is not None and self.gone_since is None:
             self._logger.info("%s is back up", entity)
             chassis_event.end(entity.device, entity.netbox, entity.id).save()
+
+    def prepare(self, containers):
+        self.is_new = not self.get_existing_model()
+
+    def cleanup(self, containers):
+        self._handle_new_entity()
+
+    def _handle_new_entity(self):
+        entity = self.get_existing_model()
+        if self.is_new and entity.is_chassis():
+            device_event.notify(
+                device=entity.device,
+                netbox=entity.netbox,
+                alert_type='deviceNewChassis',
+            ).save()
 
     @classmethod
     def get_chassis_entities(cls, containers):

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -2498,6 +2498,9 @@ class PowerSupplyOrFan(models.Model):
         (STATE_WARNING, "Warning"),
     )
 
+    PHYSICAL_CLASS_FAN = "fan"
+    PHYSICAL_CLASS_PSU = "powerSupply"
+
     id = models.AutoField(db_column='powersupplyid', primary_key=True)
     netbox = models.ForeignKey(Netbox, on_delete=models.CASCADE, db_column='netboxid')
     device = models.ForeignKey(Device, on_delete=models.CASCADE, db_column='deviceid')
@@ -2531,6 +2534,12 @@ class PowerSupplyOrFan(models.Model):
         """Returns a canonical URL to view fan/psu status"""
         base = self.netbox.get_absolute_url()
         return base + "#!sensors"
+
+    def is_psu(self):
+        return self.physical_class == self.PHYSICAL_CLASS_PSU
+
+    def is_fan(self):
+        return self.physical_class == self.PHYSICAL_CLASS_FAN
 
 
 class UnrecognizedNeighbor(models.Model):

--- a/python/nav/models/sql/changes/sc.05.04.0003.sql
+++ b/python/nav/models/sql/changes/sc.05.04.0003.sql
@@ -1,0 +1,9 @@
+-- Add new deviceState alerts
+INSERT INTO alerttype (eventtypeid,alerttype,alerttypedesc) VALUES
+  ('deviceState','deviceNewModule','The device has been found as a module.');
+INSERT INTO alerttype (eventtypeid,alerttype,alerttypedesc) VALUES
+  ('deviceState','deviceNewChassis','The device has been found as a chassis.');
+INSERT INTO alerttype (eventtypeid,alerttype,alerttypedesc) VALUES
+  ('deviceState','deviceNewPsu','The device has been found as a power supply.');
+INSERT INTO alerttype (eventtypeid,alerttype,alerttypedesc) VALUES
+  ('deviceState','deviceNewFan','The device has been found as a fan.');


### PR DESCRIPTION
Fixes #2391 

Creates alerts when discovering new devices. The alert type depends on what type of device it is, e.g. chassis, module etc.

Also fixes a small bug in EventFactory.