### PR TITLE
Set stateless state in EventFactory notify

### DIFF
--- a/python/nav/event2.py
+++ b/python/nav/event2.py
@@ -92,5 +92,5 @@ class EventFactory(object):
     def notify(self, device=None, netbox=None, subid='', varmap=None, alert_type=None):
         """Creates and returns a stateless event"""
         event = self.base(device, netbox, subid, varmap, alert_type or self.start_type)
-        event.event_type = event.STATE_STATELESS
+        event.state = event.STATE_STATELESS
         return event


### PR DESCRIPTION
Seems to be a bug. It previosuly set event.event_type in a place
where it (probably) should set event.state instead.
Found this by getting an error while trying
to create a stateless event. Seems this notify method is not
called anywhere, so makes sense it hasnt been found