### PR TITLE
Allow net_address GET argument to be filled in SeedDB's Prefix edit form

### DIFF
--- a/python/nav/web/seeddb/utils/edit.py
+++ b/python/nav/web/seeddb/utils/edit.py
@@ -112,8 +112,8 @@ def render_edit(
                     'sub_active': {'edit': True},
                 }
             )
-    extra_context.update(context)
-    return render(request, template, extra_context)
+    context.update(extra_context)
+    return render(request, template, context)
 
 
 def _get_object(model, object_id, identifier_attr='pk'):


### PR DESCRIPTION
As evidenced by #2410, SeedDB's `render_edit` (`nav.web.seedddb.utils.edit.render_edit`) was broken. The prefix edit page provides its own `form` value in the `extra_context`. However, `render_edit()` would override the contents of `extra_context` with its defaults.

This really needs to be the other way around, which this commit fixes.

Fixes #2410