### PR TITLE
Add functions to get related objects and extended description

### DIFF
--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -834,24 +834,36 @@ class Device(models.Model):
         return self.serial or ''
 
     def get_related_objects(self):
+        """
+        Returns the related modules/power supplies/fans/netbox
+        entities of a device.
+        """
         modules = self.module_set.all()
         power_supplies_or_fans = self.powersupplyorfan_set.all()
         netbox_entities = self.netboxentity_set.all()
         return modules or power_supplies_or_fans or netbox_entities
 
     def get_preferred_related_object(self):
+        """
+        Returns the first related module/power supply/fan/netbox
+        entity of a device.
+        """
         related_objects = self.get_related_objects()
         if not related_objects:
             return None
         if len(related_objects) > 1:
             _logger.info(
                 "Device.get_related_objects(): %s weirdly appears to have "
-                "duplicate entities, returning just one",
+                "duplicate related objects, returning just one",
                 self,
             )
         return related_objects[0]
 
     def get_extended_description(self):
+        """
+        Returns the extended description of a device. This is usually
+        the string representation of an related object.
+        """
         related_object = self.get_preferred_related_object()
         if related_object:
             return str(related_object)

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -833,6 +833,30 @@ class Device(models.Model):
     def __str__(self):
         return self.serial or ''
 
+    def get_related_objects(self):
+        modules = self.module_set.all()
+        power_supplies_or_fans = self.powersupplyorfan_set.all()
+        netbox_entities = self.netboxentity_set.all()
+        return modules or power_supplies_or_fans or netbox_entities
+
+    def get_preferred_related_object(self):
+        related_objects = self.get_related_objects()
+        if not related_objects:
+            return None
+        if len(related_objects) > 1:
+            _logger.info(
+                "Device.get_related_objects(): %s weirdly appears to have "
+                "duplicate entities, returning just one",
+                self,
+            )
+        return related_objects[0]
+
+    def get_extended_description(self):
+        related_object = self.get_preferred_related_object()
+        if related_object:
+            return str(related_object)
+        return str(self)
+
 
 class Module(models.Model):
     """From NAV Wiki: The module table defines modules. A module is a part of a


### PR DESCRIPTION
To supplement #2413 and #2414 this PR provided new methods that will return all related objects, which generally should only one objects. 

Since the data model allows multiple ones and it can't be guaranteed it also provides a method that return the preferred related object, which in this case is just the first of the related objects since we couldn't think of a more reasonable way to determine the preferred object.

It also introduces a method that returns an extended description, which is the string representation of the preferred object if it exists or the normal string representation of the device.