### PR TITLE
Fix scripts so they no longer use Netbox.snmp_version

### DIFF
--- a/bin/naventity
+++ b/bin/naventity
@@ -164,23 +164,28 @@ def device(devicestring):
         else:
             netbox = netbox[0]
 
-    if not netbox.read_only:
-        msg = "No SNMP community set for %s" % netbox
+    if not netbox.get_preferred_snmp_management_profile(writeable=False):
+        msg = "No SNMP management profile set for %s" % netbox
         raise argparse.ArgumentTypeError(msg)
 
     return netbox
 
 
 def _create_agentproxy(netbox, portnumber):
-    if not netbox.read_only:
+    profile = netbox.get_preferred_snmp_management_profile(writeable=False)
+    if (
+        not profile
+        or not hasattr(profile, "snmp_community")
+        or not hasattr(profile, "snmp_version")
+    ):
         return
 
     port = snmpprotocol.port()
     agent = AgentProxy(
         netbox.ip,
         portnumber,
-        community=netbox.read_only,
-        snmpVersion='v%s' % netbox.snmp_version,
+        community=profile.snmp_community,
+        snmpVersion='v%s' % profile.snmp_version,
         protocol=port.protocol,
         snmp_parameters=snmp_parameter_factory(netbox),
     )

--- a/bin/navoidverify
+++ b/bin/navoidverify
@@ -118,15 +118,20 @@ _ports = cycle([snmpprotocol.port() for _ in range(50)])
 
 
 def _create_agentproxy(netbox):
-    if not netbox.read_only:
+    profile = netbox.get_preferred_snmp_management_profile(writeable=False)
+    if (
+        not profile
+        or not hasattr(profile, "snmp_community")
+        or not hasattr(profile, "snmp_version")
+    ):
         return
 
     port = next(_ports)
     agent = AgentProxy(
         netbox.ip,
         161,
-        community=netbox.read_only,
-        snmpVersion='v%s' % netbox.snmp_version,
+        community=profile.snmp_community,
+        snmpVersion='v%s' % profile.snmp_version,
         protocol=port.protocol,
         snmp_parameters=snmp_parameter_factory(netbox),
     )

--- a/bin/navsnmp
+++ b/bin/navsnmp
@@ -69,13 +69,14 @@ def get_matching_boxes(patterns):
 
 
 def snmp_printer(netbox):
+    profile = netbox.get_preferred_snmp_management_profile()
     version = ''
-    if netbox.snmp_version == 1:
+    if getattr(profile, "snmp_version", None) == 1:
         version = '1'
-    elif netbox.snmp_version == 2:
+    elif getattr(profile, "snmp_version", None) == 2:
         version = '2c'
 
-    if not netbox.read_only or not version:
+    if not profile or not version:
         print("%s has no valid SNMP configuration in NAV" % netbox, file=sys.stderr)
         return
 
@@ -86,7 +87,9 @@ def snmp_printer(netbox):
     print("# {}".format(netbox.sysname), file=sys.stderr)
     print(
         "-v{version} -c {community} {ipaddr}".format(
-            version=version, community=netbox.read_only, ipaddr=ipaddr
+            version=version,
+            community=profile.snmp_community,
+            ipaddr=ipaddr,
         )
     )
 

--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -214,8 +214,10 @@ def populate_infodict(request, netbox, interfaces):
             "%s did not respond within the set timeouts. Values displayed are from database"
             % netbox.sysname,
         )
-        if isinstance(handler, SNMPHandler) and not netbox.read_only:
-            messages.error(request, "Read only community not set")
+        if isinstance(
+            handler, SNMPHandler
+        ) and not netbox.get_preferred_snmp_management_profile(writeable=False):
+            messages.error(request, "Read only management profile not set")
     except ProtocolError:
         readonly = True
         messages.error(

--- a/tests/unittests/arnold/arnold_snmp_test.py
+++ b/tests/unittests/arnold/arnold_snmp_test.py
@@ -15,6 +15,7 @@ class TestArnoldSnmp(unittest.TestCase):
         self.ifindex = 1
         self.port_status_oid = '.1.3.6.1.2.1.2.2.1.7'
 
+        self.profile = self.create_management_profile_mock()
         self.netbox = self.create_netbox_mock()
         self.interface = self.create_interface_mock()
 
@@ -25,14 +26,19 @@ class TestArnoldSnmp(unittest.TestCase):
         interface.ifindex = self.ifindex
         return interface
 
+    def create_management_profile_mock(self):
+        """Create management profile model mock object"""
+        profile = Mock()
+        profile.snmp_version = 1
+        profile.snmp_community = "public"
+        return profile
+
     def create_netbox_mock(self):
         """Create netbox model mock object"""
         netbox = Mock()
         netbox.ip = self.ip
-        netbox.read_write = self.read_write
-        netbox.read_only = self.read_write
-        netbox.snmp_version = 1
         netbox.type.vendor.id = 'cisco'
+        netbox.get_preferred_snmp_management_profile.return_value = self.profile
         return netbox
 
     def test_change_port_status_enable(self, snmp):
@@ -42,7 +48,9 @@ class TestArnoldSnmp(unittest.TestCase):
         identity.interface = self.interface
         change_port_status('enable', identity)
 
-        snmp.assert_called_once_with(self.ip, self.read_write, version=1)
+        snmp.assert_called_once_with(
+            self.ip, self.profile.snmp_community, self.profile.snmp_version
+        )
         instance.set.assert_called_once_with(
             self.port_status_oid + '.' + str(self.ifindex), 'i', 1
         )
@@ -54,7 +62,9 @@ class TestArnoldSnmp(unittest.TestCase):
         identity.interface = self.interface
         change_port_status('disable', identity)
 
-        snmp.assert_called_once_with(self.ip, self.read_write, version=1)
+        snmp.assert_called_once_with(
+            self.ip, self.profile.snmp_community, self.profile.snmp_version
+        )
         instance.set.assert_called_once_with(
             self.port_status_oid + '.' + str(self.ifindex), 'i', 2
         )

--- a/tests/unittests/portadmin/portadmin_test.py
+++ b/tests/unittests/portadmin/portadmin_test.py
@@ -12,6 +12,10 @@ from nav.portadmin.vlan import FantasyVlan
 
 class PortadminResponseTest(unittest.TestCase):
     def setUp(self):
+        self.profile = Mock()
+        self.profile.snmp_version = 2
+        self.profile.snmp_community = "public"
+
         self.hpVendor = Mock()
         self.hpVendor.id = u'hp'
 
@@ -29,12 +33,14 @@ class PortadminResponseTest(unittest.TestCase):
         self.netboxHP = Mock()
         self.netboxHP.type = self.hpType
         self.netboxHP.ip = '10.240.160.39'
-        self.netboxHP.snmp_version = "2c"
+        self.netboxHP.get_preferred_snmp_management_profile.return_value = self.profile
 
         self.netboxCisco = Mock()
         self.netboxCisco.type = self.ciscoType
         self.netboxCisco.ip = '10.240.160.38'
-        self.netboxCisco.snmp_version = "2c"
+        self.netboxCisco.get_preferred_snmp_management_profile.return_value = (
+            self.profile
+        )
 
         self.snmpReadOnlyHandler = None
         self.handler = None


### PR DESCRIPTION
Fixes #2389.

Introduces a new function `get_preferred_snmp_management_profile` that return the profile with the highest snmp version, which then can be used to get the profiles snmp version or community.

Also replaces the occurrences of `netbox.read_only`, `netbox.read_write` and `netbox.snmp_version` using the new function everywhere expect in ipdevpoll. In ipdevpoll it is not clear yet how to do that since shadow classes are used there, which only copy the attributes, but not functions.