### PR TITLE
Stop resource leakage when reading conf files

### DIFF
--- a/python/nav/config.py
+++ b/python/nav/config.py
@@ -81,20 +81,21 @@ def read_flat_config(config_file, delimiter='='):
     if isinstance(config_file, str):
         config_file = open_configfile(config_file)
 
-    configuration = {}
-    for line in config_file.readlines():
-        line = line.strip()
-        # Unless the line is a comment, we parse it
-        if line and line[0] != '#':
-            # Split the key/value pair (max 1 split)
-            try:
-                (key, value) = line.split(delimiter, 1)
-                value = value.split('#', 1)[0]  # Remove end-of-line comments
-                configuration[key.strip()] = value.strip()
-            except ValueError:
-                sys.stderr.write("Config file %s has errors.\n" % config_file.name)
+    with config_file:
+        configuration = {}
+        for line in config_file.readlines():
+            line = line.strip()
+            # Unless the line is a comment, we parse it
+            if line and line[0] != '#':
+                # Split the key/value pair (max 1 split)
+                try:
+                    (key, value) = line.split(delimiter, 1)
+                    value = value.split('#', 1)[0]  # Remove end-of-line comments
+                    configuration[key.strip()] = value.strip()
+                except ValueError:
+                    sys.stderr.write("Config file %s has errors.\n" % config_file.name)
 
-    return configuration
+        return configuration
 
 
 def getconfig(configfile, defaults=None):
@@ -110,17 +111,18 @@ def getconfig(configfile, defaults=None):
     if isinstance(configfile, str):
         configfile = open_configfile(configfile)
 
-    config = configparser.RawConfigParser(defaults)
-    config.read_file(configfile)
+    with configfile:
+        config = configparser.RawConfigParser(defaults)
+        config.read_file(configfile)
 
-    sections = config.sections()
-    configdict = {}
+        sections = config.sections()
+        configdict = {}
 
-    for section in sections:
-        configsection = config.items(section)
-        configdict[section] = dict(configsection)
+        for section in sections:
+            configsection = config.items(section)
+            configdict[section] = dict(configsection)
 
-    return configdict
+        return configdict
 
 
 class NAVConfigParser(configparser.ConfigParser):


### PR DESCRIPTION
This should fix the annoying ResourceWarnings coming through during the test suite:

```
/source/python/nav/config.py:339: ResourceWarning: unclosed file <_io.TextIOWrapper name='/source/.tox/integration-py37-django32/etc/nav.conf' mode='r' encoding='utf-8'>
  NAV_CONFIG = read_flat_config('nav.conf')
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/source/python/nav/django/settings.py:36: ResourceWarning: unclosed file <_io.TextIOWrapper name='/source/.tox/integration-py37-django32/etc/webfront/webfront.conf' mode='r' encoding='utf-8'>
  _webfront_config = getconfig('webfront/webfront.conf')
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/source/python/nav/db/__init__.py:104: ResourceWarning: unclosed file <_io.TextIOWrapper name='/source/.tox/integration-py37-django32/etc/db.conf' mode='r' encoding='utf-8'>
  conf = config.read_flat_config('db.conf')
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

This PR just ensures we wrap the config-reading code in a context manager so the config files always end up being closed.