### PR TITLE
Ignore VLANs with non-numerical tags in Juniper NETCONF responses.

### DIFF
--- a/python/nav/portadmin/napalm/juniper.py
+++ b/python/nav/portadmin/napalm/juniper.py
@@ -221,7 +221,11 @@ class Juniper(ManagementHandler):
                     tag, netident=vlan_object.net_ident, descr=vlan_object.description
                 )
 
-        result = {_make_vlan(vlan) for vlan in self.vlans}
+        result = {
+            _make_vlan(vlan)
+            for vlan in self.vlans
+            if isinstance(vlan.tag, int) or vlan.tag.isdigit()
+        }
         return sorted(result, key=attrgetter("vlan"))
 
     def get_netbox_vlan_tags(self) -> List[int]:

--- a/tests/unittests/portadmin/napalm/juniper_test.py
+++ b/tests/unittests/portadmin/napalm/juniper_test.py
@@ -13,12 +13,14 @@
 # more details.  You should have received a copy of the GNU General Public
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
+from unittest.mock import Mock, patch
+
 import pytest
 
 from jnpr.junos.exception import RpcError
 
 from nav.portadmin.handlers import ProtocolError
-from nav.portadmin.napalm.juniper import wrap_unhandled_rpc_errors
+from nav.portadmin.napalm.juniper import wrap_unhandled_rpc_errors, Juniper
 
 
 class TestWrapUnhandledRpcErrors:
@@ -37,3 +39,18 @@ class TestWrapUnhandledRpcErrors:
 
         with pytest.raises(TypeError):
             wrapped_function()
+
+
+class TestJuniper:
+    @patch('nav.models.manage.Vlan.objects', Mock(return_value=[]))
+    def test_get_netbox_vlans_should_ignore_vlans_with_non_integer_tags(self):
+        """Regression test for #2452"""
+
+        class MockedJuniperHandler(Juniper):
+            @property
+            def vlans(self):
+                """Mock a VLAN table response from the device"""
+                return [Mock(tag='NA'), Mock(tag='10')]
+
+        m = MockedJuniperHandler(Mock())
+        assert len(m.get_netbox_vlans()) == 1


### PR DESCRIPTION
PortAdmin only cares about VLANs that can be identified through a proper 12-bit integer tag, so it should be safe to ignore ones that do not conform to the expected response from Juniper switches.

Fixes #2452

