### PR TITLE
Make snmptrapd able to identify trap agents that use a different IP to send traps than to receive SNMP queries

### DIFF
--- a/python/nav/snmptrapd/trap.py
+++ b/python/nav/snmptrapd/trap.py
@@ -65,8 +65,8 @@ class SNMPTrap(object):
         conn = getConnection('snmptrapd')
         cur = conn.cursor()
         cur.execute(
-            "SELECT netboxid, sysname, roomid FROM netbox WHERE ip = %s",
-            (self.agent,),
+            "SELECT netboxid, sysname, roomid FROM gwportprefix JOIN interface USING (interfaceid) JOIN netbox USING (netboxid) WHERE ip = %s OR gwip = %s",
+            (self.agent, self.agent),
         )
 
         if cur.rowcount < 1:

--- a/python/nav/snmptrapd/trap.py
+++ b/python/nav/snmptrapd/trap.py
@@ -65,8 +65,13 @@ class SNMPTrap(object):
         conn = getConnection('snmptrapd')
         cur = conn.cursor()
         cur.execute(
-            "SELECT netboxid, sysname, roomid FROM gwportprefix JOIN interface USING (interfaceid) JOIN netbox USING (netboxid) WHERE ip = %s OR gwip = %s",
-            (self.agent, self.agent),
+            "SELECT DISTINCT netboxid, sysname, roomid "
+            "FROM gwportprefix "
+            "JOIN interface USING (interfaceid) "
+            "JOIN netbox USING (netboxid) "
+            "WHERE %s IN (ip, gwip) "(
+                self.agent,
+            ),
         )
 
         if cur.rowcount < 1:


### PR DESCRIPTION
Closes #2387