### PR TITLE
Update references to NAV mailing lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ found in the [HISTORY](HISTORY) file.
 ### Changed
 
 - Bump `lxml` from 4.6.5 to 4.9.1 in /tests ([#2443](https://github.com/Uninett/nav/pull/2443))
+- Links and documented references to the NAV mailing lists have changed to the `lister.sikt.no` domain.
 
 ### Added
 

--- a/doc/faq/faq.rst
+++ b/doc/faq/faq.rst
@@ -17,7 +17,7 @@ these have been a mainstay in the Norwegian higher education sector for years.
 
 For any other vendors, we suggest that you just add your devices to NAV and
 see whether NAV reports what you want it to report. If it doesn't, submit a
-question to the mailing list, nav-users@uninett.no.
+question to the mailing list, nav-users@lister.sikt.no.
 
 Why are there gaps in my graphs?
 --------------------------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -24,8 +24,8 @@ Getting help
 * Report a bug in our `bug tracker`_.
 
 .. _wiki pages: https://nav.uninett.no/wiki/
-.. _nav-users mailing list archives: https://sympa.uninett.no/lists/uninett.no/arc/nav-users
-.. _the nav-users mailing list: https://sympa.uninett.no/lists/uninett.no/info/nav-users
+.. _nav-users mailing list archives: https://lister.sikt.no/hyperkitty/list/nav-users@lister.sikt.no/
+.. _the nav-users mailing list: https://lister.sikt.no/postorius/lists/nav-users.lister.sikt.no/
 .. _#nav IRC channel: irc://irc.libera.chat/nav
 .. _bug tracker: https://github.com/Uninett/nav
 


### PR DESCRIPTION
Mailing lists are moving from Sympa at uninett.no to Mailman at lister.sikt.no.