### PR TITLE
Ensure NetboxType is loaded in a db thread

### DIFF
--- a/python/nav/ipdevpoll/plugins/typeoid.py
+++ b/python/nav/ipdevpoll/plugins/typeoid.py
@@ -81,6 +81,7 @@ class TypeOid(Plugin):
         self._set_type(shadows.NetboxType(new_type))
 
     @staticmethod
+    @db.synchronous_db_access
     def _get_type_from_oid(oid):
         """Loads from db a type object matching the sysobjectid."""
         term = str(oid).strip(".")


### PR DESCRIPTION
This would run synchronously in the MainThread, which is a big no-no. It would block the entire MainThread while waiting for the ORM result from PostgreSQL, and also potentially attempt to use closed database connections withouth the connection re-establishment precautions that come with the database thread.

In short: MainThread is not designed to access the database at all!

Fixes #2478