### PR TITLE
Authenticate API with JWT tokens

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,8 @@ RUN apt-get update \
        dnsutils \
        iproute2 \
        iputils-ping \
-       snmp
+       snmp \
+       openssh-client
 
 RUN adduser --system --group --no-create-home --home=/source --shell=/bin/bash nav
 

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -255,6 +255,17 @@ SEARCHPROVIDERS = [
     'nav.web.info.searchproviders.UnrecognizedNeighborSearchProvider',
 ]
 
+_verifying_key = None
+_pub_key_path = NAV_CONFIG.get('VERIFYING_KEY_PATH', '')
+if os.path.isfile(_pub_key_path):
+    with open(_pub_key_path) as f:
+        _verifying_key = f.read()
+
+SIMPLE_JWT = {
+    'ALGORITHM': 'RS256',
+    'VERIFYING_KEY': _verifying_key,
+}
+
 # Hack for hackers to use features like debug_toolbar etc.
 # https://code.djangoproject.com/wiki/SplitSettings (Rob Golding's method)
 if _config_dir:

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -217,10 +217,13 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'django.contrib.sessions',
     'django.contrib.humanize',
+    'django.contrib.contenttypes',
+    'django.contrib.auth',
     'django_filters',
     'crispy_forms',
     'crispy_forms_foundation',
     'rest_framework',
+    'rest_framework_simplejwt',
     'nav.auditlog',
     'nav.web.macwatch',
     'nav.web.geomap',
@@ -235,6 +238,9 @@ REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
     'DEFAULT_PAGINATION_CLASS': 'nav.web.api.v1.NavPageNumberPagination',
     'UNAUTHENTICATED_USER': 'nav.django.utils.default_account',
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework_simplejwt.authentication.JWTStatelessUserAuthentication',
+    ),
 }
 
 # Classes that implement a search engine for the web navbar

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -28,6 +28,7 @@ from django.utils.log import DEFAULT_LOGGING
 from nav.config import NAV_CONFIG, getconfig, find_config_dir
 from nav.db import get_connection_parameters
 import nav.buildconf
+from nav.web.api.config import API_CONF
 
 ALLOWED_HOSTS = ['*']
 
@@ -256,11 +257,10 @@ SEARCHPROVIDERS = [
 ]
 
 
-with open(NAV_CONFIG['VERIFYING_KEY']) as f:
-    SIMPLE_JWT = {
-        'ALGORITHM': 'RS256',
-        'VERIFYING_KEY': f.read(),
-    }
+SIMPLE_JWT = {
+    'ALGORITHM': 'RS256',
+    'VERIFYING_KEY': API_CONF.get_public_key(),
+}
 
 # Hack for hackers to use features like debug_toolbar etc.
 # https://code.djangoproject.com/wiki/SplitSettings (Rob Golding's method)

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -255,16 +255,12 @@ SEARCHPROVIDERS = [
     'nav.web.info.searchproviders.UnrecognizedNeighborSearchProvider',
 ]
 
-_verifying_key = None
-_pub_key_path = NAV_CONFIG.get('VERIFYING_KEY_PATH', '')
-if os.path.isfile(_pub_key_path):
-    with open(_pub_key_path) as f:
-        _verifying_key = f.read()
 
-SIMPLE_JWT = {
-    'ALGORITHM': 'RS256',
-    'VERIFYING_KEY': _verifying_key,
-}
+with open(NAV_CONFIG['VERIFYING_KEY']) as f:
+    SIMPLE_JWT = {
+        'ALGORITHM': 'RS256',
+        'VERIFYING_KEY': f.read(),
+    }
 
 # Hack for hackers to use features like debug_toolbar etc.
 # https://code.djangoproject.com/wiki/SplitSettings (Rob Golding's method)

--- a/python/nav/etc/api/api.conf
+++ b/python/nav/etc/api/api.conf
@@ -1,3 +1,8 @@
+# These keys are used for signing and verifying JWT tokens
+# Tip for generating keys:
+# ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key -N ""
+# openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
+# file can be given as an absolute path or path relative to the folder this file is in
 [keys]
 public_key=jwtRS256.key.pub
 private_key=jwtRS256.key

--- a/python/nav/etc/api/api.conf
+++ b/python/nav/etc/api/api.conf
@@ -1,8 +1,7 @@
-# These keys are used for signing and verifying JWT tokens
+# Supports setting a public key for authenticating JWT tokens
 # Tip for generating keys:
 # ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key -N ""
 # openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
 # file can be given as an absolute path or path relative to the folder this file is in
 [keys]
 public_key=jwtRS256.key.pub
-private_key=jwtRS256.key

--- a/python/nav/etc/api/api.conf
+++ b/python/nav/etc/api/api.conf
@@ -1,0 +1,3 @@
+[keys]
+public_key=jwtRS256.key.pub
+private_key=jwtRS256.key

--- a/python/nav/web/api/config.py
+++ b/python/nav/web/api/config.py
@@ -1,0 +1,28 @@
+from os.path import isabs, join
+from nav.config import NAVConfigParser, find_config_dir
+
+
+class APIConfig(NAVConfigParser):
+    DEFAULT_CONFIG_FILES = (join("api", "api.conf"),)
+    DEFAULT_CONFIG = """
+[keys]
+public_key=jwtRS256.key.pub
+private_key=jwtRS256.key
+"""
+
+    def get_public_key(self):
+        self.get_key('public_key')
+
+    def get_private_key(self):
+        self.get_key('private_key')
+
+    def get_key(self, key_name):
+        path = self.get('keys', key_name)
+        if not isabs(path):
+            path = join(find_config_dir(), "api", path)
+
+        with open(path) as f:
+            return f.read()
+
+
+API_CONF = APIConfig()

--- a/python/nav/web/api/config.py
+++ b/python/nav/web/api/config.py
@@ -7,20 +7,15 @@ class APIConfig(NAVConfigParser):
     DEFAULT_CONFIG = """
 [keys]
 public_key=jwtRS256.key.pub
-private_key=jwtRS256.key
 """
 
     def get_public_key(self):
         self.get_key('public_key')
 
-    def get_private_key(self):
-        self.get_key('private_key')
-
     def get_key(self, key_name):
         path = self.get('keys', key_name)
         if not isabs(path):
             path = join(find_config_dir(), "api", path)
-
         with open(path) as f:
             return f.read()
 

--- a/python/nav/web/api/config.py
+++ b/python/nav/web/api/config.py
@@ -1,12 +1,12 @@
-from os.path import isabs, join
-from nav.config import NAVConfigParser, find_config_dir
+from os.path import isabs, join, dirname
+from nav.config import ConfigurationError, NAVConfigParser, find_config_file
 
 
 class APIConfig(NAVConfigParser):
     DEFAULT_CONFIG_FILES = (join("api", "api.conf"),)
     DEFAULT_CONFIG = u"""
 [keys]
-public_key=jwtRS256.key.pub
+public_key=/etc/nav/api/jwtRS256.key.pub
 """
 
     def get_public_key(self):
@@ -14,8 +14,11 @@ public_key=jwtRS256.key.pub
 
     def get_key(self, key_name):
         path = self.get('keys', key_name)
+        if not path:
+            raise ConfigurationError(f"{key_name} is not configured")
         if not isabs(path):
-            path = join(find_config_dir(), "api", path)
+            config_file = find_config_file(self.DEFAULT_CONFIG_FILES[0])
+            path = join(dirname(config_file), path)
         with open(path) as f:
             return f.read()
 

--- a/python/nav/web/api/config.py
+++ b/python/nav/web/api/config.py
@@ -4,7 +4,7 @@ from nav.config import NAVConfigParser, find_config_dir
 
 class APIConfig(NAVConfigParser):
     DEFAULT_CONFIG_FILES = (join("api", "api.conf"),)
-    DEFAULT_CONFIG = """
+    DEFAULT_CONFIG = u"""
 [keys]
 public_key=jwtRS256.key.pub
 """

--- a/python/nav/web/api/config.py
+++ b/python/nav/web/api/config.py
@@ -18,6 +18,10 @@ public_key=/etc/nav/api/jwtRS256.key.pub
             raise ConfigurationError(f"{key_name} is not configured")
         if not isabs(path):
             config_file = find_config_file(self.DEFAULT_CONFIG_FILES[0])
+            if not config_file:
+                raise FileNotFoundError(
+                    f"Could not find {self.DEFAULT_CONFIG_FILES[0]}"
+                )
             path = join(dirname(config_file), path)
         with open(path) as f:
             return f.read()

--- a/python/nav/web/api/v1/auth.py
+++ b/python/nav/web/api/v1/auth.py
@@ -70,9 +70,9 @@ class JWTAuthentication(SimpleJWTAuthentication):
         _logger.info(f"Token payload: {validated_token.payload}")
 
         if 'exp' not in validated_token:
-            raise InvalidToken("Token contained no expiry date")
+            raise InvalidToken("Token did not contain a 'exp' claim")
         if 'nbf' not in validated_token:
-            raise InvalidToken("Token contained no valid before date")
+            raise InvalidToken("Token did not contain a 'nbf' claim")
         return None, validated_token
 
 

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -50,7 +50,12 @@ from nav.buildconf import VERSION
 from nav.web.api.v1 import serializers, alert_serializers
 from nav.web.status2 import STATELESS_THRESHOLD
 from nav.macaddress import MacPrefix
-from .auth import APIPermission, APIAuthentication, NavBaseAuthentication
+from .auth import (
+    APIPermission,
+    APIAuthentication,
+    NavBaseAuthentication,
+    JWTAuthentication,
+)
 from .helpers import prefix_collector
 from .filter_backends import (
     AlertHistoryFilterBackend,
@@ -199,7 +204,11 @@ class RelatedOrderingFilter(filters.OrderingFilter):
 class NAVAPIMixin(APIView):
     """Mixin for providing permissions and renderers"""
 
-    authentication_classes = (NavBaseAuthentication, APIAuthentication)
+    authentication_classes = (
+        NavBaseAuthentication,
+        APIAuthentication,
+        JWTAuthentication,
+    )
     permission_classes = (APIPermission,)
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
     filter_backends = (filters.SearchFilter, DjangoFilterBackend, RelatedOrderingFilter)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -35,3 +35,5 @@ pynetsnmp-2>=0.1.8,<0.2.0
 libsass==0.15.1
 
 napalm==3.4.1
+
+djangorestframework-simplejwt[crypto]

--- a/tools/docker/build.sh
+++ b/tools/docker/build.sh
@@ -15,6 +15,9 @@ sudo -u nav python3 setup.py build_sass
 if [[ ! -f "/etc/nav/nav.conf" ]]; then
     echo "Copying initial NAV config files into this container"
     nav config install --verbose /etc/nav
+    # Generate fresh JWT keys
+    ssh-keygen -t rsa -b 4096 -m PEM -f /etc/nav/api/jwtRS256.key -N ""
+    openssl rsa -in /etc/nav/api/jwtRS256.key -pubout -outform PEM -out /etc/nav/api/jwtRS256.key.pub
     chown -R nav:nav /etc/nav
     cd /etc/nav
     sed -e 's/^#\s*\(DJANGO_DEBUG.*\)$/\1/' -i nav.conf  # Enable django debug.

--- a/tools/docker/build.sh
+++ b/tools/docker/build.sh
@@ -16,7 +16,7 @@ if [[ ! -f "/etc/nav/nav.conf" ]]; then
     echo "Copying initial NAV config files into this container"
     nav config install --verbose /etc/nav
     # Generate fresh JWT keys
-    ssh-keygen -t rsa -b 4096 -m PEM -f /etc/nav/api/jwtRS256.key -N ""
+    ssh-keygen -t rsa -b 4096 -m PEM -f /etc/nav/api/jwtRS256.key -q -N ""
     openssl rsa -in /etc/nav/api/jwtRS256.key -pubout -outform PEM -out /etc/nav/api/jwtRS256.key.pub
     chown -R nav:nav /etc/nav
     cd /etc/nav


### PR DESCRIPTION
Fixes #2483 

Supports setting a public key that is used to verify JWT tokens. If verified successfully, it gives access to API.
Currently requires a path to a RS256 public key file to be set for `VERIFYING_KEY` in nav.conf, or the whole dang thing will explode. (this currently happens for github tests since no keys are generated)

Currently these claims are required:
- exp
- nbf
- token_type (access or refresh, can be disabled with simpleJWT config)
- jti (Can be disabled with simpleJWT config)

Limitations not to be addressed in this PR: 
- Currently no permission claims supported, so you get access to the entire API with no restrictions
- NAV does not create JWT tokens itself, it only authenticates externally signed tokens

Stuff this PR should maybe add:
- Config to disable/enable JWT tokens.  If someone is not interested in using JWT tokens they might not want to go through the "hassle" of generating keys and making sure they're safe.
- Changes to required claims
