### PR TITLE
Add list of chassis mac addresses to /netbox API endpoint

### DIFF
--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -28,6 +28,7 @@ from itertools import count, groupby
 import logging
 import math
 import re
+from typing import Set
 
 import IPy
 from django.conf import settings
@@ -573,6 +574,15 @@ class Netbox(models.Model):
             Q(unit_of_measurement__icontains='celsius')
             | Q(unit_of_measurement__icontains='percent')
         )
+
+    @property
+    def mac_addresses(self) -> Set[str]:
+        """Returns a set of collected chassis MAC addresses for this Netbox"""
+        macinfo_match = (Q(key="bridge_info") & Q(variable="base_address")) | (
+            Q(key="lldp") & Q(variable="chassis_mac")
+        )
+        macs = self.info_set.filter(macinfo_match).distinct("value").only("value")
+        return set(mac.value for mac in macs)
 
 
 class NetboxInfo(models.Model):

--- a/python/nav/web/api/v1/serializers.py
+++ b/python/nav/web/api/v1/serializers.py
@@ -204,6 +204,8 @@ class NetboxSerializer(serializers.ModelSerializer):
         queryset=manage.ManagementProfile.objects,
     )
 
+    mac_addresses = serializers.ListField()
+
     class Meta(object):
         model = manage.Netbox
         depth = 1

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -389,7 +389,7 @@ class NetboxViewSet(LoggerMixin, NAVAPIMixin, viewsets.ModelViewSet):
     When the filtered item is an object, it will filter on the id.
     """
 
-    queryset = manage.Netbox.objects.all()
+    queryset = manage.Netbox.objects.all().prefetch_related("info_set")
     serializer_class = serializers.NetboxSerializer
     filterset_fields = (
         'ip',

--- a/tests/integration/models/netbox_test.py
+++ b/tests/integration/models/netbox_test.py
@@ -53,6 +53,16 @@ def test_netbox_should_be_annotated_with_chassis_serial(db, localhost):
     assert netbox.chassis_serial == "first"
 
 
+def test_netbox_mac_addresses_should_return_distinct_set_of_addresses(
+    db, localhost: Netbox
+):
+    mac = "00:c0:ff:ee:ba:be"
+    localhost.info_set.create(key="lldp", variable="chassis_mac", value=mac)
+    localhost.info_set.create(key="bridge_info", variable="base_address", value=mac)
+
+    assert localhost.mac_addresses == set([mac])
+
+
 @pytest.fixture
 def wanted_profile():
     return ManagementProfile(


### PR DESCRIPTION
By request from the CNaaS core team at Sikt, the main chassis mac address (of which there may be more than one) must be made available through the `/netbox` API endpoint, so that IP Devices can be matched with inventory records from 3rd party systems (such as CMDBs).

This PR adds an extra Netbox attribute containing a unique set of  base/chassis addresses collected via `BRIDGE-MIB` or `LLDP-MIB`. 

MAC addresses of individual physical ports are not considered in this API, as these are available through the `/interfaces` endpoint.