### PR TITLE
 Update zoom correctly when requesting link to this configuration

### DIFF
--- a/python/nav/web/static/js/geomap/GeomapPlugin.js
+++ b/python/nav/web/static/js/geomap/GeomapPlugin.js
@@ -135,6 +135,22 @@ function(Spinner, fullscreen) {
             var requestedBounds = OpenLayers.Bounds.fromArray(parameters.bbox);
             requestedBounds.transform(map.displayProjection, map.getProjectionObject());
             map.zoomToExtent(requestedBounds);
+        } else if (parameters.zoom !== null && parameters.zoom !== undefined) {
+            try {
+                if (parameters.lat !== null && parameters.lat !== undefined
+                    && parameters.lon !== null && parameters.lon !== undefined) {
+                    map.setView(
+                        new OpenLayers.View({
+                            center: OpenLayers.Projection.fromLonLat([parameters.lon, parameters.lat]),
+                            extent: map.getView().calculateExtent(map.getSize()),
+                            zoom: parameters.zoom
+                        })
+                    );
+                } else {
+                    map.getView.setZoom(parameters.zoom);
+                }
+                map.getView.setZoom(parameters.zoom);
+            } catch (e) {}
         } else if (boundingBox) {
             boundingBox.transform(map.displayProjection, map.getProjectionObject());
             map.zoomToExtent(boundingBox);


### PR DESCRIPTION
### Changes made:
Function zoomToBounds() updates zoom correctly in accordance with the parameters it receives. This applies to several use cases, and specifically to a scenario when user requests a link to the current configuration.


Before, zoom value was ignored in view, but was present in the url, when user requested a link to current configuration. This commit makes zoomToBound() apply changes to zoom, when parameters are present. Parameters are present if the url with zoom, lon, lat values is present, ie when user requests link to current configuration.

Closes #2412 