### PR TITLE
Make mac_address non-required and read-only

### DIFF
--- a/python/nav/web/api/v1/serializers.py
+++ b/python/nav/web/api/v1/serializers.py
@@ -204,7 +204,7 @@ class NetboxSerializer(serializers.ModelSerializer):
         queryset=manage.ManagementProfile.objects,
     )
 
-    mac_addresses = serializers.ListField()
+    mac_addresses = serializers.ListField(read_only=True, required=False)
 
     class Meta(object):
         model = manage.Netbox


### PR DESCRIPTION
This attribute is not writeable, since it's a computed property of the Netbox model. Without these options, the API would require a client to include the mac_addresses field when posting new netboxes.

This just fixes #2487 - where three integration tests failed because of this, and still we didn't notice :-D
