### PR TITLE
Ignore devices with fake serial number 'BUILTIN'

### DIFF
--- a/python/nav/etc/ipdevpoll.conf
+++ b/python/nav/etc/ipdevpoll.conf
@@ -198,6 +198,13 @@ plugins = statsystem statsensors statmulticast
 #
 ignored = <<=127.0.0.0/8, <<=fe80::/16, =128.0.0.0/2
 
+[modules]
+# A space separated list of serial numbers that will be ignored as
+# modules/devices. The default value is used to ignore soldered-on
+# linecards that Juniper erroneously reports as fieldreplaceable
+# units in ENTITY-MIB
+#ignored-serials = BUILTIN
+
 [linkstate]
 # Which ports to generate linkState events/alerts for.  Allowed values are
 # 'topology' for uplink/downlink ports, or 'any' for all ports.

--- a/python/nav/ipdevpoll/plugins/modules.py
+++ b/python/nav/ipdevpoll/plugins/modules.py
@@ -81,6 +81,10 @@ class Modules(Plugin):
             serial_number = None
             device_key = 'unknown-%s' % ent[0]
 
+        if serial_number in self.ignored_serials:
+            self._logger.debug("ignoring %r due to ignored serial number", ent)
+            return None
+
         device = self.containers.factory(device_key, shadows.Device)
         if serial_number:
             device.serial = serial_number
@@ -113,6 +117,8 @@ class Modules(Plugin):
         for ent in modules:
             entity_index = ent[0]
             device = self._device_from_entity(ent)
+            if not device:
+                continue  # this device was ignored
             module = self._module_from_entity(ent)
             module.device = device
 

--- a/python/nav/models/sql/changes/sc.05.05.0001.sql
+++ b/python/nav/models/sql/changes/sc.05.05.0001.sql
@@ -1,0 +1,5 @@
+-- Delete crazy Juniper devices/modules that cause duplicates all over
+DELETE FROM device WHERE serial = 'BUILTIN';
+
+-- force re-collection of module data to ensure things come up-to-date after upgrade
+DELETE FROM netboxinfo WHERE key='poll_times' AND var='modules';

--- a/tests/unittests/ipdevpoll/modules_test.py
+++ b/tests/unittests/ipdevpoll/modules_test.py
@@ -1,0 +1,28 @@
+from configparser import ConfigParser
+
+from nav.ipdevpoll.plugins import modules
+
+
+class TestGetIgnoredSerials:
+    def test_should_return_correct_list_items(self):
+        cp = ConfigParser()
+        cp.read_string(
+            """
+        [modules]
+        ignored-serials = one   two three
+        """
+        )
+
+        result = modules.get_ignored_serials(cp)
+        assert result == ["one", "two", "three"]
+
+    def test_should_return_default_value_if_none_is_configured(self):
+        cp = ConfigParser()
+        result = modules.get_ignored_serials(cp)
+        assert result == ["BUILTIN"]
+
+
+class TestModulesPlugin:
+    def test_should_load_default_config_without_error(self):
+        modules.Modules.on_plugin_load()
+        assert modules.Modules.ignored_serials == ['BUILTIN']


### PR DESCRIPTION
This adds a config option to list device serial numbers that ipdevpoll should mostly ignore: I.e. it should not create modules for devices that have these serial numbers, and no Device entries either.

The default value of the serial number list is `BUILTIN`, which corresponds with the fake serial numbers lots of Juniper JunOS devices report. Making NAV Device entries out of these results in multiple Netboxes having modules and entities that point to the same Device entry, and they will compete against each other for updates to the Device entry's attributes.


This is a proposed hotfix that closes #2491