### PR TITLE
Fix broken SNMP trap agent lookup method

### DIFF
--- a/python/nav/snmptrapd/trap.py
+++ b/python/nav/snmptrapd/trap.py
@@ -66,9 +66,9 @@ class SNMPTrap(object):
         cur = conn.cursor()
         cur.execute(
             "SELECT DISTINCT netboxid, sysname, roomid "
-            "FROM gwportprefix "
-            "JOIN interface USING (interfaceid) "
-            "JOIN netbox USING (netboxid) "
+            "FROM netbox "
+            "LEFT JOIN interface USING (netboxid) "
+            "LEFT JOIN gwportprefix USING (interfaceid) "
             "WHERE %s IN (ip, gwip) ",
             (self.agent,),
         )

--- a/python/nav/snmptrapd/trap.py
+++ b/python/nav/snmptrapd/trap.py
@@ -69,9 +69,8 @@ class SNMPTrap(object):
             "FROM gwportprefix "
             "JOIN interface USING (interfaceid) "
             "JOIN netbox USING (netboxid) "
-            "WHERE %s IN (ip, gwip) "(
-                self.agent,
-            ),
+            "WHERE %s IN (ip, gwip) ",
+            (self.agent,),
         )
 
         if cur.rowcount < 1:

--- a/tests/integration/snmptrapd_test.py
+++ b/tests/integration/snmptrapd_test.py
@@ -6,7 +6,7 @@ import signal
 import time
 from nav.config import find_config_file
 from nav.snmptrapd.plugin import load_handler_modules
-
+from nav.snmptrapd.trap import SNMPTrap
 
 # Implementation tests for plugins
 
@@ -75,3 +75,20 @@ def test_traplistener_does_not_raise_error_on_signals():
         handler.close()
         signal.signal(signal.SIGALRM, signal.SIG_DFL)
         signal.alarm(0)
+
+
+class TestSnmpTrap:
+    def test_trap_agent_should_be_correctly_identified(self, localhost_using_legacy_db):
+        trap = SNMPTrap(
+            src="127.0.0.1",
+            agent="127.0.0.1",
+            type=None,
+            genericType=None,
+            snmpTrapOID=None,
+            uptime=None,
+            community="public",
+            version=2,
+            varbinds={},
+        )
+        netbox = trap.netbox
+        assert netbox.netboxid == localhost_using_legacy_db


### PR DESCRIPTION
This:

1. Adds a regression test to detect the problem
2. Fixes the silly syntax problem
3. Rewrites the SQL statement to one that actually gives results (as the test revealed that the method did not return the expected result even when the syntax problem was fixed).


Fixes #2497