### PR TITLE
Upgrade napalm to 4.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,4 +34,4 @@ pynetsnmp-2>=0.1.8,<0.2.0
 # libsass for compiling scss files to css using distutils/setuptools
 libsass==0.15.1
 
-napalm==3.4.1
+napalm==4.0.0


### PR DESCRIPTION
Fixes the tests not running due to incompatible dependencies.

Release notes from napalm: https://github.com/napalm-automation/napalm/releases