### PR TITLE
Use pip-compile's backtracking dependency resolver to fix failing CI pipelines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ COPY requirements/ /requirements
 COPY requirements.txt /
 COPY tests/requirements.txt /test-requirements.txt
 # Since we used pip3 to install pip globally, pip should now be for Python 3
-RUN pip-compile --output-file /requirements.txt.lock /requirements.txt /test-requirements.txt
+RUN pip-compile --resolver=backtracking --output-file /requirements.txt.lock /requirements.txt /test-requirements.txt
 RUN pip install -r /requirements.txt.lock
 
 ARG CUSTOM_PIP=ipython

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ allowlist_externals =
                       sed
                       mkdir
 commands_pre =
-         pip-compile --output-file {envdir}/requirements.txt tests/requirements.txt requirements/base.txt requirements/optional.txt requirements/django{env:DJANGO_VER}.txt
+         pip-compile --resolver=backtracking --output-file {envdir}/requirements.txt tests/requirements.txt requirements/base.txt requirements/optional.txt requirements/django{env:DJANGO_VER}.txt
          pip-sync {envdir}/requirements.txt
          pip install -e .
 
@@ -87,7 +87,7 @@ setenv =
        LC_ALL=C.UTF-8
        LANG=C.UTF-8
 commands_pre =
-         pip-compile --output-file {envdir}/requirements.txt tests/requirements.txt requirements/base.txt requirements/django22.txt
+         pip-compile --resolver=backtracking --output-file {envdir}/requirements.txt tests/requirements.txt requirements/base.txt requirements/django22.txt
          pip-sync {envdir}/requirements.txt
 commands =
          {toxinidir}/tests/docker/scripts/pylint.sh python/nav --jobs=4 --rcfile=python/pylint.rc --disable=I,similarities --load-plugins pylint_django --output-format=parseable
@@ -102,7 +102,7 @@ setenv =
     LANG=C.UTF-8
 allowlist_externals = sh
 commands_pre =
-         pip-compile --output-file {envdir}/requirements.txt doc/requirements.txt
+         pip-compile --resolver=backtracking --output-file {envdir}/requirements.txt doc/requirements.txt
          pip-sync {envdir}/requirements.txt
 commands =
          python setup.py build_sphinx


### PR DESCRIPTION
The CI pipeline began failing three days ago, due some dependency changes in an upstream dependency.

It seems the pip-compile step of our tox environments became unable to resolve a full dependency graph from this point on (related to versions of pylint, it seems).

Using the backtracking resolver of pip-compile allows it to select older dependencies as long our pinned requirements are satisfied.