### PR TITLE
Module endpoint

### DIFF
--- a/python/nav/web/api/v1/serializers.py
+++ b/python/nav/web/api/v1/serializers.py
@@ -275,6 +275,10 @@ class ModuleSerializer(serializers.ModelSerializer):
     """Serializer for the module model"""
 
     object_url = serializers.CharField(source='get_absolute_url')
+    netboxid = serializers.PrimaryKeyRelatedField(
+        source='netbox', queryset=manage.Netbox.objects.all()
+    )
+    sysname = serializers.StringRelatedField(source='netbox')
 
     class Meta(object):
         model = manage.Module

--- a/python/nav/web/api/v1/serializers.py
+++ b/python/nav/web/api/v1/serializers.py
@@ -271,6 +271,14 @@ class SpecificPatchSerializer(serializers.ModelSerializer):
         fields = ('id', 'cabling', 'split')
 
 
+class NetboxInlineSerializer(serializers.ModelSerializer):
+    """Serializer for including netbox information in other serializers"""
+
+    class Meta(object):
+        model = manage.Netbox
+        fields = ('id', 'sysname')
+
+
 class DeviceSerializer(serializers.ModelSerializer):
     """Serializer for the device model"""
 
@@ -283,8 +291,8 @@ class ModuleSerializer(serializers.ModelSerializer):
     """Serializer for the module model"""
 
     object_url = serializers.CharField(source='get_absolute_url')
-    sysname = serializers.StringRelatedField(source='netbox')
     device = DeviceSerializer()
+    netbox = NetboxInlineSerializer()
 
     class Meta(object):
         model = manage.Module

--- a/python/nav/web/api/v1/serializers.py
+++ b/python/nav/web/api/v1/serializers.py
@@ -287,6 +287,16 @@ class DeviceSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+class ModuleInlineSerializer(serializers.ModelSerializer):
+    """Serializer for including module information in other serializers"""
+
+    object_url = serializers.CharField(source='get_absolute_url')
+
+    class Meta(object):
+        model = manage.Module
+        fields = '__all__'
+
+
 class ModuleSerializer(serializers.ModelSerializer):
     """Serializer for the module model"""
 
@@ -333,7 +343,7 @@ class InterfaceSerializer(serializers.ModelSerializer):
     """Serializer for the interface model"""
 
     patches = SpecificPatchSerializer()
-    module = ModuleSerializer()
+    module = ModuleInlineSerializer()
     object_url = serializers.CharField(source='get_absolute_url')
     to_netbox = SubNetboxSerializer()
     to_interface = SubInterfaceSerializer()

--- a/python/nav/web/api/v1/serializers.py
+++ b/python/nav/web/api/v1/serializers.py
@@ -275,9 +275,6 @@ class ModuleSerializer(serializers.ModelSerializer):
     """Serializer for the module model"""
 
     object_url = serializers.CharField(source='get_absolute_url')
-    netboxid = serializers.PrimaryKeyRelatedField(
-        source='netbox', queryset=manage.Netbox.objects.all()
-    )
     sysname = serializers.StringRelatedField(source='netbox')
 
     class Meta(object):

--- a/python/nav/web/api/v1/serializers.py
+++ b/python/nav/web/api/v1/serializers.py
@@ -271,11 +271,20 @@ class SpecificPatchSerializer(serializers.ModelSerializer):
         fields = ('id', 'cabling', 'split')
 
 
+class DeviceSerializer(serializers.ModelSerializer):
+    """Serializer for the device model"""
+
+    class Meta(object):
+        model = manage.Device
+        fields = '__all__'
+
+
 class ModuleSerializer(serializers.ModelSerializer):
     """Serializer for the module model"""
 
     object_url = serializers.CharField(source='get_absolute_url')
     sysname = serializers.StringRelatedField(source='netbox')
+    device = DeviceSerializer()
 
     class Meta(object):
         model = manage.Module

--- a/python/nav/web/api/v1/urls.py
+++ b/python/nav/web/api/v1/urls.py
@@ -52,6 +52,7 @@ router.register(
     basename='unrecognized-neighbor',
 )
 router.register(r'auditlog', auditlogapi.LogEntryViewSet, basename='auditlog')
+router.register(r'module', views.ModuleViewSet, basename='module')
 
 
 urlpatterns = [

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -1081,3 +1081,24 @@ def get_nav_version(request):
     :type request: django.http.HttpRequest
     """
     return JsonResponse({"version": VERSION})
+
+
+class ModuleViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):
+    """Lists all modules.
+
+    Search
+    ------
+    Searches in *device__serial*
+
+    Filters
+    -------
+    - netbox
+
+    Example: `/api/1/module/?netbox=91&search=AB12345`
+    """
+
+    queryset = manage.Module.objects.all()
+    search_fields = ('device__serial',)
+    filter_backends = NAVAPIMixin.filter_backends
+    filterset_fields = ('netbox',)
+    serializer_class = serializers.ModuleSerializer

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -1094,12 +1094,15 @@ class ModuleViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):
     Filters
     -------
     - netbox
+    - device__serial
 
-    Example: `/api/1/module/?netbox=91&search=AB12345`
+    Example: `/api/1/module/?netbox=91&device__serial=AB12345`
     """
 
     queryset = manage.Module.objects.all()
-    search_fields = ('device__serial',)
     filter_backends = NAVAPIMixin.filter_backends
-    filterset_fields = ('netbox',)
+    filterset_fields = (
+        'netbox',
+        'device__serial',
+    )
     serializer_class = serializers.ModuleSerializer

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -1087,10 +1087,6 @@ def get_nav_version(request):
 class ModuleViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):
     """Lists all modules.
 
-    Search
-    ------
-    Searches in *device__serial*
-
     Filters
     -------
     - netbox

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -154,6 +154,7 @@ def get_endpoints(request=None, version=1):
         ),
         'vlan': reverse_lazy('{}vlan-list'.format(prefix), **kwargs),
         'rack': reverse_lazy('{}rack-list'.format(prefix), **kwargs),
+        'module': reverse_lazy('{}module-list'.format(prefix), **kwargs),
     }
 
 


### PR DESCRIPTION
Fixes #2517 

Adds endpoint /api/module/ that gives information about modules.

This PR updates the ModuleSerializer to include more information: 
- Includes the related Device object
- sysname for the related netbox

This will cause other endpoints that use ModuleSerializer to include this information as well (only one I could find is the interface endpoint). I figured this might be a good thing for consistencies sake, but if its better that only the module endpoint has this extra information then I will make it so.

Example of how the module endpoint looks like:

```
curl  -s -H "Authorization: Token $TOKEN"  localhost:8080/api/module/10/ | jq
{
  "id": 10,
  "object_url": "/ipdevinfo/teknobyen-5etg-sw1.uninett.no/module=I/",
  "sysname": "teknobyen-5etg-sw1.uninett.no",
  "device": {
    "id": 15,
    "serial": "SG2217RBPX",
    "hardware_version": "1",
    "firmware_version": "K.15.07",
    "software_version": "K.16.02.0031",
    "discovered": "2022-11-30T09:27:13.942425"
  },
  "module_number": null,
  "name": "I",
  "model": "J9534A",
  "description": "HP J9534A 24p Gig-T PoE+ v2 zl Module",
  "up": "y",
  "down_since": null,
  "netbox": 3
}
```
The sysname is currently just added as info along everything else, but maybe it should be nested under 'netbox' like so:

```
....
"netbox": {
 "id":3,
 "sysname": "teknobyen-5etg-sw1.uninett.no",
},
....
```

