### PR TITLE
Update libsnmp dependency for newer ubuntu

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,7 +64,7 @@ jobs:
       - name: "Install libraries needed to build external dependencies"
         run: |
           set -xe
-          sudo apt-get install -y libldap2-dev libsasl2-dev libtidy5deb1 libsnmp35
+          sudo apt-get install -y libldap2-dev libsasl2-dev libtidy5deb1 libsnmp40
 
       - uses: browser-actions/setup-chrome@latest
       - run: chrome --version


### PR DESCRIPTION
It seems the upstream `ubuntu-latest` action runner was updated by GitHub 4 days ago. The latest ubuntu is now 22.04, which features libsnmp40 rather than libsnmp35.