### PR TITLE
Use Django 3.2 for pylint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,7 @@ setenv =
        LC_ALL=C.UTF-8
        LANG=C.UTF-8
 commands_pre =
-         pip-compile --resolver=backtracking --output-file {envdir}/requirements.txt tests/requirements.txt requirements/base.txt requirements/django22.txt
+         pip-compile --resolver=backtracking --output-file {envdir}/requirements.txt tests/requirements.txt requirements/base.txt requirements/django32.txt
          pip-sync {envdir}/requirements.txt
 commands =
          {toxinidir}/tests/docker/scripts/pylint.sh python/nav --jobs=4 --rcfile=python/pylint.rc --disable=I,similarities --load-plugins pylint_django --output-format=parseable


### PR DESCRIPTION
When running various local tests I noticed that pylint doesn't run due to conflicting dependencies. 

Using Django 3.2 instead of Django 2.2 fixes that problem.