### PR TITLE
Fix a slew of new CI pipeline / test suite problems that appear after new years

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,7 +64,7 @@ jobs:
       - name: "Install libraries needed to build external dependencies"
         run: |
           set -xe
-          sudo apt-get install -y libldap2-dev libsasl2-dev libtidy5deb1 libsnmp35
+          sudo apt-get install -y libldap2-dev libsasl2-dev libtidy5deb1 libsnmp40
 
       - uses: browser-actions/setup-chrome@latest
       - run: chrome --version

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,7 +51,7 @@ jobs:
       - name: "Install test runner dependencies"
         run: |
           set -xe
-          python -m pip install --upgrade pip setuptools wheel tox tox-gh-actions coverage virtualenv snmpsim
+          python -m pip install --upgrade pip setuptools wheel 'tox<4' tox-gh-actions coverage virtualenv snmpsim
           sudo apt-get install -y nbtscan
 
       # virtualenv seems to currently be embedding a broken version of

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -14,3 +14,6 @@ pytidylib==0.3.2
 selenium==3.141.0
 whisper>=0.9.9
 whitenoise==4.1.4
+# the next dep is here because newer versions of ciscoconfparse has broken dependencies
+# this can be removed once we move to napalm 4, which no longer depends on ciscoconfparse
+ciscoconfparse<1.6.51

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,9 +1,9 @@
-astroid==2.2.4  ; python_version > '3'
+astroid==2.2.4
 gunicorn==19.7.1
 lxml==4.9.1
 mock==2.0.0
-pylint==2.3.1  ; python_version > '3'
-pylint-django==2.0.6  ; python_version > '3'
+pylint==2.3.1
+pylint-django==2.0.6
 pytest==6.2.4
 pytest-metadata<2.0.0
 pytest-cov==2.7.1
@@ -14,4 +14,3 @@ pytidylib==0.3.2
 selenium==3.141.0
 whisper>=0.9.9
 whitenoise==4.1.4
-subprocess32  ; python_version < '3'

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ setenv =
     BUILDDIR = {envdir}
     CHROME_BIN = /usr/bin/google-chrome
     DJANGO_SETTINGS_MODULE = nav.django.settings
+    COVERAGE_FILE = {toxinidir}/reports/coverage/.coverage
     PYTHONFAULTHANDLER=1
     django32: DJANGO_VER=32
     django40: DJANGO_VER=40
@@ -41,10 +42,14 @@ allowlist_externals =
                       sh
                       sed
                       mkdir
+                      chmod
+
 commands_pre =
          pip-compile --resolver=backtracking --output-file {envdir}/requirements.txt tests/requirements.txt requirements/base.txt requirements/optional.txt requirements/django{env:DJANGO_VER}.txt
          pip-sync {envdir}/requirements.txt
          pip install -e .
+         mkdir -p {toxinidir}/reports/coverage
+         chmod 777 {toxinidir}/reports/coverage
 
 commands =
          unit: pytest -o junit_suite_name="{envname} unit tests" --cov-config {toxinidir}/tests/.coveragerc --cov={toxinidir}/python --cov-report=xml:reports/{envname}/coverage.xml --junitxml=reports/{envname}/unit-results.xml --verbose {posargs:tests/unittests}

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ python =
 # Baseline test environment
 deps =
     pip-tools
-    pip<21.3
+    pip
 setenv =
     LC_ALL=C.UTF-8
     LANG=C.UTF-8


### PR DESCRIPTION
Several changes in upstream dependencies caused our test suite to break down over X-mas vacation, making the first workday of 2023 a pain.

This resolves multiple of these issues and cleans up a few things along the way.

Since these problems will also affect the current stable branch, this PR is against the stable branch, which should be merged to master as soon as the PR is approved.

### Tox

Tox 4 breaks compatibility with several bits of our tox.ini (and they must have had a lot of problems with this release, they've had 23 new releases in the month that has passed since the release of 4.0.0): https://pypi.org/project/tox/#history

Primarily, this bites us hard, in a non-compatible way: https://github.com/tox-dev/tox/issues/2635

Also, the `passenv` option seems to require comma-separated arguments now, rather than the space-separated ones required in version 3.
