### PR TITLE
Copy new version to event varmap on sw/hw/fw upgrade

### DIFF
--- a/python/nav/ipdevpoll/shadows/__init__.py
+++ b/python/nav/ipdevpoll/shadows/__init__.py
@@ -287,7 +287,10 @@ class Device(Shadow):
                 )
             )
             for version in changed_versions:
-                self.changed_versions[version] = getattr(old_device, version)
+                self.changed_versions[version] = (
+                    getattr(old_device, version),
+                    getattr(self, version),
+                )
 
     def cleanup(self, containers):
         if self.changed_versions:
@@ -296,13 +299,14 @@ class Device(Shadow):
     def _post_events_version_changes(self, containers):
         """Posts events for software, hardware or firmware changes."""
         device = self.get_existing_model()
-        for alert_type, old_version in self.changed_versions.items():
+        for alert_type, (old_version, new_version) in self.changed_versions.items():
             self.event.notify(
                 device=device,
                 netbox=containers.get(None, Netbox).get_existing_model(),
                 alert_type=ALERT_TYPE_MAPPING[alert_type],
                 varmap={
                     "old_version": old_version,
+                    "new_version": new_version,
                 },
             ).save()
 


### PR DESCRIPTION
As mentioned by @lunkwill42 in https://github.com/Uninett/nav/pull/2515#discussion_r1062402937 the new version for a sw/hw/fw upgrade should also be saved in the event varmap in the same place as the old version. 