### PR TITLE
[BUG] 

### DIFF
--- a/python/nav/ipdevpoll/shadows/__init__.py
+++ b/python/nav/ipdevpoll/shadows/__init__.py
@@ -305,8 +305,8 @@ class Device(Shadow):
                 netbox=containers.get(None, Netbox).get_existing_model(),
                 alert_type=ALERT_TYPE_MAPPING[alert_type],
                 varmap={
-                    "old_version": old_version,
-                    "new_version": new_version,
+                    "old_version": old_version if old_version else "N/A",
+                    "new_version": new_version if new_version else "N/A",
                 },
             ).save()
 


### PR DESCRIPTION
I noticed that after merging #2413 when a device is new and the inventory is first run there is an error since it tries to post an `AlertHistoryVariable` entry with the value `null`, which is not allowed. This PR fixes that by changing the old and new version to `N/A` if it is null.