### PR TITLE
Add errorhandling for missing cache in ranked statistics

### DIFF
--- a/python/nav/web/sortedstats/views.py
+++ b/python/nav/web/sortedstats/views.py
@@ -26,6 +26,7 @@ except ImportError:
 from django.shortcuts import render
 from django.core.cache import caches
 from django.conf import settings
+from django.core.cache.backends.base import InvalidCacheBackendError
 
 from .forms import ViewForm
 from . import CLASSMAP, TIMEFRAMES
@@ -109,7 +110,11 @@ def collect_result(view, timeframe, rows):
     cache_key = get_cache_key(view, timeframe, rows)
     result = get_result(view, start, end, rows)
     result.collect()
-    get_cache().set(cache_key, result, timeout=timeout)
+    try:
+        cache = get_cache()
+        cache.set(cache_key, result, timeout=timeout)
+    except InvalidCacheBackendError as e:
+        _logger.error("Error accessing cache for ranked statistics: %s".format(e))
     return result
 
 

--- a/python/nav/web/sortedstats/views.py
+++ b/python/nav/web/sortedstats/views.py
@@ -82,8 +82,13 @@ def process_form(form):
     rows = form.cleaned_data['rows']
     cache_key = get_cache_key(view, timeframe, rows)
     if form.cleaned_data['use_cache']:
-        result = get_cache().get(cache_key)
-        if result and not result.data:
+        try:
+            cache = get_cache()
+            result = cache.get(cache_key)
+            if result and not result.data:
+                result = None
+        except InvalidCacheBackendError as e:
+            _logger.error("Error accessing cache for ranked statistics: %s".format(e))
             result = None
     if not result:
         result = collect_result(view, timeframe, rows)

--- a/python/nav/web/sortedstats/views.py
+++ b/python/nav/web/sortedstats/views.py
@@ -33,7 +33,10 @@ from nav.metrics.errors import GraphiteUnreachableError
 
 GRAPHITE_TIME_FORMAT = "%H:%M_%Y%m%d"
 _logger = logging.getLogger(__name__)
-cache = caches['sortedstats']
+
+
+def get_cache():
+    return caches['sortedstats']
 
 
 def index(request):
@@ -78,7 +81,7 @@ def process_form(form):
     rows = form.cleaned_data['rows']
     cache_key = get_cache_key(view, timeframe, rows)
     if form.cleaned_data['use_cache']:
-        result = cache.get(cache_key)
+        result = get_cache().get(cache_key)
         if result and not result.data:
             result = None
     if not result:
@@ -106,7 +109,7 @@ def collect_result(view, timeframe, rows):
     cache_key = get_cache_key(view, timeframe, rows)
     result = get_result(view, start, end, rows)
     result.collect()
-    cache.set(cache_key, result, timeout=timeout)
+    get_cache().set(cache_key, result, timeout=timeout)
     return result
 
 

--- a/python/nav/web/sortedstats/views.py
+++ b/python/nav/web/sortedstats/views.py
@@ -98,7 +98,7 @@ def process_form(form):
             if result and not result.data:
                 result = None
         except InvalidCacheBackendError as e:
-            _logger.error("Error accessing cache for ranked statistics: %s".format(e))
+            _logger.error("Error accessing cache for ranked statistics: %s", e)
             result = None
     if not result:
         result = collect_result(view, timeframe, rows)
@@ -129,7 +129,7 @@ def collect_result(view, timeframe, rows):
         cache = get_cache()
         cache.set(cache_key, result, timeout=timeout)
     except InvalidCacheBackendError as e:
-        _logger.error("Error accessing cache for ranked statistics: %s".format(e))
+        _logger.error("Error accessing cache for ranked statistics: %s", e)
     return result
 
 

--- a/python/nav/web/sortedstats/views.py
+++ b/python/nav/web/sortedstats/views.py
@@ -40,6 +40,15 @@ def get_cache():
     return caches['sortedstats']
 
 
+def cache_is_misconfigured():
+    try:
+        get_cache()
+    except InvalidCacheBackendError:
+        return True
+    else:
+        return False
+
+
 def index(request):
     """Sorted stats search & result view"""
     result = None
@@ -68,6 +77,7 @@ def index(request):
         'graphite_unreachable': graphite_unreachable,
         'from_cache': from_cache,
         'duration': duration,
+        'cache_misconfigured': cache_is_misconfigured(),
     }
 
     return render(request, 'sortedstats/sortedstats.html', context)

--- a/python/nav/web/templates/sortedstats/sortedstats.html
+++ b/python/nav/web/templates/sortedstats/sortedstats.html
@@ -17,6 +17,11 @@
     {% include 'nav_header.html' %}
   {% endwith %}
 
+  {% if cache_misconfigured %}
+    <div class="alert-box error">
+      The cache for Ranked Statistics is not configured correctly.
+    </div>
+  {% endif %}
 
   {% crispy form %}
 

--- a/tests/unittests/web/sortedstats/sortedstats_test.py
+++ b/tests/unittests/web/sortedstats/sortedstats_test.py
@@ -26,10 +26,10 @@ class TestSortedStats(TestCase):
         cache_key = views.get_cache_key(view, timeframe, rows)
         self.assertEqual(cache_key, expected_cache_key)
 
-    @patch('nav.web.sortedstats.views.cache')
+    @patch('nav.web.sortedstats.views.get_cache')
     def test_process_form_returns_cache_value_if_cache_exists(self, cache_mock):
         data = "cached"
-        cache_mock.get.return_value.data = data
+        cache_mock.return_value.get.return_value.data = data
         fake_form = MagicMock()
         fake_form.cleaned_data = {
             'view': 'uptime',
@@ -42,12 +42,12 @@ class TestSortedStats(TestCase):
         self.assertEqual(result.data, data)
 
     @patch('nav.web.sortedstats.views.collect_result')
-    @patch('nav.web.sortedstats.views.cache')
+    @patch('nav.web.sortedstats.views.get_cache')
     def test_cache_not_used_if_empty_and_use_cache_is_on(
         self, cache_mock, collect_mock
     ):
         data = "new"
-        cache_mock.get.return_value.data = ""
+        cache_mock.return_value.get.return_value.data = ""
         collect_mock.return_value.data = data
         fake_form = MagicMock()
         fake_form.cleaned_data = {
@@ -61,12 +61,12 @@ class TestSortedStats(TestCase):
         self.assertEqual(result.data, data)
 
     @patch('nav.web.sortedstats.views.collect_result')
-    @patch('nav.web.sortedstats.views.cache')
+    @patch('nav.web.sortedstats.views.get_cache')
     def test_cache_not_used_if_empty_and_use_cache_is_off(
         self, cache_mock, collect_mock
     ):
         data = "new"
-        cache_mock.get.return_value.data = ""
+        cache_mock.return_value.get.return_value.data = ""
         collect_mock.return_value.data = data
         fake_form = MagicMock()
         fake_form.cleaned_data = {


### PR DESCRIPTION
Fixes #2561 

Error from cache not being configured should not be handled. When trying to get data from cache, it will now behave as if the cache is empty. When trying to write, it will now just skip the writing step instead of crashing.
An error message will be displayed on the ranked statistics page as well.