### PR TITLE
Use new_version in alert message templates

### DIFF
--- a/python/nav/etc/alertmsg/deviceNotice/deviceFwUpgrade-email.txt
+++ b/python/nav/etc/alertmsg/deviceNotice/deviceFwUpgrade-email.txt
@@ -1,2 +1,2 @@
 Subject: Device {{ device.get_extended_description }} had a firmware upgrade
-Device {{ device.get_extended_description }} had a firmware upgrade from version {{ old_version }} to version {{ device.firmware_version }}.
+Device {{ device.get_extended_description }} had a firmware upgrade from version {{ old_version }} to version {{ new_version }}.

--- a/python/nav/etc/alertmsg/deviceNotice/deviceFwUpgrade-sms.txt
+++ b/python/nav/etc/alertmsg/deviceNotice/deviceFwUpgrade-sms.txt
@@ -1,1 +1,1 @@
-Device {{ device.get_extended_description }} had a firmware upgrade from {{ old_version }} to version {{ device.firmware_version }}.
+Device {{ device.get_extended_description }} had a firmware upgrade from {{ old_version }} to version {{ new_version }}.

--- a/python/nav/etc/alertmsg/deviceNotice/deviceHwUpgrade-email.txt
+++ b/python/nav/etc/alertmsg/deviceNotice/deviceHwUpgrade-email.txt
@@ -1,2 +1,2 @@
 Subject: Device {{ device.get_extended_description }} had a hardware upgrade
-Device {{ device.get_extended_description }} had a hardware upgrade from {{ old_version }} to version {{ device.hardware_version }}.
+Device {{ device.get_extended_description }} had a hardware upgrade from {{ old_version }} to version {{ new_version }}.

--- a/python/nav/etc/alertmsg/deviceNotice/deviceHwUpgrade-sms.txt
+++ b/python/nav/etc/alertmsg/deviceNotice/deviceHwUpgrade-sms.txt
@@ -1,1 +1,1 @@
-Device {{ device.get_extended_description }} had a hardware upgrade from {{ old_version }} to version {{ device.hardware_version }}.
+Device {{ device.get_extended_description }} had a hardware upgrade from {{ old_version }} to version {{ new_version }}.

--- a/python/nav/etc/alertmsg/deviceNotice/deviceSwUpgrade-email.txt
+++ b/python/nav/etc/alertmsg/deviceNotice/deviceSwUpgrade-email.txt
@@ -1,2 +1,2 @@
 Subject: Device {{ device.get_extended_description }} had a software upgrade
-Device {{ device.get_extended_description }} had a software upgrade from {{ old_version }} to version {{ device.software_version }}.
+Device {{ device.get_extended_description }} had a software upgrade from {{ old_version }} to version {{ new_version }}.

--- a/python/nav/etc/alertmsg/deviceNotice/deviceSwUpgrade-sms.txt
+++ b/python/nav/etc/alertmsg/deviceNotice/deviceSwUpgrade-sms.txt
@@ -1,1 +1,1 @@
-Device {{ device.get_extended_description }} had a software upgrade from {{ old_version }} to version {{ device.software_version }}.
+Device {{ device.get_extended_description }} had a software upgrade from {{ old_version }} to version {{ new_version }}.


### PR DESCRIPTION
One thing I forgot since we added the variable `new_version` to the varmap in #2545 was to also use that in the alert message templates. 