### PR TITLE
Remove upper version bound for Pillow to fix security warnings

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ twisted>=20.0.0,<21
 
 
 networkx==2.6.3
-Pillow>3.3.2,<8.1
+Pillow>3.3.2
 pyrad==2.1
 sphinx==4.4.0
 sphinxcontrib-programoutput==0.17

--- a/tests/integration/web/info_test.py
+++ b/tests/integration/web/info_test.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import os
+
 import pytest
 from django.test import RequestFactory
 from django.urls import reverse
 from mock import MagicMock
 
 from nav.models.profiles import Account
+from nav.web.info.images.utils import save_thumbnail
 from nav.web.info.room.views import create_csv
 from nav.web.info.searchproviders import SearchProvider
 
@@ -45,6 +48,17 @@ def test_room_csv_download_should_not_produce_bytestring_representations():
 
     response = create_csv(request)  # type: django.http.response.HttpResponse
     assert not response.content.startswith(b"b'")
+
+
+def test_save_thumbnail_should_produce_a_file(tmpdir):
+    """This is more or less a regression test for the third party library Pillow"""
+    image = "closet.jpg"
+    save_thumbnail(
+        imagename=image,
+        imagedirectory="tests/functional",
+        thumb_dir=tmpdir,
+    )
+    assert os.path.exists(os.path.join(tmpdir, image))
 
 
 ############


### PR DESCRIPTION
Vulnerabilities have been reported in the version we're locked to. Pillow has never introduced backwards incompatibilities in the small part of the library we use, so this removes the upper bound and introduces a regression test for the small functionality used.