### PR TITLE
Add refresh endpoint for JWT tokens

### DIFF
--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -118,19 +118,11 @@ class JWTRefreshToken(models.Model):
         self.save()
 
     @classmethod
-    def _get_private_key(self) -> str:
-        """Returns private key in PEM format"""
-        return JWTConf().get_nav_private_key()
-
-    @classmethod
-    def _get_nav_name(self) -> str:
-        """Returns the name of this NAV instance. This is used for the iss and aud claim"""
-        return JWTConf().get_nav_name()
-
-    @classmethod
     def _encode_token(cls, token_data: Dict[str, Any]) -> str:
         """Returns an encoded token in JWT format"""
-        return jwt.encode(token_data, cls._get_private_key(), algorithm="RS256")
+        return jwt.encode(
+            token_data, JWTConf().get_nav_private_key(), algorithm="RS256"
+        )
 
     @classmethod
     def _generate_token(
@@ -141,7 +133,7 @@ class JWTRefreshToken(models.Model):
         """
         new_token = dict(token_data)
         now = datetime.now()
-        name = cls._get_nav_name()
+        name = JWTConf().get_nav_name()
         updated_claims = {
             'exp': (now + expiry_delta).timestamp(),
             'nbf': now.timestamp(),

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -85,8 +85,8 @@ class JWTRefreshToken(models.Model):
     def __str__(self):
         return self.token
 
-    def get_body(self) -> Dict[str, Any]:
-        """Body of token as a dict"""
+    def data(self) -> Dict[str, Any]:
+        """Data of token as a dict"""
         return self._decode_token(self.token)
 
     def is_active(self) -> bool:
@@ -94,15 +94,15 @@ class JWTRefreshToken(models.Model):
         the nbf claim is in the past and the exp claim is in the future
         """
         now = datetime.now()
-        body = self.get_body()
-        nbf = datetime.fromtimestamp(body['nbf'])
-        exp = datetime.fromtimestamp(body['exp'])
+        data = self.data()
+        nbf = datetime.fromtimestamp(data['nbf'])
+        exp = datetime.fromtimestamp(data['exp'])
         return now >= nbf and now < exp
 
     def expire(self):
         """Expires the token"""
         # Base claims for expired token on existing claims
-        expired_data = self.get_body()
+        expired_data = self.data()
         expired_data['exp'] = (datetime.now() - timedelta(hours=1)).timestamp()
         self.token = self._encode_token(expired_data)
         self.save()
@@ -155,7 +155,7 @@ class JWTRefreshToken(models.Model):
 
     @classmethod
     def _decode_token(cls, token: str) -> Dict[str, Any]:
-        """Decodes a token in JWT format and returns the body of the decoded token"""
+        """Decodes a token in JWT format and returns the data of the decoded token"""
         return jwt.decode(token, options={'verify_signature': False})
 
     class Meta(object):

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -88,7 +88,7 @@ class JWTRefreshToken(models.Model):
     @property
     def data(self) -> Dict[str, Any]:
         """Body of token as a dict"""
-        return self.decode_token(self.token)
+        return self._decode_token(self.token)
 
     @property
     def nbf(self) -> datetime:
@@ -162,7 +162,7 @@ class JWTRefreshToken(models.Model):
         )
 
     @classmethod
-    def decode_token(cls, token: str) -> Dict[str, Any]:
+    def _decode_token(cls, token: str) -> Dict[str, Any]:
         """Decodes a token in JWT format and returns the body of the decoded token"""
         return jwt.decode(token, options={'verify_signature': False})
 

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -87,7 +87,7 @@ class JWTRefreshToken(models.Model):
     @property
     def data(self):
         """Body of token as a dict"""
-        return jwt.decode(self.token, options={'verify_signature': False})
+        return self.decode_token(self.token)
 
     @property
     def nbf(self):
@@ -151,6 +151,10 @@ class JWTRefreshToken(models.Model):
         return cls._generate_token(
             token_data, cls.REFRESH_EXPIRE_DELTA, "refresh_token"
         )
+
+    @classmethod
+    def decode_token(cls, token):
+        return jwt.decode(token, options={'verify_signature': False})
 
     class Meta(object):
         db_table = 'jwtrefreshtoken'

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -90,12 +90,12 @@ class JWTRefreshToken(models.Model):
         return jwt.decode(self.token, options={'verify_signature': False})
 
     @property
-    def activates(self):
+    def nbf(self):
         """Datetime when token activates"""
         return datetime.fromtimestamp(self.data['nbf'])
 
     @property
-    def expires(self):
+    def exp(self):
         """Datetime when token expires"""
         return datetime.fromtimestamp(self.data['exp'])
 
@@ -103,7 +103,7 @@ class JWTRefreshToken(models.Model):
     def is_active(self):
         """True if token is active"""
         now = datetime.now()
-        return now >= self.activates and now < self.expires
+        return now >= self.nbf and now < self.exp
 
     def expire(self):
         """Expires the token"""

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -103,6 +103,14 @@ class JWTRefreshToken(models.Model):
         now = datetime.now()
         return now >= self.activates() and now < self.expires()
 
+    def expire(self):
+        """Expires the token"""
+        data = self.data()
+        data['exp'] = datetime.now().timestamp()
+        data['nbf'] = datetime.now().timestamp()
+        self.token = self._encode_token(data)
+        self.save()
+
     @classmethod
     def _encode_token(cls, token_data):
         return jwt.encode(

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -102,7 +102,7 @@ class JWTRefreshToken(models.Model):
     def expire(self):
         """Expires the token"""
         # Base claims for expired token on existing claims
-        expired_data = self.body
+        expired_data = self.get_body()
         expired_data['exp'] = (datetime.now() - timedelta(hours=1)).timestamp()
         self.token = self._encode_token(expired_data)
         self.save()

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -104,8 +104,9 @@ class JWTRefreshToken(models.Model):
         """Expires the token"""
         # Base claims for expired token on existing claims
         expired_data = self.data
-        expired_data['exp'] = datetime.now().timestamp()
-        expired_data['nbf'] = datetime.now().timestamp()
+        now = datetime.now()
+        expired_data['exp'] = (now - timedelta(hours=1)).timestamp()
+        expired_data['nbf'] = now.timestamp()
         self.token = self._encode_token(expired_data)
         self.save()
 

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -91,22 +91,14 @@ class JWTRefreshToken(models.Model):
         return self._decode_token(self.token)
 
     @property
-    def nbf(self) -> datetime:
-        """Datetime when token activates"""
-        return datetime.fromtimestamp(self.data['nbf'])
-
-    @property
-    def exp(self) -> datetime:
-        """Datetime when token expires"""
-        return datetime.fromtimestamp(self.data['exp'])
-
-    @property
     def is_active(self) -> bool:
         """True if token is active. A token is considered active when
         the nbf claim is in the past and the exp claim is in the future
         """
         now = datetime.now()
-        return now >= self.nbf and now < self.exp
+        nbf = datetime.fromtimestamp(self.data['nbf'])
+        exp = datetime.fromtimestamp(self.data['exp'])
+        return now >= nbf and now < exp
 
     def expire(self):
         """Expires the token"""

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -84,31 +84,32 @@ class JWTRefreshToken(models.Model):
     def __str__(self):
         return self.token
 
+    @property
     def data(self):
         """Body of token as a dict"""
         return jwt.decode(self.token, options={'verify_signature': False})
 
+    @property
     def activates(self):
         """Datetime when token activates"""
-        data = self.data()
-        return datetime.fromtimestamp(data['nbf'])
+        return datetime.fromtimestamp(self.data['nbf'])
 
+    @property
     def expires(self):
         """Datetime when token expires"""
-        data = self.data()
-        return datetime.fromtimestamp(data['exp'])
+        return datetime.fromtimestamp(self.data['exp'])
 
+    @property
     def is_active(self):
         """True if token is active"""
         now = datetime.now()
-        return now >= self.activates() and now < self.expires()
+        return now >= self.activates and now < self.expires
 
     def expire(self):
         """Expires the token"""
-        data = self.data()
-        data['exp'] = datetime.now().timestamp()
-        data['nbf'] = datetime.now().timestamp()
-        self.token = self._encode_token(data)
+        self.data['exp'] = datetime.now().timestamp()
+        self.data['nbf'] = datetime.now().timestamp()
+        self.token = self._encode_token(self.data)
         self.save()
 
     @classmethod

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -107,9 +107,11 @@ class JWTRefreshToken(models.Model):
 
     def expire(self):
         """Expires the token"""
-        self.data['exp'] = datetime.now().timestamp()
-        self.data['nbf'] = datetime.now().timestamp()
-        self.token = self._encode_token(self.data)
+        # Base claims for expired token on existing claims
+        expired_data = self.data
+        expired_data['exp'] = datetime.now().timestamp()
+        expired_data['nbf'] = datetime.now().timestamp()
+        self.token = self._encode_token(expired_data)
         self.save()
 
     @classmethod

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -101,7 +101,9 @@ class JWTRefreshToken(models.Model):
 
     @property
     def is_active(self):
-        """True if token is active"""
+        """True if token is active. A token is considered active when
+        the nbf claim is in the past and the exp claim is in the future
+        """
         now = datetime.now()
         return now >= self.nbf and now < self.exp
 

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -113,16 +113,22 @@ class JWTRefreshToken(models.Model):
         self.save()
 
     @classmethod
+    def _get_private_key(self):
+        return JWTConf().get_nav_private_key()
+
+    @classmethod
+    def _get_nav_name(self):
+        return JWTConf().get_nav_name()
+
+    @classmethod
     def _encode_token(cls, token_data):
-        return jwt.encode(
-            token_data, JWTConf().get_nav_private_key(), algorithm="RS256"
-        )
+        return jwt.encode(token_data, cls._get_private_key(), algorithm="RS256")
 
     @classmethod
     def _generate_token(cls, token_data, expiry_delta, token_type):
         new_token = dict(token_data)
         now = datetime.now()
-        name = JWTConf().get_nav_name()
+        name = cls._get_nav_name()
         updated_claims = {
             'exp': (now + expiry_delta).timestamp(),
             'nbf': now.timestamp(),

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -85,26 +85,24 @@ class JWTRefreshToken(models.Model):
     def __str__(self):
         return self.token
 
-    @property
-    def data(self) -> Dict[str, Any]:
+    def get_body(self) -> Dict[str, Any]:
         """Body of token as a dict"""
         return self._decode_token(self.token)
 
-    @property
     def is_active(self) -> bool:
         """True if token is active. A token is considered active when
         the nbf claim is in the past and the exp claim is in the future
         """
         now = datetime.now()
-        data = self.data
-        nbf = datetime.fromtimestamp(data['nbf'])
-        exp = datetime.fromtimestamp(data['exp'])
+        body = self.get_body()
+        nbf = datetime.fromtimestamp(body['nbf'])
+        exp = datetime.fromtimestamp(body['exp'])
         return now >= nbf and now < exp
 
     def expire(self):
         """Expires the token"""
         # Base claims for expired token on existing claims
-        expired_data = self.data
+        expired_data = self.body
         expired_data['exp'] = (datetime.now() - timedelta(hours=1)).timestamp()
         self.token = self._encode_token(expired_data)
         self.save()

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -108,10 +108,19 @@ class JWTRefreshToken(models.Model):
         self.save()
 
     @classmethod
-    def _encode_token(cls, token_data: Dict[str, Any]) -> str:
-        """Returns an encoded token in JWT format"""
-        return jwt.encode(
-            token_data, JWTConf().get_nav_private_key(), algorithm="RS256"
+    def generate_access_token(cls, token_data: Dict[str, Any] = {}) -> str:
+        """Generates and returns an access token in JWT format. Will use `token_data` as a basis
+        for the new token, but certain claims will be overridden
+        """
+        return cls._generate_token(token_data, cls.ACCESS_EXPIRE_DELTA, "access_token")
+
+    @classmethod
+    def generate_refresh_token(cls, token_data: Dict[str, Any] = {}) -> str:
+        """Generates and returns a refresh token in JWT format. Will use `token_data` as a basis
+        for the new token, but certain claims will be overridden
+        """
+        return cls._generate_token(
+            token_data, cls.REFRESH_EXPIRE_DELTA, "refresh_token"
         )
 
     @classmethod
@@ -136,19 +145,10 @@ class JWTRefreshToken(models.Model):
         return cls._encode_token(new_token)
 
     @classmethod
-    def generate_access_token(cls, token_data: Dict[str, Any] = {}) -> str:
-        """Generates and returns an access token in JWT format. Will use `token_data` as a basis
-        for the new token, but certain claims will be overridden
-        """
-        return cls._generate_token(token_data, cls.ACCESS_EXPIRE_DELTA, "access_token")
-
-    @classmethod
-    def generate_refresh_token(cls, token_data: Dict[str, Any] = {}) -> str:
-        """Generates and returns a refresh token in JWT format. Will use `token_data` as a basis
-        for the new token, but certain claims will be overridden
-        """
-        return cls._generate_token(
-            token_data, cls.REFRESH_EXPIRE_DELTA, "refresh_token"
+    def _encode_token(cls, token_data: Dict[str, Any]) -> str:
+        """Returns an encoded token in JWT format"""
+        return jwt.encode(
+            token_data, JWTConf().get_nav_private_key(), algorithm="RS256"
         )
 
     @classmethod

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -109,15 +109,17 @@ class JWTRefreshToken(models.Model):
 
     @classmethod
     def generate_access_token(cls, token_data: Dict[str, Any] = {}) -> str:
-        """Generates and returns an access token in JWT format. Will use `token_data` as a basis
-        for the new token, but certain claims will be overridden
+        """Generates and returns an access token in JWT format.
+        Will use `token_data` as a basis for the new token,
+        but certain claims will be overridden.
         """
         return cls._generate_token(token_data, cls.ACCESS_EXPIRE_DELTA, "access_token")
 
     @classmethod
     def generate_refresh_token(cls, token_data: Dict[str, Any] = {}) -> str:
-        """Generates and returns a refresh token in JWT format. Will use `token_data` as a basis
-        for the new token, but certain claims will be overridden
+        """Generates and returns a refresh token in JWT format.
+        Will use `token_data` as a basis for the new token,
+        but certain claims will be overridden.
         """
         return cls._generate_token(
             token_data, cls.REFRESH_EXPIRE_DELTA, "refresh_token"

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -96,8 +96,9 @@ class JWTRefreshToken(models.Model):
         the nbf claim is in the past and the exp claim is in the future
         """
         now = datetime.now()
-        nbf = datetime.fromtimestamp(self.data['nbf'])
-        exp = datetime.fromtimestamp(self.data['exp'])
+        data = self.data
+        nbf = datetime.fromtimestamp(data['nbf'])
+        exp = datetime.fromtimestamp(data['exp'])
         return now >= nbf and now < exp
 
     def expire(self):

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -104,9 +104,7 @@ class JWTRefreshToken(models.Model):
         """Expires the token"""
         # Base claims for expired token on existing claims
         expired_data = self.data
-        now = datetime.now()
-        expired_data['exp'] = (now - timedelta(hours=1)).timestamp()
-        expired_data['nbf'] = now.timestamp()
+        expired_data['exp'] = (datetime.now() - timedelta(hours=1)).timestamp()
         self.token = self._encode_token(expired_data)
         self.save()
 

--- a/python/nav/models/sql/changes/sc.05.05.0002.sql
+++ b/python/nav/models/sql/changes/sc.05.05.0002.sql
@@ -1,0 +1,7 @@
+--- Create table for storing JWT refresh tokens
+CREATE TABLE JWTRefreshToken (
+    id SERIAL PRIMARY KEY,
+    token VARCHAR NOT NULL,
+    name VARCHAR NOT NULL UNIQUE,
+    description VARCHAR
+);

--- a/python/nav/models/sql/changes/sc.05.05.0002.sql
+++ b/python/nav/models/sql/changes/sc.05.05.0002.sql
@@ -1,5 +1,5 @@
 --- Create table for storing JWT refresh tokens
-CREATE TABLE JWTRefreshToken (
+CREATE TABLE manage.JWTRefreshToken (
     id SERIAL PRIMARY KEY,
     token VARCHAR NOT NULL,
     name VARCHAR NOT NULL UNIQUE,

--- a/python/nav/web/api/v1/urls.py
+++ b/python/nav/web/api/v1/urls.py
@@ -73,4 +73,5 @@ urlpatterns = [
         name="prefix-usage-detail",
     ),
     re_path(r'^', include(router.urls)),
+    re_path(r'^refresh/$', views.JWTRefreshViewSet.as_view(), name='jwt-refresh'),
 ]

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -45,6 +45,7 @@ from rest_framework.serializers import ValidationError
 from oidc_auth.authentication import JSONWebTokenAuthentication
 
 from nav.models import manage, event, cabling, rack, profiles
+from nav.models.api import JWTRefreshToken
 from nav.models.fields import INFINITY, UNRESOLVED
 from nav.web.servicecheckers import load_checker_classes
 from nav.util import auth_token, is_valid_cidr
@@ -1105,6 +1106,33 @@ class RackViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.RackSerializer
     filterset_fields = ['room', 'rackname']
     search_fields = ['rackname']
+
+
+class JWTRefreshViewSet(APIView):
+    """
+    Accepts a valid refresh token.
+    Returns a new refresh token and an access token.
+    """
+
+    def post(self, request):
+        try:
+            db_token = JWTRefreshToken.objects.get(
+                token=request.data.get('refresh_token')
+            )
+        except JWTRefreshToken.DoesNotExist:
+            return Response("Invalid token", status=status.HTTP_403_FORBIDDEN)
+        if not db_token.is_active():
+            return Response("Inactive token", status=status.HTTP_403_FORBIDDEN)
+        token_data = db_token.data()
+        access_token = JWTRefreshToken.generate_access_token(token_data)
+        refresh_token = JWTRefreshToken.generate_refresh_token(token_data)
+        db_token.token = refresh_token
+        db_token.save()
+        response_data = {
+            'access_token': access_token,
+            'refresh_token': refresh_token,
+        }
+        return Response(response_data)
 
 
 def get_or_create_token(request):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -38,3 +38,5 @@ napalm==3.4.1
 
 backports.zoneinfo ; python_version < '3.9'
 git+https://github.com/Uninett/drf-oidc-auth@v4.0#egg=drf-oidc-auth
+
+pyjwt>=2.6.0

--- a/tests/integration/jwt_refresh_endpoint_test.py
+++ b/tests/integration/jwt_refresh_endpoint_test.py
@@ -1,0 +1,153 @@
+import pytest
+
+from unittest.mock import Mock, patch
+
+from django.urls import reverse
+from rest_framework.reverse import reverse_lazy
+from nav.models.api import JWTRefreshToken
+
+
+def test_token_not_in_database_should_be_rejected(db, api_client, url):
+    token = JWTRefreshToken.generate_refresh_token()
+    assert not JWTRefreshToken.objects.filter(token=token).exists()
+    response = api_client.post(
+        url,
+        follow=True,
+        data={
+            'refresh_token': token,
+        },
+    )
+    assert response.status_code == 403
+
+
+def test_expired_token_should_be_rejected(db, api_client, url):
+    token = JWTRefreshToken.generate_refresh_token()
+    db_token = JWTRefreshToken(token=token)
+    db_token.save()
+    db_token.expire()
+    response = api_client.post(
+        url,
+        follow=True,
+        data={
+            'refresh_token': db_token.token,
+        },
+    )
+    assert response.status_code == 403
+
+
+def test_valid_token_should_be_accepted(db, api_client, url):
+    token = JWTRefreshToken.generate_refresh_token()
+    db_token = JWTRefreshToken(token=token)
+    db_token.save()
+    response = api_client.post(
+        url,
+        follow=True,
+        data={
+            'refresh_token': token,
+        },
+    )
+    assert response.status_code == 200
+
+
+def test_valid_token_should_be_replaced_by_new_token_in_db(db, api_client, url):
+    token = JWTRefreshToken.generate_refresh_token()
+    db_token = JWTRefreshToken(token=token)
+    db_token.save()
+    response = api_client.post(
+        url,
+        follow=True,
+        data={
+            'refresh_token': token,
+        },
+    )
+    assert response.status_code == 200
+    assert not JWTRefreshToken.objects.filter(token=token).exists()
+    new_token = response.data.get("refresh_token")
+    assert JWTRefreshToken.objects.filter(token=new_token).exists()
+
+
+def test_should_include_access_and_refresh_token_in_response(db, api_client, url):
+    token = JWTRefreshToken.generate_refresh_token()
+    db_token = JWTRefreshToken(token=token)
+    db_token.save()
+    response = api_client.post(
+        url,
+        follow=True,
+        data={
+            'refresh_token': token,
+        },
+    )
+    assert response.status_code == 200
+    assert "access_token" in response.data
+    assert "refresh_token" in response.data
+
+
+@pytest.fixture()
+def url():
+    return reverse('api:1:jwt-refresh')
+
+
+@pytest.fixture(scope="module", autouse=True)
+def jwtconf_mock(private_key, nav_name) -> str:
+    """Mocks the get_nave_name and get_nav_private_key functions for
+    the JWTConf class
+    """
+    with patch("nav.models.api.JWTConf") as _jwtconf_mock:
+        instance = _jwtconf_mock.return_value
+        instance.get_nav_name = Mock(return_value=nav_name)
+        instance.get_nav_private_key = Mock(return_value=private_key)
+        yield _jwtconf_mock
+
+
+@pytest.fixture(scope="module")
+def private_key() -> str:
+    """Yields a private key in PEM format"""
+    key = """-----BEGIN PRIVATE KEY-----
+MIIEuwIBADANBgkqhkiG9w0BAQEFAASCBKUwggShAgEAAoIBAQCp+4AEZM4uYZKu
+/hrKzySMTFFx3/ncWo6XAFpADQHXLOwRB9Xh1/OwigHiqs/wHRAAmnrlkwCCQA8r
+xiHBAMjp5ApbkyggQz/DVijrpSba6Tiy1cyBTZC3cvOK2FpJzsakJLhIXD1HaULO
+ClyIJB/YrmHmQc8SL3Uzou5mMpdcBC2pzwmEW1cvQURpnvgrDF8V86GrQkjK6nIP
+IEeuW6kbD5lWFAPfLf1ohDWex3yxeSFyXNRApJhbF4HrKFemPkOi7acsky38UomQ
+jZgAMHPotJNkQvAHcnXHhg0FcWGdohv5bc/Ctt9GwZOzJxwyJLBBsSewbE310TZi
+3oLU1TmvAgMBAAECgf8zrhi95+gdMeKRpwV+TnxOK5CXjqvo0vTcnr7Runf/c9On
+WeUtRPr83E4LxuMcSGRqdTfoP0loUGb3EsYwZ+IDOnyWWvytfRoQdExSA2RM1PDo
+GRiUN4Dy8CrGNqvnb3agG99Ay3Ura6q5T20n9ykM4qKL3yDrO9fmWyMgRJbAOAYm
+xzf7H910mDZghXPpq8nzDky0JLNZcaqbxuPQ3+EI4p2dLNXbNqMPs8Y20JKLeOPs
+HikRM0zfhHEJSt5IPFQ54/CzscGHGeCleQINWTgvDLMcE5fJMvbLLZixV+YsBfAq
+e2JsSubS+9RI2ktMlSKaemr8yeoIpsXfAiJSHkECgYEA0NKU18xK+9w5IXfgNwI4
+peu2tWgwyZSp5R2pdLT7O1dJoLYRoAmcXNePB0VXNARqGxTNypJ9zmMawNmf3YRS
+BqG8aKz7qpATlx9OwYlk09fsS6MeVmaur8bHGHP6O+gt7Xg+zhiFPvU9P5LB+C0Z
+0d4grEmIxNhJCtJRQOThD8ECgYEA0GKRO9SJdnhw1b6LPLd+o/AX7IEzQDHwdtfi
+0h7hKHHGBlUMbIBwwjKmyKm6cSe0PYe96LqrVg+cVf84wbLZPAixhOjyplLznBzF
+LqOrfFPfI5lQVhslE1H1CdLlk9eyT96jDgmLAg8EGSMV8aLGj++Gi2l/isujHlWF
+BI4YpW8CgYEAsyKyhJzABmbYq5lGQmopZkxapCwJDiP1ypIzd+Z5TmKGytLlM8CK
+3iocjEQzlm/jBfBGyWv5eD8UCDOoLEMCiqXcFn+uNJb79zvoN6ZBVGl6TzhTIhNb
+73Y5/QQguZtnKrtoRSxLwcJnFE41D0zBRYOjy6gZJ6PSpPHeuiid2QECgYACuZc+
+mgvmIbMQCHrXo2qjiCs364SZDU4gr7gGmWLGXZ6CTLBp5tASqgjmTNnkSumfeFvy
+ZCaDbJbVxQ2f8s/GajKwEz/BDwqievnVH0zJxmr/kyyqw5Ybh5HVvA1GfqaVRssJ
+DvTjZQDft0a9Lyy7ix1OS2XgkcMjTWj840LNPwKBgDPXMBgL5h41jd7jCsXzPhyr
+V96RzQkPcKsoVvrCoNi8eoEYgRd9jwfiU12rlXv+fgVXrrfMoJBoYT6YtrxEJVdM
+RAjRpnE8PMqCUA8Rd7RFK9Vp5Uo8RxTNvk9yPvDv1+lHHV7lEltIk5PXuKPHIrc1
+nNUyhzvJs2Qba2L/huNC
+-----END PRIVATE KEY-----"""
+    yield key
+
+
+@pytest.fixture()
+def public_key() -> str:
+    """Yields a public key in PEM format"""
+    key = """-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqfuABGTOLmGSrv4ays8k
+jExRcd/53FqOlwBaQA0B1yzsEQfV4dfzsIoB4qrP8B0QAJp65ZMAgkAPK8YhwQDI
+6eQKW5MoIEM/w1Yo66Um2uk4stXMgU2Qt3LzithaSc7GpCS4SFw9R2lCzgpciCQf
+2K5h5kHPEi91M6LuZjKXXAQtqc8JhFtXL0FEaZ74KwxfFfOhq0JIyupyDyBHrlup
+Gw+ZVhQD3y39aIQ1nsd8sXkhclzUQKSYWxeB6yhXpj5Dou2nLJMt/FKJkI2YADBz
+6LSTZELwB3J1x4YNBXFhnaIb+W3PwrbfRsGTsyccMiSwQbEnsGxN9dE2Yt6C1NU5
+rwIDAQAB
+-----END PUBLIC KEY-----"""
+    yield key
+
+
+@pytest.fixture(scope="module")
+def nav_name() -> str:
+    yield "nav"

--- a/tests/unittests/models/jwtrefreshtoken_test.py
+++ b/tests/unittests/models/jwtrefreshtoken_test.py
@@ -1,0 +1,209 @@
+import pytest
+from unittest.mock import Mock, patch
+from datetime import datetime, timedelta
+from typing import Dict, Any
+
+from nav.models.api import JWTRefreshToken
+
+
+class TestGenerateAccessToken:
+    def test_nbf_should_be_in_the_past(self):
+        encoded_token = JWTRefreshToken.generate_access_token()
+        body = JWTRefreshToken._decode_token(encoded_token)
+        assert body['nbf'] < datetime.now().timestamp()
+
+    def test_exp_should_be_in_the_future(self):
+        encoded_token = JWTRefreshToken.generate_access_token()
+        body = JWTRefreshToken._decode_token(encoded_token)
+        assert body['exp'] > datetime.now().timestamp()
+
+    def test_iat_should_be_in_the_past(self):
+        encoded_token = JWTRefreshToken.generate_access_token()
+        body = JWTRefreshToken._decode_token(encoded_token)
+        assert body['iat'] < datetime.now().timestamp()
+
+    def test_token_type_should_be_access_token(self):
+        encoded_token = JWTRefreshToken.generate_access_token()
+        body = JWTRefreshToken._decode_token(encoded_token)
+        assert body['token_type'] == "access_token"
+
+
+class TestGenerateRefreshToken:
+    def test_nbf_should_be_in_the_past(self):
+        encoded_token = JWTRefreshToken.generate_refresh_token()
+        body = JWTRefreshToken._decode_token(encoded_token)
+        assert body['nbf'] < datetime.now().timestamp()
+
+    def test_exp_should_be_in_the_future(self):
+        encoded_token = JWTRefreshToken.generate_refresh_token()
+        body = JWTRefreshToken._decode_token(encoded_token)
+        assert body['exp'] > datetime.now().timestamp()
+
+    def test_iat_should_be_in_the_past(self):
+        encoded_token = JWTRefreshToken.generate_refresh_token()
+        body = JWTRefreshToken._decode_token(encoded_token)
+        assert body['iat'] < datetime.now().timestamp()
+
+    def test_token_type_should_be_refresh_token(self):
+        encoded_token = JWTRefreshToken.generate_refresh_token()
+        body = JWTRefreshToken._decode_token(encoded_token)
+        assert body['token_type'] == "refresh_token"
+
+
+class TestIsActive:
+    def test_should_return_false_if_nbf_is_in_the_future(self, refresh_token_data):
+        refresh_token_data['nbf'] = (datetime.now() + timedelta(hours=1)).timestamp()
+        refresh_token_data['exp'] = (datetime.now() + timedelta(hours=1)).timestamp()
+        encoded_token = JWTRefreshToken._encode_token(refresh_token_data)
+        token = JWTRefreshToken(token=encoded_token)
+        assert not token.is_active()
+
+    def test_should_return_false_if_exp_is_in_the_past(self, refresh_token_data):
+        refresh_token_data['nbf'] = (datetime.now() - timedelta(hours=1)).timestamp()
+        refresh_token_data['exp'] = (datetime.now() - timedelta(hours=1)).timestamp()
+        encoded_token = JWTRefreshToken._encode_token(refresh_token_data)
+        token = JWTRefreshToken(token=encoded_token)
+        assert not token.is_active()
+
+    def test_should_return_true_if_nbf_is_in_the_past_and_exp_is_in_the_future(
+        self, refresh_token_data
+    ):
+        now = datetime.now()
+        refresh_token_data['nbf'] = (now - timedelta(hours=1)).timestamp()
+        refresh_token_data['exp'] = (now + timedelta(hours=1)).timestamp()
+        encoded_token = JWTRefreshToken._encode_token(refresh_token_data)
+        token = JWTRefreshToken(token=encoded_token)
+        assert token.is_active()
+
+
+class TestExpire:
+    def test_should_make_active_token_inactive(self, refresh_token_data):
+        now = datetime.now()
+        # set claims so the token starts as being active
+        refresh_token_data['nbf'] = now - timedelta(hours=1)
+        refresh_token_data['exp'] = now + timedelta(hours=1)
+        encoded_token = JWTRefreshToken._encode_token(refresh_token_data)
+        token = JWTRefreshToken(token=encoded_token)
+        token.save = Mock()
+        assert token.is_active()
+        token.expire()
+        assert not token.is_active()
+
+
+class TestGetBody:
+    def test_should_return_accurate_representation_of_token_body(
+        self, refresh_token, refresh_token_data
+    ):
+        token = JWTRefreshToken(token=refresh_token)
+        assert token.get_body() == refresh_token_data
+
+
+class TestDecodeToken:
+    def test_should_return_same_body_as_when_token_was_encoded(
+        self, refresh_token, refresh_token_data
+    ):
+        decoded_data = JWTRefreshToken._decode_token(refresh_token)
+        assert decoded_data == refresh_token_data
+
+
+class TestEncodeToken:
+    def test_should_generate_a_known_token_using_the_same_body(
+        self, refresh_token, refresh_token_data
+    ):
+        encoded_token = JWTRefreshToken._encode_token(refresh_token_data)
+        assert encoded_token == refresh_token
+
+
+@pytest.fixture()
+def refresh_token_data() -> Dict[Any, str]:
+    """Yields the body of the token in the refresh_token fixture"""
+    body = {
+        "exp": 1516339022,
+        "nbf": 1516239022,
+        "iat": 1516239022,
+        "aud": "nav",
+        "iss": "nav",
+        "token_type": "refresh_token",
+    }
+    yield body
+
+
+@pytest.fixture()
+def refresh_token() -> str:
+    """Yields a refresh token with a body matching the refresh_token_data fixture"""
+    token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1\
+MTYzMzkwMjIsIm5iZiI6MTUxNjIzOTAyMiwiaWF0IjoxNTE2MjM5MDIyLCJh\
+dWQiOiJuYXYiLCJpc3MiOiJuYXYiLCJ0b2tlbl90eXBlIjoicmVmcmVzaF90\
+b2tlbiJ9.LC5YhPTrOQk2q-gPgPHAf9nWF8zjBFBmM6AEh1gSjJgvBdrwqsZ\
+7lqsEAQ09IXBrsZ3UhJDkEh5e31Tcp9afk_5f2dLA5zwcayxEbJ7Bj3M0PPb\
+D_jz5YWqJ1x9YwROh_iOVtTtVze8079rpF_0LIgbibJjJ1BLrvHLtYhTACTx\
+PKfmSJXK60_bg1jRPtlFIilNVdYQ3mnOXjg-9AjsCDH4nzABwiIpAXBR1r-9\
+3AZ_ZYxygwctVQpbIJIr0lTntczZ5sRudpK271JHdvLe-iZFz6MpfNIRBJS8\
+qawbo_kZmetm6zWmrPDcyC95tYfd2JL8XhEGGpB3nfhQipqG8nQ"
+    yield token
+
+
+@pytest.fixture(scope="module", autouse=True)
+def jwtconf_mock(private_key, nav_name) -> str:
+    """Mocks the get_nave_name and get_nav_private_key functions for
+    the JWTConf class
+    """
+    with patch("nav.models.api.JWTConf") as _jwtconf_mock:
+        instance = _jwtconf_mock.return_value
+        instance.get_nav_name = Mock(return_value=nav_name)
+        instance.get_nav_private_key = Mock(return_value=private_key)
+        yield _jwtconf_mock
+
+
+@pytest.fixture(scope="module")
+def private_key() -> str:
+    """Yields a private key in PEM format"""
+    key = """-----BEGIN PRIVATE KEY-----
+MIIEuwIBADANBgkqhkiG9w0BAQEFAASCBKUwggShAgEAAoIBAQCp+4AEZM4uYZKu
+/hrKzySMTFFx3/ncWo6XAFpADQHXLOwRB9Xh1/OwigHiqs/wHRAAmnrlkwCCQA8r
+xiHBAMjp5ApbkyggQz/DVijrpSba6Tiy1cyBTZC3cvOK2FpJzsakJLhIXD1HaULO
+ClyIJB/YrmHmQc8SL3Uzou5mMpdcBC2pzwmEW1cvQURpnvgrDF8V86GrQkjK6nIP
+IEeuW6kbD5lWFAPfLf1ohDWex3yxeSFyXNRApJhbF4HrKFemPkOi7acsky38UomQ
+jZgAMHPotJNkQvAHcnXHhg0FcWGdohv5bc/Ctt9GwZOzJxwyJLBBsSewbE310TZi
+3oLU1TmvAgMBAAECgf8zrhi95+gdMeKRpwV+TnxOK5CXjqvo0vTcnr7Runf/c9On
+WeUtRPr83E4LxuMcSGRqdTfoP0loUGb3EsYwZ+IDOnyWWvytfRoQdExSA2RM1PDo
+GRiUN4Dy8CrGNqvnb3agG99Ay3Ura6q5T20n9ykM4qKL3yDrO9fmWyMgRJbAOAYm
+xzf7H910mDZghXPpq8nzDky0JLNZcaqbxuPQ3+EI4p2dLNXbNqMPs8Y20JKLeOPs
+HikRM0zfhHEJSt5IPFQ54/CzscGHGeCleQINWTgvDLMcE5fJMvbLLZixV+YsBfAq
+e2JsSubS+9RI2ktMlSKaemr8yeoIpsXfAiJSHkECgYEA0NKU18xK+9w5IXfgNwI4
+peu2tWgwyZSp5R2pdLT7O1dJoLYRoAmcXNePB0VXNARqGxTNypJ9zmMawNmf3YRS
+BqG8aKz7qpATlx9OwYlk09fsS6MeVmaur8bHGHP6O+gt7Xg+zhiFPvU9P5LB+C0Z
+0d4grEmIxNhJCtJRQOThD8ECgYEA0GKRO9SJdnhw1b6LPLd+o/AX7IEzQDHwdtfi
+0h7hKHHGBlUMbIBwwjKmyKm6cSe0PYe96LqrVg+cVf84wbLZPAixhOjyplLznBzF
+LqOrfFPfI5lQVhslE1H1CdLlk9eyT96jDgmLAg8EGSMV8aLGj++Gi2l/isujHlWF
+BI4YpW8CgYEAsyKyhJzABmbYq5lGQmopZkxapCwJDiP1ypIzd+Z5TmKGytLlM8CK
+3iocjEQzlm/jBfBGyWv5eD8UCDOoLEMCiqXcFn+uNJb79zvoN6ZBVGl6TzhTIhNb
+73Y5/QQguZtnKrtoRSxLwcJnFE41D0zBRYOjy6gZJ6PSpPHeuiid2QECgYACuZc+
+mgvmIbMQCHrXo2qjiCs364SZDU4gr7gGmWLGXZ6CTLBp5tASqgjmTNnkSumfeFvy
+ZCaDbJbVxQ2f8s/GajKwEz/BDwqievnVH0zJxmr/kyyqw5Ybh5HVvA1GfqaVRssJ
+DvTjZQDft0a9Lyy7ix1OS2XgkcMjTWj840LNPwKBgDPXMBgL5h41jd7jCsXzPhyr
+V96RzQkPcKsoVvrCoNi8eoEYgRd9jwfiU12rlXv+fgVXrrfMoJBoYT6YtrxEJVdM
+RAjRpnE8PMqCUA8Rd7RFK9Vp5Uo8RxTNvk9yPvDv1+lHHV7lEltIk5PXuKPHIrc1
+nNUyhzvJs2Qba2L/huNC
+-----END PRIVATE KEY-----"""
+    yield key
+
+
+@pytest.fixture()
+def public_key() -> str:
+    """Yields a public key in PEM format"""
+    key = """-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqfuABGTOLmGSrv4ays8k
+jExRcd/53FqOlwBaQA0B1yzsEQfV4dfzsIoB4qrP8B0QAJp65ZMAgkAPK8YhwQDI
+6eQKW5MoIEM/w1Yo66Um2uk4stXMgU2Qt3LzithaSc7GpCS4SFw9R2lCzgpciCQf
+2K5h5kHPEi91M6LuZjKXXAQtqc8JhFtXL0FEaZ74KwxfFfOhq0JIyupyDyBHrlup
+Gw+ZVhQD3y39aIQ1nsd8sXkhclzUQKSYWxeB6yhXpj5Dou2nLJMt/FKJkI2YADBz
+6LSTZELwB3J1x4YNBXFhnaIb+W3PwrbfRsGTsyccMiSwQbEnsGxN9dE2Yt6C1NU5
+rwIDAQAB
+-----END PUBLIC KEY-----"""
+    yield key
+
+
+@pytest.fixture(scope="module")
+def nav_name() -> str:
+    yield "nav"

--- a/tests/unittests/models/jwtrefreshtoken_test.py
+++ b/tests/unittests/models/jwtrefreshtoken_test.py
@@ -9,45 +9,45 @@ from nav.models.api import JWTRefreshToken
 class TestGenerateAccessToken:
     def test_nbf_should_be_in_the_past(self):
         encoded_token = JWTRefreshToken.generate_access_token()
-        body = JWTRefreshToken._decode_token(encoded_token)
-        assert body['nbf'] < datetime.now().timestamp()
+        data = JWTRefreshToken._decode_token(encoded_token)
+        assert data['nbf'] < datetime.now().timestamp()
 
     def test_exp_should_be_in_the_future(self):
         encoded_token = JWTRefreshToken.generate_access_token()
-        body = JWTRefreshToken._decode_token(encoded_token)
-        assert body['exp'] > datetime.now().timestamp()
+        data = JWTRefreshToken._decode_token(encoded_token)
+        assert data['exp'] > datetime.now().timestamp()
 
     def test_iat_should_be_in_the_past(self):
         encoded_token = JWTRefreshToken.generate_access_token()
-        body = JWTRefreshToken._decode_token(encoded_token)
-        assert body['iat'] < datetime.now().timestamp()
+        data = JWTRefreshToken._decode_token(encoded_token)
+        assert data['iat'] < datetime.now().timestamp()
 
     def test_token_type_should_be_access_token(self):
         encoded_token = JWTRefreshToken.generate_access_token()
-        body = JWTRefreshToken._decode_token(encoded_token)
-        assert body['token_type'] == "access_token"
+        data = JWTRefreshToken._decode_token(encoded_token)
+        assert data['token_type'] == "access_token"
 
 
 class TestGenerateRefreshToken:
     def test_nbf_should_be_in_the_past(self):
         encoded_token = JWTRefreshToken.generate_refresh_token()
-        body = JWTRefreshToken._decode_token(encoded_token)
-        assert body['nbf'] < datetime.now().timestamp()
+        data = JWTRefreshToken._decode_token(encoded_token)
+        assert data['nbf'] < datetime.now().timestamp()
 
     def test_exp_should_be_in_the_future(self):
         encoded_token = JWTRefreshToken.generate_refresh_token()
-        body = JWTRefreshToken._decode_token(encoded_token)
-        assert body['exp'] > datetime.now().timestamp()
+        data = JWTRefreshToken._decode_token(encoded_token)
+        assert data['exp'] > datetime.now().timestamp()
 
     def test_iat_should_be_in_the_past(self):
         encoded_token = JWTRefreshToken.generate_refresh_token()
-        body = JWTRefreshToken._decode_token(encoded_token)
-        assert body['iat'] < datetime.now().timestamp()
+        data = JWTRefreshToken._decode_token(encoded_token)
+        assert data['iat'] < datetime.now().timestamp()
 
     def test_token_type_should_be_refresh_token(self):
         encoded_token = JWTRefreshToken.generate_refresh_token()
-        body = JWTRefreshToken._decode_token(encoded_token)
-        assert body['token_type'] == "refresh_token"
+        data = JWTRefreshToken._decode_token(encoded_token)
+        assert data['token_type'] == "refresh_token"
 
 
 class TestIsActive:
@@ -90,16 +90,16 @@ class TestExpire:
         assert not token.is_active()
 
 
-class TestGetBody:
-    def test_should_return_accurate_representation_of_token_body(
+class TestData:
+    def test_should_return_accurate_representation_of_token_data(
         self, refresh_token, refresh_token_data
     ):
         token = JWTRefreshToken(token=refresh_token)
-        assert token.get_body() == refresh_token_data
+        assert token.data() == refresh_token_data
 
 
 class TestDecodeToken:
-    def test_should_return_same_body_as_when_token_was_encoded(
+    def test_should_return_same_data_as_when_token_was_encoded(
         self, refresh_token, refresh_token_data
     ):
         decoded_data = JWTRefreshToken._decode_token(refresh_token)
@@ -107,7 +107,7 @@ class TestDecodeToken:
 
 
 class TestEncodeToken:
-    def test_should_generate_a_known_token_using_the_same_body(
+    def test_should_generate_a_known_token_using_the_same_data(
         self, refresh_token, refresh_token_data
     ):
         encoded_token = JWTRefreshToken._encode_token(refresh_token_data)
@@ -116,8 +116,8 @@ class TestEncodeToken:
 
 @pytest.fixture()
 def refresh_token_data() -> Dict[Any, str]:
-    """Yields the body of the token in the refresh_token fixture"""
-    body = {
+    """Yields the data of the token in the refresh_token fixture"""
+    data = {
         "exp": 1516339022,
         "nbf": 1516239022,
         "iat": 1516239022,
@@ -125,12 +125,12 @@ def refresh_token_data() -> Dict[Any, str]:
         "iss": "nav",
         "token_type": "refresh_token",
     }
-    yield body
+    yield data
 
 
 @pytest.fixture()
 def refresh_token() -> str:
-    """Yields a refresh token with a body matching the refresh_token_data fixture"""
+    """Yields a refresh token with data matching the refresh_token_data fixture"""
     token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1\
 MTYzMzkwMjIsIm5iZiI6MTUxNjIzOTAyMiwiaWF0IjoxNTE2MjM5MDIyLCJh\
 dWQiOiJuYXYiLCJpc3MiOiJuYXYiLCJ0b2tlbl90eXBlIjoicmVmcmVzaF90\


### PR DESCRIPTION
Based on #2569 

Adds an endpoint that accepts valid and active refresh tokens. The endpoint will then make a new refresh token and access token that is given to the user. This way the refresh token is only used once, limiting the risk of leaking.