### PR TITLE
Revert to having tox run its own dependency installer

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -65,7 +65,7 @@ RUN cd /tmp && \
     mv chromedriver /usr/local/bin/
 
 # Install our primary test runner
-RUN python3.7 -m pip install tox snmpsim 'virtualenv<20.0.0'
+RUN python3.7 -m pip install 'tox<4' snmpsim virtualenv
 
 # Add a build user
 ENV USER build

--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,12 @@ python =
 [testenv]
 # Baseline test environment
 deps =
-    pip-tools
     pip
+    -r tests/requirements.txt
+    -r requirements/base.txt
+    -r requirements/optional.txt
+    -r requirements/django{env:DJANGO_VER}.txt
+
 setenv =
     LC_ALL=C.UTF-8
     LANG=C.UTF-8
@@ -44,10 +48,8 @@ allowlist_externals =
                       mkdir
                       chmod
 
+usedevelop = true
 commands_pre =
-         pip-compile --resolver=backtracking --output-file {envdir}/requirements.txt tests/requirements.txt requirements/base.txt requirements/optional.txt requirements/django{env:DJANGO_VER}.txt
-         pip-sync {envdir}/requirements.txt
-         pip install -e .
          mkdir -p {toxinidir}/reports/coverage
          chmod 777 {toxinidir}/reports/coverage
 


### PR DESCRIPTION
Running pip-compile and pip-sync on every tox run is quite expensive, and reduces the incentive for developers to repeatedly run tests locally.

This brings us back to the inconvenience in the other end of the scale: If you change any of the requirements files, tox (`<4`) will not recognize this as a change, and the test environment is not updated. The developer who needs an updated test environment must endure a manual environment rebuild using `tox --recreate -e <env-of-choice>`

The GitHub workflows will cache the tox environments between runs. However, no changes should be necessary here, as checksums of all the requirements files are part of the cache key.

This PR also updates the test environment Dockerfile to explicitly install `tox < 4`, just as we do in the GitHub workflows (as tox 4 introduced several backwards incompatibilities with our `tox.ini`).
