### PR TITLE
Detect current virtualenv in a more compatible way

### DIFF
--- a/python/nav/config.py
+++ b/python/nav/config.py
@@ -42,7 +42,14 @@ CONFIG_LOCATIONS = [
     '/etc/nav',
     os.path.join(buildconf.datadir, 'conf'),
 ]
-_venv = os.getenv('VIRTUAL_ENV')
+# If running inside a virtualenv, add that virtualenv to the search path as well:
+_base_prefix = (
+    # Detect the base prefix in a manner compatible with both old and new virtualenv
+    getattr(sys, "base_prefix", None)
+    or getattr(sys, "real_prefix", None)
+    or sys.prefix
+)
+_venv = sys.prefix if sys.prefix != _base_prefix else None
 if _venv:
     CONFIG_LOCATIONS = [
         os.path.join(_venv, 'etc'),


### PR DESCRIPTION
Detection of current active virtualenv (used during detection of where NAV's config files may be located) broke down horribly during a bit of reorganization of how the tests are run, and under which versions of virtualenv they run.

See https://stackoverflow.com/a/1883251 for details on why this needs to change.