### PR TITLE
Update ldapauth.py to disable following referrals, to fix Active Directory login failures

### DIFF
--- a/python/nav/web/ldapauth.py
+++ b/python/nav/web/ldapauth.py
@@ -100,6 +100,7 @@ def open_ldap():
     uri = '%s://%s:%s' % (scheme, server, port)
     lconn = ldap.initialize(uri, bytes_mode=False)
     lconn.timeout = timeout
+    lconn.set_option(ldap.OPT_REFERRALS, 0)
 
     # Use STARTTLS if enabled, then fail miserably if the server
     # does not support it

--- a/tests/unittests/web/ldapauth_test.py
+++ b/tests/unittests/web/ldapauth_test.py
@@ -1,5 +1,5 @@
 from nav.config import NAVConfigParser
-from nav.web.ldapauth import LDAPUser
+from nav.web.ldapauth import LDAPUser, open_ldap
 from mock import Mock, patch
 
 
@@ -33,3 +33,39 @@ def test_ldapuser_search_dn_decode_regression():
     user = LDAPUser('zaphod', connection)
     dn, uid = user.search_dn()
     assert dn == u'CN=Zaphod Beeblebr\xf6x,CN=people,DC=example,DC=org'
+
+
+class LdapOpenTestConfig(NAVConfigParser):
+    DEFAULT_CONFIG_FILES = []
+    DEFAULT_CONFIG = u"""
+[ldap]
+server=ldap.example.org
+port=636
+encryption=tls
+timeout=3
+debug=true
+"""
+
+
+@patch('nav.web.ldapauth._config', LdapOpenTestConfig())
+def test_open_ldap_should_run_without_error():
+    with patch('ldap.initialize') as initialize:
+        assert open_ldap()
+
+
+class LdapOpenTestInvalidEncryptionConfig(NAVConfigParser):
+    DEFAULT_CONFIG_FILES = []
+    DEFAULT_CONFIG = u"""
+[ldap]
+server=ldap.example.org
+port=636
+encryption=invalid
+timeout=3
+debug=true
+"""
+
+
+@patch('nav.web.ldapauth._config', LdapOpenTestInvalidEncryptionConfig())
+def test_when_encryption_setting_is_invalid_open_ldap_should_run_without_encryption():
+    with patch('ldap.initialize') as initialize:
+        assert open_ldap()


### PR DESCRIPTION
Following referrals is disabled, to work around the error caused by Active Directory's referrals to other servers.  #1166

I don't have another LDAP authentication source to test whether it breaks non-AD LDAP integration.