### PR TITLE
Add endpoint for finding prefixes containing given CIDR address

### DIFF
--- a/doc/howto/api_parameters.rst
+++ b/doc/howto/api_parameters.rst
@@ -114,7 +114,7 @@ Provides access to NAVs prefix data
 
 :Search: None
 
-:Filters: vlan, net_address, vlan__vlan
+:Filters: vlan, net_address, vlan__vlan, contains_address
 
     .. NOTE:: The vlan__vlan is used to filter on vlan number as the vlan field
               references the primary key only.

--- a/python/nav/web/api/v1/serializers.py
+++ b/python/nav/web/api/v1/serializers.py
@@ -450,6 +450,7 @@ class PrefixSerializer(serializers.ModelSerializer):
     usages = serializers.PrimaryKeyRelatedField(
         many=True, read_only=False, required=False, queryset=manage.Usage.objects.all()
     )
+    vlan_data = VlanSerializer(read_only=True, source='vlan')
 
     class Meta(object):
         model = manage.Prefix

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -810,7 +810,7 @@ class PrefixViewSet(NAVAPIMixin, viewsets.ModelViewSet):
 
     queryset = manage.Prefix.objects.all()
     serializer_class = serializers.PrefixSerializer
-    filterset_fields = ('vlan', 'net_address', 'vlan__vlan')
+    filterset_class = PrefixFilterClass
 
     @action(detail=False)
     def search(self, request):

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -805,6 +805,7 @@ class PrefixViewSet(NAVAPIMixin, viewsets.ModelViewSet):
     - net_address
     - vlan
     - vlan__vlan: *Filters on the vlan number of the vlan*
+    - contains_address
 
     """
 

--- a/tests/integration/web/prefixviewset_test.py
+++ b/tests/integration/web/prefixviewset_test.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+import json
+import pytest
+
+from nav.models.manage import Prefix, Vlan, NetType
+from nav.compatibility import force_str
+from nav.web.api.v1.views import get_endpoints
+
+ENDPOINTS = {name: force_str(url) for name, url in get_endpoints().items()}
+prefix_url = ENDPOINTS['prefix']
+
+
+def test_contains_address_filter_returns_prefix_containing_given_address(
+    client, prefix
+):
+    response = client.get(prefix_url, {"contains_address": "10.1.1.0/24"})
+    assert response.status_code == 200
+    content = json.loads(response.content.decode('utf-8'))
+    prefix_ids = [prefix['id'] for prefix in content['results']]
+    assert prefix.id in prefix_ids
+
+
+def test_contains_address_filter_does_not_return_prefix_that_does_not_contain_given_address(
+    client, prefix
+):
+    response = client.get(prefix_url, {"contains_address": "20.4.111.0/24"})
+    assert response.status_code == 200
+    content = json.loads(response.content.decode('utf-8'))
+    prefix_ids = [prefix['id'] for prefix in content['results']]
+    assert prefix.id not in prefix_ids
+
+
+def test_contains_address_filter_fails_if_given_address_is_not_valid_cidr_address(
+    client, prefix
+):
+    response = client.get(prefix_url, {"contains_address": "invalid_address"})
+    assert response.status_code == 400
+
+
+def test_contains_address_filter_returns_prefix_identical_to_given_address(
+    client, prefix
+):
+    response = client.get(prefix_url, {"contains_address": prefix.net_address})
+    assert response.status_code == 200
+    content = json.loads(response.content.decode('utf-8'))
+    prefix_ids = [prefix['id'] for prefix in content['results']]
+    assert prefix.id in prefix_ids
+
+
+###
+#
+# Fixtures
+#
+###
+
+
+@pytest.fixture()
+def nettype(db):
+    nettype = NetType(description="test nettype")
+    nettype.save()
+    yield nettype
+    if nettype.pk:
+        nettype.delete()
+
+
+@pytest.fixture()
+def vlan(db, nettype):
+    vlan = Vlan(vlan="10", net_type=nettype)
+    vlan.save()
+    yield vlan
+    if vlan.pk:
+        vlan.delete()
+
+
+@pytest.fixture()
+def prefix(db, vlan):
+    prefix = Prefix(net_address='10.1.0.0/16', vlan=vlan)
+    prefix.save()
+    yield prefix
+    if prefix.pk:
+        prefix.delete()

--- a/tests/integration/web/prefixviewset_test.py
+++ b/tests/integration/web/prefixviewset_test.py
@@ -9,49 +9,44 @@ ENDPOINTS = {name: force_str(url) for name, url in get_endpoints().items()}
 prefix_url = ENDPOINTS['prefix']
 
 
-def test_contains_address_filter_returns_prefix_containing_given_address(
-    client, prefix
-):
-    response = client.get(prefix_url, {"contains_address": "10.1.1.0/24"})
-    assert response.status_code == 200
-    content = json.loads(response.content.decode('utf-8'))
-    prefix_ids = [prefix['id'] for prefix in content['results']]
-    assert prefix.id in prefix_ids
+class TestContainsAddressFilter:
+    def test_prefix_containing_given_address_is_returned(self, client, prefix):
+        response = client.get(prefix_url, {"contains_address": "10.1.1.0/24"})
+        assert response.status_code == 200
+        content = json.loads(response.content.decode('utf-8'))
+        prefix_ids = [prefix['id'] for prefix in content['results']]
+        assert prefix.id in prefix_ids
+
+    def test_prefix_that_does_not_contain_given_address_is_not_returned(
+        self, client, prefix
+    ):
+        response = client.get(prefix_url, {"contains_address": "20.4.111.0/24"})
+        assert response.status_code == 200
+        content = json.loads(response.content.decode('utf-8'))
+        prefix_ids = [prefix['id'] for prefix in content['results']]
+        assert prefix.id not in prefix_ids
+
+    def test_error_is_returned_if_given_address_is_not_valid_cidr_address(
+        self, client, prefix
+    ):
+        response = client.get(prefix_url, {"contains_address": "invalid_address"})
+        assert response.status_code == 400
+
+    def test_prefix_identical_to_given_address_is_returned(self, client, prefix):
+        response = client.get(prefix_url, {"contains_address": prefix.net_address})
+        assert response.status_code == 200
+        content = json.loads(response.content.decode('utf-8'))
+        prefix_ids = [prefix['id'] for prefix in content['results']]
+        assert prefix.id in prefix_ids
 
 
-def test_contains_address_filter_does_not_return_prefix_that_does_not_contain_given_address(
-    client, prefix
-):
-    response = client.get(prefix_url, {"contains_address": "20.4.111.0/24"})
-    assert response.status_code == 200
-    content = json.loads(response.content.decode('utf-8'))
-    prefix_ids = [prefix['id'] for prefix in content['results']]
-    assert prefix.id not in prefix_ids
-
-
-def test_contains_address_filter_fails_if_given_address_is_not_valid_cidr_address(
-    client, prefix
-):
-    response = client.get(prefix_url, {"contains_address": "invalid_address"})
-    assert response.status_code == 400
-
-
-def test_contains_address_filter_returns_prefix_identical_to_given_address(
-    client, prefix
-):
-    response = client.get(prefix_url, {"contains_address": prefix.net_address})
-    assert response.status_code == 200
-    content = json.loads(response.content.decode('utf-8'))
-    prefix_ids = [prefix['id'] for prefix in content['results']]
-    assert prefix.id in prefix_ids
-
-
-def test_vlan_filter_returns_prefix_with_matching_vlan(client, prefix):
-    response = client.get(prefix_url, {"vlan": prefix.vlan.id})
-    assert response.status_code == 200
-    content = json.loads(response.content.decode('utf-8'))
-    prefix_ids = [prefix['id'] for prefix in content['results']]
-    assert prefix.id in prefix_ids
+class TestVlanFilter:
+    def test_prefix_with_matching_vlan_id_is_returned(self, client, prefix):
+        response = client.get(prefix_url, {"vlan": prefix.vlan.id})
+        assert response.status_code == 200
+        content = json.loads(response.content.decode('utf-8'))
+        prefix_ids = [prefix['id'] for prefix in content['results']]
+        assert prefix.id in prefix_ids
 
 
 ###

--- a/tests/integration/web/prefixviewset_test.py
+++ b/tests/integration/web/prefixviewset_test.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import print_function
 import json
 import pytest
 

--- a/tests/integration/web/prefixviewset_test.py
+++ b/tests/integration/web/prefixviewset_test.py
@@ -48,6 +48,14 @@ def test_contains_address_filter_returns_prefix_identical_to_given_address(
     assert prefix.id in prefix_ids
 
 
+def test_vlan_filter_returns_prefix_with_matching_vlan(client, prefix):
+    response = client.get(prefix_url, {"vlan": prefix.vlan.id})
+    assert response.status_code == 200
+    content = json.loads(response.content.decode('utf-8'))
+    prefix_ids = [prefix['id'] for prefix in content['results']]
+    assert prefix.id in prefix_ids
+
+
 ###
 #
 # Fixtures


### PR DESCRIPTION
Fixes #2577 

- Adds a filter `contains_address` to the `Prefix` endpoint. The endpoint takes a CIDR address, and returns the prefixes that contains the given address.
- Updates the Prefix serializer to include `Vlan` information inline under the key `vlan_data`. the key `vlan` that contains the `Vlan` id is still included for backwards compatability