### PR TITLE
Make save function of Alert/EventQueue and AlertHistory atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ found in the [HISTORY](HISTORY) file.
 
 ### Fixed
 
-#### User-visible features
+#### User-visible fixes
 - Make save function in AlertHistory, EventHistory and AlertQueue atomic  ([#2594](https://github.com/Uninett/nav/pull/2594))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This changelog format was introduced in NAV 5.4.0. Older changelogs can be
 found in the [HISTORY](HISTORY) file.
 
+## [Unreleased]
+
+
+
+## bugfix/atomic-save-of-alerts-and-events 
+
+### Fixed
+
+#### User-visible features
+- Make save function in AlertHistory, EventHistory and AlertQueue atomic  ([#2594](https://github.com/Uninett/nav/pull/2594))
+
+
+
 ## [5.6.0] - 2023-01-20
 
 ### Added

--- a/python/nav/models/event.py
+++ b/python/nav/models/event.py
@@ -23,7 +23,7 @@ from collections import defaultdict
 import logging
 import datetime as dt
 
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Q
 from django.core.validators import MaxValueValidator, MinValueValidator
 
@@ -417,6 +417,7 @@ class EventQueue(models.Model, EventMixIn):
         )
         return string.format(self=self, state=dict(self.STATE_CHOICES)[self.state])
 
+    @transaction.atomic
     def save(self, *args, **kwargs):
         new_object = self.pk is None
         super(EventQueue, self).save(*args, **kwargs)
@@ -550,6 +551,7 @@ class AlertQueue(models.Model, EventMixIn):
             self.severity,
         )
 
+    @transaction.atomic
     def save(self, *args, **kwargs):
         new_object = self.pk is None
         super(AlertQueue, self).save(*args, **kwargs)
@@ -756,6 +758,7 @@ class AlertHistory(models.Model, EventMixIn):
 
         ack.save()
 
+    @transaction.atomic
     def save(self, *args, **kwargs):
         new_object = self.pk is None
         super(AlertHistory, self).save(*args, **kwargs)

--- a/tools/eventgenerators/devicenotice.py
+++ b/tools/eventgenerators/devicenotice.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.  You should have received a copy of the GNU General Public
+# License along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Module comment"""
+from argparse import ArgumentParser
+
+from nav.bootstrap import bootstrap_django
+
+bootstrap_django()
+
+from nav.event2 import EventFactory
+from nav.models.manage import Device
+
+from django.db import transaction
+
+
+def main():
+    """Main controller"""
+    args = parse_options()
+
+    device = Device.objects.get(serial=args.serial)
+    event = EventFactory('ipdevpoll', 'eventEngine', 'deviceNotice')
+    event.notify(
+        device=device,
+        alert_type=args.alerttype,
+        varmap={
+            "old_version": "old",
+            "new_version": "new",
+        },
+    ).save()
+
+
+def parse_options():
+    """Parse command line options and args"""
+    parser = ArgumentParser()
+    parser.add_argument('-s', dest='serial', required=True, help='Serial of device')
+    parser.add_argument(
+        '-a', dest='alerttype', required=True, help='The name of the alert type'
+    )
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
After merging #2413 and everything related to it (#2515, #2545, #2560, #2565, #2580) it happened occasionally that notifications were sent out with the error
```
no templates defined for <AlertGenerator: source=<Subsystem: ipdevpoll> device=<Device: redacted> netbox=None subid='' time=datetime.datetime(2023, 3, 17, 9, 41, 24, 79802) event_type=<EventType: deviceNotice> state='x' value=100 severity=3 history_vars={} alert_type=None varmap={}>, sending generic alert message
```

We could pinpoint that this happened due to the eventengine being notified about a new event in the EventQueue and processing it without the varmap being saved yet, which lead to this error, since the alert type is saved in the varmap.

Making the save function atomic prevents this from happening since the eventengine only starts processing the event when all information is saved properly. 