### PR TITLE
Fix backwards relation references in room search

### DIFF
--- a/python/nav/web/info/room/views.py
+++ b/python/nav/web/info/room/views.py
@@ -86,7 +86,7 @@ def search(request):
             titles.append(("Search for %s" % request.GET['query'],))
             rooms = process_searchform(searchform)
             for room in rooms:
-                room.netboxes = filter_netboxes(room)
+                room.filtered_netboxes = filter_netboxes(room)
     else:
         searchform = RoomSearchForm()
 
@@ -111,7 +111,7 @@ def process_searchform(form):
         return Room.objects.filter(
             Q(id__icontains=query)
             | Q(description__icontains=query)
-            | Q(child_locations__id__icontains=query)
+            | Q(location__id__icontains=query)
         ).order_by("id")
 
 

--- a/python/nav/web/templates/info/room/base.html
+++ b/python/nav/web/templates/info/room/base.html
@@ -45,7 +45,7 @@
                   {{ room.description }}
                 </td>
                 <td>
-                  {{ room.netboxes.count }}
+                  {{ room.filtered_netboxes.count }}
                 </td>
               </tr>
             {% endfor %}


### PR DESCRIPTION
17ef4e0 broke things by adding a related name that was used otherwise (netboxes) and me changing `location` to `child_locations`, where it was actually incorrect, which resulted in the room search not working. 

Luckily I caught this before it was included in a release. 