### PR TITLE
Fix backwards relation references in group search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ found in the [HISTORY](HISTORY) file.
 
 #### Developer-centric features
 - Document a recipe for establishing SNMP tunnels using socat/SSH ([#2426](https://github.com/Uninett/nav/issues/2426), [#2435](https://github.com/Uninett/nav/pulls/2435))
+- Updated/added explicit relation names to various ORM models ([#2544](https://github.com/Uninett/nav/pull/2544), [#2546](https://github.com/Uninett/nav/pull/2546), [#2547](https://github.com/Uninett/nav/pull/2547), [#2549](https://github.com/Uninett/nav/pull/2549), [#2550](https://github.com/Uninett/nav/pull/2550), [#2551](https://github.com/Uninett/nav/pull/2551), [#2595](https://github.com/Uninett/nav/pull/2595), [#2596](https://github.com/Uninett/nav/pull/2596))
 
 ### Fixed
 

--- a/python/nav/web/info/netboxgroup/views.py
+++ b/python/nav/web/info/netboxgroup/views.py
@@ -65,7 +65,7 @@ def index(request):
         if form.is_valid():
             query = request.GET['query']
             id_filter = Q(pk__icontains=query)
-            netbox_filter = Q(netbox__sysname__icontains=query)
+            netbox_filter = Q(netboxes__sysname__icontains=query)
             groups = (
                 NetboxGroup.objects.filter(id_filter | netbox_filter)
                 .distinct()


### PR DESCRIPTION
When writing a test for the bug that will be fixed in #2595 I also realized that something similar happened in device group search. This PR fixes that. 