### PR TITLE
Drop obsolete Python 2 compatibility statement

### DIFF
--- a/python/nav/eventengine/alerts.py
+++ b/python/nav/eventengine/alerts.py
@@ -80,8 +80,6 @@ class AlertGenerator(dict):
         """
         return True
 
-    __nonzero__ = __bool__  # For PY2 compatibility
-
     def make_alert(self):
         """Generates an alert object based on the current attributes"""
         attrs = {}


### PR DESCRIPTION
This was introduced by 16536ab4ba9de4d122ea0045fb8329c304fd6cda . It hasn't been needed since NAV dropped support for Python 2.