### PR TITLE
Create events when PowerSupplyOrFans are deleted

### DIFF
--- a/changelog.d/2982.added.md
+++ b/changelog.d/2982.added.md
@@ -1,0 +1,1 @@
+Post event when a PowerSupplyOrFan is deleted

--- a/doc/reference/alerttypes.rst
+++ b/doc/reference/alerttypes.rst
@@ -213,6 +213,10 @@ Registers the state of a device
      - The device has been found as a power supply.
    * - ``deviceNewFan``
      - The device has been found as a fan.
+   * - ``deviceDeletedFan``
+     - The device has been removed as a fan.
+   * - ``deviceDeletedPsu``
+     - The device has been removed as a power supply.
 
 
 

--- a/python/nav/etc/alertmsg/deviceState/deviceDeletedFan-email.txt
+++ b/python/nav/etc/alertmsg/deviceState/deviceDeletedFan-email.txt
@@ -1,0 +1,2 @@
+Subject: Device has been removed as a fan
+Device {{ device.get_extended_description }} has been removed from {{netbox}} as a fan

--- a/python/nav/etc/alertmsg/deviceState/deviceDeletedFan-email.txt
+++ b/python/nav/etc/alertmsg/deviceState/deviceDeletedFan-email.txt
@@ -1,2 +1,2 @@
 Subject: Device has been removed as a fan
-Device {{ device.get_extended_description }} has been removed from {{netbox}} as a fan
+Device {{device}} has been removed from {{netbox}} as a fan

--- a/python/nav/etc/alertmsg/deviceState/deviceDeletedFan-sms.txt
+++ b/python/nav/etc/alertmsg/deviceState/deviceDeletedFan-sms.txt
@@ -1,0 +1,1 @@
+Device {{ device.get_extended_description }} has been removed from {{netbox}} as a fan

--- a/python/nav/etc/alertmsg/deviceState/deviceDeletedFan-sms.txt
+++ b/python/nav/etc/alertmsg/deviceState/deviceDeletedFan-sms.txt
@@ -1,1 +1,1 @@
-Device {{ device.get_extended_description }} has been removed from {{netbox}} as a fan
+Device {{device}} has been removed from {{netbox}} as a fan

--- a/python/nav/etc/alertmsg/deviceState/deviceDeletedPsu-email.txt
+++ b/python/nav/etc/alertmsg/deviceState/deviceDeletedPsu-email.txt
@@ -1,0 +1,2 @@
+Subject: Device has been removed as a power supply
+Device {{ device.get_extended_description }} has been removed from {{netbox}} as a power supply

--- a/python/nav/etc/alertmsg/deviceState/deviceDeletedPsu-email.txt
+++ b/python/nav/etc/alertmsg/deviceState/deviceDeletedPsu-email.txt
@@ -1,2 +1,2 @@
 Subject: Device has been removed as a power supply
-Device {{ device.get_extended_description }} has been removed from {{netbox}} as a power supply
+Device {{device}} has been removed from {{netbox}} as a power supply

--- a/python/nav/etc/alertmsg/deviceState/deviceDeletedPsu-sms.txt
+++ b/python/nav/etc/alertmsg/deviceState/deviceDeletedPsu-sms.txt
@@ -1,1 +1,1 @@
-Device {{ device.get_extended_description }} has been removed from {{netbox}} as a power supply
+Device {{device}} has been removed from {{netbox}} as a power supply

--- a/python/nav/etc/alertmsg/deviceState/deviceDeletedPsu-sms.txt
+++ b/python/nav/etc/alertmsg/deviceState/deviceDeletedPsu-sms.txt
@@ -1,0 +1,1 @@
+Device {{ device.get_extended_description }} has been removed from {{netbox}} as a power supply

--- a/python/nav/ipdevpoll/shadows/__init__.py
+++ b/python/nav/ipdevpoll/shadows/__init__.py
@@ -847,9 +847,11 @@ class PowerSupplyOrFan(Shadow):
                     device_event.notify(
                         device=psufan.device,
                         netbox=psufan.netbox,
-                        alert_type="deviceDeletedPsu"
-                        if psufan.is_psu()
-                        else "deviceDeletedFan",
+                        alert_type=(
+                            "deviceDeletedPsu"
+                            if psufan.is_psu()
+                            else "deviceDeletedFan"
+                        ),
                     ).save()
             except manage.Device.DoesNotExist:
                 pass

--- a/python/nav/ipdevpoll/shadows/__init__.py
+++ b/python/nav/ipdevpoll/shadows/__init__.py
@@ -842,13 +842,17 @@ class PowerSupplyOrFan(Shadow):
     @classmethod
     def _alert_missing_devices_are_deleted(cls, deleted_psus_and_fans):
         for psufan in deleted_psus_and_fans:
-            device_event.notify(
-                device=psufan.device,
-                netbox=psufan.netbox,
-                alert_type="deviceDeletedPsu"
-                if psufan.is_psu()
-                else "deviceDeletedFan",
-            ).save()
+            try:
+                if psufan.device.serial:
+                    device_event.notify(
+                        device=psufan.device,
+                        netbox=psufan.netbox,
+                        alert_type="deviceDeletedPsu"
+                        if psufan.is_psu()
+                        else "deviceDeletedFan",
+                    ).save()
+            except manage.Device.DoesNotExist:
+                pass
 
 
 class POEPort(Shadow):

--- a/python/nav/ipdevpoll/shadows/__init__.py
+++ b/python/nav/ipdevpoll/shadows/__init__.py
@@ -827,6 +827,7 @@ class PowerSupplyOrFan(Shadow):
             netbox.sysname,
             ", ".join(psu_and_fan_names),
         )
+        cls._alert_missing_devices_are_deleted(missing_psus_and_fans)
         missing_psus_and_fans.delete()
 
     @classmethod
@@ -837,6 +838,17 @@ class PowerSupplyOrFan(Shadow):
             netbox=netbox.id
         ).exclude(pk__in=found_psus_and_fans_pks)
         return missing_psus_and_fans
+
+    @classmethod
+    def _alert_missing_devices_are_deleted(cls, deleted_psus_and_fans):
+        for psufan in deleted_psus_and_fans:
+            device_event.notify(
+                device=psufan.device,
+                netbox=psufan.netbox,
+                alert_type="deviceDeletedPsu"
+                if psufan.is_psu()
+                else "deviceDeletedFan",
+            ).save()
 
 
 class POEPort(Shadow):

--- a/python/nav/models/sql/changes/sc.05.05.0002.sql
+++ b/python/nav/models/sql/changes/sc.05.05.0002.sql
@@ -1,0 +1,5 @@
+-- Add new deviceState alert
+INSERT INTO alerttype (eventtypeid,alerttype,alerttypedesc) VALUES
+  ('deviceState','deviceDeletedFan','The device has been removed as a fan.');
+  INSERT INTO alerttype (eventtypeid,alerttype,alerttypedesc) VALUES
+  ('deviceState','deviceDeletedPsu','The device has been removed as a power supply.');


### PR DESCRIPTION
Closes #2982 

This PR adds alerts for deviceDeletedFan and deviceDeletedPsu. These are used to create events when PowerSupplyOrFan objects are deleted
