### PR TITLE
Add a docstring to "bootstrap_django"

### DIFF
--- a/python/nav/bootstrap.py
+++ b/python/nav/bootstrap.py
@@ -29,6 +29,14 @@ RUN = False
 
 
 def bootstrap_django(caller=None):
+    """
+    Set up django (especially important: the database connection)
+
+    This is necessary when having standalone Python scripts that use the
+    database via the Django model definitions. NAV is older than Django, the
+    Django native way is to use management-commands. The Django "manage.py"
+    script essentially does this before it runs a command.
+    """
     global RUN
 
     if 'DJANGO_SETTINGS_MODULE' not in os.environ:


### PR DESCRIPTION
Closes #2168

Explains why it is needed in the first place.