### PR TITLE
Fix related name in cabling search in api

### DIFF
--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -597,7 +597,7 @@ class CablingViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):
         queryset = cabling.Cabling.objects.all()
         not_patched = self.request.query_params.get('available', None)
         if not_patched:
-            queryset = queryset.filter(patch=None)
+            queryset = queryset.filter(patches=None)
 
         return queryset
 


### PR DESCRIPTION
When adding related names to the models this was overlooked. To reproduce the bug visit `api/1/cabling/?available=1`.