### PR TITLE
Version lock indirect dependencies of our test suites

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,7 +49,7 @@ jobs:
       - name: "Install test runner dependencies"
         run: |
           set -xe
-          python -m pip install --upgrade pip setuptools wheel 'tox<4' tox-gh-actions coverage virtualenv snmpsim
+          python -m pip install --upgrade pip setuptools wheel 'tox<4' tox-gh-actions coverage virtualenv snmpsim 'pyasn1<0.5.0'
           sudo apt-get install -y nbtscan
 
       # virtualenv seems to currently be embedding a broken version of

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -65,7 +65,7 @@ RUN cd /tmp && \
     mv chromedriver /usr/local/bin/
 
 # Install our primary test runner
-RUN python3.7 -m pip install 'tox<4' snmpsim virtualenv
+RUN python3.7 -m pip install 'tox<4' snmpsim 'pyasn1<0.5.0' virtualenv
 
 # Add a build user
 ENV USER build

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -17,3 +17,5 @@ whitenoise==4.1.4
 # the next dep is here because newer versions of ciscoconfparse has broken dependencies
 # this can be removed once we move to napalm 4, which no longer depends on ciscoconfparse
 ciscoconfparse<1.6.51
+# Our version of selenium breaks down if it is allowed to pull in the newest version of urllib3
+urllib3<2.0


### PR DESCRIPTION
A couple of the libraries we utilize as part of our test suite have seen their dependencies be released in new versions that are no longer compatible.

This PR locks those indirect dependencies to versions that are know to work for us.

Fixes #2617 