### PR TITLE
Stop making validation tests for non HTML content

### DIFF
--- a/tests/integration/web/crawler_test.py
+++ b/tests/integration/web/crawler_test.py
@@ -113,6 +113,16 @@ class WebCrawler(object):
             if page:
                 yield page
 
+    def crawl_only_html(self):
+        """Only yields crawled pages that have a content-type of html and is not
+        blacklisted.
+        """
+        for page in self.crawl():
+            if not page.content_type or 'html' not in page.content_type.lower():
+                continue
+            if should_validate(page.url):
+                yield page
+
     def _visit_with_error_handling(self, url):
         try:
             page = self._visit(url)
@@ -256,7 +266,7 @@ def _content_as_string(content):
     "(ADMINUSERNAME, ADMINPASSWORD) , skipping crawler "
     "tests!",
 )
-@pytest.mark.parametrize("page", crawler.crawl(), ids=page_id)
+@pytest.mark.parametrize("page", crawler.crawl_only_html(), ids=page_id)
 def test_page_should_be_valid_html(page):
     if page.response != 200:
         pytest.skip("not validating non-reachable page")


### PR DESCRIPTION
The web crawler would generate HTML validation tests for all reachable pages, and marked them as *skipped* if the page is blacklisted or the retrieved page has a content-type that doesn't appear to be HTML-related.

Skipped tests should be an indicator of some unusual situation or missing condition that prevents the test from running.  However, non-HTML pages can never be validated as such, and the *normal* situation is that these tests are useless.  Since a lot of the crawled content isn't actually HTML, a large number of SKIP results is produced in test reports.  These results only serve to hide the results of tests that were skipped for *factually* unexpected or extraordinary reasons.

This change will filter crawled pages based on blacklist status and content-type before the result is used to parametrize the `test_page_should_be_valid_html` test.