### PR TITLE
Run development web server in insecure mode

### DIFF
--- a/tools/docker/web.sh
+++ b/tools/docker/web.sh
@@ -8,4 +8,4 @@ mydir=$(dirname $0)
 cd /source
 
 
-django-admin check && exec django-admin runserver 0.0.0.0:80
+django-admin check && exec django-admin runserver --insecure 0.0.0.0:80


### PR DESCRIPTION
The development web container doesn't work properly if `DJANGO_DEBUG=False` is set in `nav.conf`, since the staticfiles app would not serve most static resources in that case.  This would prevent us from seeing what a non-debug site looks like while developing.