### PR TITLE
Add support for configuring PoE for cisco equipment

### DIFF
--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -352,3 +352,7 @@ class POEStateNotSupportedError(ManagementError):
 
 class XMLParseError(ManagementError):
     """Raised when failing to parse XML"""
+
+
+class POEIndexNotFoundError(ManagementError):
+    """Raised when a PoE index could not be found for an interface"""

--- a/python/nav/portadmin/snmp/cisco.py
+++ b/python/nav/portadmin/snmp/cisco.py
@@ -358,7 +358,7 @@ class Cisco(SNMPHandler):
         interface_number = poeport.index
         return unit_number, interface_number
 
-    def _get_poeport(interface: manage.Interface):
+    def _get_poeport(self, interface: manage.Interface):
         return manage.POEPort.objects.get(interface=interface)
 
     def get_poe_states(

--- a/python/nav/portadmin/snmp/cisco.py
+++ b/python/nav/portadmin/snmp/cisco.py
@@ -349,7 +349,7 @@ class Cisco(SNMPHandler):
     ) -> Tuple[int, int]:
         """Returns the unit number and interface number for the given interface"""
         try:
-            poeport = manage.POEPort.objects.get(interface=interface)
+            poeport = self._get_poeport(interface)
         except manage.POEPort.DoesNotExist:
             raise POEIndexNotFoundError(
                 "This interface does not have PoE indexes defined"
@@ -357,6 +357,9 @@ class Cisco(SNMPHandler):
         unit_number = poeport.poegroup.index
         interface_number = poeport.index
         return unit_number, interface_number
+
+    def _get_poeport(interface: manage.Interface):
+        return manage.POEPort.objects.get(interface=interface)
 
     def get_poe_states(
         self, interfaces: Optional[Sequence[manage.Interface]] = None

--- a/python/nav/portadmin/snmp/cisco.py
+++ b/python/nav/portadmin/snmp/cisco.py
@@ -35,6 +35,7 @@ class Cisco(SNMPHandler):
 
     VTPNODES = get_mib('CISCO-VTP-MIB')['nodes']
     PAENODES = get_mib('CISCO-PAE-MIB')['nodes']
+    POENODES = get_mib('CISCO-POWER-ETHERNET-EXT-MIB')['nodes']
 
     VTPVLANSTATE = VTPNODES['vtpVlanState']['oid']
     VTPVLANTYPE = VTPNODES['vtpVlanType']['oid']
@@ -56,6 +57,8 @@ class Cisco(SNMPHandler):
     dot1xPortAuth = PAENODES['cpaePortCapabilitiesEnabled']['oid']
     DOT1X_AUTHENTICATOR = 0b10000000
     DOT1X_SUPPLICANT = 0b01000000
+
+    POEENABLE = POENODES['cpeExtPsePortEnable']['oid']
 
     def __init__(self, netbox, **kwargs):
         super(Cisco, self).__init__(netbox, **kwargs)

--- a/python/nav/portadmin/snmp/cisco.py
+++ b/python/nav/portadmin/snmp/cisco.py
@@ -23,6 +23,7 @@ from nav.oids import OID
 from nav.portadmin.snmp.base import SNMPHandler, translate_protocol_errors
 from nav.smidumps import get_mib
 from nav.enterprise.ids import VENDOR_ID_CISCOSYSTEMS
+from nav.portadmin.handlers import PoeState
 
 
 _logger = logging.getLogger(__name__)
@@ -59,6 +60,10 @@ class Cisco(SNMPHandler):
     DOT1X_SUPPLICANT = 0b01000000
 
     POEENABLE = POENODES['cpeExtPsePortEnable']['oid']
+    POE_AUTO = PoeState(state=1, name="AUTO")
+    POE_STATIC = PoeState(state=2, name="STATIC")
+    POE_LIMIT = PoeState(state=3, name="LIMIT")
+    POE_DISABLE = PoeState(state=4, name="DISABLE")
 
     def __init__(self, netbox, **kwargs):
         super(Cisco, self).__init__(netbox, **kwargs)

--- a/python/nav/portadmin/snmp/cisco.py
+++ b/python/nav/portadmin/snmp/cisco.py
@@ -16,7 +16,7 @@
 #
 """Cisco specific PortAdmin SNMP handling"""
 import logging
-from typing import Sequence, Dict, Optional
+from typing import Sequence, Dict, Optional, Tuple
 
 from nav.Snmp.errors import SnmpError
 from nav.bitvector import BitVector
@@ -345,7 +345,7 @@ class Cisco(SNMPHandler):
 
     def _get_poe_indexes_for_interface(
         self, interface: manage.Interface
-    ) -> tuple[int, int]:
+    ) -> Tuple[int, int]:
         """Returns the unit number and interface number for the given interface"""
         try:
             poeport = manage.POEPort.objects.get(interface=interface)

--- a/python/nav/portadmin/snmp/cisco.py
+++ b/python/nav/portadmin/snmp/cisco.py
@@ -332,7 +332,7 @@ class Cisco(SNMPHandler):
         Available options should be retrieved using `get_poe_state_options`
         """
         unit_number, interface_number = self._get_poe_indexes_for_interface(interface)
-        oid_with_unit_number = self.POEENABLE + f".{unit_number}"
+        oid_with_unit_number = self.POEENABLE + OID((unit_number,))
         try:
             self._set_netbox_value(
                 oid_with_unit_number, interface_number, 'i', state.state
@@ -390,7 +390,7 @@ class Cisco(SNMPHandler):
     ) -> PoeState:
         """Retrieves current PoE state for given the given interface"""
         unit_number, interface_number = self._get_poe_indexes_for_interface(interface)
-        oid_with_unit_number = self.POEENABLE + f".{unit_number}"
+        oid_with_unit_number = self.POEENABLE + OID((unit_number,))
         state_value = self._query_netbox(oid_with_unit_number, interface_number)
         if state_value == None:
             raise POENotSupportedError("This interface does not support PoE")

--- a/python/nav/portadmin/snmp/cisco.py
+++ b/python/nav/portadmin/snmp/cisco.py
@@ -358,7 +358,7 @@ class Cisco(SNMPHandler):
         return unit_number, interface_number
 
     def get_poe_states(
-        self, interfaces: Sequence[manage.Interface] = None
+        self, interfaces: Optional[Sequence[manage.Interface]] = None
     ) -> Dict[int, Optional[PoeState]]:
         """Retrieves current PoE state for interfaces on this device.
 

--- a/python/nav/portadmin/snmp/cisco.py
+++ b/python/nav/portadmin/snmp/cisco.py
@@ -360,7 +360,7 @@ class Cisco(SNMPHandler):
 
     def get_poe_states(
         self, interfaces: Optional[Sequence[manage.Interface]] = None
-    ) -> Dict[int, Optional[PoeState]]:
+    ) -> Dict[str, Optional[PoeState]]:
         """Retrieves current PoE state for interfaces on this device.
 
         :param interfaces: Optional sequence of interfaces to filter for, as fetching
@@ -369,7 +369,7 @@ class Cisco(SNMPHandler):
                            the default behavior is to filter on all Interface objects
                            registered for this device.
         :returns: A dict mapping interfaces to their discovered PoE state.
-                  The key matches the `ifindex` attribute for the related
+                  The key matches the `ifname` attribute for the related
                   Interface object.
                   The value will be None if the interface does not support PoE.
         """
@@ -381,7 +381,7 @@ class Cisco(SNMPHandler):
                 state = self._get_poe_state_for_single_interface(interface)
             except POENotSupportedError:
                 state = None
-            states_dict[interface.ifindex] = state
+            states_dict[interface.ifname] = state
         return states_dict
 
     @translate_protocol_errors

--- a/python/nav/portadmin/snmp/cisco.py
+++ b/python/nav/portadmin/snmp/cisco.py
@@ -16,6 +16,7 @@
 #
 """Cisco specific PortAdmin SNMP handling"""
 import logging
+from typing import Sequence
 
 from nav.Snmp.errors import SnmpError
 from nav.bitvector import BitVector
@@ -307,6 +308,16 @@ class Cisco(SNMPHandler):
             names.get(OID(oid)[-1]): state[0] & self.DOT1X_AUTHENTICATOR
             for oid, state in self._bulkwalk(self.dot1xPortAuth)
         }
+
+    def get_poe_state_options(self) -> Sequence[PoeState]:
+        """Returns the available options for enabling/disabling PoE on this netbox"""
+        options_list = [
+            self.POE_AUTO,
+            self.POE_STATIC,
+            self.POE_LIMIT,
+            self.POE_DISABLE,
+        ]
+        return options_list
 
 
 CHARS_IN_1024_BITS = 128

--- a/python/nav/portadmin/snmp/cisco.py
+++ b/python/nav/portadmin/snmp/cisco.py
@@ -72,6 +72,13 @@ class Cisco(SNMPHandler):
     POE_LIMIT = PoeState(state=3, name="LIMIT")
     POE_DISABLE = PoeState(state=4, name="DISABLE")
 
+    POE_OPTIONS = [
+        POE_AUTO,
+        POE_STATIC,
+        POE_LIMIT,
+        POE_DISABLE,
+    ]
+
     def __init__(self, netbox, **kwargs):
         super(Cisco, self).__init__(netbox, **kwargs)
         self.vlan_oid = '1.3.6.1.4.1.9.9.68.1.2.2.1.2'
@@ -317,13 +324,7 @@ class Cisco(SNMPHandler):
 
     def get_poe_state_options(self) -> Sequence[PoeState]:
         """Returns the available options for enabling/disabling PoE on this netbox"""
-        options_list = [
-            self.POE_AUTO,
-            self.POE_STATIC,
-            self.POE_LIMIT,
-            self.POE_DISABLE,
-        ]
-        return options_list
+        return self.POE_OPTIONS
 
     @translate_protocol_errors
     def set_poe_state(self, interface: manage.Interface, state: PoeState):

--- a/python/nav/portadmin/snmp/cisco.py
+++ b/python/nav/portadmin/snmp/cisco.py
@@ -349,7 +349,7 @@ class Cisco(SNMPHandler):
     ) -> Tuple[int, int]:
         """Returns the unit number and interface number for the given interface"""
         try:
-            poeport = self._get_poeport(interface)
+            poeport = manage.POEPort.objects.get(interface=interface)
         except manage.POEPort.DoesNotExist:
             raise POEIndexNotFoundError(
                 "This interface does not have PoE indexes defined"
@@ -357,9 +357,6 @@ class Cisco(SNMPHandler):
         unit_number = poeport.poegroup.index
         interface_number = poeport.index
         return unit_number, interface_number
-
-    def _get_poeport(self, interface: manage.Interface):
-        return manage.POEPort.objects.get(interface=interface)
 
     def get_poe_states(
         self, interfaces: Optional[Sequence[manage.Interface]] = None

--- a/tests/unittests/portadmin/conftest.py
+++ b/tests/unittests/portadmin/conftest.py
@@ -1,0 +1,58 @@
+from mock import Mock
+
+import pytest
+
+from nav.enterprise.ids import VENDOR_ID_HEWLETT_PACKARD, VENDOR_ID_CISCOSYSTEMS
+from nav.portadmin.management import ManagementFactory
+
+
+@pytest.fixture
+def profile():
+    profile = Mock()
+    profile.snmp_version = 2
+    profile.snmp_community = "public"
+    return profile
+
+
+@pytest.fixture
+def netbox_hp(profile):
+    vendor = Mock()
+    vendor.id = u'hp'
+
+    netbox_type = Mock()
+    netbox_type.vendor = vendor
+    netbox_type.get_enterprise_id.return_value = VENDOR_ID_HEWLETT_PACKARD
+
+    netbox = Mock()
+    netbox.type = netbox_type
+    netbox.ip = '10.240.160.39'
+    netbox.get_preferred_snmp_management_profile.return_value = profile
+
+    return netbox
+
+
+@pytest.fixture
+def netbox_cisco(profile):
+    vendor = Mock()
+    vendor.id = u'cisco'
+
+    netbox_type = Mock()
+    netbox_type.vendor = vendor
+    netbox_type.get_enterprise_id.return_value = VENDOR_ID_CISCOSYSTEMS
+
+    netbox = Mock()
+    netbox.type = netbox_type
+    netbox.ip = '10.240.160.38'
+    netbox.get_preferred_snmp_management_profile.return_value = profile
+
+    return netbox
+
+
+@pytest.fixture
+def handler_hp(netbox_hp):
+    return ManagementFactory.get_instance(netbox_hp)
+
+
+@pytest.fixture
+def handler_cisco(netbox_cisco):
+    return ManagementFactory.get_instance(netbox_cisco)

--- a/tests/unittests/portadmin/portadmin_poe_cisco_test.py
+++ b/tests/unittests/portadmin/portadmin_poe_cisco_test.py
@@ -22,7 +22,7 @@ class TestGetPoeStateOptions:
 class TestGetPoeState:
     def test_should_raise_exception_if_unknown_poe_state_cisco(self, handler_cisco):
         handler_cisco._query_netbox = Mock(return_value=76)
-        interface = Mock()
+        interface = Mock(interface="interface")
         with pytest.raises(POEStateNotSupportedError):
             handler_cisco.get_poe_states([interface])
 
@@ -30,7 +30,7 @@ class TestGetPoeState:
         handler_cisco._get_poe_indexes_for_interface = Mock(
             side_effect=POEIndexNotFoundError("Fail")
         )
-        interface = Mock()
+        interface = Mock(interface="interface")
         with pytest.raises(POEIndexNotFoundError):
             handler_cisco.get_poe_states([interface])
 

--- a/tests/unittests/portadmin/portadmin_poe_cisco_test.py
+++ b/tests/unittests/portadmin/portadmin_poe_cisco_test.py
@@ -49,3 +49,12 @@ class TestGetPoeState:
         interface = Mock(ifname="interface")
         state = handler_cisco.get_poe_states([interface])
         assert state[interface.ifname] == expected_state
+
+    def test_use_interfaces_from_db_if_empty_interfaces_arg(self, handler_cisco):
+        expected_state = Cisco.POE_AUTO
+        handler_cisco._get_poe_indexes_for_interface = Mock(return_value=(1, 1))
+        handler_cisco._query_netbox = Mock(return_value=expected_state.state)
+        interface = Mock(ifname="interface")
+        handler_cisco.netbox.interfaces = [interface]
+        state = handler_cisco.get_poe_states()
+        assert interface.ifname in state

--- a/tests/unittests/portadmin/portadmin_poe_cisco_test.py
+++ b/tests/unittests/portadmin/portadmin_poe_cisco_test.py
@@ -7,7 +7,6 @@ from nav.portadmin.handlers import (
     POEIndexNotFoundError,
     POEStateNotSupportedError,
 )
-from nav.models import manage
 
 
 def test_returns_correct_poe_state_options_cisco(handler_cisco):
@@ -18,9 +17,9 @@ def test_returns_correct_poe_state_options_cisco(handler_cisco):
     assert Cisco.POE_DISABLE in state_options
 
 
+@pytest.mark.usefixtures('get_poeport_mock')
 class TestGetPoeState:
     def test_should_raise_exception_if_unknown_poe_state_cisco(self, handler_cisco):
-        handler_cisco._get_poe_indexes_for_interface = Mock(return_value=(1, 1))
         handler_cisco._query_netbox = Mock(return_value=76)
         interface = Mock()
         with pytest.raises(POEStateNotSupportedError):
@@ -37,7 +36,6 @@ class TestGetPoeState:
     def test_dict_should_give_none_if_interface_does_not_support_poe(
         self, handler_cisco
     ):
-        handler_cisco._get_poe_indexes_for_interface = Mock(return_value=(1, 1))
         handler_cisco._query_netbox = Mock(return_value=None)
         interface = Mock(interface="interface")
         states = handler_cisco.get_poe_states([interface])
@@ -45,7 +43,6 @@ class TestGetPoeState:
 
     def test_returns_correct_poe_state_cisco(self, handler_cisco):
         expected_state = Cisco.POE_AUTO
-        handler_cisco._get_poe_indexes_for_interface = Mock(return_value=(1, 1))
         handler_cisco._query_netbox = Mock(return_value=expected_state.state)
         interface = Mock(ifname="interface")
         state = handler_cisco.get_poe_states([interface])
@@ -53,7 +50,6 @@ class TestGetPoeState:
 
     def test_use_interfaces_from_db_if_empty_interfaces_arg(self, handler_cisco):
         expected_state = Cisco.POE_AUTO
-        handler_cisco._get_poe_indexes_for_interface = Mock(return_value=(1, 1))
         handler_cisco._query_netbox = Mock(return_value=expected_state.state)
         interface = Mock(ifname="interface")
         handler_cisco.netbox.interfaces = [interface]
@@ -61,20 +57,8 @@ class TestGetPoeState:
         assert interface.ifname in state
 
 
-class TestGetPoeIndexesForInterface:
-    def test_returns_correct_values(self, handler_cisco):
-        poegroup_mock = Mock(index=1)
-        poeport_mock = Mock(poegroup=poegroup_mock, index=2)
-        handler_cisco._get_poeport = Mock(return_value=poeport_mock)
-        interface = Mock(ifname="interface")
-        unit_number, if_number = handler_cisco._get_poe_indexes_for_interface(interface)
-        assert unit_number == poegroup_mock.index
-        assert if_number == poeport_mock.index
-
-    def test_raises_exception_if_no_poeport_exists(self, handler_cisco):
-        handler_cisco._get_poeport = Mock(
-            side_effect=manage.POEPort.DoesNotExist("Fail")
-        )
-        interface = Mock(ifname="interface")
-        with pytest.raises(POEIndexNotFoundError):
-            handler_cisco._get_poe_indexes_for_interface(interface)
+@pytest.fixture()
+def get_poeport_mock(handler_cisco):
+    poegroup_mock = Mock(index=1)
+    poeport_mock = Mock(poegroup=poegroup_mock, index=1)
+    handler_cisco._get_poeport = Mock(return_value=poeport_mock)

--- a/tests/unittests/portadmin/portadmin_poe_cisco_test.py
+++ b/tests/unittests/portadmin/portadmin_poe_cisco_test.py
@@ -1,0 +1,51 @@
+from mock import Mock
+
+import pytest
+
+from nav.portadmin.snmp.cisco import Cisco
+from nav.portadmin.handlers import (
+    POEIndexNotFoundError,
+    POEStateNotSupportedError,
+)
+
+
+def test_returns_correct_poe_state_options_cisco(handler_cisco):
+    state_options = handler_cisco.get_poe_state_options()
+    assert Cisco.POE_AUTO in state_options
+    assert Cisco.POE_STATIC in state_options
+    assert Cisco.POE_LIMIT in state_options
+    assert Cisco.POE_DISABLE in state_options
+
+
+class TestGetPoeState:
+    def test_should_raise_exception_if_unknown_poe_state_cisco(self, handler_cisco):
+        handler_cisco._get_poe_indexes_for_interface = Mock(return_value=(1, 1))
+        handler_cisco._query_netbox = Mock(return_value=76)
+        interface = Mock()
+        with pytest.raises(POEStateNotSupportedError):
+            handler_cisco.get_poe_states([interface])
+
+    def test_should_raise_exception_if_no_poe_indexes_cisco(self, handler_cisco):
+        handler_cisco._get_poe_indexes_for_interface = Mock(
+            side_effect=POEIndexNotFoundError("Fail")
+        )
+        interface = Mock()
+        with pytest.raises(POEIndexNotFoundError):
+            handler_cisco.get_poe_states([interface])
+
+    def test_dict_should_give_none_if_interface_does_not_support_poe(
+        self, handler_cisco
+    ):
+        handler_cisco._get_poe_indexes_for_interface = Mock(return_value=(1, 1))
+        handler_cisco._query_netbox = Mock(return_value=None)
+        interface = Mock(ifindex=1)
+        states = handler_cisco.get_poe_states([interface])
+        assert states[interface.ifindex] is None
+
+    def test_returns_correct_poe_state_cisco(self, handler_cisco):
+        expected_state = Cisco.POE_AUTO
+        handler_cisco._get_poe_indexes_for_interface = Mock(return_value=(1, 1))
+        handler_cisco._query_netbox = Mock(return_value=expected_state.state)
+        interface = Mock(ifindex=1)
+        state = handler_cisco.get_poe_states([interface])
+        assert state[interface.ifindex] == expected_state

--- a/tests/unittests/portadmin/portadmin_poe_cisco_test.py
+++ b/tests/unittests/portadmin/portadmin_poe_cisco_test.py
@@ -9,12 +9,13 @@ from nav.portadmin.handlers import (
 )
 
 
-def test_returns_correct_poe_state_options_cisco(handler_cisco):
-    state_options = handler_cisco.get_poe_state_options()
-    assert Cisco.POE_AUTO in state_options
-    assert Cisco.POE_STATIC in state_options
-    assert Cisco.POE_LIMIT in state_options
-    assert Cisco.POE_DISABLE in state_options
+class TestGetPoeStateOptions:
+    def test_returns_correct_options(self, handler_cisco):
+        state_options = handler_cisco.get_poe_state_options()
+        assert Cisco.POE_AUTO in state_options
+        assert Cisco.POE_STATIC in state_options
+        assert Cisco.POE_LIMIT in state_options
+        assert Cisco.POE_DISABLE in state_options
 
 
 @pytest.mark.usefixtures('get_poeport_mock')

--- a/tests/unittests/portadmin/portadmin_poe_cisco_test.py
+++ b/tests/unittests/portadmin/portadmin_poe_cisco_test.py
@@ -38,14 +38,14 @@ class TestGetPoeState:
     ):
         handler_cisco._get_poe_indexes_for_interface = Mock(return_value=(1, 1))
         handler_cisco._query_netbox = Mock(return_value=None)
-        interface = Mock(ifindex=1)
+        interface = Mock(interface="interface")
         states = handler_cisco.get_poe_states([interface])
-        assert states[interface.ifindex] is None
+        assert states[interface.ifname] is None
 
     def test_returns_correct_poe_state_cisco(self, handler_cisco):
         expected_state = Cisco.POE_AUTO
         handler_cisco._get_poe_indexes_for_interface = Mock(return_value=(1, 1))
         handler_cisco._query_netbox = Mock(return_value=expected_state.state)
-        interface = Mock(ifindex=1)
+        interface = Mock(ifname="interface")
         state = handler_cisco.get_poe_states([interface])
-        assert state[interface.ifindex] == expected_state
+        assert state[interface.ifname] == expected_state

--- a/tests/unittests/portadmin/portadmin_poe_cisco_test.py
+++ b/tests/unittests/portadmin/portadmin_poe_cisco_test.py
@@ -7,6 +7,7 @@ from nav.portadmin.handlers import (
     POEIndexNotFoundError,
     POEStateNotSupportedError,
 )
+from nav.models import manage
 
 
 def test_returns_correct_poe_state_options_cisco(handler_cisco):
@@ -58,3 +59,22 @@ class TestGetPoeState:
         handler_cisco.netbox.interfaces = [interface]
         state = handler_cisco.get_poe_states()
         assert interface.ifname in state
+
+
+class TestGetPoeIndexesForInterface:
+    def test_returns_correct_values(self, handler_cisco):
+        poegroup_mock = Mock(index=1)
+        poeport_mock = Mock(poegroup=poegroup_mock, index=2)
+        handler_cisco._get_poeport = Mock(return_value=poeport_mock)
+        interface = Mock(ifname="interface")
+        unit_number, if_number = handler_cisco._get_poe_indexes_for_interface(interface)
+        assert unit_number == poegroup_mock.index
+        assert if_number == poeport_mock.index
+
+    def test_raises_exception_if_no_poeport_exists(self, handler_cisco):
+        handler_cisco._get_poeport = Mock(
+            side_effect=manage.POEPort.DoesNotExist("Fail")
+        )
+        interface = Mock(ifname="interface")
+        with pytest.raises(POEIndexNotFoundError):
+            handler_cisco._get_poe_indexes_for_interface(interface)

--- a/tests/unittests/portadmin/portadmin_poe_cisco_test.py
+++ b/tests/unittests/portadmin/portadmin_poe_cisco_test.py
@@ -20,39 +20,38 @@ class TestGetPoeStateOptions:
 
 
 class TestGetPoeState:
-    def test_should_raise_exception_if_unknown_poe_state_cisco(
-        self, handler_cisco, poeport_get_mock
-    ):
+    @pytest.mark.usefixtures('poeport_get_mock')
+    def test_should_raise_exception_if_unknown_poe_state_cisco(self, handler_cisco):
         handler_cisco._query_netbox = Mock(return_value=76)
         interface = Mock(interface="interface")
         with pytest.raises(POEStateNotSupportedError):
             handler_cisco.get_poe_states([interface])
 
-    def test_should_raise_exception_if_no_poe_indexes_cisco(
-        self, handler_cisco, poeport_get_mock_error
-    ):
+    @pytest.mark.usefixtures('poeport_get_mock_error')
+    def test_should_raise_exception_if_no_poe_indexes_cisco(self, handler_cisco):
         interface = Mock(interface="interface")
         with pytest.raises(POEIndexNotFoundError):
             handler_cisco.get_poe_states([interface])
 
+    @pytest.mark.usefixtures('poeport_get_mock')
     def test_dict_should_give_none_if_interface_does_not_support_poe(
-        self, handler_cisco, poeport_get_mock
+        self, handler_cisco
     ):
         handler_cisco._query_netbox = Mock(return_value=None)
         interface = Mock(interface="interface")
         states = handler_cisco.get_poe_states([interface])
         assert states[interface.ifname] is None
 
-    def test_returns_correct_poe_state_cisco(self, handler_cisco, poeport_get_mock):
+    @pytest.mark.usefixtures('poeport_get_mock')
+    def test_returns_correct_poe_state_cisco(self, handler_cisco):
         expected_state = Cisco.POE_AUTO
         handler_cisco._query_netbox = Mock(return_value=expected_state.state)
         interface = Mock(ifname="interface")
         state = handler_cisco.get_poe_states([interface])
         assert state[interface.ifname] == expected_state
 
-    def test_use_interfaces_from_db_if_empty_interfaces_arg(
-        self, handler_cisco, poeport_get_mock
-    ):
+    @pytest.mark.usefixtures('poeport_get_mock')
+    def test_use_interfaces_from_db_if_empty_interfaces_arg(self, handler_cisco):
         expected_state = Cisco.POE_AUTO
         handler_cisco._query_netbox = Mock(return_value=expected_state.state)
         interface = Mock(ifname="interface")

--- a/tests/unittests/portadmin/portadmin_poe_cisco_test.py
+++ b/tests/unittests/portadmin/portadmin_poe_cisco_test.py
@@ -21,14 +21,16 @@ class TestGetPoeStateOptions:
 
 class TestGetPoeState:
     @pytest.mark.usefixtures('poeport_get_mock')
-    def test_should_raise_exception_if_unknown_poe_state_cisco(self, handler_cisco):
+    def test_should_raise_exception_if_unknown_poe_state(self, handler_cisco):
         handler_cisco._query_netbox = Mock(return_value=76)
         interface = Mock(interface="interface")
         with pytest.raises(POEStateNotSupportedError):
             handler_cisco.get_poe_states([interface])
 
     @pytest.mark.usefixtures('poeport_get_mock_error')
-    def test_should_raise_exception_if_no_poe_indexes_cisco(self, handler_cisco):
+    def test_should_raise_exception_if_interface_is_missing_poeport(
+        self, handler_cisco
+    ):
         interface = Mock(interface="interface")
         with pytest.raises(POEIndexNotFoundError):
             handler_cisco.get_poe_states([interface])
@@ -43,7 +45,7 @@ class TestGetPoeState:
         assert states[interface.ifname] is None
 
     @pytest.mark.usefixtures('poeport_get_mock')
-    def test_returns_correct_poe_state_cisco(self, handler_cisco):
+    def test_returns_correct_poe_state(self, handler_cisco):
         expected_state = Cisco.POE_AUTO
         handler_cisco._query_netbox = Mock(return_value=expected_state.state)
         interface = Mock(ifname="interface")

--- a/tests/unittests/portadmin/portadmin_test.py
+++ b/tests/unittests/portadmin/portadmin_test.py
@@ -1,9 +1,6 @@
 from mock import Mock
 
-import pytest
-
 from nav.oids import OID
-from nav.enterprise.ids import VENDOR_ID_HEWLETT_PACKARD, VENDOR_ID_CISCOSYSTEMS
 from nav.portadmin.management import ManagementFactory
 from nav.portadmin.snmp.hp import HP
 from nav.portadmin.snmp.cisco import Cisco
@@ -77,55 +74,3 @@ class TestPortadminResponseCisco:
         expected = {1: 'jomar', 2: 'knut', 3: 'hjallis'}
         snmp_read_only_handler.bulkwalk = Mock(return_value=walkdata)
         assert handler_cisco._get_all_ifaliases() == expected, "getAllIfAlias failed."
-
-
-@pytest.fixture
-def profile():
-    profile = Mock()
-    profile.snmp_version = 2
-    profile.snmp_community = "public"
-    return profile
-
-
-@pytest.fixture
-def netbox_hp(profile):
-    vendor = Mock()
-    vendor.id = u'hp'
-
-    netbox_type = Mock()
-    netbox_type.vendor = vendor
-    netbox_type.get_enterprise_id.return_value = VENDOR_ID_HEWLETT_PACKARD
-
-    netbox = Mock()
-    netbox.type = netbox_type
-    netbox.ip = '10.240.160.39'
-    netbox.get_preferred_snmp_management_profile.return_value = profile
-
-    return netbox
-
-
-@pytest.fixture
-def netbox_cisco(profile):
-    vendor = Mock()
-    vendor.id = u'cisco'
-
-    netbox_type = Mock()
-    netbox_type.vendor = vendor
-    netbox_type.get_enterprise_id.return_value = VENDOR_ID_CISCOSYSTEMS
-
-    netbox = Mock()
-    netbox.type = netbox_type
-    netbox.ip = '10.240.160.38'
-    netbox.get_preferred_snmp_management_profile.return_value = profile
-
-    return netbox
-
-
-@pytest.fixture
-def handler_hp(netbox_hp):
-    return ManagementFactory.get_instance(netbox_hp)
-
-
-@pytest.fixture
-def handler_cisco(netbox_cisco):
-    return ManagementFactory.get_instance(netbox_cisco)


### PR DESCRIPTION
Fixes #2632.

Adds backend for getting current PoE state for interfaces and changing the state.