### PR TITLE
Add abstract functions for PoE enabling

### DIFF
--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -278,6 +278,10 @@ class ManagementHandler:
             return False
         return True
 
+    def get_poe_state_options(self) -> Tuple[Tuple[int, str]]:
+        """Returns the available options for enabling/disabling PoE on this netbox"""
+        raise NotImplementedError
+
 
 class ManagementError(Exception):
     """Base exception class for device management errors"""

--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -278,18 +278,18 @@ class ManagementHandler:
             return False
         return True
 
-    def get_poe_state_options(self) -> Tuple[str, ...]:
-        """Returns the available options for enabling/disabling PoE on this netbox"""
+    def get_poe_state_options(self, interface: manage.Interface) -> Tuple[str, ...]:
+        """Returns the available options for enabling/disabling PoE on this interface"""
         raise NotImplementedError
 
     def set_poe_state(self, interface: manage.Interface, state: str):
-        """Set state for enabling/disabling PoE on this netbox.
+        """Set state for enabling/disabling PoE on this interface.
         Available options should be retrieved using `get_poe_state_options`
         """
         raise NotImplementedError
 
     def get_poe_state(self, interface: manage.Interface) -> str:
-        """Returns current poe state"""
+        """Returns current poe state of this interface"""
         raise NotImplementedError
 
 

--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -15,7 +15,7 @@
 #
 """Interface definition for PortAdmin management handlers"""
 import time
-from typing import List, Tuple, Dict, Any, Sequence, Union
+from typing import List, Tuple, Dict, Any, Sequence, Union, Optional
 import logging
 from dataclasses import dataclass
 
@@ -302,7 +302,7 @@ class ManagementHandler:
 
     def get_poe_states(
         self, interfaces: Sequence[manage.Interface] = None
-    ) -> Dict[int, PoeState]:
+    ) -> Dict[int, Optional[PoeState]]:
         """Retrieves current PoE state for interfaces on this device.
 
         :param interfaces: Optional sequence of interfaces to filter for, as fetching
@@ -313,11 +313,8 @@ class ManagementHandler:
         :returns: A dict mapping interfaces to their discovered PoE state.
                   The key matches the `ifindex` attribute for the related
                   Interface object.
+                  The value will be None if the interface does not support PoE.
         """
-        raise NotImplementedError
-
-    def interface_supports_poe(self, interface: manage.Interface) -> bool:
-        """Returns True if this interface supports PoE"""
         raise NotImplementedError
 
 

--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -290,7 +290,7 @@ class ManagementHandler:
             return False
         return True
 
-    def get_poe_state_options(self) -> Sequence[PoeState, ...]:
+    def get_poe_state_options(self) -> Sequence[PoeState]:
         """Returns the available options for enabling/disabling PoE on this netbox"""
         raise NotImplementedError
 

--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -282,6 +282,12 @@ class ManagementHandler:
         """Returns the available options for enabling/disabling PoE on this netbox"""
         raise NotImplementedError
 
+    def set_poe_state(self, interface: manage.Interface, state: int):
+        """Set state for enabling/disabling PoE on this netbox.
+        Available options should be retrieved using `get_poe_state_options`
+        """
+        raise NotImplementedError
+
 
 class ManagementError(Exception):
     """Base exception class for device management errors"""

--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -15,14 +15,26 @@
 #
 """Interface definition for PortAdmin management handlers"""
 import time
-from typing import List, Tuple, Dict, Any, Sequence
+from typing import List, Tuple, Dict, Any, Sequence, Union
 import logging
+from dataclasses import dataclass
 
 from nav.models import manage
 from nav.portadmin.vlan import FantasyVlan
 
 
 _logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PoeState:
+    """Class for defining PoE states.
+    `state` is the value used on the device itself.
+    `name` is a human readable name for the state
+    """
+
+    state: Union[str, int]
+    name: str
 
 
 class ManagementHandler:
@@ -278,17 +290,17 @@ class ManagementHandler:
             return False
         return True
 
-    def get_poe_state_options(self) -> Tuple[str, ...]:
+    def get_poe_state_options(self) -> Tuple[PoeState, ...]:
         """Returns the available options for enabling/disabling PoE on this netbox"""
         raise NotImplementedError
 
-    def set_poe_state(self, interface: manage.Interface, state: str):
+    def set_poe_state(self, interface: manage.Interface, state: PoeState):
         """Set state for enabling/disabling PoE on this interface.
         Available options should be retrieved using `get_poe_state_options`
         """
         raise NotImplementedError
 
-    def get_poe_state(self, interface: manage.Interface) -> str:
+    def get_poe_state(self, interface: manage.Interface) -> PoeState:
         """Returns current PoE state of this interface"""
         raise NotImplementedError
 

--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -311,7 +311,8 @@ class ManagementHandler:
                            the default behavior is to filter on all Interface objects
                            registered for this device.
         :returns: A dict mapping interfaces to their discovered PoE state.
-                  The key matches the `ifindex` attribute for the related Interface object
+                  The key matches the `ifindex` attribute for the related
+                  Interface object.
         """
         raise NotImplementedError
 

--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -304,6 +304,21 @@ class ManagementHandler:
         """Returns current PoE state of this interface"""
         raise NotImplementedError
 
+    def get_poe_states(
+        self, interfaces: Sequence[manage.Interface] = None
+    ) -> Dict[int, PoeState]:
+        """Retrieves current PoE state for interfaces on this device.
+
+        :param interfaces: Optional sequence of interfaces to filter for, as fetching
+                           data for all interfaces may be a waste of time if only a
+                           single interface is needed. If this parameter is omitted,
+                           the default behavior is to filter on all Interface objects
+                           registered for this device.
+        :returns: A dict mapping interfaces to their discovered PoE state.
+                  The key matches the `ifindex` attribute for the related Interface object
+        """
+        raise NotImplementedError
+
     def interface_supports_poe(self, interface: manage.Interface) -> bool:
         """Returns True if this interface supports PoE"""
         raise NotImplementedError

--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -289,7 +289,7 @@ class ManagementHandler:
         raise NotImplementedError
 
     def get_poe_state(self, interface: manage.Interface) -> str:
-        """Returns current poe state of this interface"""
+        """Returns current PoE state of this interface"""
         raise NotImplementedError
 
 

--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -278,17 +278,17 @@ class ManagementHandler:
             return False
         return True
 
-    def get_poe_state_options(self) -> Tuple[Tuple[int, str]]:
+    def get_poe_state_options(self) -> Tuple[str, ...]:
         """Returns the available options for enabling/disabling PoE on this netbox"""
         raise NotImplementedError
 
-    def set_poe_state(self, interface: manage.Interface, state: int):
+    def set_poe_state(self, interface: manage.Interface, state: str):
         """Set state for enabling/disabling PoE on this netbox.
         Available options should be retrieved using `get_poe_state_options`
         """
         raise NotImplementedError
 
-    def get_poe_state(self, interface: manage.Interface) -> int:
+    def get_poe_state(self, interface: manage.Interface) -> str:
         """Returns current poe state"""
         raise NotImplementedError
 

--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -288,6 +288,10 @@ class ManagementHandler:
         """
         raise NotImplementedError
 
+    def get_poe_state(self, interface: manage.Interface) -> int:
+        """Returns current poe state"""
+        raise NotImplementedError
+
 
 class ManagementError(Exception):
     """Base exception class for device management errors"""

--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -278,8 +278,8 @@ class ManagementHandler:
             return False
         return True
 
-    def get_poe_state_options(self, interface: manage.Interface) -> Tuple[str, ...]:
-        """Returns the available options for enabling/disabling PoE on this interface"""
+    def get_poe_state_options(self) -> Tuple[str, ...]:
+        """Returns the available options for enabling/disabling PoE on this netbox"""
         raise NotImplementedError
 
     def set_poe_state(self, interface: manage.Interface, state: str):
@@ -290,6 +290,10 @@ class ManagementHandler:
 
     def get_poe_state(self, interface: manage.Interface) -> str:
         """Returns current PoE state of this interface"""
+        raise NotImplementedError
+
+    def interface_supports_poe(self, interface: manage.Interface) -> bool:
+        """Returns True if this interface supports PoE"""
         raise NotImplementedError
 
 

--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -290,7 +290,7 @@ class ManagementHandler:
             return False
         return True
 
-    def get_poe_state_options(self) -> Tuple[PoeState, ...]:
+    def get_poe_state_options(self) -> Sequence[PoeState, ...]:
         """Returns the available options for enabling/disabling PoE on this netbox"""
         raise NotImplementedError
 

--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -300,10 +300,6 @@ class ManagementHandler:
         """
         raise NotImplementedError
 
-    def get_poe_state(self, interface: manage.Interface) -> PoeState:
-        """Returns current PoE state of this interface"""
-        raise NotImplementedError
-
     def get_poe_states(
         self, interfaces: Sequence[manage.Interface] = None
     ) -> Dict[int, PoeState]:


### PR DESCRIPTION
For #1938.

Adds empty functions to ManagementHandler that should be implemented by vendor specific handlers in different ways. Different
vendors support different PoE states, so `get_poe_state_options` should return all available options. These options should then be displayed in PortAdmin and be selectable.
