### PR TITLE
Various improvements to the SNMP forwarding/proxying container setup

### DIFF
--- a/doc/hacking/snmp-tunnels.rst
+++ b/doc/hacking/snmp-tunnels.rst
@@ -26,7 +26,8 @@ Course of action - with docker
 
 2. Change the line ``command: 192.168.0.1 user@my-hop-host 10000`` to the ip
    address or name of the device you want to reach, the relevant hop host and
-   whatever port you want to tunnel through.
+   whatever port you want to tunnel through.  This port should be free to use
+   on the hop-host.
 
 3. Make sure that ssh key to the hop host is saved (you can test this by doing
    ``ssh user@my-hop-host``, it is saved if you're not prompted for a password).
@@ -54,7 +55,8 @@ When starting docker:
 - if the error message
   ``mydevice.mydomain_1  | 2023/02/21 13:36:11 socat[1744] E bind(5,
   {AF=2 0.0.0.0:10000}, 16): Address already in use``
-  appears: change the port in the docker file
+  appears: change the port in the docker file. Some other process on the hop-host is
+  using this port.
 
 When adding IP device in SeedDB:
 
@@ -111,14 +113,14 @@ Troubleshooting - without docker
 
       sudo netstat -aupn
 
-  (these flags are Linux specific, use 
-  
+  (these flags are Linux specific, use
+
   .. code-block:: sh
-   
+
       man netstat
 
   to figure out which flags might be helpful on other operating systems).
-  
+
   Then kill the process by running
 
   .. code-block:: sh

--- a/tools/forward/Dockerfile
+++ b/tools/forward/Dockerfile
@@ -1,10 +1,10 @@
 FROM debian:bullseye
 RUN apt-get update && apt-get install -y openssh-server socat sudo tini
-COPY snmp_forward.sh /
 RUN echo '%adm ALL=NOPASSWD: /usr/bin/socat' > /etc/sudoers.d/socat
 RUN chmod 0440 /etc/sudoers.d/socat
 ARG USER
 RUN useradd -g adm --no-create-home $USER
 USER $USER
 
+COPY snmp_forward.sh /
 ENTRYPOINT ["tini", "/snmp_forward.sh"]

--- a/tools/forward/snmp_forward.sh
+++ b/tools/forward/snmp_forward.sh
@@ -20,7 +20,7 @@ tunnel_port=${3:-10000}
 remote_tunnel ()
 {
     echo "Setting up SSH tunnel to $snmp_agent via $hop_host ..."
-    ssh -tt -L${tunnel_port}:127.0.0.1:${tunnel_port} $hop_host socat -T10 TCP4-LISTEN:${tunnel_port},fork UDP4:${snmp_agent}:161
+    ssh -tt -o ConnectTimeout=4 -L${tunnel_port}:127.0.0.1:${tunnel_port} $hop_host socat -T10 TCP4-LISTEN:${tunnel_port},fork UDP4:${snmp_agent}:161
 }
 
 local_tunnel ()

--- a/tools/forward/snmp_forward.sh
+++ b/tools/forward/snmp_forward.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # -----------------------------------------------------------------------
 # Shell script snmp_forward.sh
 # Create an SNMP tunnel to remote Agent through a hop host
@@ -20,7 +20,13 @@ tunnel_port=${3:-10000}
 remote_tunnel ()
 {
     echo "Setting up SSH tunnel to $snmp_agent via $hop_host ..."
-    ssh -tt -o ConnectTimeout=4 -L${tunnel_port}:127.0.0.1:${tunnel_port} $hop_host socat -T10 TCP4-LISTEN:${tunnel_port},fork UDP4:${snmp_agent}:161
+    if [[ "$snmp_agent" == *":"* ]]; then
+        echo "$snmp_agent looks like an IPv6 address, using an IPv6 tunnel"
+        remote_addr=UDP6:\\[${snmp_agent}\]:161
+    else
+        remote_addr=UDP4:${snmp_agent}:161
+    fi
+    ssh -tt -o ConnectTimeout=4 -L${tunnel_port}:127.0.0.1:${tunnel_port} $hop_host socat -T10 TCP4-LISTEN:${tunnel_port},fork ${remote_addr}
 }
 
 local_tunnel ()

--- a/tools/forward/snmp_forward.sh
+++ b/tools/forward/snmp_forward.sh
@@ -18,10 +18,10 @@ tunnel_port=${3:-10000}
 
 remote_tunnel ()
 {
-    ssh -f -L${tunnel_port}:127.0.0.1:${tunnel_port} $hop_host socat -T10 TCP4-LISTEN:${tunnel_port},fork UDP4:${snmp_agent}:161
+    ssh -tt -L${tunnel_port}:127.0.0.1:${tunnel_port} $hop_host socat -T10 TCP4-LISTEN:${tunnel_port},fork UDP4:${snmp_agent}:161
 }
 
-remote_tunnel
+remote_tunnel &
 
 echo "local tunnel..."
 sudo socat UDP4-LISTEN:161,fork TCP4:localhost:${tunnel_port}

--- a/tools/forward/snmp_forward.sh
+++ b/tools/forward/snmp_forward.sh
@@ -19,6 +19,7 @@ tunnel_port=${3:-10000}
 
 remote_tunnel ()
 {
+    echo "Setting up SSH tunnel to $snmp_agent via $hop_host ..."
     ssh -tt -L${tunnel_port}:127.0.0.1:${tunnel_port} $hop_host socat -T10 TCP4-LISTEN:${tunnel_port},fork UDP4:${snmp_agent}:161
 }
 

--- a/tools/forward/snmp_forward.sh
+++ b/tools/forward/snmp_forward.sh
@@ -11,6 +11,7 @@
 # -----------------------------------------------------------------------
 
 PROGNAME=$0
+PGID=$$
 
 snmp_agent=${1:-158.38.12.155}
 hop_host=${2:-teknobyen-vk.uninett.no}
@@ -27,6 +28,9 @@ local_tunnel ()
     sudo socat UDP4-LISTEN:161,fork TCP4:localhost:${tunnel_port}
 }
 
+
+# Ensure everything in process group is stopped if either tunnel process dies
+trap "echo A tunnel subprocess died, stopping all forwarding; kill -HUP -$PGID" CHLD
 
 remote_tunnel &
 local_tunnel &

--- a/tools/forward/snmp_forward.sh
+++ b/tools/forward/snmp_forward.sh
@@ -21,7 +21,14 @@ remote_tunnel ()
     ssh -tt -L${tunnel_port}:127.0.0.1:${tunnel_port} $hop_host socat -T10 TCP4-LISTEN:${tunnel_port},fork UDP4:${snmp_agent}:161
 }
 
-remote_tunnel &
+local_tunnel ()
+{
+    echo "Setting up local socat tunnel to SSH tunnel..."
+    sudo socat UDP4-LISTEN:161,fork TCP4:localhost:${tunnel_port}
+}
 
-echo "local tunnel..."
-sudo socat UDP4-LISTEN:161,fork TCP4:localhost:${tunnel_port}
+
+remote_tunnel &
+local_tunnel &
+wait  # Just wait for all background processes to die
+


### PR DESCRIPTION
The SNMP forwarder container setup had three main drawbacks that this PR aims to fix:

1. The remote `socat` process on the hop-host was never terminated, keeping the forwarding port bound indefinitely, causing every subsequent attempt to start the forwarding container to fail with "address already in use" errors.
2. The forwarding container would never exit if there was a problem with setting up the tunnels - it would at best log the errors and keep running forever.  Exiting is the best way to signal a real problem.
3. The forwarding container did not support forwarding SNMP requests to agents on IPv6 addresses.

Docs are also slighty updated to clarify on *what* host the problem resides when the "address already in use" error appears.