### PR TITLE
Filter by ip manually instead of using django in netbox api

### DIFF
--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -402,7 +402,6 @@ class NetboxViewSet(LoggerMixin, NAVAPIMixin, viewsets.ModelViewSet):
     queryset = manage.Netbox.objects.all().prefetch_related("info_set")
     serializer_class = serializers.NetboxSerializer
     filterset_fields = (
-        'ip',
         'sysname',
         'room',
         'organization',
@@ -440,6 +439,15 @@ class NetboxViewSet(LoggerMixin, NAVAPIMixin, viewsets.ModelViewSet):
                 qs = qs.filter(type__name__istartswith=value[1:])
             else:
                 qs = qs.filter(type__name=value)
+        ip = params.get('ip', None)
+        if ip:
+            try:
+                addr = IP(ip)
+            except ValueError:
+                raise IPParseError
+            oper = '=' if addr.len() == 1 else '<<'
+            expr = "netbox.ip {} '{}'".format(oper, addr)
+            qs = qs.extra(where=[expr])
 
         return qs
 

--- a/tests/integration/api_test.py
+++ b/tests/integration/api_test.py
@@ -131,6 +131,22 @@ def test_update_group_on_org(db, api_client, token):
 # Netbox specific tests
 
 
+def test_filter_netbox_by_invalid_ip(db, api_client, token):
+    create_token_endpoint(token, 'netbox')
+    response = api_client.get('{}?ip=10'.format(ENDPOINTS['netbox']))
+    print(response)
+    assert response.status_code == 200
+
+
+def test_filter_netbox_by_invalid_ip_that_cannot_be_converted_throws_error(
+    db, api_client, token
+):
+    create_token_endpoint(token, 'netbox')
+    response = api_client.get('{}?ip=x'.format(ENDPOINTS['netbox']))
+    print(response)
+    assert response.status_code == 400
+
+
 def test_update_netbox(db, api_client, token):
     endpoint = 'netbox'
     create_token_endpoint(token, endpoint)


### PR DESCRIPTION
Without this fix the API throws an error when filtering on invalid IPs.

To replicate access the url `/api/netbox/?ip=10`:
```
DataError at /api/1/netbox/

invalid input syntax for type inet: "10"
LINE 1: ... AS "__count" FROM "netbox" WHERE "netbox"."ip" = '10'::inet
```