### PR TITLE
Log refusing to send alerts to addresses of blacklisted types as debug instead of warning

### DIFF
--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -432,7 +432,7 @@ class AlertAddress(models.Model):
             return True
 
         if self.type.is_blacklisted():
-            _logger.warning(
+            _logger.debug(
                 'Not sending alert %s to %s as handler %s is blacklisted: %s',
                 alert.id,
                 self.address,


### PR DESCRIPTION
One log entry is created for each alert every 30 seconds. The debug level is changed to debug since no new error is discovered, since we already have set the address type to blacklisted.

Closes #1787.