### PR TITLE
Handle invalid alert address in alert sending

### DIFF
--- a/python/nav/alertengine/dispatchers/__init__.py
+++ b/python/nav/alertengine/dispatchers/__init__.py
@@ -101,6 +101,13 @@ class FatalDispatcherException(DispatcherException):
     pass
 
 
+class InvalidAlertAddressError(Exception):
+    """Raised when an alert address is invalid, which is determined by the
+    is_valid_address method of each dispatcher"""
+
+    pass
+
+
 def is_valid_email(address):
     """Validates a string as an e-mail address"""
     try:

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -406,6 +406,12 @@ class AlertAddress(models.Model):
     def __str__(self):
         return self.type.scheme() + self.address
 
+    def has_valid_address(self):
+        if not self.type.supported or not self.address:
+            return False
+        dispatcher = self.type.load_dispatcher_class()
+        return dispatcher.is_valid_address(self.address)
+
     @transaction.atomic
     def send(self, alert, subscription):
         """Handles sending of alerts to with defined alert notification types

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -505,7 +505,7 @@ class AlertSender(models.Model):
         if not self.supported:
             raise FatalDispatcherException("{} is not supported".format(self.name))
         if self.handler not in self._handlers:
-            dispatcher_class = self._load_dispatcher_class()
+            dispatcher_class = self.load_dispatcher_class()
             dispatcher = dispatcher_class(
                 config=AlertSender.config.get(self.handler, {})
             )
@@ -516,7 +516,7 @@ class AlertSender(models.Model):
         # Delegate sending of message
         return dispatcher.send(*args, **kwargs)
 
-    def _load_dispatcher_class(self):
+    def load_dispatcher_class(self):
         # Get config
         if not hasattr(AlertSender, 'config'):
             AlertSender.config = get_alertengine_config('alertengine.conf')

--- a/tests/integration/alertengine_test.py
+++ b/tests/integration/alertengine_test.py
@@ -4,5 +4,5 @@ from nav.alertengine.dispatchers import Dispatcher
 
 def test_all_handlers_should_be_loadable():
     for sender in AlertSender.objects.filter(supported=True):
-        dispatcher = sender._load_dispatcher_class()
+        dispatcher = sender.load_dispatcher_class()
         assert issubclass(dispatcher, Dispatcher)


### PR DESCRIPTION
When we try to send an alert, but the alert address is empty currently no alert is sent, an error is logged, but it is reported back as a successful sending, which can become very confusing. 

This PR fixes that and even widens the application. Before sending an alert the address it is to be sent to is validated and in case it is invalid an error is logged and an `InvalidAlertAddressError` is thrown. That is caught further up and the alert is deleted in that case and the sending is reported back as failed.

This popped up due to #1787.