### PR TITLE
Update portadmin tests to use fixtures

### DIFF
--- a/tests/unittests/portadmin/portadmin_test.py
+++ b/tests/unittests/portadmin/portadmin_test.py
@@ -7,11 +7,19 @@ from nav.enterprise.ids import VENDOR_ID_HEWLETT_PACKARD, VENDOR_ID_CISCOSYSTEMS
 from nav.portadmin.management import ManagementFactory, HP, Cisco
 
 
-class TestPortadminResponseHP:
-    def test_management_factory_get_hp(self, handler_hp):
-        assert handler_hp != None, "Could not get handler-object"
-        assert isinstance(handler_hp, HP), "Wrong handler-type"
+class TestPortadminManagementFactory:
+    def test_get_hp(self, netbox_hp):
+        handler = ManagementFactory.get_instance(netbox_hp)
+        assert handler != None, "Could not get handler-object"
+        assert isinstance(handler, HP), "Wrong handler-type"
 
+    def test_get_cisco(self, netbox_cisco):
+        handler = ManagementFactory.get_instance(netbox_cisco)
+        assert handler != None, "Could not get handler-object"
+        assert isinstance(handler, Cisco), "Wrong handler-type"
+
+
+class TestPortadminResponseHP:
     def test_get_vlan_hp(self, handler_hp):
         # get hold of the read-only Snmp-object
         snmpReadOnlyHandler = handler_hp._get_read_only_handle()
@@ -46,10 +54,6 @@ class TestPortadminResponseHP:
 
 
 class TestPortadminResponseCisco:
-    def test_management_factory_get_cisco(self, handler_cisco):
-        assert handler_cisco != None, "Could not get handler-object"
-        assert isinstance(handler_cisco, Cisco), "Wrong handler-type"
-
     def test_get_vlan_cisco(self, handler_cisco):
         # get hold of the read-only Snmp-object
         snmpReadOnlyHandler = handler_cisco._get_read_only_handle()

--- a/tests/unittests/portadmin/portadmin_test.py
+++ b/tests/unittests/portadmin/portadmin_test.py
@@ -1,6 +1,7 @@
 from mock import Mock
 
 import unittest
+import pytest
 
 from nav.oids import OID
 from nav.enterprise.ids import VENDOR_ID_HEWLETT_PACKARD, VENDOR_ID_CISCOSYSTEMS
@@ -146,6 +147,58 @@ class PortadminResponseTest(unittest.TestCase):
         self.assertEqual(
             self.handler._get_all_ifaliases(), expected, "getAllIfAlias failed."
         )
+
+
+@pytest.fixture
+def profile():
+    profile = Mock()
+    profile.snmp_version = 2
+    profile.snmp_community = "public"
+    return profile
+
+
+@pytest.fixture
+def netbox_hp(profile):
+    vendor = Mock()
+    vendor.id = u'hp'
+
+    netbox_type = Mock()
+    netbox_type.vendor = vendor
+    netbox_type.get_enterprise_id.return_value = VENDOR_ID_HEWLETT_PACKARD
+
+    netbox = Mock()
+    netbox.type = netbox_type
+    netbox.ip = '10.240.160.39'
+    netbox.get_preferred_snmp_management_profile.return_value = profile
+
+    return netbox
+
+
+@pytest.fixture
+def netbox_cisco(profile):
+    vendor = Mock()
+    vendor.id = u'cisco'
+
+    netbox_type = Mock()
+    netbox_type.vendor = vendor
+    netbox_type.get_enterprise_id.return_value = VENDOR_ID_CISCOSYSTEMS
+
+    netbox = Mock()
+    netbox.type = netbox_type
+    netbox.ip = '10.240.160.38'
+    netbox.get_preferred_snmp_management_profile.return_value = profile
+
+    return netbox
+
+
+@pytest.fixture
+def handler_hp(netbox_hp):
+    return ManagementFactory.get_instance(netbox_hp)
+
+
+@pytest.fixture
+def handler_cisco(netbox_cisco):
+    return ManagementFactory.get_instance(netbox_cisco)
 
 
 if __name__ == '__main__':

--- a/tests/unittests/portadmin/portadmin_test.py
+++ b/tests/unittests/portadmin/portadmin_test.py
@@ -24,30 +24,32 @@ class TestPortadminManagementFactory:
 class TestPortadminResponseHP:
     def test_get_vlan_hp(self, handler_hp):
         # get hold of the read-only Snmp-object
-        snmpReadOnlyHandler = handler_hp._get_read_only_handle()
+        snmp_read_only_handler = handler_hp._get_read_only_handle()
         # replace get-method on Snmp-object with a mock-method
         # this get-method returns a vlan-number
-        snmpReadOnlyHandler.get = Mock(return_value=666)
+        snmp_read_only_handler.get = Mock(return_value=666)
         ifc = Mock(baseport=1)
         assert handler_hp.get_interface_native_vlan(ifc) == 666, "getVlan-test failed"
-        snmpReadOnlyHandler.get.assert_called_with(OID('.1.3.6.1.2.1.17.7.1.4.5.1.1.1'))
+        snmp_read_only_handler.get.assert_called_with(
+            OID('.1.3.6.1.2.1.17.7.1.4.5.1.1.1')
+        )
 
     def test_get_ifaliases_hp(self, handler_hp):
         # get hold of the read-only Snmp-object
-        snmpReadOnlyHandler = handler_hp._get_read_only_handle()
+        snmp_read_only_handler = handler_hp._get_read_only_handle()
         # replace get-method on Snmp-object with a mock-method
         # for getting all IfAlias
         walkdata = [('.1', b'hjalmar'), ('.2', b'snorre'), ('.3', b'bjarne')]
         expected = {1: 'hjalmar', 2: 'snorre', 3: 'bjarne'}
-        snmpReadOnlyHandler.bulkwalk = Mock(return_value=walkdata)
+        snmp_read_only_handler.bulkwalk = Mock(return_value=walkdata)
         assert handler_hp._get_all_ifaliases() == expected, "getAllIfAlias failed."
 
     def test_set_ifalias_hp(self, handler_hp):
         # get hold of the read-write Snmp-object
-        snmpReadWriteHandler = handler_hp._get_read_write_handle()
+        snmp_read_only_handler = handler_hp._get_read_write_handle()
         # replace set-method on Snmp-object with a mock-method
         # all set-methods return None
-        snmpReadWriteHandler.set = Mock(return_value=None)
+        snmp_read_only_handler.set = Mock(return_value=None)
         interface = Mock()
         interface.ifindex = 1
         assert (
@@ -58,22 +60,22 @@ class TestPortadminResponseHP:
 class TestPortadminResponseCisco:
     def test_get_vlan_cisco(self, handler_cisco):
         # get hold of the read-only Snmp-object
-        snmpReadOnlyHandler = handler_cisco._get_read_only_handle()
+        snmp_read_only_handler = handler_cisco._get_read_only_handle()
         # replace get-method on Snmp-object with a mock-method
         # this get-method returns a vlan-number
-        snmpReadOnlyHandler.get = Mock(return_value=77)
+        snmp_read_only_handler.get = Mock(return_value=77)
         ifc = Mock(ifindex=1)
         assert handler_cisco.get_interface_native_vlan(ifc) == 77, "getVlan-test failed"
-        snmpReadOnlyHandler.get.assert_called_with('1.3.6.1.4.1.9.9.68.1.2.2.1.2.1')
+        snmp_read_only_handler.get.assert_called_with('1.3.6.1.4.1.9.9.68.1.2.2.1.2.1')
 
     def test_get_ifaliases_cisco(self, handler_cisco):
         # get hold of the read-only Snmp-object
-        snmpReadOnlyHandler = handler_cisco._get_read_only_handle()
+        snmp_read_only_handler = handler_cisco._get_read_only_handle()
         # replace get-method on Snmp-object with a mock-method
         # for getting all IfAlias
         walkdata = [('.1', b'jomar'), ('.2', b'knut'), ('.3', b'hjallis')]
         expected = {1: 'jomar', 2: 'knut', 3: 'hjallis'}
-        snmpReadOnlyHandler.bulkwalk = Mock(return_value=walkdata)
+        snmp_read_only_handler.bulkwalk = Mock(return_value=walkdata)
         assert handler_cisco._get_all_ifaliases() == expected, "getAllIfAlias failed."
 
 

--- a/tests/unittests/portadmin/portadmin_test.py
+++ b/tests/unittests/portadmin/portadmin_test.py
@@ -1,6 +1,5 @@
 from mock import Mock
 
-import unittest
 import pytest
 
 from nav.oids import OID
@@ -11,142 +10,74 @@ from nav.portadmin.management import *
 from nav.portadmin.vlan import FantasyVlan
 
 
-class PortadminResponseTest(unittest.TestCase):
-    def setUp(self):
-        self.profile = Mock()
-        self.profile.snmp_version = 2
-        self.profile.snmp_community = "public"
-
-        self.hpVendor = Mock()
-        self.hpVendor.id = u'hp'
-
-        self.ciscoVendor = Mock()
-        self.ciscoVendor.id = u'cisco'
-
-        self.hpType = Mock()
-        self.hpType.vendor = self.hpVendor
-        self.hpType.get_enterprise_id.return_value = VENDOR_ID_HEWLETT_PACKARD
-
-        self.ciscoType = Mock()
-        self.ciscoType.vendor = self.ciscoVendor
-        self.ciscoType.get_enterprise_id.return_value = VENDOR_ID_CISCOSYSTEMS
-
-        self.netboxHP = Mock()
-        self.netboxHP.type = self.hpType
-        self.netboxHP.ip = '10.240.160.39'
-        self.netboxHP.get_preferred_snmp_management_profile.return_value = self.profile
-
-        self.netboxCisco = Mock()
-        self.netboxCisco.type = self.ciscoType
-        self.netboxCisco.ip = '10.240.160.38'
-        self.netboxCisco.get_preferred_snmp_management_profile.return_value = (
-            self.profile
-        )
-
-        self.snmpReadOnlyHandler = None
-        self.handler = None
-
-    def tearDown(self):
-        self.hpVendor = None
-        self.ciscoVendor = None
-        self.hpType = None
-        self.ciscoType = None
-        self.netboxHP = None
-        self.netboxCisco = None
-        self.handler = None
-        self.snmpReadOnlyHandler = None
-        self.snmpReadWriteHandler = None
-
+class TestPortadminResponse:
     ####################################################################
     #  HP-netbox
+    def test_management_factory_get_hp(self, handler_hp):
+        assert handler_hp != None, "Could not get handler-object"
+        assert isinstance(handler_hp, HP), "Wrong handler-type"
 
-    def test_management_factory_get_hp(self):
-        self.handler = ManagementFactory.get_instance(self.netboxHP)
-        self.assertNotEqual(self.handler, None, 'Could not get handler-object')
-        self.assertIsInstance(self.handler, HP, msg='Wrong handler-type')
-
-    def test_get_vlan_hp(self):
-        self.handler = ManagementFactory.get_instance(self.netboxHP)
+    def test_get_vlan_hp(self, handler_hp):
         # get hold of the read-only Snmp-object
-        self.snmpReadOnlyHandler = self.handler._get_read_only_handle()
+        snmpReadOnlyHandler = handler_hp._get_read_only_handle()
         # replace get-method on Snmp-object with a mock-method
         # this get-method returns a vlan-number
-        self.snmpReadOnlyHandler.get = Mock(return_value=666)
+        snmpReadOnlyHandler.get = Mock(return_value=666)
         ifc = Mock(baseport=1)
-        self.assertEqual(
-            self.handler.get_interface_native_vlan(ifc), 666, "getVlan-test failed"
-        )
-        self.snmpReadOnlyHandler.get.assert_called_with(
-            OID('.1.3.6.1.2.1.17.7.1.4.5.1.1.1')
-        )
+        assert handler_hp.get_interface_native_vlan(ifc) == 666, "getVlan-test failed"
+        snmpReadOnlyHandler.get.assert_called_with(OID('.1.3.6.1.2.1.17.7.1.4.5.1.1.1'))
 
-    def test_get_ifaliases_hp(self):
-        self.handler = ManagementFactory.get_instance(self.netboxHP)
+    def test_get_ifaliases_hp(self, handler_hp):
         # get hold of the read-only Snmp-object
-        self.snmpReadOnlyHandler = self.handler._get_read_only_handle()
+        snmpReadOnlyHandler = handler_hp._get_read_only_handle()
         # replace get-method on Snmp-object with a mock-method
         # for getting all IfAlias
         walkdata = [('.1', b'hjalmar'), ('.2', b'snorre'), ('.3', b'bjarne')]
         expected = {1: 'hjalmar', 2: 'snorre', 3: 'bjarne'}
-        self.snmpReadOnlyHandler.bulkwalk = Mock(return_value=walkdata)
-        self.assertEqual(
-            self.handler._get_all_ifaliases(), expected, "getAllIfAlias failed."
-        )
+        snmpReadOnlyHandler.bulkwalk = Mock(return_value=walkdata)
+        assert handler_hp._get_all_ifaliases() == expected, "getAllIfAlias failed."
 
-    def test_set_ifalias_hp(self):
-        self.handler = ManagementFactory.get_instance(self.netboxHP)
+    def test_set_ifalias_hp(self, handler_hp):
         # get hold of the read-write Snmp-object
-        self.snmpReadWriteHandler = self.handler._get_read_write_handle()
-
+        snmpReadWriteHandler = handler_hp._get_read_write_handle()
         # replace set-method on Snmp-object with a mock-method
         # all set-methods return None
-        self.snmpReadWriteHandler.set = Mock(return_value=None)
+        snmpReadWriteHandler.set = Mock(return_value=None)
         interface = Mock()
         interface.ifindex = 1
-        self.assertEqual(
-            self.handler.set_interface_description(interface, "punkt1"),
-            None,
-            "setIfAlias failed",
-        )
+        assert (
+            handler_hp.set_interface_description(interface, "punkt1") == None
+        ), "setIfAlias failed"
 
     ####################################################################
     #  CISCO-netbox
 
-    def test_management_factory_get_cisco(self):
+    def test_management_factory_get_cisco(self, handler_cisco):
         ####################################################################
         #  cisco-netbox
-        self.handler = ManagementFactory.get_instance(self.netboxCisco)
-        self.assertNotEqual(self.handler, None, 'Could not get handler-object')
-        self.assertIsInstance(self.handler, Cisco, 'Wrong handler-type')
+        assert handler_cisco != None, "Could not get handler-object"
+        assert isinstance(handler_cisco, Cisco), "Wrong handler-type"
 
-    def test_get_vlan_cisco(self):
-        self.handler = ManagementFactory.get_instance(self.netboxCisco)
-        assert type(self.handler) == Cisco
+    def test_get_vlan_cisco(self, handler_cisco):
+        assert type(handler_cisco) == Cisco
         # get hold of the read-only Snmp-object
-        self.snmpReadOnlyHandler = self.handler._get_read_only_handle()
+        snmpReadOnlyHandler = handler_cisco._get_read_only_handle()
         # replace get-method on Snmp-object with a mock-method
         # this get-method returns a vlan-number
-        self.snmpReadOnlyHandler.get = Mock(return_value=77)
+        snmpReadOnlyHandler.get = Mock(return_value=77)
         ifc = Mock(ifindex=1)
-        self.assertEqual(
-            self.handler.get_interface_native_vlan(ifc), 77, "getVlan-test failed"
-        )
-        self.snmpReadOnlyHandler.get.assert_called_with(
-            '1.3.6.1.4.1.9.9.68.1.2.2.1.2.1'
-        )
+        assert handler_cisco.get_interface_native_vlan(ifc) == 77, "getVlan-test failed"
+        snmpReadOnlyHandler.get.assert_called_with('1.3.6.1.4.1.9.9.68.1.2.2.1.2.1')
 
-    def test_get_ifaliases_cisco(self):
-        self.handler = ManagementFactory.get_instance(self.netboxCisco)
+    def test_get_ifaliases_cisco(self, handler_cisco):
         # get hold of the read-only Snmp-object
-        self.snmpReadOnlyHandler = self.handler._get_read_only_handle()
+        snmpReadOnlyHandler = handler_cisco._get_read_only_handle()
         # replace get-method on Snmp-object with a mock-method
         # for getting all IfAlias
         walkdata = [('.1', b'jomar'), ('.2', b'knut'), ('.3', b'hjallis')]
         expected = {1: 'jomar', 2: 'knut', 3: 'hjallis'}
-        self.snmpReadOnlyHandler.bulkwalk = Mock(return_value=walkdata)
-        self.assertEqual(
-            self.handler._get_all_ifaliases(), expected, "getAllIfAlias failed."
-        )
+        snmpReadOnlyHandler.bulkwalk = Mock(return_value=walkdata)
+        assert handler_cisco._get_all_ifaliases() == expected, "getAllIfAlias failed."
 
 
 @pytest.fixture
@@ -199,7 +130,3 @@ def handler_hp(netbox_hp):
 @pytest.fixture
 def handler_cisco(netbox_cisco):
     return ManagementFactory.get_instance(netbox_cisco)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/unittests/portadmin/portadmin_test.py
+++ b/tests/unittests/portadmin/portadmin_test.py
@@ -12,12 +12,12 @@ from nav.portadmin.snmp.cisco import Cisco
 class TestPortadminManagementFactory:
     def test_get_hp(self, netbox_hp):
         handler = ManagementFactory.get_instance(netbox_hp)
-        assert handler != None, "Could not get handler-object"
+        assert handler is not None, "Could not get handler-object"
         assert isinstance(handler, HP), "Wrong handler-type"
 
     def test_get_cisco(self, netbox_cisco):
         handler = ManagementFactory.get_instance(netbox_cisco)
-        assert handler != None, "Could not get handler-object"
+        assert handler is not None, "Could not get handler-object"
         assert isinstance(handler, Cisco), "Wrong handler-type"
 
 

--- a/tests/unittests/portadmin/portadmin_test.py
+++ b/tests/unittests/portadmin/portadmin_test.py
@@ -51,7 +51,6 @@ class TestPortadminResponseCisco:
         assert isinstance(handler_cisco, Cisco), "Wrong handler-type"
 
     def test_get_vlan_cisco(self, handler_cisco):
-        assert type(handler_cisco) == Cisco
         # get hold of the read-only Snmp-object
         snmpReadOnlyHandler = handler_cisco._get_read_only_handle()
         # replace get-method on Snmp-object with a mock-method

--- a/tests/unittests/portadmin/portadmin_test.py
+++ b/tests/unittests/portadmin/portadmin_test.py
@@ -6,9 +6,6 @@ from nav.oids import OID
 from nav.enterprise.ids import VENDOR_ID_HEWLETT_PACKARD, VENDOR_ID_CISCOSYSTEMS
 from nav.portadmin.management import *
 
-###############################################################################
-from nav.portadmin.vlan import FantasyVlan
-
 
 class TestPortadminResponse:
     ####################################################################

--- a/tests/unittests/portadmin/portadmin_test.py
+++ b/tests/unittests/portadmin/portadmin_test.py
@@ -53,7 +53,7 @@ class TestPortadminResponseHP:
         interface = Mock()
         interface.ifindex = 1
         assert (
-            handler_hp.set_interface_description(interface, "punkt1") == None
+            handler_hp.set_interface_description(interface, "punkt1") is None
         ), "setIfAlias failed"
 
 

--- a/tests/unittests/portadmin/portadmin_test.py
+++ b/tests/unittests/portadmin/portadmin_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from nav.oids import OID
 from nav.enterprise.ids import VENDOR_ID_HEWLETT_PACKARD, VENDOR_ID_CISCOSYSTEMS
-from nav.portadmin.management import *
+from nav.portadmin.management import ManagementFactory, HP, Cisco
 
 
 class TestPortadminResponse:

--- a/tests/unittests/portadmin/portadmin_test.py
+++ b/tests/unittests/portadmin/portadmin_test.py
@@ -7,9 +7,7 @@ from nav.enterprise.ids import VENDOR_ID_HEWLETT_PACKARD, VENDOR_ID_CISCOSYSTEMS
 from nav.portadmin.management import ManagementFactory, HP, Cisco
 
 
-class TestPortadminResponse:
-    ####################################################################
-    #  HP-netbox
+class TestPortadminResponseHP:
     def test_management_factory_get_hp(self, handler_hp):
         assert handler_hp != None, "Could not get handler-object"
         assert isinstance(handler_hp, HP), "Wrong handler-type"
@@ -46,12 +44,9 @@ class TestPortadminResponse:
             handler_hp.set_interface_description(interface, "punkt1") == None
         ), "setIfAlias failed"
 
-    ####################################################################
-    #  CISCO-netbox
 
+class TestPortadminResponseCisco:
     def test_management_factory_get_cisco(self, handler_cisco):
-        ####################################################################
-        #  cisco-netbox
         assert handler_cisco != None, "Could not get handler-object"
         assert isinstance(handler_cisco, Cisco), "Wrong handler-type"
 

--- a/tests/unittests/portadmin/portadmin_test.py
+++ b/tests/unittests/portadmin/portadmin_test.py
@@ -4,7 +4,9 @@ import pytest
 
 from nav.oids import OID
 from nav.enterprise.ids import VENDOR_ID_HEWLETT_PACKARD, VENDOR_ID_CISCOSYSTEMS
-from nav.portadmin.management import ManagementFactory, HP, Cisco
+from nav.portadmin.management import ManagementFactory
+from nav.portadmin.snmp.hp import HP
+from nav.portadmin.snmp.cisco import Cisco
 
 
 class TestPortadminManagementFactory:


### PR DESCRIPTION
Portadmin tests need a revamp. Had issues writing new tests in #2635 because of how these tests are written. 

This PR swaps from using unittest and setup/teardown to using fixtures, groups tests together better and fixes some other bad practices (importing all from a module using * for example)