### PR TITLE
Show blacklisted reason of alert address in alert profiles

### DIFF
--- a/python/nav/web/templates/alertprofiles/address_list.html
+++ b/python/nav/web/templates/alertprofiles/address_list.html
@@ -63,7 +63,7 @@
                 {% if not a.type.supported %}
                     <div class="alert-box error with-icon inside-table">{{ a.type.name }}: No longer supported</div>
                 {% elif a.type.blacklisted_reason %}
-                    <div class="alert-box warning inside-table">{{ a.type.name }}: Blacklisted - {{ a.type.blacklisted_reason }}</div>
+                    <div class="alert-box warning inside-table">{{ a.type.name }} is currently non-functional: {{ a.type.blacklisted_reason }}</div>
                 {% else %}
                     {{ a.type.name }}
                 {% endif %}

--- a/python/nav/web/templates/alertprofiles/address_list.html
+++ b/python/nav/web/templates/alertprofiles/address_list.html
@@ -62,6 +62,8 @@
             <td>
                 {% if not a.type.supported %}
                     <div class="alert-box error with-icon inside-table">{{ a.type.name }}: No longer supported</div>
+                {% elif a.type.blacklisted_reason %}
+                    <div class="alert-box warning inside-table">{{ a.type.name }}: Blacklisted - {{ a.type.blacklisted_reason }}</div>
                 {% else %}
                     {{ a.type.name }}
                 {% endif %}

--- a/python/nav/web/templates/alertprofiles/subscription_form.html
+++ b/python/nav/web/templates/alertprofiles/subscription_form.html
@@ -44,7 +44,7 @@
                 <td><a href="{% url 'alertprofiles-filter_groups-detail' s.filter_group.id %}">{{ s.filter_group.name }}</a></td>
                 <td>
                     {% if not s.alert_address.type.supported %}<div class="alert-box error with-icon inside-table" title="{{ s.alert_address.type.name }} is no longer supported">{% endif %}
-                    {% if s.alert_address.type.blacklisted_reason %}<div class="alert-box warning inside-table" title="{{ s.alert_address.type.name }} is blacklisted: {{ s.alert_address.type.blacklisted_reason }}">{% endif %}
+                    {% if s.alert_address.type.blacklisted_reason %}<div class="alert-box warning inside-table" title="{{ s.alert_address.type.name }} is currently non-functional: {{ s.alert_address.type.blacklisted_reason }}">{% endif %}
                     <a href="{% url 'alertprofiles-address-detail' s.alert_address.id %}">{{ s.alert_address }}</a>
                     {% if not s.alert_address.type.supported or s.alert_address.type.blacklisted_reason %}</div>{% endif %}
                 </td>

--- a/python/nav/web/templates/alertprofiles/subscription_form.html
+++ b/python/nav/web/templates/alertprofiles/subscription_form.html
@@ -44,8 +44,9 @@
                 <td><a href="{% url 'alertprofiles-filter_groups-detail' s.filter_group.id %}">{{ s.filter_group.name }}</a></td>
                 <td>
                     {% if not s.alert_address.type.supported %}<div class="alert-box error with-icon inside-table" title="{{ s.alert_address.type.name }} is no longer supported">{% endif %}
+                    {% if s.alert_address.type.blacklisted_reason %}<div class="alert-box warning inside-table" title="{{ s.alert_address.type.name }} is blacklisted: {{ s.alert_address.type.blacklisted_reason }}">{% endif %}
                     <a href="{% url 'alertprofiles-address-detail' s.alert_address.id %}">{{ s.alert_address }}</a>
-                    {% if not s.alert_address.type.supported %}</div>{% endif %}
+                    {% if not s.alert_address.type.supported or s.alert_address.type.blacklisted_reason %}</div>{% endif %}
                 </td>
                 <td>{{ s.get_type_display|capfirst }}</td>
                 <td>{{ s.ignore_resolved_alerts|yesno:"Yes,No" }}</td>

--- a/python/nav/web/templates/alertprofiles/timeperiods.html
+++ b/python/nav/web/templates/alertprofiles/timeperiods.html
@@ -50,7 +50,7 @@
                 Watch <em><a href="{% url 'alertprofiles-filter_groups-detail' b.filter_group.id %}">{{ b.filter_group.name }}</a></em>,
                 send to
                 {% if not b.alert_address.type.supported %}<div class="alert-box error with-icon inside-table" title="{{ b.alert_address.type.name }} is no longer supported">{% endif %}
-                {% if b.alert_address.type.blacklisted_reason %}<div class="alert-box warning inside-table" title="{{ b.alert_address.type.name }} is blacklisted: {{b.alert_address.type.blacklisted_reason}}">{% endif %}
+                {% if b.alert_address.type.blacklisted_reason %}<div class="alert-box warning inside-table" title="{{ b.alert_address.type.name }} is currently non-functional: {{b.alert_address.type.blacklisted_reason}}">{% endif %}
                 <em><a href="{% url 'alertprofiles-address-detail' b.alert_address.id %}">{{ b.alert_address.address }}</a></em>
                 {% if not b.alert_address.type.supported or b.alert_address.type.blacklisted_reason %}</div>{% endif %},
                 {{ b.get_type_display }}.

--- a/python/nav/web/templates/alertprofiles/timeperiods.html
+++ b/python/nav/web/templates/alertprofiles/timeperiods.html
@@ -50,8 +50,9 @@
                 Watch <em><a href="{% url 'alertprofiles-filter_groups-detail' b.filter_group.id %}">{{ b.filter_group.name }}</a></em>,
                 send to
                 {% if not b.alert_address.type.supported %}<div class="alert-box error with-icon inside-table" title="{{ b.alert_address.type.name }} is no longer supported">{% endif %}
+                {% if b.alert_address.type.blacklisted_reason %}<div class="alert-box warning inside-table" title="{{ b.alert_address.type.name }} is blacklisted: {{b.alert_address.type.blacklisted_reason}}">{% endif %}
                 <em><a href="{% url 'alertprofiles-address-detail' b.alert_address.id %}">{{ b.alert_address.address }}</a></em>
-                {% if not b.alert_address.type.supported %}</div>{% endif %},
+                {% if not b.alert_address.type.supported or b.alert_address.type.blacklisted_reason %}</div>{% endif %},
                 {{ b.get_type_display }}.
             </li>
             {% endfor %}


### PR DESCRIPTION
Closes #2653. 

I modeled it after how it is shown when an alert sender is no longer supported, but used the warning box instead of the error box.
(basically copied https://github.com/Uninett/nav/commit/8b2700c3c4c5a2371314e96f2148d313313d0870) 

Dependent on #2678.