### PR TITLE
Add an snmpd service container for SNMPv3 comms

### DIFF
--- a/docker-compose.snmp.yml
+++ b/docker-compose.snmp.yml
@@ -1,5 +1,5 @@
 # This compose file shows an example of how you can add SNMP proxying
-# services to the Docker Compose development environment.
+# or test services to the Docker Compose development environment.
 
 # To set up a full dev environment with proxying, either copy the examples
 # from this file to docker-compose.override.yml, or tell docker compose to also
@@ -42,3 +42,10 @@ services:
   mydevice.mydomain:
     << : *forwarder
     command: 192.168.0.1 user@my-hop-host 10000
+
+  # This creates an SNMPv3 test server, see tools/snmpdv3 for details
+  snmpdv3:
+    build: tools/snmpdv3
+    ports:
+      - 161:161/udp
+

--- a/tools/snmpdv3/Dockerfile
+++ b/tools/snmpdv3/Dockerfile
@@ -1,0 +1,4 @@
+FROM polinux/snmpd
+COPY snmpd.conf /etc/snmpd/snmpd.conf
+EXPOSE 161:161/udp
+CMD ["-c", "/etc/snmpd/snmpd.conf"]

--- a/tools/snmpdv3/README.md
+++ b/tools/snmpdv3/README.md
@@ -1,0 +1,34 @@
+# SNMPv3 enabled SNMP daemon for SNMPv3 testing
+
+This directory defines a simple docker image for a NET-SNMP-based SNMP daemon
+that is enabled for responding to SNMPv3 requests.
+
+## Building the image
+
+```sh
+docker build -t snmpd .
+```
+
+## Running a container to respond to SNMP locally
+
+```sh
+docker run --name snmpd -p 161:161/udp snmpd
+```
+
+## Authentication and privacy
+
+Using the SNMPv3 user security model (USM), this image sets up a read-only user
+named `myv3user`, with an authentication password of `my_authpass`, using AES
+encryption for security with a privacy password of `my_privpass`.
+
+For SNMP v1 or v2c communication, it sets up a default read-only community of
+`notpublic`.
+
+## Local testing
+
+The entirety of the daemon's mib view can be queried using SNMPv3 by running
+the following `snmpwalk` command:
+
+```sh
+snmpwalk -v3 -l authPriv -u myv3user -a SHA -A "my_authpass" -x AES -X "my_privpass" localhost
+```

--- a/tools/snmpdv3/snmpd.conf
+++ b/tools/snmpdv3/snmpd.conf
@@ -1,0 +1,13 @@
+com2sec	notConfigUser	default		 notpublic
+group	notConfigGroup	v1		 notConfigUser
+group	notConfigGroup	v2c		 notConfigUser
+view	systemview	included	 .1.3.6.1.2.1.1
+view	systemview	included	 .1.3.6.1.2.1.25.1.1
+access	notConfigGroup ""      any	 noauth	   exact  systemview none none
+
+createUser myv3user SHA "my_authpass" AES "my_privpass"
+rouser myv3user
+
+syslocation Milliways
+syscontact NAV Developer <somebody@example.org>
+dontLogTCPWrappersConnects yes


### PR DESCRIPTION
As part of working on #2692, this adds useful examples to the developer tools directory and docker example files to run a local `snmpd` entity capable of responding to SNMPv3 requests while developing support for SNMPv3.
