### PR TITLE
Add toggle for automatic creation of remote users

### DIFF
--- a/python/nav/etc/webfront/webfront.conf
+++ b/python/nav/etc/webfront/webfront.conf
@@ -110,8 +110,8 @@ enabled = no
 # authenticated user?
 #varname = REMOTE_USER
 
-# Whether usernames set in REMOTE_USER should automatically be created in the
-# database if they do not already exist.
+# Whether a username set in REMOTE_USER should lead to the automatic creation
+# of a user in the database if the user does not already exist.
 # autocreate = off
 
 # If the supplied remote username value needs modification to become more

--- a/python/nav/etc/webfront/webfront.conf
+++ b/python/nav/etc/webfront/webfront.conf
@@ -44,13 +44,13 @@ server = ldap.example.com
 #
 basedn = ou=people,dc=example,dc=com
 
-# How to lookup a user object from LDAP. 
+# How to lookup a user object from LDAP.
 # 'direct' binds to <uid_attr>=<login name>,<user_basedn>
 # 'search' searches for <uid_attr>=<login name> using basedn as searchbase.
 #lookupmethod=direct
 
 # Choose to bind to LDAP as the user with 'suffix' for Active Directory support.
-# lookupmethod should be set to search for this option to function. 
+# lookupmethod should be set to search for this option to function.
 #suffix = @ad.example.com
 
 # If the LDAP directory requires an authenticated user to search for a user
@@ -109,6 +109,10 @@ enabled = no
 # Which header/environment variable will contain the username of the remotely
 # authenticated user?
 #varname = REMOTE_USER
+
+# Whether usernames set in REMOTE_USER should automatically be created in the
+# database if they do not already exist.
+# autocreate = off
 
 # If the supplied remote username value needs modification to become more
 # "username-like", specify which workaround to use here. Only `feide-oidc` is


### PR DESCRIPTION
Add a new flag to the remote user config that by default is off. If remote users is enabled and the new flag is toggled on, the username in REMOTE_USER will be used to automatically create a new user with that username. Automatic creation regardless used to be the default behavior.

Because the default behavior for remote users has changed this needs to be flagged well in NOTES.

Depends on #2706.

For https://github.com/Uninett/campus-tasks/issues/22