### PR TITLE
 Add SNMPv3 support to nav.Snmp.pynetsnmp implementation #2703 

### DIFF
--- a/python/nav/Snmp/defines.py
+++ b/python/nav/Snmp/defines.py
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2023 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.  You should have received a copy of the GNU General Public
+# License along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Defines types and enumerations for SNMP communication parameters"""
+from enum import Enum
+
+
+class SecurityLevel(Enum):
+    """SNMPv3 security levels"""
+
+    NO_AUTH_NO_PRIV = "noAuthNoPriv"
+    AUTH_NO_PRIV = "authNoPriv"
+    AUTH_PRIV = "authPriv"
+
+
+class AuthenticationProtocol(Enum):
+    """SNMPv3 authentication protocols supported by NET-SNMP"""
+
+    MD5 = "MD5"
+    SHA = "SHA"
+    SHA512 = "SHA-512"
+    SHA384 = "SHA-384"
+    SHA256 = "SHA-256"
+    SHA224 = "SHA-224"
+
+
+class PrivacyProtocol(Enum):
+    """SNMPv3 privacy protocols supported by NET-SNMP"""
+
+    DES = "DES"
+    AES = "AES"

--- a/python/nav/Snmp/errors.py
+++ b/python/nav/Snmp/errors.py
@@ -31,3 +31,7 @@ class UnsupportedSnmpVersionError(SnmpError):
 
 class NoSuchObjectError(SnmpError):
     """SNMP agent did not know of this object"""
+
+
+class SNMPv3ConfigurationError(SnmpError):
+    """Error in SNMPv3 configuration parameters"""

--- a/python/nav/Snmp/pynetsnmp.py
+++ b/python/nav/Snmp/pynetsnmp.py
@@ -31,6 +31,7 @@ from ctypes import (
     c_ulong,
     c_uint64,
 )
+from typing import Union
 
 from IPy import IP
 from pynetsnmp import netsnmp
@@ -85,7 +86,13 @@ class Snmp(object):
     """
 
     def __init__(
-        self, host, community="public", version="1", port=161, retries=3, timeout=1
+        self,
+        host: str,
+        community: str = "public",
+        version: Union[str, int] = "1",
+        port: Union[str, int] = 161,
+        retries: int = 3,
+        timeout: int = 1,
     ):
         """Makes a new Snmp-object.
 

--- a/python/nav/Snmp/pynetsnmp.py
+++ b/python/nav/Snmp/pynetsnmp.py
@@ -116,7 +116,7 @@ class Snmp(object):
         :param priv_password: SNMPv3 privacy password
 
         """
-
+        self.handle = None
         self.host = host
         self.community = str(community)
         self.version = str(version)
@@ -197,7 +197,8 @@ class Snmp(object):
         return tuple(params)
 
     def __del__(self):
-        self.handle.close()
+        if self.handle:
+            self.handle.close()
 
     def get(self, query="1.3.6.1.2.1.1.1.0"):
         """Performs an SNMP GET query.


### PR DESCRIPTION
This adds the necessary arguments, validation and a reworked command line builder for SNMPv3 communication to the synchronous SNMP implementation in `nav.Snmp.pynetsnmp.Snmp`.

Closes #2700 

This replaces #2703, which got "merged" due to an error, and cannot be reopened.