### PR TITLE
Avoid exception on adding ip device with wrong ip/hostname

### DIFF
--- a/python/nav/Snmp/pynetsnmp.py
+++ b/python/nav/Snmp/pynetsnmp.py
@@ -36,6 +36,7 @@ from IPy import IP
 from pynetsnmp import netsnmp
 from pynetsnmp.netsnmp import (
     Session,
+    SnmpError as PynetSnmpError,
     SNMP_MSG_GETNEXT,
     mkoid,
     lib,
@@ -107,7 +108,10 @@ class Snmp(object):
         self.timeout = timeout
 
         self.handle = _MySnmpSession(self._build_cmdline())
-        self.handle.open()
+        try:
+            self.handle.open()
+        except PynetSnmpError:
+            raise SnmpError
 
     def _build_cmdline(self):
         try:

--- a/python/nav/web/seeddb/page/netbox/edit.py
+++ b/python/nav/web/seeddb/page/netbox/edit.py
@@ -265,8 +265,8 @@ def get_type_id(ip_addr, profile):
 
 def snmp_type(ip_addr, snmp_ro, snmp_version):
     """Query ip for sysobjectid using form data"""
-    snmp = Snmp(ip_addr, snmp_ro, snmp_version)
     try:
+        snmp = Snmp(ip_addr, snmp_ro, snmp_version)
         sysobjectid = snmp.get('.1.3.6.1.2.1.1.2.0')
     except SnmpError:
         return None


### PR DESCRIPTION
Closes #2696.

Doesn't really show a nice error message, only catches the exception. 
If I should show a clearer error message I would need some pointers on how to do that, since I don't see a way to send the error message up