### PR TITLE
Enable SNMPv3 write profile checks in SeedDB

### DIFF
--- a/python/nav/web/seeddb/page/netbox/edit.py
+++ b/python/nav/web/seeddb/page/netbox/edit.py
@@ -187,7 +187,11 @@ def get_snmp_read_only_variables(ip_address: str, profile: ManagementProfile):
 
 
 def snmp_write_test(ip, profile):
-    """Test that snmp write works"""
+    """Tests that an SNMP profile really has write access.
+
+    Tests by fetching sysLocation.0 and setting the same value.  This will fail if
+    the device only allows writing to other parts of its mib view.
+    """
 
     testresult = {
         'error_message': '',
@@ -199,11 +203,7 @@ def snmp_write_test(ip, profile):
     syslocation = '1.3.6.1.2.1.1.6.0'
     value = ''
     try:
-        snmp = Snmp(
-            ip,
-            profile.configuration.get("community"),
-            profile.configuration.get("version"),
-        )
+        snmp = get_snmp_session_for_profile(profile)(ip)
         value = safestring(snmp.get(syslocation))
         snmp.set(syslocation, 's', value.encode('utf-8'))
     except SnmpError as error:

--- a/tools/snmpdv3/Dockerfile
+++ b/tools/snmpdv3/Dockerfile
@@ -1,4 +1,4 @@
 FROM polinux/snmpd
-COPY snmpd.conf /etc/snmpd/snmpd.conf
+COPY snmpd.conf /etc/snmp/snmpd.conf
 EXPOSE 161:161/udp
-CMD ["-c", "/etc/snmpd/snmpd.conf"]
+CMD ["-c", "/etc/snmp/snmpd.conf"]

--- a/tools/snmpdv3/README.md
+++ b/tools/snmpdv3/README.md
@@ -17,12 +17,12 @@ docker run --name snmpd -p 161:161/udp snmpd
 
 ## Authentication and privacy
 
-Using the SNMPv3 user security model (USM), this image sets up a read-only user
+Using the SNMPv3 user security model (USM), this image sets up a read&write user
 named `myv3user`, with an authentication password of `my_authpass`, using AES
 encryption for security with a privacy password of `my_privpass`.
 
 For SNMP v1 or v2c communication, it sets up a default read-only community of
-`notpublic`.
+`public` and a read-write community of `private`.
 
 ## Local testing
 

--- a/tools/snmpdv3/snmpd.conf
+++ b/tools/snmpdv3/snmpd.conf
@@ -1,13 +1,27 @@
-com2sec	notConfigUser	default		 notpublic
-group	notConfigGroup	v1		 notConfigUser
-group	notConfigGroup	v2c		 notConfigUser
-view	systemview	included	 .1.3.6.1.2.1.1
-view	systemview	included	 .1.3.6.1.2.1.25.1.1
-access	notConfigGroup ""      any	 noauth	   exact  systemview none none
+#        sec.name   source   community
+com2sec  read       default  public
+com2sec  readwrite  default  private
+
+#      groupName       securityModel  securityName
+group  readGroup       v1             read
+group  readGroup       v2c            read
+group  readwriteGroup  v1             readwrite
+group  readwriteGroup  v2c            readwrite
+group  readwriteGroup  usm            readwrite
+
+#     group       context   sec.model       sec.level  prefix  read  write  notif
+view  allview     included  .1
+view  publicview  included  .1.3.6.1.2.1.1
+
+#       group           context  sec.model  sec.level  prefix  read        write    notif
+access  readGroup       ""       any        noauth     exact   publicview  none     none
+access  readwriteGroup  ""       any        noauth     exact   allview     allview  none
 
 createUser myv3user SHA "my_authpass" AES "my_privpass"
-rouser myv3user
+rwuser myv3user
 
-syslocation Milliways
-syscontact NAV Developer <somebody@example.org>
+# Setting these here will make them read-only, unfortunately.
+# NAV/SeedDB needs them to be writeable to test for write-access
+#syslocation Milliways
+#syscontact NAV Developer <somebody@example.org>
 dontLogTCPWrappersConnects yes


### PR DESCRIPTION
This augments #2734 and closes #2727.

This includes reworking the snmpdv3 example container to allow for testing write operations.