### PR TITLE
Fix broken navoidverify on Linux

### DIFF
--- a/bin/navoidverify
+++ b/bin/navoidverify
@@ -22,6 +22,7 @@ NAV-monitored devices.
 
 from __future__ import print_function
 
+import platform
 import sys
 from itertools import cycle
 from argparse import ArgumentParser
@@ -29,6 +30,11 @@ from argparse import ArgumentParser
 from nav.bootstrap import bootstrap_django
 
 bootstrap_django(__file__)
+
+if platform.system() == "Linux":
+    from nav.ipdevpoll.epollreactor2 import install
+
+    install()
 
 from nav.ipdevpoll.snmp.common import snmp_parameter_factory, SnmpError
 from nav.models.manage import Netbox, ManagementProfile


### PR DESCRIPTION
While working on SNMPv3 implementation for the async/ipdevpoll parts of NAV, I incidentally found the `navoidverify` command to be broken before I started.

For the same reasons as documented in `nav.ipdevpoll.epollreactor2`, `navoidverify` seems to have stopped working (at least on Linux), due to incompatibilites between the default epollreactor implementation and pynetsnmp.

This change installs NAV's epollreactor2 in Twisted before any of the twisted imports run and install the default reactor.  ipdevpoll does the same, but since this is an all-in-one script, this mucks about with code in between imports to ensure it runs before twisted, while a multi-module system like ipdevpoll can simply do it before calling the `main()` function.


### Reference

https://github.com/Uninett/nav/blob/ea4f3c5091423186b78d97a849b713424ffd9827/python/nav/ipdevpoll/epollreactor2.py#L34-L53