### PR TITLE
Add initial SNMPv3 support to ipdevpoll

### DIFF
--- a/python/nav/ipdevpoll/__init__.py
+++ b/python/nav/ipdevpoll/__init__.py
@@ -77,7 +77,7 @@ class Plugin(object):
         """
         snmp_up = getattr(netbox, 'snmp_up', True)
 
-        basic_req = netbox.is_up() and snmp_up and bool(netbox.read_only)
+        basic_req = netbox.is_up() and snmp_up and bool(netbox.snmp_parameters)
         vendor_check = cls._verify_vendor_restriction(netbox)
         return basic_req and vendor_check
 

--- a/python/nav/ipdevpoll/dataloader.py
+++ b/python/nav/ipdevpoll/dataloader.py
@@ -176,12 +176,11 @@ def is_netbox_changed(netbox1, netbox2):
     for attr in (
         'ip',
         'type',
-        'read_only',
-        'snmp_version',
         'up',
         'snmp_up',
         'deleted_at',
     ):
+        # TODO Need some way to detect an updated SNMP profile
         if getattr(netbox1, attr) != getattr(netbox2, attr):
             _logger.debug(
                 "%s.%s changed from %r to %r",

--- a/python/nav/ipdevpoll/dataloader.py
+++ b/python/nav/ipdevpoll/dataloader.py
@@ -178,9 +178,9 @@ def is_netbox_changed(netbox1, netbox2):
         'type',
         'up',
         'snmp_up',
+        'snmp_parameters',
         'deleted_at',
     ):
-        # TODO Need some way to detect an updated SNMP profile
         if getattr(netbox1, attr) != getattr(netbox2, attr):
             _logger.debug(
                 "%s.%s changed from %r to %r",

--- a/python/nav/ipdevpoll/plugins/snmpcheck.py
+++ b/python/nav/ipdevpoll/plugins/snmpcheck.py
@@ -14,7 +14,7 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """snmp check plugin"""
-
+from pynetsnmp.netsnmp import SnmpTimeoutError
 from twisted.internet import error, defer
 from twisted.internet.defer import returnValue
 
@@ -69,7 +69,7 @@ class SnmpCheck(Plugin):
         self._logger.debug("checking SNMP v%s availability", self.agent.snmpVersion)
         try:
             result = yield self.agent.walk(SYSTEM_OID)
-        except (defer.TimeoutError, error.TimeoutError):
+        except (defer.TimeoutError, error.TimeoutError, SnmpTimeoutError):
             self._logger.debug("SNMP v%s timed out", self.agent.snmpVersion)
             returnValue(False)
 

--- a/python/nav/ipdevpoll/plugins/snmpcheck.py
+++ b/python/nav/ipdevpoll/plugins/snmpcheck.py
@@ -66,11 +66,11 @@ class SnmpCheck(Plugin):
 
     @defer.inlineCallbacks
     def _do_check(self):
-        self._logger.debug("checking SNMP%s availability", self.agent.snmpVersion)
+        self._logger.debug("checking SNMP v%s availability", self.agent.snmpVersion)
         try:
             result = yield self.agent.walk(SYSTEM_OID)
         except (defer.TimeoutError, error.TimeoutError):
-            self._logger.debug("SNMP%s timed out", self.agent.snmpVersion)
+            self._logger.debug("SNMP v%s timed out", self.agent.snmpVersion)
             returnValue(False)
 
         self._logger.debug("SNMP response: %r", result)

--- a/python/nav/ipdevpoll/plugins/snmpcheck.py
+++ b/python/nav/ipdevpoll/plugins/snmpcheck.py
@@ -44,14 +44,16 @@ class SnmpCheck(Plugin):
 
     @classmethod
     def can_handle(cls, netbox):
-        return netbox.is_up() and bool(netbox.read_only)
+        return netbox.is_up() and bool(netbox.snmp_parameters)
 
     def __init__(self, *args, **kwargs):
         super(SnmpCheck, self).__init__(*args, **kwargs)
 
     @defer.inlineCallbacks
     def handle(self):
-        self._logger.debug("snmp version from db: %s", self.netbox.snmp_version)
+        self._logger.debug(
+            "snmp version from db: %s", self.netbox.snmp_parameters.version
+        )
         was_down = yield db.run_in_thread(self._currently_down)
         is_ok = yield self._do_check()
 

--- a/python/nav/ipdevpoll/shadows/netbox.py
+++ b/python/nav/ipdevpoll/shadows/netbox.py
@@ -14,9 +14,12 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """netbox related shadow classes"""
+from typing import Union
+
 from django.db.models import Q
 from django.db import transaction
 
+from nav.ipdevpoll.snmp.common import SNMPParameters
 from nav.models import manage
 from nav.ipdevpoll.storage import Shadow
 
@@ -29,13 +32,14 @@ class Netbox(Shadow):
     def __init__(self, *args, **kwargs):
         super(Netbox, self).__init__(*args, **kwargs)
         if args:
-            obj = args[0]
+            obj: Union[Netbox, manage.Netbox] = args[0]
             self.snmp_up = getattr(obj, 'snmp_up', not obj.is_snmp_down())
             self.last_updated = getattr(
                 obj, 'last_updated', self._translate_last_jobs(obj)
             )
-            self.read_only = getattr(obj, 'read_only')
-            self.snmp_version = getattr(obj, 'snmp_version')
+            self.snmp_parameters = getattr(obj, "snmp_parameters", {})
+            if not self.snmp_parameters:
+                self.snmp_parameters = SNMPParameters.factory(obj)
 
     @staticmethod
     def _translate_last_jobs(netbox):

--- a/python/nav/ipdevpoll/shadows/netbox.py
+++ b/python/nav/ipdevpoll/shadows/netbox.py
@@ -37,7 +37,7 @@ class Netbox(Shadow):
             self.last_updated = getattr(
                 obj, 'last_updated', self._translate_last_jobs(obj)
             )
-            self.snmp_parameters = getattr(obj, "snmp_parameters", {})
+            self.snmp_parameters = getattr(obj, "snmp_parameters", None)
             if not self.snmp_parameters:
                 self.snmp_parameters = SNMPParameters.factory(obj)
 

--- a/python/nav/ipdevpoll/shadows/netbox.py
+++ b/python/nav/ipdevpoll/shadows/netbox.py
@@ -62,13 +62,15 @@ class Netbox(Shadow):
         return self.up == manage.Netbox.UP_UP
 
     def copy(self, other):
+        """In addition to copying the 'official' attrs of another Netbox object,
+        this also copies 'computed'/'internal' attributes that are only part of the
+        Netbox shadow class definition.
+        """
         super(Netbox, self).copy(other)
         for attr in (
             "snmp_up",
             "last_updated",
-            "snmp_version",
-            "read_only",
-            "read_write",
+            "snmp_parameters",
         ):
             if hasattr(other, attr):
                 setattr(self, attr, getattr(other, attr))

--- a/python/nav/ipdevpoll/snmp/common.py
+++ b/python/nav/ipdevpoll/snmp/common.py
@@ -173,7 +173,9 @@ class SNMPParameters:
         return "2c" if self.version == 2 else str(self.version)
 
     @classmethod
-    def factory(cls, netbox: Optional[Netbox] = None, **kwargs):
+    def factory(
+        cls, netbox: Optional[Netbox] = None, **kwargs
+    ) -> Optional["SNMPParameters"]:
         """Creates and returns a set of SNMP parameters based on three sources, in
         reverse order of precedence:
 
@@ -184,6 +186,9 @@ class SNMPParameters:
         Beware that this method will synchronously fetch management profiles from the
         database using the Django ORM, and should not be called from async code
         unless deferred to a worker thread.
+
+        If the netbox argument is a Netbox without a configured SNMP profile, None will
+        be returned.
         """
         kwargs_out = {}
         if netbox:
@@ -194,6 +199,9 @@ class SNMPParameters:
                 kwargs_out.update(
                     {k: v for k, v in profile.configuration.items() if hasattr(cls, k)}
                 )
+            else:
+                _logger.debug("%r has no snmp profile", netbox)
+                return None
 
         kwargs_out.update(cls.get_params_from_ipdevpoll_config())
         kwargs_out.update(kwargs)

--- a/python/nav/ipdevpoll/snmp/common.py
+++ b/python/nav/ipdevpoll/snmp/common.py
@@ -18,6 +18,7 @@ import time
 import logging
 from dataclasses import dataclass
 from functools import wraps
+from typing import Union, Literal, Optional, Any
 
 from twisted.internet import reactor
 from twisted.internet.defer import succeed
@@ -136,11 +137,36 @@ class AgentProxyMixIn(object):
 
 @dataclass
 class SNMPParameters:
-    """SNMP session parameters and configuration"""
+    """SNMP session parameters common to all SNMP protocol versions"""
 
-    timeout: int = 1.5
+    # Common for all SNMP sessions
+    version: Union[Literal[1], Literal[2], Literal[3]] = 1
+    timeout: float = 1.5
+    tries: int = 3
+
+    # Common for v1 and v2 only
+    community: str = "public"
+
+    # Common for v2c +
     max_repetitions: int = 50
+
+    # SNMPv3 only
+    sec_level: Optional[
+        Union[Literal["noAuthNoPriv"], Literal["authNoPriv"], Literal["authPriv"]]
+    ] = None
+    auth_protocol: str = None
+    sec_name: str = None
+    auth_password: Optional[str] = None
+    priv_protocol: Optional[str] = None
+    priv_password: Optional[str] = None
+
+    # Specific to ipdevpoll-derived implementations
     throttle_delay: int = 0
+
+    @property
+    def version_string(self):
+        """Returns the SNMP protocol version as a command line compatible string"""
+        return "2c" if self.version == 2 else str(self.version)
 
 
 # pylint: disable=W0212

--- a/python/nav/ipdevpoll/snmp/common.py
+++ b/python/nav/ipdevpoll/snmp/common.py
@@ -97,7 +97,9 @@ class AgentProxyMixIn(object):
         self._last_request = 0
         self.throttle_delay = self.snmp_parameters.throttle_delay
 
-        super(AgentProxyMixIn, self).__init__(*args, **kwargs)
+        kwargs_out = self.snmp_parameters.as_agentproxy_args()
+        kwargs_out.update(kwargs)
+        super(AgentProxyMixIn, self).__init__(*args, **kwargs_out)
         # If we're mixed in with a pure twistedsnmp AgentProxy, the timeout
         # parameter will have no effect, since it is an argument to individual
         # method calls.

--- a/python/nav/ipdevpoll/snmp/common.py
+++ b/python/nav/ipdevpoll/snmp/common.py
@@ -216,6 +216,33 @@ class SNMPParameters:
 
         return params
 
+    def as_agentproxy_args(self) -> dict[str, Any]:
+        """Returns the SNMP session parameters in a dict format compatible with
+        pynetsnmp.twistedsnmp.AgentProxy() keyword arguments.
+        """
+        kwargs = {"snmpVersion": self.version_string}
+        if self.version in (1, 2):
+            kwargs["community"] = self.community
+        if self.timeout:
+            kwargs["timeout"] = self.timeout
+        if self.tries:
+            kwargs["tries"] = self.tries
+
+        if self.version == 3:
+            params = []
+            params.extend(["-l", self.sec_level, "-u", self.sec_name])
+            if self.auth_protocol:
+                params.extend(["-a", self.auth_protocol])
+            if self.auth_password:
+                params.extend(["-A", self.auth_password])
+            if self.priv_protocol:
+                params.extend(["-x", self.priv_protocol])
+            if self.priv_password:
+                params.extend(["-X", self.priv_password])
+            kwargs["cmdLineArgs"] = tuple(params)
+
+        return kwargs
+
 
 # pylint: disable=W0212
 def snmp_parameter_factory(host=None):

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -28,7 +28,7 @@ from itertools import count, groupby
 import logging
 import math
 import re
-from typing import Set
+from typing import Set, Optional
 
 import IPy
 from django.conf import settings
@@ -358,7 +358,9 @@ class Netbox(models.Model):
         if profiles:
             return profiles[0].configuration.get(variable)
 
-    def get_preferred_snmp_management_profile(self, writeable=None):
+    def get_preferred_snmp_management_profile(
+        self, writeable=None
+    ) -> Optional[ManagementProfile]:
         """
         Returns the snmp management profile with the highest available
         SNMP version.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,7 @@ crispy-forms-foundation>=0.7,<0.8
 # REST framework
 iso8601
 
-pynetsnmp-2>=0.1.8,<0.2.0
+pynetsnmp-2>=0.1.10
 
 # libsass for compiling scss files to css using distutils/setuptools
 libsass==0.15.1

--- a/tests/unittests/ipdevpoll/snmp/common_test.py
+++ b/tests/unittests/ipdevpoll/snmp/common_test.py
@@ -1,0 +1,55 @@
+import pytest
+
+from nav.ipdevpoll.snmp.common import SNMPParameters
+from nav.Snmp.defines import AuthenticationProtocol, PrivacyProtocol, SecurityLevel
+
+
+class TestSNMPParameters:
+    def test_when_instantiated_with_no_arguments_it_should_not_complain(self):
+        assert SNMPParameters()
+
+    def test_when_sec_level_is_given_as_string_it_should_be_convert_to_enum(self):
+        param = SNMPParameters(sec_level="authPriv")
+        assert param.sec_level == SecurityLevel.AUTH_PRIV
+
+    def test_when_auth_protocol_is_given_as_string_it_should_be_convert_to_enum(self):
+        param = SNMPParameters(auth_protocol="MD5")
+        assert param.auth_protocol == AuthenticationProtocol.MD5
+
+    def test_when_priv_protocol_is_given_as_string_it_should_be_convert_to_enum(self):
+        param = SNMPParameters(priv_protocol="AES")
+        assert param.priv_protocol == PrivacyProtocol.AES
+
+
+class TestSNMPParametersAsAgentProxyArgs:
+    def test_should_contain_cmdline_args(self, snmpv3_params):
+        kwargs = snmpv3_params.as_agentproxy_args()
+        assert "cmdLineArgs" in kwargs
+
+    def test_should_contain_version_argument(self, snmpv3_params):
+        kwargs = snmpv3_params.as_agentproxy_args()
+        assert kwargs.get("snmpVersion") == "3"
+
+    def test_should_contain_sec_level_cmdline_argument(self, snmpv3_params):
+        kwargs = snmpv3_params.as_agentproxy_args()
+        args = " ".join(kwargs["cmdLineArgs"])
+        assert "-l authPriv" in args
+
+    def test_should_contain_sec_name_cmdline_argument(self, snmpv3_params):
+        kwargs = snmpv3_params.as_agentproxy_args()
+        args = " ".join(kwargs["cmdLineArgs"])
+        assert "-u foobar" in args
+
+
+@pytest.fixture
+def snmpv3_params():
+    param = SNMPParameters(
+        version=3,
+        sec_level=SecurityLevel.AUTH_PRIV,
+        sec_name="foobar",
+        auth_protocol=AuthenticationProtocol.SHA,
+        auth_password="secret",
+        priv_protocol=PrivacyProtocol.AES,
+        priv_password="secret2",
+    )
+    yield param


### PR DESCRIPTION
This adds SNMPv3 support to ipdevpoll and the asynchronous SNMP libraries of NAV.

Summary:
- Individual SNMP attributes were still stored directly on Netbox objects ("shadow" objects, not Django models).  The pre-existing `SNMPParameters` namedtuple was changed into a dataclass with all necessary parameters for establishing SNMP v1/v2c/v3 communication, and each `Netbox` object now has an `snmp_parameters` attribute attached to it (unless it has no SNMP profile, that is).

- SNMPv3-related bugs were found and fixed in the `pynetsnmp-2` library during the development of this PR.  This PR updates NAV's required version of this library as a result.

- Additionally, SNMPv3 communication may lead to another type of timeout error being raised in unexpected places, so the `SnmpTimeoutError` from pynetsnmp needed to be handled in various places. Details are in the commit logs.

Closes #2736
Fixes #2522 as part of reworking how ipdevpoll accesses SNMP credentials.
