### PR TITLE
Remove unused function snmp_parameter_factory

### DIFF
--- a/bin/naventity
+++ b/bin/naventity
@@ -33,7 +33,7 @@ from nav.bootstrap import bootstrap_django
 bootstrap_django(__file__)
 
 from nav.util import is_valid_ip
-from nav.ipdevpoll.snmp.common import snmp_parameter_factory, SnmpError, SNMPParameters
+from nav.ipdevpoll.snmp.common import SnmpError, SNMPParameters
 from nav.ipdevpoll.snmp import AgentProxy, snmpprotocol
 from nav.mibs.entity_mib import EntityMib
 from nav.models.manage import Netbox

--- a/python/nav/ipdevpoll/snmp/common.py
+++ b/python/nav/ipdevpoll/snmp/common.py
@@ -264,16 +264,5 @@ class SNMPParameters:
         return kwargs
 
 
-# pylint: disable=W0212
-def snmp_parameter_factory(host=None):
-    """Returns specific SNMP parameters for `host`, or default values from
-    ipdevpoll's config if host specific values aren't available.
-
-    :returns: An SNMPParameters namedtuple.
-
-    """
-    return SNMPParameters.factory(netbox=host)
-
-
 class SnmpError(Exception):
     pass


### PR DESCRIPTION
This has been replaced by SNMPParameters.factory() and no callers are left.