### PR TITLE
Remove deprecated Netbox SNMP properties

### DIFF
--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -303,61 +303,6 @@ class Netbox(models.Model):
         for chassis in self.get_chassis().order_by('index'):
             return chassis.device
 
-    @property
-    def read_only(self):
-        """Returns the read-only SNMP community"""
-        warnings.warn(
-            "The Netbox.read_only attribute will be removed in a future release",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._get_snmp_config('community', writeable=False)
-
-    @property
-    def read_write(self):
-        """Returns the read-write SNMP community"""
-        warnings.warn(
-            "The Netbox.read_write attribute will be removed in a future release",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._get_snmp_config('community', writeable=True)
-
-    @property
-    def snmp_version(self):
-        """Returns the configured SNMP version as an integer"""
-        warnings.warn(
-            "The Netbox.snmp_version attribute will be removed in the next "
-            "feature release",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        value = self._get_snmp_config('version')
-        if value or value == 0:
-            if value == "2c":
-                return 2
-            return int(value)
-
-    def _get_snmp_config(self, variable='community', writeable=None):
-        """Returns SNMP profile configuration variables, preferring the profile
-        with the highest available SNMP version.
-        """
-        # TODO: This method can be removed when the SNMP properties above are removed
-        query = Q(protocol=ManagementProfile.PROTOCOL_SNMP)
-        if writeable:
-            query = query & Q(configuration__write=True)
-        elif writeable is not None:
-            query = query & (
-                Q(configuration__write=False) | ~Q(configuration__has_key='write')
-            )
-        profiles = sorted(
-            self.profiles.filter(query),
-            key=lambda p: str(p.configuration.get('version') or 0),
-            reverse=True,
-        )
-        if profiles:
-            return profiles[0].configuration.get(variable)
-
     def get_preferred_snmp_management_profile(
         self, writeable=None
     ) -> Optional[ManagementProfile]:

--- a/tests/integration/models/netbox_test.py
+++ b/tests/integration/models/netbox_test.py
@@ -9,31 +9,6 @@ from nav.models.manage import (
 )
 
 
-def test_get_snmp_config_should_pick_highest_available_snmp_version(
-    db,
-    localhost,
-    wanted_profile,
-    faulty_profile,
-    snmpv1_string_profile,
-    snmpv1_integer_profile,
-    null_profile,
-):
-    for profile in (
-        faulty_profile,
-        snmpv1_integer_profile,
-        wanted_profile,
-        snmpv1_string_profile,
-        null_profile,
-    ):
-        profile.save()
-        NetboxProfile(netbox=localhost, profile=profile).save()
-
-    assert (
-        localhost._get_snmp_config(variable="community")
-        == wanted_profile.configuration["community"]
-    )
-
-
 def test_netbox_should_be_annotated_with_chassis_serial(db, localhost):
     """Mainly, this verifies that regressions haven't rendered the raw SQL used to
     annotate netboxes with serial numbers incompatible with the current schema.
@@ -61,46 +36,3 @@ def test_netbox_mac_addresses_should_return_distinct_set_of_addresses(
     localhost.info_set.create(key="bridge_info", variable="base_address", value=mac)
 
     assert localhost.mac_addresses == set([mac])
-
-
-@pytest.fixture
-def wanted_profile():
-    return ManagementProfile(
-        protocol=ManagementProfile.PROTOCOL_SNMP,
-        name="wanted",
-        configuration={"version": "2c", "community": "42"},
-    )
-
-
-@pytest.fixture
-def faulty_profile():
-    return ManagementProfile(
-        protocol=ManagementProfile.PROTOCOL_SNMP, name="faulty", configuration={}
-    )
-
-
-@pytest.fixture
-def null_profile():
-    return ManagementProfile(
-        protocol=ManagementProfile.PROTOCOL_SNMP,
-        name="null",
-        configuration={"version": None},
-    )
-
-
-@pytest.fixture
-def snmpv1_string_profile():
-    return ManagementProfile(
-        protocol=ManagementProfile.PROTOCOL_SNMP,
-        name="onestring",
-        configuration={"version": "1", "community": "onestring"},
-    )
-
-
-@pytest.fixture
-def snmpv1_integer_profile():
-    return ManagementProfile(
-        protocol=ManagementProfile.PROTOCOL_SNMP,
-        name="oneinteger",
-        configuration={"version": 1, "community": "oneinteger"},
-    )


### PR DESCRIPTION
There is no code left referencing these deprecated properties, they can safely be removed now.