### PR TITLE
Fix SeedDB edit netbox regression

### DIFF
--- a/python/nav/web/seeddb/page/netbox/edit.py
+++ b/python/nav/web/seeddb/page/netbox/edit.py
@@ -56,20 +56,16 @@ def log_netbox_change(account, old, new):
 
     # Compare changes from old to new
     attribute_list = [
-        'read_only',
-        'read_write',
         'category',
         'ip',
         'room',
         'organization',
-        'snmp_version',
     ]
     LogEntry.compare_objects(
         account,
         old,
         new,
         attribute_list,
-        censored_attributes=['read_only', 'read_write'],
     )
 
 

--- a/tests/integration/seeddb_test.py
+++ b/tests/integration/seeddb_test.py
@@ -7,7 +7,7 @@ from mock import MagicMock
 
 from nav.models.manage import Netbox, Room
 from nav.models.profiles import Account, AlertProfile
-from nav.web.seeddb.page.netbox.edit import netbox_edit
+from nav.web.seeddb.page.netbox.edit import netbox_edit, log_netbox_change
 from nav.web.seeddb.utils.delete import dependencies
 
 import pytest
@@ -58,3 +58,14 @@ def test_dependencies_no_whitelist(netbox):
     deps = dependencies(qs, [])
     assert Netbox.objects.get(pk=netbox.pk)
     assert deps == {}
+
+
+def test_log_netbox_change_should_not_crash(admin_account, netbox):
+    """Regression test to ensure this function doesn't try to access removed or
+    invalid attributes on Netbox.
+    """
+    old = Netbox.objects.get(id=netbox.id)
+    new = netbox
+    new.category_id = "OTHER"
+
+    assert log_netbox_change(admin_account, old, new) is None

--- a/tests/integration/seeddb_test.py
+++ b/tests/integration/seeddb_test.py
@@ -6,7 +6,6 @@ from django.test.client import RequestFactory
 from mock import MagicMock
 
 from nav.models.manage import Netbox, Room
-from nav.models.profiles import Account, AlertProfile
 from nav.web.seeddb.page.netbox.edit import netbox_edit, log_netbox_change
 from nav.web.seeddb.utils.delete import dependencies
 


### PR DESCRIPTION
This fixes a regression that appeared once deprecated attributes were removed from the `Netbox` model in #2754 .  The regression causes SeedDB to crash when making changes to Netbox objects.

We had no tests in place to detect this issue, which also was not discovered by other linting tools, since the attribute accesses are dynamic.

This also adds a simple test to ensure the audit logging comparison doesn't crash.

(this regression was only on master, it never made it into a release)