### PR TITLE
Fix SNMP v1/v2c regression in async libraries

### DIFF
--- a/python/nav/ipdevpoll/snmp/common.py
+++ b/python/nav/ipdevpoll/snmp/common.py
@@ -209,6 +209,8 @@ class SNMPParameters:
                 kwargs_out.update(
                     {k: v for k, v in profile.configuration.items() if hasattr(cls, k)}
                 )
+                # Sometimes profiles store the version number as a string
+                kwargs_out["version"] = int(kwargs_out["version"])
             else:
                 _logger.debug("%r has no snmp profile", netbox)
                 return None


### PR DESCRIPTION
The `SNMPParameters` class expects its SNMP version attribute to be an integer.  However, some (or perhaps all) SNMPv1/v2c management profiles tend to store the version numbers as strings, for some reason.

The net result is that the `as_agentproxy_args()` method would fail to provide a `community` argument to SNMP v1/v2 sessions because it was unable to compare an integer version number to a string.  This would cause `ipdevpoll`/`navoidverify`/`naventity` to **always** use `public` as the SNMP community of all v1/v2c sessions.

Fortunately, this did not make it into a release.