### PR TITLE
Parse SNMP profile version numbers using existing `ManagementProfile.snmp_version` property

### DIFF
--- a/python/nav/ipdevpoll/snmp/common.py
+++ b/python/nav/ipdevpoll/snmp/common.py
@@ -204,13 +204,11 @@ class SNMPParameters:
         if netbox:
             profile = netbox.get_preferred_snmp_management_profile()
             if profile:
-                if profile.protocol == profile.PROTOCOL_SNMPV3:
-                    kwargs["version"] = 3
                 kwargs_out.update(
                     {k: v for k, v in profile.configuration.items() if hasattr(cls, k)}
                 )
-                # Sometimes profiles store the version number as a string
-                kwargs_out["version"] = int(kwargs_out["version"])
+                # Let profile object parse its own version to an int
+                kwargs_out["version"] = profile.snmp_version
             else:
                 _logger.debug("%r has no snmp profile", netbox)
                 return None

--- a/tests/unittests/ipdevpoll/snmp/common_test.py
+++ b/tests/unittests/ipdevpoll/snmp/common_test.py
@@ -45,29 +45,13 @@ class TestSNMPParametersAsAgentProxyArgs:
 
 
 class TestSNMPParametersFactory:
-    def test_snmp_profile_with_v2c_version_string_should_be_parsed_without_error(
-        self, snmpv2c_profile
+    @pytest.mark.parametrize("version_value", (2, "2", "2c"))
+    def test_snmp_v2_profile_should_be_parsed_without_error(
+        self, snmpv2c_profile, version_value
     ):
         mock_netbox = Mock()
         mock_netbox.get_preferred_snmp_management_profile.return_value = snmpv2c_profile
-        params = SNMPParameters.factory(mock_netbox)
-        assert params.version == 2
-
-    def test_snmp_profile_with_v2_version_string_should_be_parsed_without_error(
-        self, snmpv2c_profile
-    ):
-        mock_netbox = Mock()
-        mock_netbox.get_preferred_snmp_management_profile.return_value = snmpv2c_profile
-        snmpv2c_profile.configuration["version"] = "2"
-        params = SNMPParameters.factory(mock_netbox)
-        assert params.version == 2
-
-    def test_snmp_profile_with_v2_version_integer_should_be_parsed_without_error(
-        self, snmpv2c_profile
-    ):
-        mock_netbox = Mock()
-        mock_netbox.get_preferred_snmp_management_profile.return_value = snmpv2c_profile
-        snmpv2c_profile.configuration["version"] = 2
+        snmpv2c_profile.configuration["version"] = version_value
         params = SNMPParameters.factory(mock_netbox)
         assert params.version == 2
 


### PR DESCRIPTION
This fixes #2767 by moving the responsibility for "parsing" the snmp version value of a profile from the `SNMPParameters.factory()` method to the `ManagementProfile` object itself.

Regression tests included.