### PR TITLE
Constrain `ciscoconfparse` on Python 3.7

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 # We only need a few build tools and the requirements files, that is all
 !tools/**/*
 !requirements.txt
+!constraints.txt
 !tests/requirements.txt
 !doc/requirements.txt
 !requirements/**/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,10 +85,11 @@ COPY tools/docker/supervisord.conf /etc/supervisor/conf.d/nav.conf
 
 COPY requirements/ /requirements
 COPY requirements.txt /
+COPY constraints.txt /
 COPY tests/requirements.txt /test-requirements.txt
 COPY doc/requirements.txt /doc-requirements.txt
 # Since we used pip3 to install pip globally, pip should now be for Python 3
-RUN pip-compile --resolver=backtracking --output-file /requirements.txt.lock /requirements.txt /test-requirements.txt /doc-requirements.txt
+RUN pip-compile --resolver=backtracking --output-file /requirements.txt.lock -c /constraints.txt /requirements.txt /test-requirements.txt /doc-requirements.txt
 RUN pip install -r /requirements.txt.lock
 
 ARG CUSTOM_PIP=ipython

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,3 @@
+# ciscoconfparse 1.8 has a bug that prevents it from being imported on Python 3.7,
+# even though it claims compatibility with 3.7.
+ciscoconfparse<1.8.0 ; python_version < '3.8'

--- a/doc/howto/generic-install-from-source.rst
+++ b/doc/howto/generic-install-from-source.rst
@@ -39,9 +39,10 @@ the same server as NAV.
 The required Python modules can be installed either from your OS package
 manager, or from the Python Package Index (PyPI_) using the regular ``setup.py``
 method described below. The packages can also be installed from PyPI_ in a
-separate step, using the pip_ tool and the provided requirements files::
+separate step, using the pip_ tool and the provided requirements and constraints
+files::
 
-  pip install -r requirements.txt
+  pip install -r requirements.txt -c constraints.txt
 
 *However*, some of the required modules are C extensions that will require the
 presence of some C libraries to be correctly built (unless PyPI provides binary
@@ -74,7 +75,7 @@ Installing NAV
 
 To build and install NAV and all its Python dependencies::
 
-  pip install -r requirements.txt .
+  pip install -r requirements.txt -c constraints.txt .
 
 This will build and install NAV in the default system-wide directories for your
 system. If you wish to customize the install locations, please consult the

--- a/doc/howto/manual-install-on-debian.rst
+++ b/doc/howto/manual-install-on-debian.rst
@@ -39,7 +39,7 @@ available tags, and ``git checkout x.y.z`` to checkout version ``x.y.z``.
 To install NAV's Python requirements::
 
   apt-get install -y libpq-dev libjpeg-dev libz-dev libldap2-dev libsasl2-dev
-  pip install -r requirements.txt
+  pip install -r requirements.txt -c constraints.txt
 
 4. Install NAV itself
 =====================

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
 -r ../requirements/django32.txt
 -r ../requirements/base.txt
+-c ../constraints.txt
 sphinx-bootstrap-theme==0.8.1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -14,8 +14,5 @@ pytidylib==0.3.2
 selenium==3.141.0
 whisper>=0.9.9
 whitenoise==4.1.4
-# the next dep is here because newer versions of ciscoconfparse has broken dependencies
-# this can be removed once we move to napalm 4, which no longer depends on ciscoconfparse
-ciscoconfparse<1.6.51
 # Our version of selenium breaks down if it is allowed to pull in the newest version of urllib3
 urllib3<2.0

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ deps =
     -r requirements/base.txt
     -r requirements/optional.txt
     -r requirements/django{env:DJANGO_VER}.txt
+    -c constraints.txt
 
 setenv =
     LC_ALL=C.UTF-8


### PR DESCRIPTION
This adds a `constraints.txt` file where constraints on third party libraries can be specified.

The initial version of this file constrains `ciscoconfparse` specifically on Python versions less than 3.8 to be a version below the failing 1.8 version.

Documentation and build scripts are updated to include the new constraints file.

An existing "constraint" existed in the test environment requirements, because early `ciscoconfparse` releases in the 1.7 series did not declare dependencies (these versions were later yanked from PyPI).  This constraint is likely why our test suite never discovered this problem on Python 3.7.


Closes #2770 