### PR TITLE
Do not make portadmin readonly if poe error

### DIFF
--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -252,8 +252,10 @@ def populate_infodict(request, netbox, interfaces):
         XMLParseError,
         POEStateNotSupportedError,
     ) as error:
-        readonly = True
-        messages.error(request, str(error))
+        supports_poe = False
+        _logger.error(
+            'Error getting PoE information from netbox %s: %s', str(netbox), str(error)
+        )
 
     if handler and not handler.is_configurable():
         add_readonly_reason(request, handler)


### PR DESCRIPTION
Fixes #2773

stop poe error from making portadmin unusable, instead disable poe and log error