### PR TITLE
Ensure `AgentProxy.snmpVersion` is prefixed by `v`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This changelog format was introduced in NAV 5.4.0. Older changelogs can be
 found in the [HISTORY](HISTORY) file.
 
+## [Unreleased]
+
+### Fixed
+
+- Fix non-working SNMPv1 communication ([#2772](https://github.com/Uninett/nav/issues/2772), [#2779](https://github.com/Uninett/nav/issues/2779), [#2780](https://github.com/Uninett/nav/pull/2780))
+
 ## [5.8.2] - 2023-11-30
 
 ### Fixed

--- a/python/nav/ipdevpoll/snmp/common.py
+++ b/python/nav/ipdevpoll/snmp/common.py
@@ -240,7 +240,7 @@ class SNMPParameters:
         """Returns the SNMP session parameters in a dict format compatible with
         pynetsnmp.twistedsnmp.AgentProxy() keyword arguments.
         """
-        kwargs = {"snmpVersion": self.version_string}
+        kwargs = {"snmpVersion": f"v{self.version_string}"}
         if self.version in (1, 2):
             kwargs["community"] = self.community
         if self.timeout:

--- a/tests/unittests/ipdevpoll/snmp/common_test.py
+++ b/tests/unittests/ipdevpoll/snmp/common_test.py
@@ -31,7 +31,7 @@ class TestSNMPParametersAsAgentProxyArgs:
 
     def test_should_contain_version_argument(self, snmpv3_params):
         kwargs = snmpv3_params.as_agentproxy_args()
-        assert kwargs.get("snmpVersion") == "3"
+        assert kwargs.get("snmpVersion") == "v3"
 
     def test_should_contain_sec_level_cmdline_argument(self, snmpv3_params):
         kwargs = snmpv3_params.as_agentproxy_args()


### PR DESCRIPTION
If the `snmpVersion` argument to `AgentProxy` is not a version string prefixed by the letter `v`, `AgentProxy` will silently default to `v2c`.

Using `2c` as a value works, since it defaults then to `v2c`.  Using `3` also seems to work, as providing further SNMPv3 configuration arguments to the Net-SNMP library seems to automatically set the session version to `v3`, regardless of the version parameter.

However, using `1` will not work, as that will also silently default the session to `v2c`, making SNMPv1 communication impossible.

Fixes #2779 
Fixes #2772