### PR TITLE
Fix PoE config not showing up for Cisco if interface is missing POEPort

### DIFF
--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -352,7 +352,3 @@ class POEStateNotSupportedError(ManagementError):
 
 class XMLParseError(ManagementError):
     """Raised when failing to parse XML"""
-
-
-class POEIndexNotFoundError(ManagementError):
-    """Raised when a PoE index could not be found for an interface"""

--- a/python/nav/portadmin/snmp/cisco.py
+++ b/python/nav/portadmin/snmp/cisco.py
@@ -351,7 +351,7 @@ class Cisco(SNMPHandler):
         try:
             poeport = manage.POEPort.objects.get(interface=interface)
         except manage.POEPort.DoesNotExist:
-            raise POEIndexNotFoundError(
+            raise POENotSupportedError(
                 "This interface does not have PoE indexes defined"
             )
         unit_number = poeport.poegroup.index

--- a/python/nav/portadmin/snmp/cisco.py
+++ b/python/nav/portadmin/snmp/cisco.py
@@ -28,7 +28,6 @@ from nav.portadmin.handlers import (
     PoeState,
     POEStateNotSupportedError,
     POENotSupportedError,
-    POEIndexNotFoundError,
 )
 from nav.models import manage
 

--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -56,7 +56,6 @@ from nav.portadmin.handlers import (
     NoResponseError,
     ProtocolError,
     ManagementError,
-    POEIndexNotFoundError,
     XMLParseError,
     POEStateNotSupportedError,
 )
@@ -248,7 +247,6 @@ def populate_infodict(request, netbox, interfaces):
         messages.error(request, str(error))
 
     except (
-        POEIndexNotFoundError,
         XMLParseError,
         POEStateNotSupportedError,
     ) as error:

--- a/tests/unittests/portadmin/portadmin_poe_cisco_test.py
+++ b/tests/unittests/portadmin/portadmin_poe_cisco_test.py
@@ -28,12 +28,12 @@ class TestGetPoeState:
             handler_cisco.get_poe_states([interface])
 
     @pytest.mark.usefixtures('poeport_get_mock_error')
-    def test_should_raise_exception_if_interface_is_missing_poeport(
+    def test_dict_should_give_none_if_interface_does_not_have_poeport(
         self, handler_cisco
     ):
         interface = Mock(interface="interface")
-        with pytest.raises(POEIndexNotFoundError):
-            handler_cisco.get_poe_states([interface])
+        states = handler_cisco.get_poe_states([interface])
+        assert states[interface.ifname] is None
 
     @pytest.mark.usefixtures('poeport_get_mock')
     def test_dict_should_give_none_if_interface_does_not_support_poe(

--- a/tests/unittests/portadmin/portadmin_poe_cisco_test.py
+++ b/tests/unittests/portadmin/portadmin_poe_cisco_test.py
@@ -3,10 +3,7 @@ from mock import Mock, patch
 import pytest
 
 from nav.portadmin.snmp.cisco import Cisco
-from nav.portadmin.handlers import (
-    POEIndexNotFoundError,
-    POEStateNotSupportedError,
-)
+from nav.portadmin.handlers import POEStateNotSupportedError
 from nav.models import manage
 
 

--- a/tests/unittests/portadmin/portadmin_poe_cisco_test.py
+++ b/tests/unittests/portadmin/portadmin_poe_cisco_test.py
@@ -23,7 +23,7 @@ class TestGetPoeState:
     @pytest.mark.usefixtures('poeport_get_mock')
     def test_should_raise_exception_if_unknown_poe_state(self, handler_cisco):
         handler_cisco._query_netbox = Mock(return_value=76)
-        interface = Mock(interface="interface")
+        interface = Mock(ifname="interface")
         with pytest.raises(POEStateNotSupportedError):
             handler_cisco.get_poe_states([interface])
 
@@ -31,7 +31,7 @@ class TestGetPoeState:
     def test_dict_should_give_none_if_interface_does_not_have_poeport(
         self, handler_cisco
     ):
-        interface = Mock(interface="interface")
+        interface = Mock(ifname="interface")
         states = handler_cisco.get_poe_states([interface])
         assert states[interface.ifname] is None
 
@@ -40,7 +40,7 @@ class TestGetPoeState:
         self, handler_cisco
     ):
         handler_cisco._query_netbox = Mock(return_value=None)
-        interface = Mock(interface="interface")
+        interface = Mock(ifname="interface")
         states = handler_cisco.get_poe_states([interface])
         assert states[interface.ifname] is None
 


### PR DESCRIPTION
During navref, UIA mentioned that the new PoE Status column did not show up for their Cisco equipment.

Turns out this is because `get_poe_states`  fails if even a single interface does not have a related POEPort object.

This was originally intended functionality, even the cisco PoE tests reflects this behaviour. But I realize that a device not having a relation to a POEPort device simply means it does not support PoE, and in that case it should not crash the entire function. It should instead set the state for that interface to `None` as specified in the docstring for `get_poe_states` 

This PR fixes this and updates tests accordingly. It also updates `set_poe_state` to behave similarly when it comes to missing PoE indexes

Also fixes a small issue with tests where the property for certain mock objects were named incorrectly.