### PR TITLE
Fix save button moving for ports without PoE support

### DIFF
--- a/python/nav/web/templates/portadmin/portlist.html
+++ b/python/nav/web/templates/portadmin/portlist.html
@@ -177,7 +177,6 @@
                   <option value="{{ poe_option.name }}" label="{{ poe_option.name }}"
                           {% if interface.poe_state.name == poe_option.name %}selected="selected"
                           data-orig="{{ poe_option.name }}"{% endif %}>
-                    {{ vlan }}
                 {% endfor %}
               </select>
             </form>

--- a/python/nav/web/templates/portadmin/portlist.html
+++ b/python/nav/web/templates/portadmin/portlist.html
@@ -169,20 +169,20 @@
 
       {# POE STATE #}
       {% if supports_poe %}
-        {% if interface.supports_poe %}
         <div class="medium-1 small-4 column">
-          <form class="custom">
-            <select class="poelist" name="{{ interface.ifname }}">
-              {% for poe_option in poe_options %}
+          {% if interface.supports_poe %}
+            <form class="custom">
+              <select class="poelist" name="{{ interface.ifname }}">
+                {% for poe_option in poe_options %}
                   <option value="{{ poe_option.name }}" label="{{ poe_option.name }}"
                           {% if interface.poe_state.name == poe_option.name %}selected="selected"
                           data-orig="{{ poe_option.name }}"{% endif %}>
                     {{ vlan }}
-              {% endfor %}
-            </select>
-          </form>
+                {% endfor %}
+              </select>
+            </form>
+          {% endif %}
         </div>
-        {% endif %}
       {% endif %}
 
       {# Button for saving #}


### PR DESCRIPTION
Fixes problem that occurs if some ports support PoE and some dont. The lines that do not suppot PoE will not have a dropdown, so the space will not be occupied by anything. This causes the save button to move to the left, as seen below.

![image](https://github.com/Uninett/nav/assets/31960753/0d1b7b9c-2de4-413d-9c19-5fe8badbce30)

This PR makes it so the space is always occupied if the PoE column is active.

Also remove random vlan tag that shouldnt be there