### PR TITLE
Initialize variables that are potentially referenced before assignment in maintenance `edit()` view

### DIFF
--- a/python/nav/web/maintenance/views.py
+++ b/python/nav/web/maintenance/views.py
@@ -252,9 +252,7 @@ def cancel(request, task_id):
 def edit(request, task_id=None, start_time=None, **_):
     account = get_account(request)
     quickselect = QuickSelect(service=True)
-    component_trail = None
-    component_keys = None
-    task = None
+    component_trail = component_keys_errors = component_data = task = None
 
     if task_id:
         task = get_object_or_404(MaintenanceTask, pk=task_id)


### PR DESCRIPTION
Due to the convoluted logic of the edit() function, multiple variables may be referenced before proper assignment unless they are given a value of `None` first.

Unfortunately, at least two such variables were potentially referenced without being initialized first.

This ensures all variables that may remain "unassigned" are initialized to `None` at the start of the function.

Fixes #2783 