### PR TITLE
Always allow admins to edit any interface in PortAdmin

### DIFF
--- a/tests/unittests/web/portadmin/utils_test.py
+++ b/tests/unittests/web/portadmin/utils_test.py
@@ -1,0 +1,39 @@
+from unittest.mock import patch, Mock
+
+from nav.web.portadmin.utils import set_editable_flag_on_interfaces
+
+
+class TestSetEditableFlagOnInterfaces:
+    def test_when_user_is_admin_it_should_set_all_interfaces_to_editable(self):
+        with patch(
+            "nav.web.portadmin.utils.should_check_access_rights", return_value=False
+        ):
+            mock_admin = Mock()
+            mock_interfaces = [Mock(iseditable=False)] * 3
+            set_editable_flag_on_interfaces(mock_interfaces, [], mock_admin)
+
+            assert all(ifc.iseditable for ifc in mock_interfaces)
+
+    def test_when_user_is_not_admin_it_should_set_only_matching_interfaces_to_editable(
+        self,
+    ):
+        with patch(
+            "nav.web.portadmin.utils.should_check_access_rights", return_value=True
+        ):
+            mock_user = Mock()
+            mock_vlans = [Mock(vlan=42), Mock(vlan=69), Mock(vlan=666)]
+            editable_interface = Mock(vlan=666, iseditable=False)
+            mock_interfaces = [
+                Mock(vlan=99, iseditable=False),
+                editable_interface,
+                Mock(vlan=27, iseditable=False),
+            ]
+
+            set_editable_flag_on_interfaces(mock_interfaces, mock_vlans, mock_user)
+
+            assert editable_interface.iseditable
+            assert all(
+                not ifc.iseditable
+                for ifc in mock_interfaces
+                if ifc is not editable_interface
+            )


### PR DESCRIPTION
This changes the authorization logic for editing interface in PortAdmin.  Originally, an interface is only considered "editable" if its native VLAN value is one of the VLANs the logged-in user is allowed to edit.  For an admin, this list of VLANs consists of all the VLANs that PortAdmin found to be configured on a switch.  However, if a port is configured with an invalid native VLAN value, or, as is supported on platforms like JunOS, no default VLAN value is set at all, PortAdmin was unable to determine that such a port was editable at all.

This change ensures the VLAN verification is outright skipped if the user has admin privileges in NAV.  All interfaces will be marked as editable.


Fixes #2477 