### PR TITLE
Upgrade psycopg2 to 2.9.9

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@
 # Dockerfile
 
 asciitree==0.3.3  # optional, for naventity
-psycopg2==2.8.4  # requires libpq to build
+psycopg2==2.9.9  # requires libpq to build
 IPy==1.01
 pyaml
 


### PR DESCRIPTION
Because 2.8.4 will not build on Python 3.11.


Closes #2793
