### PR TITLE
Upgrade Twisted to a version compatible with both Python 3.7 and 3.11

### DIFF
--- a/python/nav/ipdevpoll/pool.py
+++ b/python/nav/ipdevpoll/pool.py
@@ -158,11 +158,25 @@ class ProcessAMP(amp.AMP):
         self.lost_handler = None
 
     def makeConnection(self, transport):
-        """Called when a connection has been made to the AMP endpoint"""
-        if not hasattr(transport, 'getPeer'):
+        """Overrides the base implementation to fake the required getPeer() and
+        getHost() methods on the incoming process transport object, if needed ( the
+        base AMP class was not really designed with process pipe transports in mind,
+        but with IP transports).
+
+        Process transports in Twisted<21 did not implement these methods at all,
+        while in Twisted>=21 they resolve to base methods that raise
+        `NotImplementError`.
+        """
+        try:
+            transport.getPeer()
+        except (AttributeError, NotImplementedError):
             setattr(transport, 'getPeer', lambda: "peer")
-        if not hasattr(transport, 'getHost'):
+
+        try:
+            transport.getHost()
+        except (AttributeError, NotImplementedError):
             setattr(transport, 'getHost', lambda: "host")
+
         super(ProcessAMP, self).makeConnection(transport)
 
     def connectionLost(self, reason):

--- a/python/nav/mibs/mibretriever.py
+++ b/python/nav/mibs/mibretriever.py
@@ -37,6 +37,7 @@ from pynetsnmp.netsnmp import SnmpTimeoutError
 from twisted.internet import defer, reactor
 from twisted.internet.defer import returnValue
 from twisted.internet.error import TimeoutError
+from twisted.python.failure import Failure
 
 from nav.Snmp import safestring
 from nav.ipdevpoll import ContextLogger
@@ -428,7 +429,7 @@ class MibRetriever(object, metaclass=MibRetrieverMaker):
 
             return formatted_result
 
-        def _snmp_timeout_handler(failure: defer.failure.Failure):
+        def _snmp_timeout_handler(failure: Failure):
             """Transforms SnmpTimeoutErrors into "regular" TimeoutErrors"""
             failure.trap(SnmpTimeoutError)
             raise TimeoutError(failure.value)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,8 +6,7 @@ psycopg2==2.9.9  # requires libpq to build
 IPy==1.01
 pyaml
 
-twisted>=20.0.0,<21
-
+twisted~=23.8.0  # last version that still supports Python 3.7
 
 networkx==2.6.3
 Pillow>3.3.2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,7 +9,7 @@ pytest-metadata<2.0.0
 pytest-cov==2.7.1
 pytest-selenium==2.0.1
 pytest-timeout
-pytest-twisted~=1.14.0
+pytest-twisted~=1.13.0
 pytidylib==0.3.2
 selenium==3.141.0
 whisper>=0.9.9

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,7 +9,7 @@ pytest-metadata<2.0.0
 pytest-cov==2.7.1
 pytest-selenium==2.0.1
 pytest-timeout
-pytest-twisted==1.12
+pytest-twisted~=1.14.0
 pytidylib==0.3.2
 selenium==3.141.0
 whisper>=0.9.9


### PR DESCRIPTION
Because Twisted 20 won't build for Python 3.11.

Closes #2792 