### PR TITLE
Test pkg_resource usage

### DIFF
--- a/python/nav/pgsync.py
+++ b/python/nav/pgsync.py
@@ -281,13 +281,16 @@ class Synchronizer(object):
         (None, 'indexes.sql'),
     ]
 
-    def __init__(self, resource_module, apply_out_of_order_changes=False):
+    def __init__(self, resource_module, apply_out_of_order_changes=False, config=None):
         self.resource_module = resource_module
         self.connection = None
         self.cursor = None
-        self.connect_options = ConnectionParameters.from_config()
         self.apply_out_of_order_changes = apply_out_of_order_changes
         self.finder = ChangeScriptFinder(self.resource_module)
+        if config:
+            self.connect_options = config
+        else:
+            self.connect_options = ConnectionParameters.from_config()
 
     def connect(self):
         """Connects the synchronizer to the NAV configured database."""
@@ -532,7 +535,7 @@ class Synchronizer(object):
         Terminates the process if there are errors.
 
         """
-        sql = resource_string(self.resource_module, filename)
+        sql = self._read_sql_file(filename)
         print_color("%-20s " % (filename + ":"), COLOR_CYAN, newline=False)
         try:
             self.cursor.execute(sql)
@@ -541,6 +544,9 @@ class Synchronizer(object):
             sys.exit(2)
         else:
             print_color("OK", COLOR_GREEN)
+
+    def _read_sql_file(self, filename):
+        return resource_string(self.resource_module, filename)
 
 
 class ChangeScriptFinder(list):

--- a/tests/unittests/buildconf_test.py
+++ b/tests/unittests/buildconf_test.py
@@ -1,0 +1,9 @@
+from unittest import TestCase
+
+
+class TestBuildconf(TestCase):
+    def test_VERSION_can_be_imported(self):
+        try:
+            from nav.buildconf import VERSION
+        except ImportError:
+            self.fail('VERSION could not be imported')

--- a/tests/unittests/config_test.py
+++ b/tests/unittests/config_test.py
@@ -1,0 +1,16 @@
+from nav.config import _config_resource_walk
+
+
+from unittest import TestCase
+
+
+class TestConfigResourceWalk(TestCase):
+    def test_should_read_relative_paths_as_strings_from_nav_package_and_return_a_long_list_of_strings(
+        self,
+    ):
+        # result should be many, many relative paths as strings
+        result = tuple(_config_resource_walk())  # generator
+        self.assertTrue(len(result) > 20)
+        for relpath in result:
+            self.assertIsInstance(relpath, str)
+            self.assertFalse(relpath.startswith('/'))

--- a/tests/unittests/pgsync_test.py
+++ b/tests/unittests/pgsync_test.py
@@ -1,0 +1,15 @@
+from nav.pgsync import ChangeScriptFinder
+
+
+from unittest import TestCase
+
+
+class TestChangeScriptFinder(TestCase):
+    def test_init_should_read_sql_filenames_from_package_and_return_list_of_relative_filenames(
+        self,
+    ):
+        csf = ChangeScriptFinder('nav.models')
+        self.assertTrue(len(csf) > 40)
+        for sql_filename in csf:
+            self.assertTrue(sql_filename.startswith('sql/'))
+            self.assertTrue(sql_filename.endswith('.sql'))

--- a/tests/unittests/pgsync_test.py
+++ b/tests/unittests/pgsync_test.py
@@ -1,4 +1,4 @@
-from nav.pgsync import ChangeScriptFinder
+from nav.pgsync import ChangeScriptFinder, Synchronizer
 
 
 from unittest import TestCase
@@ -13,3 +13,11 @@ class TestChangeScriptFinder(TestCase):
         for sql_filename in csf:
             self.assertTrue(sql_filename.startswith('sql/'))
             self.assertTrue(sql_filename.endswith('.sql'))
+
+
+class TestSynchronizer(TestCase):
+    def test_should_read_sql_file_from_package_and_return_bytes(self):
+        syncer = Synchronizer('nav.models', config=True)
+        filename = "sql/baseline/manage.sql"
+        sql = syncer._read_sql_file(filename)
+        self.assertIn("CREATE TABLE org", str(sql))


### PR DESCRIPTION
Ensure that the stuff that uses pkg_resource is tested, so that we can know it all still works after replacing pkg_resources with importlib.

Preparation for #2791.