### PR TITLE
Cycle session ID on login

### DIFF
--- a/python/nav/web/auth/remote_user.py
+++ b/python/nav/web/auth/remote_user.py
@@ -22,7 +22,7 @@ from os.path import join
 from nav.auditlog.models import LogEntry
 from nav.config import NAVConfigParser
 from nav.models.profiles import Account
-from nav.web.auth.utils import ACCOUNT_ID_VAR
+from nav.web.auth.utils import _set_account
 
 try:
     # Python 3.6+
@@ -122,8 +122,7 @@ def login(request):
         # Get or create an account from the REMOTE_USER http header
         account = authenticate(request)
         if account:
-            request.session[ACCOUNT_ID_VAR] = account.id
-            request.account = account
+            _set_account(request, account)
             return account
     return None
 

--- a/python/nav/web/auth/remote_user.py
+++ b/python/nav/web/auth/remote_user.py
@@ -22,7 +22,7 @@ from os.path import join
 from nav.auditlog.models import LogEntry
 from nav.config import NAVConfigParser
 from nav.models.profiles import Account
-from nav.web.auth.utils import _set_account
+from nav.web.auth.utils import set_account
 
 try:
     # Python 3.6+
@@ -122,7 +122,7 @@ def login(request):
         # Get or create an account from the REMOTE_USER http header
         account = authenticate(request)
         if account:
-            _set_account(request, account)
+            set_account(request, account)
             return account
     return None
 

--- a/python/nav/web/auth/sudo.py
+++ b/python/nav/web/auth/sudo.py
@@ -22,7 +22,7 @@ import logging
 from nav.auditlog.models import LogEntry
 from nav.django.utils import is_admin, get_account
 from nav.models.profiles import Account
-from nav.web.auth.utils import _set_account, ACCOUNT_ID_VAR
+from nav.web.auth.utils import set_account, ACCOUNT_ID_VAR
 
 
 _logger = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ def sudo(request, other_user):
         raise SudoNotAdminError()
     original_user = request.account
     request.session[SUDOER_ID_VAR] = original_user.id
-    _set_account(request, other_user)
+    set_account(request, other_user)
     _logger.info('Sudo: "%s" acting as "%s"', original_user, other_user)
     _logger.debug(
         'Sudo: (session: %s, account: %s)', dict(request.session), request.account
@@ -70,7 +70,7 @@ def desudo(request):
 
     del request.session[ACCOUNT_ID_VAR]
     del request.session[SUDOER_ID_VAR]
-    _set_account(request, original_user)
+    set_account(request, original_user)
     _logger.info(
         'DeSudo: "%s" no longer acting as "%s"', original_user, request.account
     )

--- a/python/nav/web/auth/utils.py
+++ b/python/nav/web/auth/utils.py
@@ -31,7 +31,7 @@ _logger = logging.getLogger(__name__)
 ACCOUNT_ID_VAR = 'account_id'
 
 
-def _set_account(request, account):
+def set_account(request, account):
     """Updates request with new account.
     Cycles the session ID to avoid session fixation.
     """
@@ -56,7 +56,7 @@ def ensure_account(request):
         # Assumes nobody has locked it..
         account = Account.objects.get(id=Account.DEFAULT_ACCOUNT)
 
-    _set_account(request, account)
+    set_account(request, account)
 
 
 def authorization_not_required(fullpath):

--- a/python/nav/web/auth/utils.py
+++ b/python/nav/web/auth/utils.py
@@ -32,9 +32,13 @@ ACCOUNT_ID_VAR = 'account_id'
 
 
 def _set_account(request, account):
+    """Updates request with new account.
+    Cycles the session ID to avoid session fixation.
+    """
     request.session[ACCOUNT_ID_VAR] = account.id
     request.account = account
     _logger.debug('Set active account to "%s"', account.login)
+    request.session.cycle_key()
     request.session.save()
 
 

--- a/python/nav/web/auth/utils.py
+++ b/python/nav/web/auth/utils.py
@@ -31,14 +31,15 @@ _logger = logging.getLogger(__name__)
 ACCOUNT_ID_VAR = 'account_id'
 
 
-def set_account(request, account):
+def set_account(request, account, cycle_session_id=True):
     """Updates request with new account.
-    Cycles the session ID to avoid session fixation.
+    Cycles the session ID by default to avoid session fixation.
     """
     request.session[ACCOUNT_ID_VAR] = account.id
     request.account = account
     _logger.debug('Set active account to "%s"', account.login)
-    request.session.cycle_key()
+    if cycle_session_id:
+        request.session.cycle_key()
     request.session.save()
 
 
@@ -56,7 +57,8 @@ def ensure_account(request):
         # Assumes nobody has locked it..
         account = Account.objects.get(id=Account.DEFAULT_ACCOUNT)
 
-    set_account(request, account)
+    # Do not cycle to avoid session_id being changed on every request
+    set_account(request, account, cycle_session_id=False)
 
 
 def authorization_not_required(fullpath):

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -37,10 +37,10 @@ from django.utils.http import urlquote
 from nav.auditlog.models import LogEntry
 from nav.django.utils import get_account
 from nav.models.profiles import NavbarLink, AccountDashboard, AccountNavlet
-from nav.web.auth.utils import ACCOUNT_ID_VAR
 from nav.web.auth import logout as auth_logout
 from nav.web import auth
 from nav.web.auth import ldap
+from nav.web.auth.utils import _set_account
 from nav.web.utils import require_param
 from nav.web.webfront.utils import quick_read, tool_list
 from nav.web.webfront.forms import (
@@ -230,8 +230,7 @@ def do_login(request):
                 LogEntry.add_log_entry(
                     account, 'log-in', '{actor} logged in', before=account
                 )
-                request.session[ACCOUNT_ID_VAR] = account.id
-                request.account = account
+                _set_account(request, account)
                 _logger.info("%s successfully logged in", account.login)
                 if not origin:
                     origin = reverse('webfront-index')

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -40,7 +40,7 @@ from nav.models.profiles import NavbarLink, AccountDashboard, AccountNavlet
 from nav.web.auth import logout as auth_logout
 from nav.web import auth
 from nav.web.auth import ldap
-from nav.web.auth.utils import _set_account
+from nav.web.auth.utils import set_account
 from nav.web.utils import require_param
 from nav.web.webfront.utils import quick_read, tool_list
 from nav.web.webfront.forms import (
@@ -230,7 +230,7 @@ def do_login(request):
                 LogEntry.add_log_entry(
                     account, 'log-in', '{actor} logged in', before=account
                 )
-                _set_account(request, account)
+                set_account(request, account)
                 _logger.info("%s successfully logged in", account.login)
                 if not origin:
                     origin = reverse('webfront-index')

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -217,7 +217,7 @@ def localhost_using_legacy_db():
     conn.commit()
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='function')
 def client(admin_username, admin_password):
     """Provides a Django test Client object already logged in to the web UI as
     an admin"""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -218,16 +218,14 @@ def localhost_using_legacy_db():
 
 
 @pytest.fixture(scope='session')
-def client():
+def client(admin_username, admin_password):
     """Provides a Django test Client object already logged in to the web UI as
     an admin"""
     from django.urls import reverse
 
     client_ = Client()
     url = reverse('webfront-login')
-    username = os.environ.get('ADMINUSERNAME', 'admin')
-    password = os.environ.get('ADMINPASSWORD', 'admin')
-    client_.post(url, {'username': username, 'password': password})
+    client_.post(url, {'username': admin_username, 'password': admin_password})
     return client_
 
 
@@ -373,3 +371,13 @@ def admin_account(db):
     from nav.models.profiles import Account
 
     yield Account.objects.get(id=Account.ADMIN_ACCOUNT)
+
+
+@pytest.fixture(scope='session')
+def admin_username():
+    return os.environ.get('ADMINUSERNAME', 'admin')
+
+
+@pytest.fixture(scope='session')
+def admin_password():
+    return os.environ.get('ADMINPASSWORD', 'admin')

--- a/tests/integration/web/auth/conftest.py
+++ b/tests/integration/web/auth/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+from django.test import RequestFactory
+from django.contrib.sessions.middleware import SessionMiddleware
+
+
+@pytest.fixture()
+def session_request(db):
+    """Request object with a real session"""
+    r = RequestFactory()
+    session_request = r.post('/anyurl')
+
+    # use middleware to make session for session_request
+    middleware = SessionMiddleware()
+    middleware.process_request(session_request)
+    session_request.session.save()
+    return session_request

--- a/tests/integration/web/auth/middleware_test.py
+++ b/tests/integration/web/auth/middleware_test.py
@@ -5,7 +5,7 @@ from nav.web.auth.middleware import AuthenticationMiddleware
 from nav.models.profiles import Account
 
 
-def test_remote_user_being_logged_in_should_change_session_id(
+def test_when_remote_user_logs_in_it_should_change_the_session_id(
     db, session_request, remote_account
 ):
     pre_login_session_id = session_request.session.session_key

--- a/tests/integration/web/auth/middleware_test.py
+++ b/tests/integration/web/auth/middleware_test.py
@@ -1,0 +1,28 @@
+import pytest
+from mock import patch
+
+from nav.web.auth.middleware import AuthenticationMiddleware
+from nav.models.profiles import Account
+
+
+def test_remote_user_being_logged_in_should_change_session_id(
+    db, session_request, remote_account
+):
+    pre_login_session_id = session_request.session.session_key
+    with patch(
+        'nav.web.auth.remote_user.get_username', return_value=remote_account.login
+    ):
+        middleware = AuthenticationMiddleware()
+        middleware.process_request(session_request)
+    assert session_request.account == remote_account
+    post_login_session_id = session_request.session.session_key
+    assert pre_login_session_id != post_login_session_id
+
+
+@pytest.fixture()
+def remote_account(db):
+    account = Account(login="remote")
+    account.set_password("supersecret")
+    account.save()
+    yield account
+    account.delete()

--- a/tests/integration/web/auth/sudo_test.py
+++ b/tests/integration/web/auth/sudo_test.py
@@ -1,0 +1,57 @@
+import pytest
+
+from django.test import RequestFactory
+from django.contrib.sessions.middleware import SessionMiddleware
+
+from nav.web.auth.utils import set_account
+from nav.web.auth.sudo import sudo, desudo
+from nav.models.profiles import Account
+
+
+def test_sudo_should_change_session_id(
+    db, session_request, admin_account, other_account
+):
+    # login with admin acount
+    set_account(session_request, admin_account)
+
+    pre_sudo_session_id = session_request.session.session_key
+    sudo(session_request, other_account)
+    post_sudo_session_id = session_request.session.session_key
+
+    assert pre_sudo_session_id != post_sudo_session_id
+
+
+def test_desudo_should_change_session_id(
+    db, session_request, admin_account, other_account
+):
+    # login with admin acount
+    set_account(session_request, admin_account)
+
+    sudo(session_request, other_account)
+
+    pre_desudo_session_id = session_request.session.session_key
+    desudo(session_request)
+    post_desudo_session_id = session_request.session.session_key
+
+    assert pre_desudo_session_id != post_desudo_session_id
+
+
+@pytest.fixture()
+def other_account(db):
+    account = Account(login="other_user")
+    account.save()
+    yield account
+    account.delete()
+
+
+@pytest.fixture()
+def session_request(db):
+    """Request object with a real session"""
+    r = RequestFactory()
+    session_request = r.post('/anyurl')
+
+    # use middleware to make session for session_request
+    middleware = SessionMiddleware()
+    middleware.process_request(session_request)
+    session_request.session.save()
+    return session_request

--- a/tests/integration/web/auth/sudo_test.py
+++ b/tests/integration/web/auth/sudo_test.py
@@ -42,16 +42,3 @@ def other_account(db):
     account.save()
     yield account
     account.delete()
-
-
-@pytest.fixture()
-def session_request(db):
-    """Request object with a real session"""
-    r = RequestFactory()
-    session_request = r.post('/anyurl')
-
-    # use middleware to make session for session_request
-    middleware = SessionMiddleware()
-    middleware.process_request(session_request)
-    session_request.session.save()
-    return session_request

--- a/tests/integration/web/webfront_test.py
+++ b/tests/integration/web/webfront_test.py
@@ -68,14 +68,14 @@ def test_set_default_dashboard_with_multiple_previous_defaults_should_succeed(
     )
 
 
-def test_session_id_is_changed_after_logging_in(db, client, admin_account):
+def test_session_id_is_changed_after_logging_in(
+    db, client, admin_username, admin_password
+):
     login_url = reverse('webfront-login')
     # make sure we have a session ID we can use for comparison
     assert client.session.session_key
     session_id_pre_login = client.session.session_key
-    client.post(
-        login_url, {'username': admin_account.login, 'password': admin_account.password}
-    )
+    client.post(login_url, {'username': admin_username, 'password': admin_password})
     session_id_post_login = client.session.session_key
     assert session_id_post_login != session_id_pre_login
 

--- a/tests/integration/web/webfront_test.py
+++ b/tests/integration/web/webfront_test.py
@@ -75,8 +75,7 @@ def test_when_logging_in_it_should_change_the_session_id(
     logout_url = reverse('webfront-logout')
     # log out first to compare before and after being logged in
     client.post(logout_url)
-    # make sure we have a session ID we can use for comparison
-    assert client.session.session_key
+    assert client.session.session_key, "the initial session lacks an ID"
     session_id_pre_login = client.session.session_key
     client.post(login_url, {'username': admin_username, 'password': admin_password})
     session_id_post_login = client.session.session_key
@@ -88,8 +87,7 @@ def test_non_expired_session_id_should_not_be_changed_on_request_unrelated_to_lo
 ):
     """Client should be fresh and guaranteed to not be expired"""
     index_url = reverse('webfront-index')
-    # make sure we have a session ID we can use for comparison
-    assert client.session.session_key
+    assert client.session.session_key, "the initial session lacks an ID"
     session_id_pre_login = client.session.session_key
     client.get(index_url)
     session_id_post_login = client.session.session_key

--- a/tests/integration/web/webfront_test.py
+++ b/tests/integration/web/webfront_test.py
@@ -83,7 +83,10 @@ def test_session_id_is_changed_after_logging_in(
     assert session_id_post_login != session_id_pre_login
 
 
-def test_session_id_is_not_changed_after_request_unrelated_to_login(db, client):
+def test_non_expired_session_id_is_not_changed_after_request_unrelated_to_login(
+    db, client
+):
+    """Client should be fresh and guaranteed to not be expired"""
     index_url = reverse('webfront-index')
     # make sure we have a session ID we can use for comparison
     assert client.session.session_key

--- a/tests/integration/web/webfront_test.py
+++ b/tests/integration/web/webfront_test.py
@@ -72,6 +72,9 @@ def test_session_id_is_changed_after_logging_in(
     db, client, admin_username, admin_password
 ):
     login_url = reverse('webfront-login')
+    logout_url = reverse('webfront-logout')
+    # log out first to compare before and after being logged in
+    client.post(logout_url)
     # make sure we have a session ID we can use for comparison
     assert client.session.session_key
     session_id_pre_login = client.session.session_key

--- a/tests/integration/web/webfront_test.py
+++ b/tests/integration/web/webfront_test.py
@@ -78,3 +78,13 @@ def test_session_id_is_changed_after_logging_in(db, client, admin_account):
     )
     session_id_post_login = client.session.session_key
     assert session_id_post_login != session_id_pre_login
+
+
+def test_session_id_is_not_changed_after_request_unrelated_to_login(db, client):
+    index_url = reverse('webfront-index')
+    # make sure we have a session ID we can use for comparison
+    assert client.session.session_key
+    session_id_pre_login = client.session.session_key
+    client.get(index_url)
+    session_id_post_login = client.session.session_key
+    assert session_id_post_login == session_id_pre_login

--- a/tests/integration/web/webfront_test.py
+++ b/tests/integration/web/webfront_test.py
@@ -66,3 +66,15 @@ def test_set_default_dashboard_with_multiple_previous_defaults_should_succeed(
         AccountDashboard.objects.filter(account=admin_account, is_default=True).count()
         == 1
     )
+
+
+def test_session_id_is_changed_after_logging_in(db, client, admin_account):
+    login_url = reverse('webfront-login')
+    # make sure we have a session ID we can use for comparison
+    assert client.session.session_key
+    session_id_pre_login = client.session.session_key
+    client.post(
+        login_url, {'username': admin_account.login, 'password': admin_account.password}
+    )
+    session_id_post_login = client.session.session_key
+    assert session_id_post_login != session_id_pre_login

--- a/tests/integration/web/webfront_test.py
+++ b/tests/integration/web/webfront_test.py
@@ -68,7 +68,7 @@ def test_set_default_dashboard_with_multiple_previous_defaults_should_succeed(
     )
 
 
-def test_session_id_is_changed_after_logging_in(
+def test_when_logging_in_it_should_change_the_session_id(
     db, client, admin_username, admin_password
 ):
     login_url = reverse('webfront-login')
@@ -83,7 +83,7 @@ def test_session_id_is_changed_after_logging_in(
     assert session_id_post_login != session_id_pre_login
 
 
-def test_non_expired_session_id_is_not_changed_after_request_unrelated_to_login(
+def test_non_expired_session_id_should_not_be_changed_on_request_unrelated_to_login(
     db, client
 ):
     """Client should be fresh and guaranteed to not be expired"""

--- a/tests/unittests/general/web_middleware_test.py
+++ b/tests/unittests/general/web_middleware_test.py
@@ -29,6 +29,9 @@ class FakeSession(dict):
     def save(self, *_):
         pass
 
+    def cycle_key(self, *_):
+        pass
+
 
 def test_set_account():
     r = RequestFactory()

--- a/tests/unittests/general/web_middleware_test.py
+++ b/tests/unittests/general/web_middleware_test.py
@@ -3,7 +3,7 @@ import os
 
 from django.test import RequestFactory
 
-from nav.web.auth.utils import ACCOUNT_ID_VAR, _set_account, ensure_account
+from nav.web.auth.utils import ACCOUNT_ID_VAR, set_account, ensure_account
 from nav.web.auth.sudo import SUDOER_ID_VAR
 from nav.web.auth.middleware import AuthenticationMiddleware
 from nav.web.auth.middleware import AuthorizationMiddleware
@@ -34,7 +34,7 @@ def test_set_account():
     r = RequestFactory()
     request = r.get('/')
     request.session = FakeSession()
-    _set_account(request, DEFAULT_ACCOUNT)
+    set_account(request, DEFAULT_ACCOUNT)
     assert ACCOUNT_ID_VAR in request.session, 'Account id is not in the session'
     assert hasattr(request, 'account'), 'Account not set'
     assert request.account.id == request.session[ACCOUNT_ID_VAR], 'Correct user not set'
@@ -88,7 +88,7 @@ class TestAuthenticationMiddleware(object):
         fake_request.session = FakeSession(ACCOUNT_ID_VAR=PLAIN_ACCOUNT.id)
         with patch(
             'nav.web.auth.middleware.ensure_account',
-            side_effect=_set_account(fake_request, PLAIN_ACCOUNT),
+            side_effect=set_account(fake_request, PLAIN_ACCOUNT),
         ):
             AuthenticationMiddleware(lambda x: x).process_request(fake_request)
             assert fake_request.account == PLAIN_ACCOUNT
@@ -102,7 +102,7 @@ class TestAuthenticationMiddleware(object):
         )
         with patch(
             'nav.web.auth.middleware.ensure_account',
-            side_effect=_set_account(fake_request, PLAIN_ACCOUNT),
+            side_effect=set_account(fake_request, PLAIN_ACCOUNT),
         ):
             with patch('nav.web.auth.middleware.get_sudoer', return_value=SUDO_ACCOUNT):
                 AuthenticationMiddleware(lambda x: x).process_request(fake_request)
@@ -116,7 +116,7 @@ class TestAuthenticationMiddleware(object):
         fake_request.session = FakeSession()
         with patch(
             'nav.web.auth.middleware.ensure_account',
-            side_effect=_set_account(fake_request, DEFAULT_ACCOUNT),
+            side_effect=set_account(fake_request, DEFAULT_ACCOUNT),
         ):
             with patch('nav.web.auth.remote_user.get_username', return_value=None):
                 AuthenticationMiddleware(lambda x: x).process_request(fake_request)
@@ -129,7 +129,7 @@ class TestAuthenticationMiddleware(object):
         fake_request.session = FakeSession()
         with patch(
             'nav.web.auth.middleware.ensure_account',
-            side_effect=_set_account(fake_request, DEFAULT_ACCOUNT),
+            side_effect=set_account(fake_request, DEFAULT_ACCOUNT),
         ):
             with patch(
                 'nav.web.auth.remote_user.get_username',
@@ -137,7 +137,7 @@ class TestAuthenticationMiddleware(object):
             ):
                 with patch(
                     'nav.web.auth.remote_user.login',
-                    side_effect=_set_account(fake_request, PLAIN_ACCOUNT),
+                    side_effect=set_account(fake_request, PLAIN_ACCOUNT),
                 ):
                     AuthenticationMiddleware(lambda x: x).process_request(fake_request)
                     assert fake_request.account == PLAIN_ACCOUNT
@@ -149,7 +149,7 @@ class TestAuthenticationMiddleware(object):
         fake_request.session = FakeSession()
         with patch(
             'nav.web.auth.middleware.ensure_account',
-            side_effect=_set_account(fake_request, PLAIN_ACCOUNT),
+            side_effect=set_account(fake_request, PLAIN_ACCOUNT),
         ):
             with patch(
                 'nav.web.auth.remote_user.get_username',
@@ -157,7 +157,7 @@ class TestAuthenticationMiddleware(object):
             ):
                 with patch(
                     'nav.web.auth.remote_user.login',
-                    side_effect=_set_account(fake_request, ANOTHER_PLAIN_ACCOUNT),
+                    side_effect=set_account(fake_request, ANOTHER_PLAIN_ACCOUNT),
                 ):
                     with patch('nav.web.auth.logout'):
                         AuthenticationMiddleware(lambda x: x).process_request(

--- a/tests/unittests/general/webfront_test.py
+++ b/tests/unittests/general/webfront_test.py
@@ -23,6 +23,9 @@ class FakeSession(dict):
     def save(self, *_):
         pass
 
+    def cycle_key(self, *_):
+        pass
+
 
 @patch("nav.web.auth.Account.save", new=MagicMock(return_value=True))
 @patch("nav.web.auth.Account.objects.get", new=MagicMock(return_value=LDAP_ACCOUNT))


### PR DESCRIPTION
For #2804 (might not solve it fully depending on how many changes to session id we want to do)

Cycles session ID on login. Or more generally, every time a different user is made into the active account for the session, so this includes the sudo/desudo functions where the logged in account is changed.


Had some issues testing against sessions with a session scoped `client` fixture. Changing this to `function` scoped and ensuring I get a fresh client for each test was a lot better