### PR TITLE
Clean up overview/intro docs

### DIFF
--- a/doc/intro/getting-organized.rst
+++ b/doc/intro/getting-organized.rst
@@ -29,7 +29,7 @@ NAV's data model allows you to organize your IP device information in several wa
 
 All these definitions are entered into NAV through the *SeedDB* tool, where
 you added your devices in the :doc:`getting started guide <getting-started>`.
-If you alreadu have much of this information in electronic format, it too can
+If you already have much of this information in electronic format, it too can
 be bulk imported into NAV using the text formats described in each SeedDB tab.
 
 As seen in that guide, NAV ships with an example location, room and

--- a/doc/intro/getting-organized.rst
+++ b/doc/intro/getting-organized.rst
@@ -67,7 +67,7 @@ corresponds to each prefix. Sometimes, VLANs will have multiple prefixes, in
 the case of secondary network addresses or when both IPv4 and IPv6 are
 deployed in a subnet.
 
-NAV features a subnet matrix tool, which charts your subnet allocations and
+NAV features a subnet matrix tool which charts your subnet allocations and
 their utilization percentages. To take advantage of this, you must manually
 add one ore more *scope prefixes* through the SeedDB *Prefix* tab. Each scope
 prefix will usually correspond to an IP address block you have been assigned
@@ -94,16 +94,16 @@ Each device type in NAV is mapped to a *vendor ID*, a moniker such as
 ``cisco`` or ``juniper``. You can edit your device types and vendors through
 the SeedDB tool.
 
-When NAV sees a previously unknown *sysObjectID*, it will automatically
+When NAV sees a previously unknown *sysObjectID* it will automatically
 register a new device type and attach it to the ``unknown`` vendor id. You may
 wish to later edit these auto-created device types using the SeedDB *Type*
-tab, to set the correct vendor id and a more proper type name and description.
+tab to set the correct vendor id and a more proper type name and description.
 
 
 Cabling and patching
 --------------------
 
-If desireable, you can also document your cabling plans and your patch panels,
+If desireable, you can also document your cabling plans and your patch panels
 using SeedDB. This would enable NAV to tell you to which office each switch
 port is patched through to (unless you are already diligent and add this
 information to the switch port description when patching).

--- a/doc/intro/getting-organized.rst
+++ b/doc/intro/getting-organized.rst
@@ -85,7 +85,7 @@ Vendors and device types
 ------------------------
 
 NAV will automatically discover and assign *device types* to SNMP-enabled
-devices being monitored. Each device type corresponds to a unique
+devices that are being monitored. Each device type corresponds to a unique
 *sysObjectID*. An SNMP-enabled device will usually report a vendor-specific
 and unique *sysObjectID*, which may map to some specific device model, type
 and/or software.

--- a/doc/intro/getting-started.rst
+++ b/doc/intro/getting-started.rst
@@ -81,7 +81,7 @@ processes can be controlled using the :program:`nav` command.
 
 The backend processes consist of some daemon processes, and some cron jobs.
 Running :kbd:`nav start` will start all the daemon processes in the
-background, and install all the cron jobs in the `navcron` user's crontab.
+background, and install all the cron jobs in the ``navcron`` user's crontab.
 
 Depending on your OS of choice, you should configure it to run :kbd:`nav
 start` on boot.
@@ -93,10 +93,10 @@ Logging in to the web interface
 When browsing the web interface at |URL| you will see the front page of NAV.
 This is openly accessible to anonymous users by default.
 
-To log in for the first time, click the `Login` link on the upper right of the
-page, and enter the username "admin" and the default password "admin".  Then
-click `My stuff` and `My account` in the navigation bar on top and change the
-adminstrator's password to something more sensible.
+To log in for the first time, click the :guilabel:`Login` link on the upper right of
+the page, and enter the username "admin" and the default password "admin".  Then
+click :guilabel:`My stuff` and :guilabel:`My account` in the navigation bar on top and
+change the adminstrator's password to something more sensible.
 
 
 Seeding your database
@@ -197,17 +197,16 @@ Verifying that collection is working
 Within two minutes, NAV's :doc:`SNMP collection engine </reference/ipdevpoll>` should launch a job to poll
 your newly added device for information. The navigation bar on top features a
 search field; search for your newly entered device's IP address or DNS name to
-show its `IP Device Info` page. The resulting page should look something like
+show its :guilabel:`IP Device Info` page. The resulting page should look something like
 this:
 
 .. image:: ipdevinfo-switch-display.png
    :scale: 50%
 
-The `IP Device Info` page will try to display every bit of pertinent
+The :guilabel:`IP Device Info` page will try to display every bit of pertinent
 information about a monitored device.  For now, the key information here is
-in the lower-right :guilabel:`Jobs` panel. Keep reloading the page until the panel
-appears and the :guilabel:`End time` field is filled and the :guilabel:`Status`
-indicators are green.
+the :guilabel:`Last updated` field of the top-left detail panel.  Keep reloading the
+page until its value changes from ``N/A`` into a meaningful timestamp.
 
 .. NOTE:: If no new information appears on this page within three minutes
           after adding your switch to NAV, you may need to start
@@ -252,7 +251,7 @@ categories:
   Any other type of device not fitting neatly into the other categories.
 
 All categories will *require* a read-only SNMP profile to be assigned to the device, except for
-`SRV` and `OTHER`, where it is optional.
+``SRV`` and ``OTHER``, where it is optional.
 
 .. _seeddb-bulk-import-intro:
 
@@ -271,7 +270,7 @@ upload or paste it into the :guilabel:`bulk import` form.
 
 The format is pretty straightforward: The initial fields are required, while
 the fields listed in square brackets are optional. Optional fields can be
-omitted or left blank. A line beginning with a `#` sign will be regarded as a
+omitted or left blank. A line beginning with a ``#`` sign will be regarded as a
 comment and ignored. Thus, for adding some switch using the default SNMP
 management profile you added earlier, and a function description of
 :kbd:`Packet switching`, this line would do it::

--- a/doc/intro/getting-started.rst
+++ b/doc/intro/getting-started.rst
@@ -95,7 +95,7 @@ This is openly accessible to anonymous users by default.
 
 To log in for the first time, click the `Login` link on the upper right of the
 page, and enter the username "admin" and the default password "admin".  Then
-click the `Userinfo` link in the grey navigation bar and change the
+click `My stuff` and `My account` in the navigation bar on top and change the
 adminstrator's password to something more sensible.
 
 
@@ -106,13 +106,13 @@ NAV will *not* autodiscover the routers and switches of your network. The
 assumption is that you already have this information in some inventory
 system.
 
-The *SeedDB* tool enables to you add and edit a multitude of "seed" information
+The *Seed Database* tool enables to you add and edit a multitude of "seed" information
 in the NAV database, which tells NAV what and how to monitor. The essential bit
 here is the :term:`IP Device`, which represents your switches, routers and
 other networked devices.
 
-The *SeedDB* tool is listed on NAV's *Toolbox* page, reachable from the grey
-navigation bar.
+The *Seed Database* tool is listed on NAV's *Toolbox* page, reachable from the
+navigation bar on top.
 
 Adding your first management profile
 ------------------------------------
@@ -126,7 +126,7 @@ devices can be managed using SNMP v2c and a default community string of
 1. Click the :guilabel:`Management Profile` tab and then the sub-tab
    :guilabel:`Add new management profile`.
 2. Choose and fill out a unique name for your profile, e.g. ``Default SNMP v2c
-   read-only profile``, and add an optional description of it.
+   read-only profile``, and optionally add a description of it.
 3. Select ``SNMP`` from the :guilabel:`Protocol` dropdown menu. An
    :guilabel:`SNMP Configuration` form will appear to the right.
 4. Ensure ``v2c`` is selected from the :guilabel:`Version` dropdown, and put
@@ -195,7 +195,7 @@ Verifying that collection is working
 ------------------------------------
 
 Within two minutes, NAV's :doc:`SNMP collection engine </reference/ipdevpoll>` should launch a job to poll
-your newly added device for information. The grey navigation bar features a
+your newly added device for information. The navigation bar on top features a
 search field; search for your newly entered device's IP address or DNS name to
 show its `IP Device Info` page. The resulting page should look something like
 this:
@@ -205,8 +205,9 @@ this:
 
 The `IP Device Info` page will try to display every bit of pertinent
 information about a monitored device.  For now, the key information here is
-the `Last updated` field of the top-left detail panel.  Keep reloading the
-page until its value changes from `N/A` into a meaningful timestamp.
+in the lower-right :guilabel:`Jobs` panel. Keep reloading the page until the panel
+appears and the :guilabel:`End time` field is filled and the :guilabel:`Status`
+indicators are green.
 
 .. NOTE:: If no new information appears on this page within three minutes
           after adding your switch to NAV, you may need to start

--- a/doc/intro/getting-started.rst
+++ b/doc/intro/getting-started.rst
@@ -40,8 +40,8 @@ before running NAV:
     2. :kbd:`makepasswd --chars 51`
     3. :kbd:`pwgen -s 51 1`
 
-  Please see
-  https://docs.djangoproject.com/en/1.7/ref/settings/#std:setting-SECRET_KEY
+  Please see the 
+  `Django secret key documentation <https://docs.djangoproject.com/en/3.2/ref/settings/#std-setting-SECRET_KEY>`_
   if you want to know more about this.
 
 `TIME_ZONE`

--- a/doc/intro/install.rst
+++ b/doc/intro/install.rst
@@ -56,7 +56,7 @@ patches from the Debian team.
 
 This is normally our recommended option for regular NAV users.
 
-`Instructions for installing the Debian package is available on the official
+`Instructions for installing the Debian package are available on the official
 NAV web site <https://nav.uninett.no/install-instructions/#debian>`_.
 
 After installing the Debian package, you will need to :ref:`integrate Graphite

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -23,7 +23,7 @@ NAV gives you:
 * The ability to block or quarantine access ports of network abusers.
 * The ability to perform simple access port configuration tasks via web, and
   also to delegate this access to other administrators within your
-  organizational hiearchy.
+  organizational hierarchy.
 
 Although NAV specializes in network infrastructure monitoring, it also
 provides simple service monitoring for those who have less complex service


### PR DESCRIPTION
When working on #2641 I noticed that a lot of things are outdated in the documentation. I am planning on going through it with a fine comb and fix anything that sticks out to me.

Always open for disagreements on my changes. 

I also found the line "For now, the key information here is the `Last updated` field of the top-left detail panel." in `getting_started.rst`, while I cannot find such a field in the picture below it. So that would need to be changed, but I don't know to what.