### PR TITLE
Upgrade python-ldap from 3.4.0->3.4.4

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,1 +1,1 @@
-python-ldap==3.4.0 # optional for LDAP authentication, requires libldap (OpenLDAP) to build
+python-ldap==3.4.4 # optional for LDAP authentication, requires libldap (OpenLDAP) to build


### PR DESCRIPTION
python-ldap 3.4.0 cannot be built against newer versions of the OpenLDAP library, which no longer provide `libldap_r`, just `libldap` (which apparently now have the same re-entrant capabilities that were unique to `libldap_r` before).
