### PR TITLE
Fix activeipcollector `get_timestamp` function implementation and its broken timezone-naive test

### DIFF
--- a/python/nav/activeipcollector/manager.py
+++ b/python/nav/activeipcollector/manager.py
@@ -16,9 +16,11 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Manage collection and storing of active ip-addresses statistics"""
-
+import datetime
 import logging
 import time
+from typing import Optional
+
 from IPy import IP
 
 import nav.activeipcollector.collector as collector
@@ -82,11 +84,7 @@ def find_range(prefix):
         return 0
 
 
-def get_timestamp(timestamp=None):
+def get_timestamp(timestamp: Optional[datetime.datetime] = None) -> int:
     """Find timestamp closest to 30 minutes intervals"""
 
-    def get_epoch():
-        """Find epoch from a datetime object"""
-        return int(time.mktime(timestamp.timetuple()))
-
-    return get_epoch() if timestamp else int(time.time())
+    return timestamp.timestamp() if timestamp else int(time.time())

--- a/tests/unittests/general/prefix_ip_collector_test.py
+++ b/tests/unittests/general/prefix_ip_collector_test.py
@@ -3,7 +3,7 @@
 """Tests for prefix_ip_collector"""
 
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from nav.activeipcollector.manager import find_range, get_timestamp
 
 
@@ -14,5 +14,5 @@ class TestPrefixIpCollector(unittest.TestCase):
         self.assertEqual(find_range('2001:700:0:251e::/64'), 0)
 
     def test_find_timestamp(self):
-        ts = datetime(2012, 10, 4, 14, 30)
-        self.assertEqual(get_timestamp(ts), 1349353800)
+        ts = datetime(2012, 10, 4, 14, 30, tzinfo=timezone.utc)
+        self.assertEqual(get_timestamp(ts), 1349361000)


### PR DESCRIPTION
Don't test epoch values against naive datetimes

When running the test suite on a machine set to the UTC timezone, `test_find_timestamp` would fail, because the datetime object used to seed the value is timezone-naive.  The test would work fine in UTC+1 timezones, but not in other timezones. 

This also refactors the convoluted logic of the function itself.