### PR TITLE
Fix broken statemon tests

### DIFF
--- a/tests/unittests/statemon/conftest.py
+++ b/tests/unittests/statemon/conftest.py
@@ -1,0 +1,10 @@
+import os
+import pytest
+
+
+@pytest.fixture
+def modulo_pid():
+    """Returns this process' PID number, modulo 2^16. Because that's what pping uses
+    to produce ping packet IDs
+    """
+    yield os.getpid() % 2**16

--- a/tests/unittests/statemon/host_test.py
+++ b/tests/unittests/statemon/host_test.py
@@ -1,58 +1,50 @@
-from unittest import TestCase
-import os
 from nav.statemon.megaping import Host
 from nav.statemon.icmppacket import PacketV4, PacketV6
 
 
-class HostTestcase(TestCase):
-    def test_make_v4_packet(self):
-        """
-        Test to make a v4 packet
-        """
+class TestHost:
+    """Tests for the Host class"""
+
+    def test_make_v4_packet(self, modulo_pid):
+        """Test to make a v4 packet"""
         host = Host('127.0.0.1')
-        pid = os.getpid()
-        self.assertFalse(host.is_v6())
+        assert not host.is_v6()
 
-        self.assertTrue(host.packet)
-        self.assertTrue(isinstance(host.packet, PacketV4))
+        assert host.packet
+        assert isinstance(host.packet, PacketV4)
 
         packet, cookie = host.make_packet(64)
 
-        self.assertTrue(packet)
-        self.assertTrue(cookie)
-        self.assertEqual(len(packet), 64)
-        self.assertEqual(len(cookie), 16)
+        assert packet
+        assert cookie
+        assert len(packet) == 64
+        assert len(cookie) == 16
 
-        self.assertEqual(host.packet.sequence, 0)
-        self.assertEqual(host.packet.id, pid)
+        assert host.packet.sequence == 0
+        assert host.packet.id, modulo_pid
 
-    def test_make_v6_packet(self):
-        """
-        Test to make a v6 packet
-        """
+    def test_make_v6_packet(self, modulo_pid):
+        """Test to make a v6 packet"""
         host = Host('2001:701::FFFF')
-        pid = os.getpid()
-        self.assertTrue(host.is_v6())
+        assert host.is_v6()
 
-        self.assertTrue(host.packet)
-        self.assertTrue(isinstance(host.packet, PacketV6))
+        assert host.packet
+        assert isinstance(host.packet, PacketV6)
 
         packet, cookie = host.make_packet(64)
 
-        self.assertTrue(packet)
-        self.assertTrue(cookie)
-        self.assertEqual(len(packet), 64)
-        self.assertEqual(len(cookie), 16)
+        assert packet
+        assert cookie
+        assert len(packet) == 64
+        assert len(cookie) == 16
 
-        self.assertEqual(host.packet.sequence, 0)
-        self.assertEqual(host.packet.id, pid)
+        assert host.packet.sequence == 0
+        assert host.packet.id == modulo_pid
 
     def test_ip_validation(self):
-        """
-        Test the IP valdidation helper methods for both v6 & v4
-        """
-        self.assertTrue(Host('129.241.105.210').is_valid_ipv4())
-        self.assertFalse(Host('129.241.105.256').is_valid_ipv4())
+        """Test the IP valdidation helper methods for both v6 & v4"""
+        assert Host('129.241.105.210').is_valid_ipv4()
+        assert not Host('129.241.105.256').is_valid_ipv4()
 
-        self.assertTrue(Host('2001:701::FFFF').is_valid_ipv6())
-        self.assertFalse(Host('127.0.0.1').is_valid_ipv6())
+        assert Host('2001:701::FFFF').is_valid_ipv6()
+        assert not Host('127.0.0.1').is_valid_ipv6()

--- a/tests/unittests/statemon/icmp_test.py
+++ b/tests/unittests/statemon/icmp_test.py
@@ -1,15 +1,13 @@
 from nav.statemon.icmppacket import PacketV6, PacketV4, inet_checksum
-from unittest import TestCase
 import os
 
 
-class ICMPPacketTestcase(TestCase):
-    def test_assemble_v6_packet_echo(self):
-
+class TestICMPPacket:
+    def test_assemble_v6_packet_echo(self, modulo_pid):
         # Make packet
         packet = PacketV6()
         packet.data = b'Testing'
-        packet.id = os.getpid()
+        packet.id = modulo_pid
         packet.sequence = 3
         packet = packet.assemble()
 
@@ -17,27 +15,26 @@ class ICMPPacketTestcase(TestCase):
         v6_packet = PacketV6(packet, False)
 
         # Check if ICMP_ECHO
-        self.assertEqual(v6_packet.type, PacketV6.ICMP_ECHO)
+        assert v6_packet.type == PacketV6.ICMP_ECHO
 
         # Check sequence number
-        self.assertEqual(v6_packet.sequence, 3)
+        assert v6_packet.sequence == 3
 
         # Check payload
-        self.assertEqual(v6_packet.data, b'Testing')
+        assert v6_packet.data == b'Testing'
 
         # Check if Id of the packet is process id
-        self.assertEqual(os.getpid(), v6_packet.id)
+        assert modulo_pid == v6_packet.id
 
         # Check if the checksum is correct
         unpacked_packet = packet[v6_packet.packet_slice]
-        self.assertEqual(inet_checksum(unpacked_packet), 0)
+        assert inet_checksum(unpacked_packet) == 0
 
-    def test_assemble_v4_packet_echo(self):
-
+    def test_assemble_v4_packet_echo(self, modulo_pid):
         # Make packet
         packet = PacketV4()
         packet.data = b'Testing'
-        packet.id = os.getpid()
+        packet.id = modulo_pid
         packet.sequence = 3
         packet = packet.assemble()
 
@@ -49,17 +46,17 @@ class ICMPPacketTestcase(TestCase):
         v4_packet = PacketV4(packet, False)
 
         # Check if ICMP_ECHO
-        self.assertEqual(v4_packet.type, PacketV4.ICMP_ECHO)
+        assert v4_packet.type == PacketV4.ICMP_ECHO
 
         # Check sequence number
-        self.assertEqual(v4_packet.sequence, 3)
+        assert v4_packet.sequence == 3
 
         # Check if Id of the packet is process id
-        self.assertEqual(os.getpid(), v4_packet.id)
+        assert modulo_pid == v4_packet.id
 
         # Check payload
-        self.assertEqual(v4_packet.data, b'Testing')
+        assert v4_packet.data == b'Testing'
 
         # Check if the checksum is correct
         unpacked_packet = packet[v4_packet.packet_slice]
-        self.assertEqual(inet_checksum(unpacked_packet), 0)
+        assert inet_checksum(unpacked_packet) == 0


### PR DESCRIPTION
I accidentally discovered that several of the statemon tests were in fact broken.  They expect pping code to use the process PID as a packet ID, and end up using this in their assertions.

However, this is only sort-of true: pping actually uses the process PID modulo 2^16, since the value needs to fit in a 16-bit packet header field.  If the tests ran on a system where the test runner PID is higher than 65536, these tests would fail for no apparent reason.

This would rarely have been encountered, since the test suite most often runs inside newly created VMs or containers that are torn down immediately after the test run.  This way, the test suite would almost always encounter very low PID values.  Running the teste on my workstation with a high uptime was a different story, though.

This more or less rewrites the tests to pytest format, so they can easily re-use a fixture to get the proper "PID" value.