### PR TITLE
Define FakeSession as a fixture

### DIFF
--- a/tests/unittests/general/conftest.py
+++ b/tests/unittests/general/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+class FakeSession(dict):
+    def set_expiry(self, *_):
+        pass
+
+    def save(self, *_):
+        pass
+
+    def cycle_key(self, *_):
+        pass
+
+
+@pytest.fixture
+def fake_session():
+    return FakeSession()

--- a/tests/unittests/general/web_middleware_test.py
+++ b/tests/unittests/general/web_middleware_test.py
@@ -37,7 +37,6 @@ class TestEnsureAccount(object):
     def test_account_is_set_if_missing(self, fake_session):
         r = RequestFactory()
         request = r.get('/')
-        request.session = {}
         request.session = fake_session
         with patch("nav.web.auth.Account.objects.get", return_value=DEFAULT_ACCOUNT):
             ensure_account(request)

--- a/tests/unittests/general/webfront_test.py
+++ b/tests/unittests/general/webfront_test.py
@@ -16,17 +16,6 @@ REMOTE_USER_ACCOUNT = auth.Account(
 )
 
 
-class FakeSession(dict):
-    def set_expiry(self, *_):
-        pass
-
-    def save(self, *_):
-        pass
-
-    def cycle_key(self, *_):
-        pass
-
-
 @patch("nav.web.auth.Account.save", new=MagicMock(return_value=True))
 @patch("nav.web.auth.Account.objects.get", new=MagicMock(return_value=LDAP_ACCOUNT))
 class TestLdapAuthenticate(object):
@@ -154,19 +143,19 @@ class TestGetRemoteUsername(object):
 
 
 class TestLoginRemoteUser(object):
-    def test_remote_user_unset(self):
+    def test_remote_user_unset(self, fake_session):
         r = RequestFactory()
         request = r.get('/')
-        request.session = FakeSession()
+        request.session = fake_session
         with patch("nav.web.auth.remote_user.get_username", return_value=False):
             remote_user.login(request)
             assert not getattr(request, 'account', False)
             assert ACCOUNT_ID_VAR not in request.session
 
-    def test_remote_user_set(self):
+    def test_remote_user_set(self, fake_session):
         r = RequestFactory()
         request = r.get('/')
-        request.session = FakeSession()
+        request.session = fake_session
         with patch("nav.web.auth.remote_user.get_username", return_value=True):
             with patch(
                 "nav.web.auth.remote_user.authenticate",


### PR DESCRIPTION
Fixes #2841 

Only reasonable way to share code like this between files is via a fixture afaik. Could have defined the fixture to return the class itself and not an instance of the class, but that felt weird. This should work fine