### PR TITLE
Remove deprecation warning for Django 4.0 in tests

### DIFF
--- a/tests/integration/web/auth/conftest.py
+++ b/tests/integration/web/auth/conftest.py
@@ -11,7 +11,7 @@ def session_request(db):
     session_request = r.post('/anyurl')
 
     # use middleware to make session for session_request
-    middleware = SessionMiddleware()
+    middleware = SessionMiddleware(lambda request: None)
     middleware.process_request(session_request)
     session_request.session.save()
     return session_request

--- a/tests/integration/web/auth/middleware_test.py
+++ b/tests/integration/web/auth/middleware_test.py
@@ -12,7 +12,7 @@ def test_when_remote_user_logs_in_it_should_change_the_session_id(
     with patch(
         'nav.web.auth.remote_user.get_username', return_value=remote_account.login
     ):
-        middleware = AuthenticationMiddleware()
+        middleware = AuthenticationMiddleware(lambda request: None)
         middleware.process_request(session_request)
     assert session_request.account == remote_account
     post_login_session_id = session_request.session.session_key

--- a/tests/integration/web/auth/sudo_test.py
+++ b/tests/integration/web/auth/sudo_test.py
@@ -1,7 +1,6 @@
 import pytest
 
 from django.test import RequestFactory
-from django.contrib.sessions.middleware import SessionMiddleware
 
 from nav.web.auth.utils import set_account
 from nav.web.auth.sudo import sudo, desudo


### PR DESCRIPTION
Stops the following warning:

RemovedInDjango40Warning: Passing None for the middleware get_response argument is deprecated