### PR TITLE
Stop testing on Python 3.8

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.9]
 
     steps:
       - uses: actions/checkout@v3

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -18,7 +18,6 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get -y install --no-install-recommends \
       curl git build-essential \
       python3.7-dbg python3.7-dev python3.7-distutils \
-      python3.8-dbg python3.8-dev \
       python3.9-dbg python3.9-dev \
       python3-pip
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 # When changing the python or django version also change it in the tox example
 # of the documentation in hacking.rst
 [tox]
-envlist = {unit,integration,functional}-py{37,38,39}-django{32}, javascript, docs
+envlist = {unit,integration,functional}-py{37,39}-django{32}, javascript, docs
 skipsdist = True
 basepython = python3.7
 
@@ -18,7 +18,6 @@ markers =
 [gh-actions]
 python =
     3.7: py37
-    3.8: py38
     3.9: py39
 
 [testenv]


### PR DESCRIPTION
In production we are running on Python 3.7 and 3.9 (soon also to be running on 3.11) so speed up tests by not running them on Python 3.8.