### PR TITLE
Stop using PickleSerializer for sessions

### DIFF
--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -135,7 +135,6 @@ MIDDLEWARE = (
     'django.contrib.messages.middleware.MessageMiddleware',
 )
 
-SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 SESSION_COOKIE_AGE = int(_webfront_config.get('sessions', {}).get('timeout', 3600))
 SESSION_COOKIE_NAME = 'nav_sessionid'


### PR DESCRIPTION
Depends on #2828

The default has been JSONSerializer since after Django 1.6. The oldest docs I could find was for 1.8:

https://docs.djangoproject.com/en/1.8/topics/http/sessions/#session-serialization

PickleSerializer has been deprecated since Django 4.1 and was removed in Django 5.0.

Merging this will get rid of this warning while testing:

`RemovedInDjango50Warning: PickleSerializer is deprecated due to its security risk. Use JSONSerializer instead.`