### PR TITLE
Fix warnings during integration tests

### DIFF
--- a/python/nav/ipdevpoll/jobs.py
+++ b/python/nav/ipdevpoll/jobs.py
@@ -319,7 +319,7 @@ class JobHandler(object):
             return failure
 
         def save(result):
-            if self.cancelled.isSet():
+            if self.cancelled.is_set():
                 return wrap_up_job(result)
 
             df = self._save_container()
@@ -524,7 +524,7 @@ class JobHandler(object):
 
     def _raise_if_cancelled(self):
         """Raises an AbortedJobError if the current job is cancelled"""
-        if self.cancelled.isSet():
+        if self.cancelled.is_set():
             raise AbortedJobError("Job was already cancelled")
 
     @classmethod

--- a/python/nav/statemon/db.py
+++ b/python/nav/statemon/db.py
@@ -73,7 +73,7 @@ class _DB(threading.Thread):
 
     def __init__(self):
         threading.Thread.__init__(self)
-        self.setDaemon(1)
+        self.daemon = True
         self.queue = queue.Queue()
         self._hosts_to_ping = []
         self._checkers = []


### PR DESCRIPTION
Closes #2847.

I was not able to reproduce 
```
tests/integration/watchdog_test.py::test_get_status_cache_does_not_raise
  /source/.tox/integration-py310-django32/lib/python3.10/site-packages/django/core/cache/backends/filebased.py:36: RuntimeWarning: Pickled model instance's Django version 3.2.23 does not match the current version 3.2.24.
    return pickle.loads(zlib.decompress(f.read()))
```