### PR TITLE
Preserve 500-error in test

### DIFF
--- a/tests/integration/web/crawler_test.py
+++ b/tests/integration/web/crawler_test.py
@@ -277,7 +277,11 @@ def test_page_should_be_valid_html(page):
 
 def should_validate(page: Page):
     """Returns True if page is eligible for HTML validation, False if not"""
-    if not page.content_type or 'html' not in page.content_type.lower():
+    if (
+        page.response == 500
+        or not page.content_type
+        or 'html' not in page.content_type.lower()
+    ):
         return False
     path = normalize_path(page.url)
     for blacklisted_path in TIDY_BLACKLIST:


### PR DESCRIPTION
On (some?) 500-errors, content Page.content_type does not have the method "lower", triggering a new exception that makes more of a hassle finding what caused the 500.

A request that returns with a 500 response-code has no HTML to validate anyway so let's just bail.