### PR TITLE
Vendor the PickleSerializer

### DIFF
--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -135,7 +135,7 @@ MIDDLEWARE = (
     'django.contrib.messages.middleware.MessageMiddleware',
 )
 
-SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
+SESSION_SERIALIZER = 'nav.web.session_serializer.PickleSerializer'
 SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 SESSION_COOKIE_AGE = int(_webfront_config.get('sessions', {}).get('timeout', 3600))
 SESSION_COOKIE_NAME = 'nav_sessionid'

--- a/python/nav/web/session_serializer.py
+++ b/python/nav/web/session_serializer.py
@@ -6,8 +6,22 @@ from django.core.exceptions import ImproperlyConfigured
 
 class PickleSerializer:
     """
-    Simple wrapper around pickle to be used in signing.dumps()/loads() and
-    cache backends.
+    Simple wrapper around pickle to be used for serializing data to be put in
+    cookies.
+
+    This was vendored from the version found in Django 4.2. JSONSerializer has
+    been the default in Django since 1.6, deprecated since 4.1 and purged from
+    the codebase since 5.0. What Django did not provide is a migration path:
+    a test showed that any access of a cookie after the serializer had been
+    changed lead to a rather useless exception.
+
+    PickleSerializer was removed due to it being danegerous in the
+    signed_cookie session backend. NAV doesn't use that see we can keep the old
+    serializer.
+
+    Changes from the original: A deprecation warning has been removed and
+    a check that it is not used with the signed_cookie session backend has been
+    added.
     """
 
     def __init__(self, protocol=None):

--- a/python/nav/web/session_serializer.py
+++ b/python/nav/web/session_serializer.py
@@ -1,0 +1,24 @@
+import pickle
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+
+class PickleSerializer:
+    """
+    Simple wrapper around pickle to be used in signing.dumps()/loads() and
+    cache backends.
+    """
+
+    def __init__(self, protocol=None):
+        if settings.SESSION_ENGINE == 'django.contrib.sessions.backends.signed_cookies':
+            raise ImproperlyConfigured(
+                "PickleSerializer cannot be used with signed_cookies SESSION_ENGINE"
+            )
+        self.protocol = pickle.HIGHEST_PROTOCOL if protocol is None else protocol
+
+    def dumps(self, obj):
+        return pickle.dumps(obj, self.protocol)
+
+    def loads(self, data):
+        return pickle.loads(data)


### PR DESCRIPTION
Replaces #2852 and does not depend on #2828

> The default has been JSONSerializer since after Django 1.6. /../  PickleSerializer has been deprecated since Django 4.1 and was removed in Django 5.0.

If using `signed_cookies` as the session engine, serializing with pickle is a security problem. We do not use signed_cookies, so we can continue to use PickleSerializer.

This vendored version makes the serializer incompatible with the signed_cookies engine just in case.

See also #2865