### PR TITLE
Remove nonsensical pydantic requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "pydantic >= 2.0",
     "importlib_metadata; python_version < '3.8'",
     "importlib_resources; python_version < '3.9'",
 ]


### PR DESCRIPTION
For some unknown reason, pydantic was added to the dependency list in pyproject.toml, but NAV has no such dependency.  This removes it.