### PR TITLE
Upgrade codecov-action to v4

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -91,11 +91,11 @@ jobs:
             /tmp/pytest-of-runner
 
       - name: "Upload coverage to Codecov"
-        if: "github.repository_owner == 'Uninett'"
-        uses: codecov/codecov-action@v3
+        if: github.repository_owner == 'Uninett'
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for forks of public repos
 
       - name: Upload test reports (${{ matrix.python-version }})
         if: always()
@@ -154,4 +154,3 @@ jobs:
           name: javascript-test-reports
           path: |
             reports/**/*
-


### PR DESCRIPTION
`CODECOV_TOKEN` is already added to the repository secrets.