### PR TITLE
Proof-of-concept: Introduce HTMX-based replacement for QuickSelect component in Maintenance tool

### DIFF
--- a/python/nav/web/maintenance/urls.py
+++ b/python/nav/web/maintenance/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     re_path(r'^active/$', views.active, name='maintenance-active'),
     re_path(r'^planned/$', views.planned, name='maintenance-planned'),
     re_path(r'^historic/$', views.historic, name='maintenance-historic'),
+    re_path(r'^search/$', views.component_search, name='maintenance-component-search'),
     re_path(r'^new/$', views.edit, name='maintenance-new'),
     re_path(
         r'^new/(?P<start_time>\d{4}-\d{2}-\d{2})/$',

--- a/python/nav/web/maintenance/views.py
+++ b/python/nav/web/maintenance/views.py
@@ -25,6 +25,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.safestring import mark_safe
+from django.views.decorators.http import require_http_methods
 
 import nav.maintengine
 from nav.django.utils import get_account
@@ -350,6 +351,7 @@ def edit(request, task_id=None, start_time=None, **_):
     )
 
 
+@require_http_methods(["POST"])
 def component_search(request):
     """HTMX endpoint for component searches from maintenance task form"""
     search = request.POST.get("search")

--- a/python/nav/web/templates/maintenance/component-search-results-frag.html
+++ b/python/nav/web/templates/maintenance/component-search-results-frag.html
@@ -1,0 +1,14 @@
+{% if results %}
+    {% for component_type, values in results.items %}
+        {% if values %}
+            <h4>{{ component_type }}</h4>
+            <ul>
+                {% for value in values %}
+                    <li>{{ value }}</li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+    {% endfor %}
+{% else %}
+    <strong>No hits</strong>
+{% endif %}

--- a/python/nav/web/templates/maintenance/new_task.html
+++ b/python/nav/web/templates/maintenance/new_task.html
@@ -45,6 +45,20 @@
             <legend>Select components</legend>
             {{ quickselect }}
           </fieldset>
+
+            <h3>Search components
+            </h3>
+            <input class="form-control" type="search"
+                   name="search" placeholder="Begin Typing To Search for stuff..."
+                   hx-post="{% url 'maintenance-component-search' %}"
+                   hx-trigger="input changed delay:500ms, search"
+                   hx-target="#search-results"
+                   hx-indicator=".htmx-indicator">
+            <span class="htmx-indicator">
+                <img src="/static/images/select2/select2-spinner.gif"/> Searching...
+            </span>
+            <div id="search-results"></div>
+
         </div>
 
         <div class="large-4 columns">
@@ -81,6 +95,7 @@
                      value="Remove selected" disabled="disabled" class="button small secondary"/>
             {% endif %}
           </fieldset>
+
         </div> {# column #}
       </div> {# row #}
 


### PR DESCRIPTION
This is related to both #2639 and #2251 .

It's a very crude start to a PoC that can potentially replace the b0rked QuickSelect component used in the Maintenance tool.  The QuickSelect component is also used by the IP Device History tool, and could be replaced also there once complete.

Quick explanation, for now: The QuickSelect component is pre-populated with all netboxes, locations, rooms, services, etc. from NAV, and is consequently output into the resulting HTML of the maintenance task edit form.  From that HTML, QuickSelect's JavaScript counterpart allows the user to filter form values from this potentially giant list of stuff.  This is exactly why the page load times can grow very long in big NAV installs, as mentioned in #2251.  It will grow even bigger if we add an option to put interfaces on maintenance, which is a feature that has been suggested to us.

This PR intends to demonstrate how to use HTMX to dynamically look up maintenance components by having the backend do the searching and return fully formed HTML with the results.  The potential downside to this approach is that there will be no initial scrollable list of *all* components: The user *must* enter at least a single letter search query to see any selectable components.  This might still be preferable to loading "everything" from the database into an HTML fragment (this is equivalent to the API strategy that refuses to return all the millions of ARP entries when no arguments are given to the endpoint)
