### PR TITLE
Fix broken `full-nav-restore.sh` script

### DIFF
--- a/tools/docker/full-nav-restore.sh
+++ b/tools/docker/full-nav-restore.sh
@@ -10,7 +10,7 @@ if ! which navsyncdb 2>/dev/null; then
     echo "NAV source directory not correctly mounted on /source" > /dev/stderr
     exit 1
 fi
-nav stop
+sudo nav stop
 export PGHOST=postgres
 export PGUSER=postgres
 


### PR DESCRIPTION
After the Docker development container was re-engineered (in #2859) to run as a non-root user, this helper script stopped working, as it now needs sudo to run the nav start/stop command.

This doesn't constitute a user-visible change, so I don't think we will need a news fragment for this.