### PR TITLE
Update PostgreSQL requirement to version 11

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -71,7 +71,7 @@ jobs:
       - name: "Set up PostgreSQL"
         uses: harmon758/postgresql-action@v1
         with:
-          postgresql version: '9.6'  # minimum NAV requirement
+          postgresql version: '11'  # minimum NAV requirement
           postgresql user: $PGUSER
           postgresql password: $PGPASSWORD
 

--- a/NOTES.rst
+++ b/NOTES.rst
@@ -8,6 +8,15 @@ existing bug reports, go to https://github.com/uninett/nav/issues .
 To see an overview of upcoming release milestones and the issues they resolve,
 please go to https://github.com/uninett/nav/milestones .
 
+NAV 5.10 (Unreleased)
+=====================
+
+Dependency changes
+------------------
+
+.. IMPORTANT:: NAV 5.10 requires PostgreSQL to be at least version *11*.
+
+
 NAV 5.9
 =======
 

--- a/changelog.d/+pg11.changed
+++ b/changelog.d/+pg11.changed
@@ -1,0 +1,1 @@
+Changed required PostgreSQL version to 11

--- a/doc/howto/generic-install-from-source.rst
+++ b/doc/howto/generic-install-from-source.rst
@@ -27,7 +27,7 @@ Runtime requirements
 To run NAV, these software packages are required:
 
  * Apache2 + mod_wsgi (or, really, any web server that supports the WSGI interface)
- * PostgreSQL >= 9.6 (With the ``hstore`` extension available)
+ * PostgreSQL >= 11 (With the ``hstore`` extension available)
  * :xref:`Graphite`
  * Python >= 3.7.0
  * nbtscan = 1.5.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
     restart: on-failure:5
 
   postgres:
-    image: "postgres:9.6"
+    image: "postgres:13"
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     restart: on-failure:5


### PR DESCRIPTION
Realistically, nothing in NAV currently uses any PostgreSQL syntax newer than version 9.6.  However, this version of PostgreSQL has been EOL for many years, and we cannot even dump production data from modern PostgreSQL versions and expect to load them into our development installs by now.  Also, we expect to update to a newer Django release soon, and Django has deprecated support for PostgreSQLs older than 12.

PostgreSQL 13 ought to be our target, but the next NAV release should still be able to run on Debian Buster, which means PostgreSQL 11 must be the minimum for this release.  We can move to require PostgreSQL 13 in NAV 5.11.

This ensures that the dev environment will run PostgreSQL 13.  The Docker test environment and the GitHub test environments should be running PostgreSQL 11 until the next feature release.