### PR TITLE
Add QR Code link to 'My Stuff'

### DIFF
--- a/changelog.d/2897.added.md
+++ b/changelog.d/2897.added.md
@@ -1,0 +1,1 @@
+Add link to My Stuff that opens a pop up with a generated QR Code linking to that page

--- a/python/nav/web/sass/nav.scss
+++ b/python/nav/web/sass/nav.scss
@@ -20,6 +20,7 @@
 @import "nav/select2";
 @import "nav/footer";
 @import "nav/rickshaw";
+@import "nav/qr_code";
 
 // Overriding classes and mixins
 @import "overrides";

--- a/python/nav/web/sass/nav/_qr_code.scss
+++ b/python/nav/web/sass/nav/_qr_code.scss
@@ -1,0 +1,32 @@
+// Mostly copied from python/nav/web/sass/foundation/components/_reveal.scss
+
+#qr-code-modal {
+    .modal-underlay {
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background: rgba($black, .45);
+        z-index: 1004;
+    }
+
+    .modal-content {
+        position: absolute;
+        z-index: 1005;
+        width: 30%;
+        top:rem-calc(100);
+        left: 0;
+        right: 0;
+        margin: 0 auto;
+        border-radius: $global-radius;
+        box-shadow: 0 0 10px rgba($black,.4);
+        background-color: $white;
+        padding: rem-calc(20);
+
+        /* Center qr code */
+        text-align: center;
+
+    .close-reveal-modal { @include reveal-close; }
+    }
+}

--- a/python/nav/web/templates/base.html
+++ b/python/nav/web/templates/base.html
@@ -101,6 +101,7 @@
               <li><a href="{{ link.uri }}">{{ link.name }}</a></li>
             {% endfor %}
             <li class="divider"><a href="{% url 'webfront-preferences' %}">My account <i class="fa fa-gear"></i></a></li>
+            <li class="divider"><a hx-get="{% url 'webfront-qr-code' %}" hx-target="body" hx-swap="beforeend">QR Code <i class="fa fa-qrcode"></i></a></li>
           </ul>
         </li>
       {% endif %}

--- a/python/nav/web/templates/webfront/_qr_code.html
+++ b/python/nav/web/templates/webfront/_qr_code.html
@@ -1,0 +1,7 @@
+<div id="qr-code-modal">
+    <div class="modal-underlay" hx-on:click="htmx.remove(this.closest('#qr-code-modal'))"></div>
+    <div class="modal-content">
+        <a class="close-reveal-modal" aria-label="Close" hx-on:click="htmx.remove(this.closest('#qr-code-modal'))">&#215;</a>
+        <img src="data:image/png;base64,{{qr_code}}" alt="QR Code linking to current page">
+    </div>
+</div>

--- a/python/nav/web/utils.py
+++ b/python/nav/web/utils.py
@@ -79,11 +79,11 @@ def require_param(parameter):
     return wrap
 
 
-def generate_qr_code(url: str, caption: str = "") -> io.BytesIO:
+def generate_qr_code(url: str, caption: str = "") -> bytes:
     """
     Generate a QR code from a given url, and, if given, adds a caption to it
 
-    Returns the generated image as a bytes buffer
+    Returns the generated image as bytes
     """
     # Creating QR code
     qr = qrcode.QRCode(box_size=10)
@@ -113,25 +113,15 @@ def generate_qr_code(url: str, caption: str = "") -> io.BytesIO:
     img.save(file_object, "PNG")
     img.close()
 
-    return file_object
+    return file_object.getvalue()
 
 
-def convert_bytes_buffer_to_bytes_string(bytes_buffer: io.BytesIO) -> str:
-    return base64.b64encode(bytes_buffer.getvalue()).decode('utf-8')
-
-
-def generate_qr_codes_as_byte_strings(url_dict: dict[str, str]) -> list[str]:
+def generate_qr_code_as_string(url: str, caption: str = "") -> str:
     """
-    Takes a dict of the form {name:url} and returns a list of generated QR codes as
-    byte strings
+    Takes an url and an optional caption and returns a QR code as a string
     """
-    qr_code_byte_strings = []
-    for caption, url in url_dict.items():
-        qr_code_byte_buffer = generate_qr_code(url=url, caption=caption)
-        qr_code_byte_strings.append(
-            convert_bytes_buffer_to_bytes_string(bytes_buffer=qr_code_byte_buffer)
-        )
-    return qr_code_byte_strings
+    qr_code_bytes = generate_qr_code(url=url, caption=caption)
+    return base64.b64encode(qr_code_bytes).decode('utf-8')
 
 
 def validate_timedelta_for_overflow(days: int = 0, hours: int = 0):

--- a/python/nav/web/webfront/urls.py
+++ b/python/nav/web/webfront/urls.py
@@ -92,4 +92,5 @@ urlpatterns = [
         views.set_account_preference,
         name='set-account-preference',
     ),
+    re_path(r'^qr-code/$', views.qr_code, name='webfront-qr-code'),
 ]

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -41,6 +41,7 @@ from nav.web.auth import logout as auth_logout
 from nav.web import auth
 from nav.web.auth import ldap
 from nav.web.auth.utils import set_account
+from nav.web.utils import generate_qr_code_as_string
 from nav.web.utils import require_param
 from nav.web.webfront.utils import quick_read, tool_list
 from nav.web.webfront.forms import (
@@ -318,6 +319,14 @@ def preferences(request):
     context = _create_preference_context(request)
 
     return render(request, 'webfront/preferences.html', context)
+
+
+def qr_code(request):
+    """Show qr code linking to current page"""
+    url = request.headers.get("referer")
+    qr_code = generate_qr_code_as_string(url=url, caption=url)
+
+    return render(request, 'webfront/_qr_code.html', {'qr_code': qr_code})
 
 
 @sensitive_post_parameters('old_password', 'new_password1', 'new_password2')

--- a/tests/integration/web/webfront_test.py
+++ b/tests/integration/web/webfront_test.py
@@ -141,3 +141,18 @@ def test_shows_password_issue_banner_on_own_password_issues(db, client):
         "Your account has an insecure or old password. It should be reset."
         in smart_str(response.content)
     )
+
+
+def test_show_qr_code_returns_fragment_with_qr_code(client):
+    """
+    Tests that calling the qr_code view will return a fragment with a generated QR
+    code
+    """
+    url = reverse("webfront-qr-code")
+    header = {'HTTP_REFERER': 'www.example.com'}
+    response = client.get(url, follow=True, **header)
+
+    assert response.status_code == 200
+    assert "qr-code-modal" in smart_str(response.content)
+    assert "img" in smart_str(response.content)
+    assert "QR Code linking to current page" in smart_str(response.content)

--- a/tests/unittests/web/qrcode_test.py
+++ b/tests/unittests/web/qrcode_test.py
@@ -1,16 +1,13 @@
-import io
-
-from nav.web.utils import generate_qr_code, generate_qr_codes_as_byte_strings
+from nav.web.utils import generate_qr_code, generate_qr_code_as_string
 
 
-def test_generate_qr_code_returns_byte_buffer():
+def test_generate_qr_code_returns_bytes():
     qr_code = generate_qr_code(url="www.example.com", caption="buick.lab.uninett.no")
-    assert isinstance(qr_code, io.BytesIO)
+    assert isinstance(qr_code, bytes)
 
 
-def test_generate_qr_codes_as_byte_strings_returns_list_of_byte_strings():
-    qr_codes = generate_qr_codes_as_byte_strings(
-        {"buick.lab.uninett.no": "www.example.com"}
+def test_generate_qr_code_as_string_returns_string():
+    qr_code = generate_qr_code_as_string(
+        url="www.example.com", caption="buick.lab.uninett.no"
     )
-    assert isinstance(qr_codes, list)
-    assert isinstance(qr_codes[0], str)
+    assert isinstance(qr_code, str)


### PR DESCRIPTION
Dependent on #3386. Another part to #2586.

This adds a button to 'My Stuff' that when clicked opens a modal displaying a QR code with the link to current page. This modal can be dismissed by clicking on the "X" button or clicking outside of the modal. 

# Screenshots - before and after
## Before: 
![Screenshot from 2024-05-16 13-03-51](https://github.com/Uninett/nav/assets/39082189/7aa317a6-d6ae-49f4-baf8-5869104a6e1c)
## After:
<img width="2503" height="1243" alt="image" src="https://github.com/user-attachments/assets/524b5cf9-d2e4-4958-8cac-2947530aecdd" />

