### PR TITLE
Add back missing delete icon for form selectors

### DIFF
--- a/changelog.d/2898.fixed.md
+++ b/changelog.d/2898.fixed.md
@@ -1,0 +1,1 @@
+Fix missing delete icon in form selector labels

--- a/python/nav/web/sass/nav/_select2.scss
+++ b/python/nav/web/sass/nav/_select2.scss
@@ -592,7 +592,7 @@ disabled look for disabled choices in the results dropdown
 
 @media only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-resolution: 144dpi)  {
   .select2-search input, .select2-search-choice-close, .select2-container .select2-choice abbr, .select2-container .select2-choice .select2-arrow b {
-      background-image: url('#{$image-path-partials}/select2/select2x2.png') !important;
+      background-image: url('#{$image-path-partials}/select2/select2.png') !important;
       background-repeat: no-repeat !important;
       background-size: 60px 40px !important;
   }


### PR DESCRIPTION
Selector labels in forms did once have a visible delete icon (the X), not sure when they disappeared.  It seems the image they refer to has never been in the NAV code under that name, even if I'm sure I've seen it work at some point.

### Before

![2024-05-03_08-13](https://github.com/Uninett/nav/assets/100995/8d6572de-f873-4a38-919c-0cffd6b56173)


### After

![2024-05-03_08-13_1](https://github.com/Uninett/nav/assets/100995/a0fce12b-5794-4295-b136-35e666c08f1c)

