### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.7", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,4 +15,4 @@ python:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.7"
+    python: "3.9"

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -11,7 +11,7 @@ sonar.sources=bin, python
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
 
-sonar.python.version=3.7, 3.8, 3.9
+sonar.python.version=3.9,3.10
 sonar.tests=tests
 
 sonar.exclusions=python/nav/smidumps/**, python/nav/enterprise/ids.py, python/nav/etc/geomap/config.py

--- a/changelog.d/2790.changed.md
+++ b/changelog.d/2790.changed.md
@@ -1,0 +1,1 @@
+Upgrade dependencies after dropping support for Python 3.7

--- a/changelog.d/2790.removed.md
+++ b/changelog.d/2790.removed.md
@@ -1,0 +1,1 @@
+Drop support for Python 3.7

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,0 @@
-# ciscoconfparse 1.8 has a bug that prevents it from being imported on Python 3.7,
-# even though it claims compatibility with 3.7.
-ciscoconfparse<1.8.0 ; python_version < '3.8'

--- a/doc/howto/generic-install-from-source.rst
+++ b/doc/howto/generic-install-from-source.rst
@@ -18,7 +18,7 @@ Build requirements
 
 To build NAV, you need at least the following:
 
- * Python >= 3.7.0
+ * Python >= 3.9.0
  * Sphinx >= 1.0 (for building this documentation)
 
 Runtime requirements
@@ -29,7 +29,7 @@ To run NAV, these software packages are required:
  * Apache2 + mod_wsgi (or, really, any web server that supports the WSGI interface)
  * PostgreSQL >= 11 (With the ``hstore`` extension available)
  * :xref:`Graphite`
- * Python >= 3.7.0
+ * Python >= 3.9.0
  * nbtscan = 1.5.1
  * dhcping (only needed if using DHCP service monitor)
 
@@ -47,7 +47,7 @@ files::
 *However*, some of the required modules are C extensions that will require the
 presence of some C libraries to be correctly built (unless PyPI provides binary
 wheels for your platform). These include the ``psycopg2`` driver and the
-``python-ldap`` and ``Pillow`` modules).
+``python-ldap`` and ``Pillow`` modules.
 
 The current Python requirements are as follows:
 

--- a/doc/howto/manual-install-on-debian.rst
+++ b/doc/howto/manual-install-on-debian.rst
@@ -160,7 +160,7 @@ Copy the file :file:`/etc/nav/apache/apache.conf.example` to
 * ``documentation_path`` is where Sphinx put the docs, in
   ``$SOURCE_CODE_DIRECTORY/build/sphinx/html/``.
 * ``nav_uploads_path`` is the upload path you created in step 8.
-* ``nav_python_base`` should be :file:`/usr/local/lib/python3.7/dist-packages` (or wherever the ``nav`` Python module was installed)
+* ``nav_python_base`` should be :file:`/usr/local/lib/python3.9/dist-packages` (or wherever the ``nav`` Python module was installed)
 
 We suggest creating a new Apache site config:
 Inside a ``VirtualHost``-directive, add:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,6 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
 dynamic = ["version"]
-dependencies = [
-    "importlib_metadata; python_version < '3.8'",
-    "importlib_resources; python_version < '3.9'",
-]
 
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "nav"
 description = "Network Administration Visualized - A comprehensive, free Network Management System"
 authors = [{name="Sikt - Norwegian agency for shared services in education and research", email="nav-support@uninett.no"}]
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 license = {text = "GPLv3"}
 keywords = ["nms", "snmp"]
 classifiers = [

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ psycopg2==2.9.9  # requires libpq to build
 IPy==1.01
 pyaml
 
-twisted~=23.8.0  # last version that still supports Python 3.7
+twisted>=23.8.0
 
 networkx==2.6.3
 Pillow>3.3.2
@@ -35,7 +35,4 @@ libsass==0.15.1
 
 napalm==3.4.1
 
-backports.zoneinfo ; python_version < '3.9'
-importlib_metadata ; python_version < '3.8'
-importlib_resources ; python_version < '3.9'
 git+https://github.com/Uninett/drf-oidc-auth@v4.0#egg=drf-oidc-auth

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -20,7 +20,6 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get -y install --no-install-recommends \
       curl git build-essential \
-      python3.7-dbg python3.7-dev python3.7-distutils \
       python3.9-dbg python3.9-dev \
       python3.10-dbg python3.10-dev \
       python3-pip
@@ -68,7 +67,7 @@ RUN cd /tmp && \
     mv chromedriver /usr/local/bin/
 
 # Install our primary test runner
-RUN python3.7 -m pip install 'tox<4' snmpsim 'pyasn1<0.5.0' virtualenv
+RUN python3.9 -m pip install 'tox<4' snmpsim 'pyasn1<0.5.0' virtualenv
 
 # Add a build user
 ENV USER build

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,11 @@
 # of the documentation in hacking.rst
 [tox]
 envlist =
-    {unit,integration,functional}-py{37,39,310}-django{32}
+    {unit,integration,functional}-py{39,310}-django{32}
     javascript
     docs
 skipsdist = True
-basepython = python3.7
+basepython = python3.9
 
 [pytest]
 addopts = --failed-first
@@ -20,7 +20,6 @@ markers =
 
 [gh-actions]
 python =
-    3.7: py37
     3.9: py39
     3.10: py310
 


### PR DESCRIPTION
This closes #2891 and is one step in fixing #2790.

The things this PR does:
1. Update docker, tox, readthedocs, sonarcloud, Github workflows to not use Python 3.7 and only Python 3.9/3.10.
2. Upgrade dependencies that were stuck to an old version due to it being the last one supporting Python 3.7. 
3. Update docs and pyproject.toml to mention minimum requirement of Python 3.9.