### PR TITLE
Update PostgreSQL requirement to version 13

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -71,7 +71,7 @@ jobs:
       - name: "Set up PostgreSQL"
         uses: harmon758/postgresql-action@v1
         with:
-          postgresql version: '11'  # minimum NAV requirement
+          postgresql version: '13'  # minimum NAV requirement
           postgresql user: $PGUSER
           postgresql password: $PGPASSWORD
 

--- a/NOTES.rst
+++ b/NOTES.rst
@@ -8,6 +8,14 @@ existing bug reports, go to https://github.com/uninett/nav/issues .
 To see an overview of upcoming release milestones and the issues they resolve,
 please go to https://github.com/uninett/nav/milestones .
 
+NAV 5.11 (Unreleased)
+=====================
+
+Dependency changes
+------------------
+
+.. IMPORTANT:: NAV 5.11 requires PostgreSQL to be at least version *13*.
+
 NAV 5.10 (Unreleased)
 =====================
 

--- a/changelog.d/2892.changed.md
+++ b/changelog.d/2892.changed.md
@@ -1,0 +1,1 @@
+Changed required PostgreSQL version to 13

--- a/doc/howto/generic-install-from-source.rst
+++ b/doc/howto/generic-install-from-source.rst
@@ -27,7 +27,7 @@ Runtime requirements
 To run NAV, these software packages are required:
 
  * Apache2 + mod_wsgi (or, really, any web server that supports the WSGI interface)
- * PostgreSQL >= 11 (With the ``hstore`` extension available)
+ * PostgreSQL >= 13 (With the ``hstore`` extension available)
  * :xref:`Graphite`
  * Python >= 3.9.0
  * nbtscan = 1.5.1


### PR DESCRIPTION
Closes #2892.

After dropping support for Python 3.7 NAV will not run on Debian Buster anymore, only Debian Bullseye and therefore we can update our required PostgreSQL version to 13.