### PR TITLE
Remove all IRC channel references from documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,9 +13,6 @@
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :alt: Code style: black
    :target: https://github.com/psf/black
-.. image:: https://img.shields.io/badge/irc.libera.chat-%23nav-blue.svg
-   :alt: #nav@libera.chat
-   :target: https://web.libera.chat/?channel=#nav
 
 
 This is NAV - Network Administration Visualized - an advanced software suite

--- a/changelog.d/2907.removed.md
+++ b/changelog.d/2907.removed.md
@@ -1,0 +1,1 @@
+Removed references to IRC support channel from documentation, as the channel is closing down

--- a/doc/hacking/hacking.rst
+++ b/doc/hacking/hacking.rst
@@ -19,10 +19,9 @@ While Sikt is still the main contributor to NAV, developing NAV to support the
 needs of the Norwegian higher education community, contributions from third
 parties are highly appreciated.
 
-We communicate mainly through mailing lists, GitHub_, and the ``#nav`` IRC
-channel on *Libera.Chat*. At times, Sikt also arranges workshops and
-gatherings for its customers: Norwegian universities, university colleges and
-research institutions.
+We communicate mainly through mailing lists and GitHub_. At times, Sikt also
+arranges workshops and gatherings for its customers: Norwegian universities,
+university colleges and research institutions.
 
 To contribute:
 

--- a/doc/hacking/release-procedure.rst
+++ b/doc/hacking/release-procedure.rst
@@ -87,7 +87,5 @@ Announcing the release
 * Draft a new release for the new tag at GitHub.
 * Add a new release entry in the NAV homepage at
   https://github.com/Uninett/nav-landing-page/tree/master/content/releases
-* Change the topic of the #nav Libera.Chat IRC channel to reference the new
-  release + GitHub URL.
 * Send email announcement to the ``nav-users`` mailing list. Use previous
   release announcements as your template.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -19,8 +19,6 @@ Getting help
 * Post a question on `the nav-users mailing list`_ or search the
   `nav-users mailing list archives`_.
 
-* Ask a question on the `#nav IRC channel`_ on Libera.Chat.
-
 * Ask a question in our `GitHub discussion forum`_.
 
 * Report a bug in our `bug tracker`_.
@@ -28,7 +26,6 @@ Getting help
 .. _wiki pages: https://nav.uninett.no/wiki/
 .. _nav-users mailing list archives: https://lister.sikt.no/hyperkitty/list/nav-users@lister.sikt.no/
 .. _the nav-users mailing list: https://lister.sikt.no/postorius/lists/nav-users.lister.sikt.no/
-.. _#nav IRC channel: irc://irc.libera.chat/nav
 .. _bug tracker: https://github.com/Uninett/nav
 .. _GitHub discussion forum: https://github.com/Uninett/nav/discussions/categories/q-a
 


### PR DESCRIPTION
We are closing down our IRC support channel due to many years of low activity levels.  We have several other means of team and user communication that are far more popular.

This removes references to the IRC channel from our docs.