### PR TITLE
Remove Dict, List, Tuple and Type imports from Typing

### DIFF
--- a/python/nav/Snmp/pynetsnmp.py
+++ b/python/nav/Snmp/pynetsnmp.py
@@ -31,7 +31,7 @@ from ctypes import (
     c_ulong,
     c_uint64,
 )
-from typing import Union, Optional
+from typing import Optional, Union
 
 from IPy import IP
 from pynetsnmp import netsnmp

--- a/python/nav/bin/navclean.py
+++ b/python/nav/bin/navclean.py
@@ -21,7 +21,6 @@
 """Cleans old data from the NAV database"""
 import argparse
 import sys
-from typing import List
 
 from nav.bootstrap import bootstrap_django
 
@@ -171,7 +170,7 @@ def postgresql_interval(value):
 
 def get_selected_cleaners(
     args: argparse.Namespace, connection
-) -> List["RecordCleaner"]:
+) -> list["RecordCleaner"]:
     """Returns a list of RecordCleaner instances for each of the tables
     selected in the supplied ArgumentParser.
     """

--- a/python/nav/eventengine/severity.py
+++ b/python/nav/eventengine/severity.py
@@ -58,8 +58,8 @@ class Expression(typing.NamedTuple):
 
 
 SeverityModifier = typing.Callable[[int], int]
-Expressions = typing.Union[typing.Tuple[Expression], typing.Tuple[()]]
-Rule = typing.Tuple[Expressions, SeverityModifier]
+Expressions = typing.Union[tuple[Expression], tuple]
+Rule = tuple[Expressions, SeverityModifier]
 AlertObject = typing.Union[event.EventQueue, event.AlertQueue, event.AlertHistory]
 
 #
@@ -155,7 +155,7 @@ class SeverityRules(tuple):
 
     @classmethod
     def _parse_rule_sublist(
-        cls, current: Expressions, definitions: typing.List[dict]
+        cls, current: Expressions, definitions: list[dict]
     ) -> typing.Generator[Rule, None, None]:
         """Generator that parses a nested list of severity rule definitions and their
         corresponding severity modifiers, yielding a list of tuples describing the rules

--- a/python/nav/ipdevpoll/plugins/modules.py
+++ b/python/nav/ipdevpoll/plugins/modules.py
@@ -25,7 +25,6 @@ entity and an interface from IF-MIB is kept.  For each mapping found,
 the interface will have its module set to be whatever the ancestor
 module of the physical entity is.
 """
-from typing import List
 import configparser
 import re
 
@@ -164,7 +163,7 @@ class Modules(Plugin):
         self._process_ports(entities, module_containers)
 
 
-def get_ignored_serials(config: configparser.ConfigParser) -> List[str]:
+def get_ignored_serials(config: configparser.ConfigParser) -> list[str]:
     """Returns a list of ignored serial numbers from a ConfigParser instance"""
     if config is None:
         return []

--- a/python/nav/ipdevpoll/plugins/paloaltoarp.py
+++ b/python/nav/ipdevpoll/plugins/paloaltoarp.py
@@ -26,7 +26,6 @@ for example:
 """
 
 import xml.etree.ElementTree as ET
-from typing import Dict
 
 from IPy import IP
 from twisted.internet import defer, reactor, ssl
@@ -40,7 +39,7 @@ from nav.ipdevpoll.plugins.arp import Arp
 
 
 class PaloaltoArp(Arp):
-    configured_devices: Dict[str, str] = {}
+    configured_devices: dict[str, str] = {}
 
     @classmethod
     def on_plugin_load(cls):

--- a/python/nav/ipdevpoll/snmp/common.py
+++ b/python/nav/ipdevpoll/snmp/common.py
@@ -18,7 +18,7 @@ import time
 import logging
 from dataclasses import dataclass
 from functools import wraps
-from typing import Optional, Any, Dict
+from typing import Any, Optional
 
 from twisted.internet import reactor
 from twisted.internet.defer import succeed
@@ -218,7 +218,7 @@ class SNMPParameters:
         return cls(**kwargs_out)
 
     @classmethod
-    def get_params_from_ipdevpoll_config(cls, section: str = "snmp") -> Dict[str, Any]:
+    def get_params_from_ipdevpoll_config(cls, section: str = "snmp") -> dict[str, Any]:
         """Reads and returns global SNMP parameters from ipdevpoll configuration as a
         simple dict.
         """
@@ -236,7 +236,7 @@ class SNMPParameters:
 
         return params
 
-    def as_agentproxy_args(self) -> Dict[str, Any]:
+    def as_agentproxy_args(self) -> dict[str, Any]:
         """Returns the SNMP session parameters in a dict format compatible with
         pynetsnmp.twistedsnmp.AgentProxy() keyword arguments.
         """

--- a/python/nav/jwtconf.py
+++ b/python/nav/jwtconf.py
@@ -2,7 +2,7 @@ import logging
 from os.path import join
 from functools import partial
 import configparser
-from typing import Dict, Any
+from typing import Any
 
 from nav.config import ConfigurationError, NAVConfigParser
 
@@ -15,7 +15,7 @@ class JWTConf(NAVConfigParser):
     DEFAULT_CONFIG_FILES = [join('webfront', 'jwt.conf')]
     NAV_SECTION = "nav"
 
-    def get_issuers_setting(self) -> Dict[str, Any]:
+    def get_issuers_setting(self) -> dict[str, Any]:
         """Parses the webfront/jwt.conf config file and returns a dictionary that can
         be used as settings for the `drf-oidc-auth` django extension.
         If the parsing fails, an empty dict is returned.

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -28,7 +28,7 @@ from itertools import count, groupby
 import logging
 import math
 import re
-from typing import Set, Optional
+from typing import Optional
 
 import IPy
 from django.conf import settings
@@ -592,7 +592,7 @@ class Netbox(models.Model):
         )
 
     @property
-    def mac_addresses(self) -> Set[str]:
+    def mac_addresses(self) -> set[str]:
         """Returns a set of collected chassis MAC addresses for this Netbox"""
         macinfo_match = (Q(key="bridge_info") & Q(variable="base_address")) | (
             Q(key="lldp") & Q(variable="chassis_mac")

--- a/python/nav/napalm.py
+++ b/python/nav/napalm.py
@@ -16,7 +16,7 @@
 """This module contains NAPALM connectivity interfaces for NAV"""
 import weakref
 from tempfile import NamedTemporaryFile
-from typing import TypeVar, Type
+from typing import TypeVar
 import logging
 import napalm
 from napalm.base import NetworkDriver
@@ -71,7 +71,7 @@ def _write_key_to_temporary_file(config: dict, optional_args: dict):
 
 def get_driver(
     profile: manage.ManagementProfile,
-) -> Type[napalm.base.base.NetworkDriver]:
+) -> type[napalm.base.base.NetworkDriver]:
     """Returns a NAPALM NetworkDriver based on a management profile config"""
     if profile.protocol != profile.PROTOCOL_NAPALM:
         raise NapalmError("Management profile is not a NAPALM profile")

--- a/python/nav/portadmin/handlers.py
+++ b/python/nav/portadmin/handlers.py
@@ -15,7 +15,7 @@
 #
 """Interface definition for PortAdmin management handlers"""
 import time
-from typing import List, Tuple, Dict, Any, Sequence, Union, Optional
+from typing import Any, Optional, Sequence, Union
 import logging
 from dataclasses import dataclass
 
@@ -58,7 +58,7 @@ class ManagementHandler:
 
     def get_interfaces(
         self, interfaces: Sequence[manage.Interface] = None
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Retrieves running configuration switch ports on the device.
 
         :param interfaces: Optional list of interfaces to filter for, as fetching
@@ -140,7 +140,7 @@ class ManagementHandler:
 
     def _filter_oper_up_interfaces(
         self, interfaces: Sequence[manage.Interface]
-    ) -> List[manage.Interface]:
+    ) -> list[manage.Interface]:
         """Filters a list of Interface objects, returning only those that are
         currently operationally up.
 
@@ -183,7 +183,7 @@ class ManagementHandler:
         """
         raise NotImplementedError
 
-    def get_netbox_vlans(self) -> List[FantasyVlan]:
+    def get_netbox_vlans(self) -> list[FantasyVlan]:
         """Returns a list of FantasyVlan objects representing the enabled VLANs on
         this netbox.
 
@@ -193,7 +193,7 @@ class ManagementHandler:
         """
         raise NotImplementedError
 
-    def get_netbox_vlan_tags(self) -> List[int]:
+    def get_netbox_vlan_tags(self) -> list[int]:
         """Returns a list of enabled VLANs on this netbox.
 
         :returns: A list of VLAN tags (integers)
@@ -232,7 +232,7 @@ class ManagementHandler:
         """Should not be implemented on anything else than Cisco"""
         raise NotImplementedError
 
-    def get_native_and_trunked_vlans(self, interface) -> Tuple[int, List[int]]:
+    def get_native_and_trunked_vlans(self, interface) -> tuple[int, list[int]]:
         """Get the trunked vlans on this interface
 
         :returns: (native_vlan_tag, list_of_trunked_vlan_tags)
@@ -264,7 +264,7 @@ class ManagementHandler:
         """Returns True if 802.1X authentication is is enabled on interface"""
         raise NotImplementedError
 
-    def get_dot1x_enabled_interfaces(self) -> Dict[str, bool]:
+    def get_dot1x_enabled_interfaces(self) -> dict[str, bool]:
         """Fetches the 802.1X enabled state of every interface.
 
         :returns: A dict mapping each interface name to a "802.1X enabled" value
@@ -302,7 +302,7 @@ class ManagementHandler:
 
     def get_poe_states(
         self, interfaces: Optional[Sequence[manage.Interface]] = None
-    ) -> Dict[str, Optional[PoeState]]:
+    ) -> dict[str, Optional[PoeState]]:
         """Retrieves current PoE state for interfaces on this device.
 
         :param interfaces: Optional sequence of interfaces to filter for, as fetching

--- a/python/nav/portadmin/napalm/juniper.py
+++ b/python/nav/portadmin/napalm/juniper.py
@@ -26,9 +26,8 @@ but many of the operations PortAdmin needs are not directly supported by the NAP
 so the underlying Juniper PyEZ library is utilized directly in most cases.
 
 """
-from __future__ import annotations
 from operator import attrgetter
-from typing import List, Any, Dict, Tuple, Sequence, Optional
+from typing import Any, Optional, Sequence
 
 from django.template.loader import get_template
 from napalm.base.exceptions import ConnectAuthError, ConnectionException
@@ -165,7 +164,7 @@ class Juniper(ManagementHandler):
 
     def get_interfaces(
         self, interfaces: Sequence[manage.Interface] = None
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         vlan_map = self._get_untagged_vlans()
         if interfaces and len(interfaces) == 1:
             # we can use a filter if only a single interface was specified
@@ -211,7 +210,7 @@ class Juniper(ManagementHandler):
             switching.get()
             return {port.ifname: port.tag for port in switching if not port.tagged}
 
-    def get_netbox_vlans(self) -> List[FantasyVlan]:
+    def get_netbox_vlans(self) -> list[FantasyVlan]:
         vlan_objects = manage.Vlan.objects.filter(
             swport_vlans__interface__netbox=self.netbox
         ).distinct()
@@ -234,7 +233,7 @@ class Juniper(ManagementHandler):
         }
         return sorted(result, key=attrgetter("vlan"))
 
-    def get_netbox_vlan_tags(self) -> List[int]:
+    def get_netbox_vlan_tags(self) -> list[int]:
         return [vlan.tag for vlan in self.vlans]
 
     def get_interface_native_vlan(self, interface: manage.Interface) -> int:
@@ -244,7 +243,7 @@ class Juniper(ManagementHandler):
     def set_native_vlan(self, interface: manage.Interface, vlan: int):
         raise NotImplementedError  # This is in fact never used on Juniper!
 
-    def get_native_and_trunked_vlans(self, interface) -> Tuple[int, List[int]]:
+    def get_native_and_trunked_vlans(self, interface) -> tuple[int, list[int]]:
         if not self.is_els:
             switching = EthernetSwitchingInterfaceTable(self.device.device)
             switching.get(interface_name=interface.ifname)
@@ -472,7 +471,7 @@ class Juniper(ManagementHandler):
 
     def get_poe_states(
         self, interfaces: Optional[Sequence[manage.Interface]] = None
-    ) -> Dict[str, Optional[PoeState]]:
+    ) -> dict[str, Optional[PoeState]]:
         """Retrieves current PoE state for interfaces on this device.
 
         :param interfaces: Optional sequence of interfaces to filter for, as fetching
@@ -520,7 +519,7 @@ class Juniper(ManagementHandler):
 
     def _get_poe_states_bulk(
         self, interfaces: Sequence[manage.Interface]
-    ) -> Dict[str, Optional[PoeState]]:
+    ) -> dict[str, Optional[PoeState]]:
         tree = self._get_all_poe_interface_information()
         interface_information_elements = tree.findall(".//interface-information")
         ifname_to_state_dict = {}
@@ -558,7 +557,7 @@ class Juniper(ManagementHandler):
     # dot1x authentication configuration fetchers aren't implemented yet, for lack
     # of configured devices to test on
     # def is_dot1x_enabled(self, interface: manage.Interface) -> bool:
-    # def get_dot1x_enabled_interfaces(self) -> Dict[str, bool]:
+    # def get_dot1x_enabled_interfaces(self) -> dict[str, bool]:
     # def is_port_access_control_enabled(self) -> bool:
 
     # These are not relevant for Juniper
@@ -578,7 +577,7 @@ def is_unit(name: str) -> bool:
     return len(names) == 2
 
 
-def split_master_unit(name: str) -> Tuple[str, str]:
+def split_master_unit(name: str) -> tuple[str, str]:
     """Splits an interface name into master and unit parts. If the name doesn't
     already refer to a unit, unit 0 will be assumed.
     """

--- a/python/nav/portadmin/snmp/base.py
+++ b/python/nav/portadmin/snmp/base.py
@@ -17,7 +17,7 @@
 from functools import wraps
 from operator import attrgetter
 import logging
-from typing import Dict, Sequence, List, Any
+from typing import Any, Sequence
 
 from nav.Snmp.profile import get_snmp_session_for_profile
 from nav.Snmp import safestring, OID
@@ -250,7 +250,7 @@ class SNMPHandler(ManagementHandler):
     @translate_protocol_errors
     def get_interfaces(
         self, interfaces: Sequence[manage.Interface] = None
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         names = self._get_interface_names()
         aliases = self._get_all_ifaliases()
         oper = dict(self._get_all_interfaces_oper_status())
@@ -270,7 +270,7 @@ class SNMPHandler(ManagementHandler):
         ]
         return result
 
-    def _get_interface_names(self) -> Dict[int, str]:
+    def _get_interface_names(self) -> dict[int, str]:
         """Returns a mapping of interface indexes to ifName values"""
         return {
             OID(index)[-1]: safestring(value)

--- a/python/nav/portadmin/snmp/cisco.py
+++ b/python/nav/portadmin/snmp/cisco.py
@@ -16,7 +16,7 @@
 #
 """Cisco specific PortAdmin SNMP handling"""
 import logging
-from typing import Sequence, Dict, Optional, Tuple
+from typing import Optional, Sequence
 
 from nav.Snmp.errors import SnmpError
 from nav.bitvector import BitVector
@@ -345,7 +345,7 @@ class Cisco(SNMPHandler):
 
     def _get_poe_indexes_for_interface(
         self, interface: manage.Interface
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         """Returns the unit number and interface number for the given interface"""
         try:
             poeport = manage.POEPort.objects.get(interface=interface)
@@ -359,7 +359,7 @@ class Cisco(SNMPHandler):
 
     def get_poe_states(
         self, interfaces: Optional[Sequence[manage.Interface]] = None
-    ) -> Dict[str, Optional[PoeState]]:
+    ) -> dict[str, Optional[PoeState]]:
         """Retrieves current PoE state for interfaces on this device.
 
         :param interfaces: Optional sequence of interfaces to filter for, as fetching

--- a/python/nav/web/alertprofiles/forms.py
+++ b/python/nav/web/alertprofiles/forms.py
@@ -18,7 +18,7 @@
 
 # pylint: disable=R0903
 
-from typing import Any, Dict
+from typing import Any
 
 from django import forms
 from django.db.models import Q
@@ -642,7 +642,7 @@ class ExpressionForm(forms.ModelForm):
             else:
                 self.fields['value'] = forms.CharField(required=True)
 
-    def clean(self) -> Dict[str, Any]:
+    def clean(self) -> dict[str, Any]:
         validated_data = super().clean()
 
         match_field = validated_data["match_field"]

--- a/python/nav/web/portadmin/utils.py
+++ b/python/nav/web/portadmin/utils.py
@@ -15,7 +15,7 @@
 #
 """Util functions for the PortAdmin"""
 from __future__ import unicode_literals
-from typing import List, Sequence, Dict, Any, Optional
+from typing import Any, Optional, Sequence
 import re
 import logging
 from operator import attrgetter
@@ -45,7 +45,7 @@ def get_and_populate_livedata(netbox, interfaces):
 
 
 def update_interfaces_with_collected_data(
-    interfaces: Sequence[manage.Interface], livedata: Sequence[Dict[str, Any]]
+    interfaces: Sequence[manage.Interface], livedata: Sequence[dict[str, Any]]
 ):
     """Updates the list of Interface objects with data gathered via
     ManagementHandler.get_interfaces().
@@ -83,7 +83,7 @@ def find_and_populate_allowed_vlans(
 
 def find_allowed_vlans_for_user_on_netbox(
     account: profiles.Account, netbox: manage.Netbox, handler: ManagementHandler = None
-) -> List[FantasyVlan]:
+) -> list[FantasyVlan]:
     """Finds allowed vlans for this user on this netbox"""
     netbox_vlans = find_vlans_on_netbox(netbox, handler=handler)
 
@@ -101,7 +101,7 @@ def find_allowed_vlans_for_user_on_netbox(
 
 def find_vlans_on_netbox(
     netbox: manage.Netbox, handler: ManagementHandler = None
-) -> List[FantasyVlan]:
+) -> list[FantasyVlan]:
     """Find all the available vlans on this netbox
 
     :param netbox: The Netbox whose available VLANs you want to find.

--- a/python/nav/web/utils.py
+++ b/python/nav/web/utils.py
@@ -17,7 +17,6 @@
 import base64
 import io
 import os
-from typing import Dict, List
 
 from django.http import HttpResponse
 from django.views.generic.list import ListView
@@ -114,7 +113,7 @@ def convert_bytes_buffer_to_bytes_string(bytes_buffer: io.BytesIO) -> str:
     return base64.b64encode(bytes_buffer.getvalue()).decode('utf-8')
 
 
-def generate_qr_codes_as_byte_strings(url_dict: Dict[str, str]) -> List[str]:
+def generate_qr_codes_as_byte_strings(url_dict: dict[str, str]) -> list[str]:
     """
     Takes a dict of the form {name:url} and returns a list of generated QR codes as
     byte strings

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,7 +8,6 @@ from itertools import cycle
 from shutil import which
 import subprocess
 import time
-from typing import Dict
 
 import toml
 import pytest
@@ -120,12 +119,12 @@ def _nav_script_tests():
                 yield [script] + args[1:]
 
 
-def _nav_scripts_map() -> Dict[str, str]:
+def _nav_scripts_map() -> dict[str, str]:
     """Returns a map of installable script names to NAV module names from
     pyproject.toml.
     """
     data = toml.load('pyproject.toml')
-    scripts: Dict[str, str] = data.get('project', {}).get('scripts', {})
+    scripts: dict[str, str] = data.get('project', {}).get('scripts', {})
     return {
         script: module.split(':', maxsplit=1)[0]
         for script, module in scripts.items()


### PR DESCRIPTION
Dependent on #2949.

See https://peps.python.org/pep-0585/. 
Since Python 3.9 one can simply use the build-in version.