### PR TITLE
Delay ARP record closures for devices that have been down for a while

### DIFF
--- a/changelog.d/2913.fixed.md
+++ b/changelog.d/2913.fixed.md
@@ -1,0 +1,1 @@
+ARP records of unreachable devices are now closed by `navclean` cron job at configurable expiry intervals, rather than immediately as a response to a short ICMP packet loss

--- a/doc/reference/backend-processes.rst
+++ b/doc/reference/backend-processes.rst
@@ -126,7 +126,9 @@ dbclean
 Regularly cleans out old data from the NAV database, using the
 :program:`navclean` program. The standard cleanup routine removes old web user
 interface sessions, and deletes IP devices that have been scheduled for
-deletion through either SeedDB or the API.
+deletion through either SeedDB or the API.  Additionally, it closes open ARP
+records that have been collected from routers that have been unreachable for
+more than 30 minutes (adjustable by modifying the `dbclean` cron fragment).
 
 :Dependencies:
   None

--- a/python/nav/bin/navclean.py
+++ b/python/nav/bin/navclean.py
@@ -54,8 +54,8 @@ def main():
             count = cleaner.clean(expiry, dry_run=not args.force)
             if not args.quiet:
                 print(
-                    "Expired records in {table}: {count}".format(
-                        table=cleaner.expiry_type,
+                    "Expired {expiry_type} records: {count}".format(
+                        expiry_type=cleaner.expiry_type,
                         count=count if count is not None else "N/A",
                     )
                 )

--- a/python/nav/bin/navclean.py
+++ b/python/nav/bin/navclean.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -*- testargs: --arp -*-
+# -*- testargs: --close-arp -*-
 #
 # Copyright (C) 2017 Uninett AS
 # Copyright (C) 2024 Sikt

--- a/python/nav/bin/navclean.py
+++ b/python/nav/bin/navclean.py
@@ -3,6 +3,7 @@
 # -*- testargs: --arp -*-
 #
 # Copyright (C) 2017 Uninett AS
+# Copyright (C) 2024 Sikt
 #
 # This file is part of Network Administration Visualized (NAV).
 #
@@ -16,7 +17,7 @@
 # details.  You should have received a copy of the GNU General Public License
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
-"""Deletes old data from the NAV database"""
+"""Cleans old data from the NAV database"""
 import sys
 import argparse
 
@@ -86,39 +87,50 @@ def main():
 def make_argparser():
     """Makes this program's ArgumentParser"""
     parser = argparse.ArgumentParser(
-        description="Deletes old data from the NAV database",
-        epilog="Unless options are given, the number of expired records will "
-        "be printed. The default expiry limit is 6 months. The -e and -E"
-        " options set a common expiry date for all selected tables. If "
-        "you want different expiry dates for each table, you need to "
-        "run navclean more than once. To actually delete the expired "
-        "records, add the -f option.",
+        description="Cleans old data from the NAV database",
+        epilog="Cleaning old data means either deleting old records, or updating "
+        "expired records.  Use options to select which types of data to clean. "
+        "The -e and -E options set an expiry date that applies to all "
+        "selected data types.  Every run is a dry-run by default, unless the "
+        "-f option is given, in order to avoid accidental data deletion.",
     )
     arg = parser.add_argument
 
-    arg("-q", "--quiet", action="store_true", help="be quiet")
-    arg("-f", "--force", action="store_true", help="force deletion of expired records")
+    arg("-q", "--quiet", action="store_true", help="Be quiet")
+    arg("-f", "--force", action="store_true", help="Force actual database updates")
     arg(
         "-e",
         "--datetime",
         type=postgresql_datetime,
-        help="set an explicit expiry date on ISO format",
+        help="Set an explicit expiry date on ISO format",
     )
     arg(
         "-E",
         "--interval",
         type=postgresql_interval,
         default="6 months",
-        help="set an expiry interval using PostgreSQL interval syntax, e.g. "
-        "'30 days', '4 weeks', '6 months'",
+        help="Set an expiry interval using PostgreSQL interval syntax, e.g. "
+        "'30 days', '4 weeks', '6 months', '30 minutes'",
     )
 
-    arg("--arp", action="store_true", help="delete from ARP table")
-    arg("--cam", action="store_true", help="delete from CAM table")
-    arg("--radiusacct", action="store_true", help="delete from Radius accounting table")
-    arg("--radiuslog", action="store_true", help="delete from Radius error log table")
-    arg("--netbox", action="store_true", help="delete from NETBOX table")
-    arg("--websessions", action="store_true", help="delete expired web sessions")
+    arg("--arp", action="store_true", help="Delete old records from ARP table")
+    arg("--cam", action="store_true", help="Delete old records from CAM table")
+    arg(
+        "--radiusacct",
+        action="store_true",
+        help="Delete old records from Radius accounting table",
+    )
+    arg(
+        "--radiuslog",
+        action="store_true",
+        help="Delete old records from Radius error log table",
+    )
+    arg(
+        "--netbox",
+        action="store_true",
+        help="Delete netboxes that have been marked for deletion by Seed Database",
+    )
+    arg("--websessions", action="store_true", help="Delete expired web sessions")
 
     return parser
 

--- a/python/nav/bin/navclean.py
+++ b/python/nav/bin/navclean.py
@@ -235,7 +235,7 @@ class ArpCloser(RecordCleaner):
     def sql(self, expiry):
         """Returns the full UPDATE statement based on the expiry date"""
         return f"""
-            WITH downsince AS (
+            WITH unreachable_devices AS (
                 SELECT
                     netboxid,
                     start_time AS downsince
@@ -254,7 +254,7 @@ class ArpCloser(RecordCleaner):
                     SELECT
                         netboxid
                     FROM
-                        downsince
+                        unreachable_devices
                     WHERE
                         downsince < {expiry})
                 AND end_time >= 'infinity'

--- a/python/nav/bin/navclean.py
+++ b/python/nav/bin/navclean.py
@@ -17,8 +17,6 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Deletes old data from the NAV database"""
-from __future__ import print_function
-
 import sys
 import argparse
 

--- a/python/nav/etc/cron.d/dbclean
+++ b/python/nav/etc/cron.d/dbclean
@@ -1,2 +1,3 @@
 ## info: Clean database with navclean
 */5 * * * * navclean -f -q --netbox --websessions
+*/5 * * * * navclean -f -q --close-arp --interval '30 minutes'

--- a/python/nav/models/sql/changes/sc.05.10.0001.sql
+++ b/python/nav/models/sql/changes/sc.05.10.0001.sql
@@ -1,0 +1,2 @@
+-- Remove malfunctioning ARP record closing rule, see #2910
+DROP RULE IF EXISTS netbox_close_arp ON netbox;


### PR DESCRIPTION
Instead of immediately closing the ARP records read from a netbox as soon as its pping up/down status flaps, we should wait for the netbox to stay down for longer.  At this point, we cannot accomplish this usefully as a PostgreSQL rule or trigger, so this suggests removing the old database rule and replacing it with a new argument to the already-existing `navclean` command.  In this way, the expiry interval is even configurable for end users (or can be disabled entirely).

The terminology used in the `navclean` code was heavily centered around the concept on deletion, so this PR also introduces a renaming of this concept to just the generic "cleaning", since the new cleaner type doesn't actually delete records, it just sets a timestamp in them.

Fixes #2910
