### PR TITLE
Do not publish test reports on pushes to master

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -31,7 +31,7 @@ jobs:
            done
 
       - name: "Publish test results"
-        uses: EnricoMi/publish-unit-test-result-action/composite@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           check_name: "Test results"

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -5,6 +5,7 @@ on:
     workflows: ["Build NAV and run full test suite"]
     types:
       - completed
+    branches-ignore: ["master"] # Do not run on pushes to master
 
 jobs:
   publish-test-results:


### PR DESCRIPTION
Closes #2862.

This will only publish test results if the branch the workflow "Build NAV and run full test suite" is running on is not master.

Reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_runbranchesbranches-ignore

Does this workflow usually fail on pushes to other branches? Because the commit https://github.com/Uninett/nav/commit/3e434bc8f6c50284f1fd0b87189a0103d158d949#diff-208a7f7ef0a1174d68708f24502994bd2a136c75128806eb0cf63c0a70679321 does not do anything about this as far as I understand it. 

See https://github.com/EnricoMi/publish-unit-test-result-action/releases/tag/v2.15.0 for the change in the publish Github action.