### PR TITLE
Reduce number of concurrent DNS lookups in Machine Tracker

### DIFF
--- a/changelog.d/+2669.fixed.md
+++ b/changelog.d/+2669.fixed.md
@@ -1,0 +1,1 @@
+Fix Machine Tracker DNS search crashing from exhausting all available file descriptors

--- a/python/nav/asyncdns.py
+++ b/python/nav/asyncdns.py
@@ -89,7 +89,7 @@ class Resolver(object):
                 for deferred in self.lookup(name):
                     deferred.addCallback(self._extract_records, name)
                     deferred.addErrback(self._errback, name)
-                    deferred.addCallback(self._parse_result)
+                    deferred.addCallback(self._save_result)
                     yield deferred
 
         # Limits the number of parallel requests to BATCH_SIZE
@@ -116,7 +116,7 @@ class Resolver(object):
     def _extract_records(result, name):
         raise NotImplementedError
 
-    def _parse_result(self, result):
+    def _save_result(self, result):
         name, response = result
         if isinstance(response, Exception):
             self.results[name] = response


### PR DESCRIPTION
Fixes #2669 

Limits concurrent parallel lookups to 100 at a time.

Tested manually that machine tracker no longer crashes from hitting the file descriptor limit with `ulimit` set as low as 200 on a search with 4096 results.  This would previously crash instantly

The amount of parallel lookups should perhaps be configurable but that can be separate pr if we see the need

A practical change I made is that saving the results from a lookup to the dict `self.results` will now happen during the parallel lookups, instead of at the end. I made this change simply because using `Cooperator` changes how the `DefferedList` we use look like. Instead of all the separate lookup tasks being in the list, the list now contains 100 iterators. 
I dont know how to add a callback to the list that will actually be able to go through all the results produced instead of just going over the iterators themselves, so I moved the saving step to be part of the smaller work units.

Errors that were previously raised by themselves are now eaten up by the `Cooperator`. Tried to fix this by saving all errors then raising the first one that occurred. I expect this keeps the interfacing with the `asyncdns` module intact, but side effect is that it will only raise the exceptions after its done running, so its slower to fail