### PR TITLE
Also deprecate Python 3.8

### DIFF
--- a/NOTES.rst
+++ b/NOTES.rst
@@ -15,7 +15,7 @@ Deprecation warnings
 --------------------
 
 .. warning:: The next feature release of NAV (5.11) will drop support for
-             Python 3.7.
+             Python versions older than 3.9.
 
 Dependency changes
 ------------------

--- a/changelog.d/+py37-deprecation.deprecated.md
+++ b/changelog.d/+py37-deprecation.deprecated.md
@@ -1,1 +1,1 @@
-Support for Python 3.7 will be dropped in NAV 5.11.
+Support for Python versions older than 3.9 will be dropped in NAV 5.11.


### PR DESCRIPTION
Our deprecation of Python 3.7 is a de-facto deprecation also of Python 3.8, since we will only explicitly target that and newer versions.  The notes and changelogs should be more explicit about this.