### PR TITLE
Fix syntax for branches-ignore in publish tests results

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -5,7 +5,8 @@ on:
     workflows: ["Build NAV and run full test suite"]
     types:
       - completed
-    branches-ignore: ["master"] # Do not run on pushes to master
+    branches-ignore:  # Do not run on pushes to master
+      - "master"
 
 jobs:
   publish-test-results:


### PR DESCRIPTION
We have observed that after merging #2914 no test reports have been published, after observing #2920 and looking at the documentation for [branches-ignore](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_runbranchesbranches-ignore) I realized that the syntax looks a bit different...Let's hope this fixes it. 