### PR TITLE
Only publish test results if triggering workflow was triggered by PR

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -12,7 +12,8 @@ jobs:
     name: "Publish test results"
     runs-on: ubuntu-latest
     if: >
-      github.event.workflow_run.conclusion != 'skipped'
+      github.event.workflow_run.conclusion != 'skipped' &&
+      github.event.workflow_run.event == 'pull_request'
 
     steps:
       - name: Download and Extract Artifacts

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -5,7 +5,6 @@ on:
     workflows: ["Build NAV and run full test suite"]
     types:
       - completed
-    branches-ignore: ["master"] # Do not run on pushes to master
 
 jobs:
   publish-test-results:


### PR DESCRIPTION
Tested in my own private repo, both with a succeeding triggering workflow as well as a failing triggering workflow. 

Reverts #2914.

Reference:
https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run (See: Properties of `workflow_run`)