### PR TITLE
Make parse_arp index agnostic

### DIFF
--- a/changelog.d/2924.fixed.md
+++ b/changelog.d/2924.fixed.md
@@ -1,0 +1,1 @@
+Parsing paloalto XML based on keys instead of indexes

--- a/python/nav/ipdevpoll/plugins/paloaltoarp.py
+++ b/python/nav/ipdevpoll/plugins/paloaltoarp.py
@@ -138,11 +138,11 @@ def parse_arp(arp):
     arps = []
 
     root = ET.fromstring(arp)
-    entries = root[0][4]
+    entries = root.find("result").find("entries")
     for entry in entries:
-        status = entry[0].text
-        ip = entry[1].text
-        mac = entry[2].text
+        status = entry.find("status").text
+        ip = entry.find("ip").text
+        mac = entry.find("mac").text
         if status.strip() != "i":
             if mac != "(incomplete)":
                 arps.append(('ifindex', IP(ip), mac))


### PR DESCRIPTION
This resolves #2924 by making the parse_arp function index agnostic.