### PR TITLE
Reinstate database rule `netbox_close_arp` and delete `netbox_status_close_arp` instead

### DIFF
--- a/changelog.d/2910.fixed.md
+++ b/changelog.d/2910.fixed.md
@@ -1,0 +1,1 @@
+Replace incorrect fix for premature ARP record closure introduced in 5.10.1

--- a/python/nav/models/sql/changes/sc.05.10.0002.sql
+++ b/python/nav/models/sql/changes/sc.05.10.0002.sql
@@ -1,0 +1,12 @@
+-- Reinstate rule that closes ARP records on netbox deletion, see #2910
+CREATE OR REPLACE RULE netbox_close_arp AS ON DELETE TO netbox
+  DO UPDATE arp SET end_time=NOW()
+     WHERE netboxid=OLD.netboxid AND end_time='infinity';
+
+-- Close all open ARP records that have no associated netbox (those that may have been kept open in error due to
+-- deletions between 5.10.1 and 5.10.2)
+UPDATE arp SET end_time=NOW()
+  WHERE end_time>='infinity' AND netboxid IS NULL;
+
+-- Remove actually malfunctioning ARP record closing rule, see #2910
+DROP RULE IF EXISTS netbox_status_close_arp ON netbox;


### PR DESCRIPTION
Unfortunately, #2913 (43d5543be92494877c92e082373ceaebd24568e6) deleted the incorrect database rule and made it into a release.  This reinstates the rule, ensures data integrity and deletes the *correct* rule: `netbox_status_close_arp`

Fixes #2910