### PR TITLE
Factor out codecov upload

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,10 +12,10 @@ jobs:
         python-version: ["3.7", "3.9", "3.10"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Cache pip packages"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: pip-cache
         with:
           path: ~/.cache/pip
@@ -24,14 +24,14 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: "Cache tox environments"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: tox-cache
         with:
           path: .tox
           key: ${{ runner.os }}-tox-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt', '**/requirements/*.txt', 'tox.ini') }}
 
       - name: "Set up Python ${{ matrix.python-version }}"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -84,9 +84,9 @@ jobs:
 
       - name: Upload Selenium driver logs (${{ matrix.python-version }})
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: pytest-logs
+          name: pytest-logs-${{ matrix.python-version }}
           path: |
             /tmp/pytest-of-runner
 
@@ -99,17 +99,17 @@ jobs:
 
       - name: Upload test reports (${{ matrix.python-version }})
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test-reports
+          name: test-reports-${{ matrix.python-version }}
           path: |
             reports/**/*
 
       - name: Upload core dumps (${{ matrix.python-version }})
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: core-dumps
+          name: core-dumps-${{ matrix.python-version }}
           path: |
             /tmp/core-*
 
@@ -130,11 +130,11 @@ jobs:
     name: "Test Javascript code"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: browser-actions/setup-chrome@latest
       - uses: browser-actions/setup-firefox@latest
       - run: chrome --version
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -149,7 +149,7 @@ jobs:
 
       - name: Upload JavaScript test reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: javascript-test-reports
           path: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -90,13 +90,6 @@ jobs:
           path: |
             /tmp/pytest-of-runner
 
-      - name: "Upload coverage to Codecov"
-        if: github.repository_owner == 'Uninett'
-        uses: codecov/codecov-action@v4
-        with:
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }} # not required for forks of public repos
-
       - name: Upload test reports (${{ matrix.python-version }})
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -147,3 +147,24 @@ jobs:
           name: javascript-test-reports
           path: |
             reports/**/*
+
+  upload-pr-number-base-sha:
+    name: Save PR number and base SHA in artifact
+    runs-on: ubuntu-latest
+    if: ${{ github.event.number && always() }}
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+    steps:
+      - name: Make PR number file
+        run: |
+          mkdir -p ./extra
+          echo $PR_NUMBER > ./extra/pr_number
+      - name: Make base SHA file
+        run: |
+          echo $BASE_SHA > ./extra/base_sha
+      - name: Upload PR number file and base SHA file
+        uses: actions/upload-artifact@v4
+        with:
+          name: extra
+          path: extra/

--- a/.github/workflows/dockercompose.yml
+++ b/.github/workflows/dockercompose.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: docker-compose build
         run: |
@@ -37,7 +37,7 @@ jobs:
       - name: Send GitHub Action trigger data to Slack workflow
         id: slack
         if: failure()
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@v1.26.0
         with:
           payload: |
             {

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -39,7 +39,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
@@ -48,7 +48,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: github/super-linter/slim@v6
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -30,7 +30,7 @@ jobs:
            done
 
       - name: "Publish test results"
-        uses: EnricoMi/publish-unit-test-result-action/composite@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           check_name: "Test results"

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -35,8 +35,31 @@ jobs:
           check_name: "Test results"
           files: artifacts/**/*-results.xml
 
+      - name: Read PR number file
+        if: ${{ hashFiles('artifacts/extra/pr_number') != '' }}
+        run: |
+          pr_number=$(cat artifacts/extra/pr_number)
+          re='^[0-9]+$'
+          if [[ $pr_number =~ $re ]] ; then
+            echo "PR_NUMBER=$pr_number" >> $GITHUB_ENV
+          fi
+
+      - name: Read base SHA file
+        if: ${{ hashFiles('artifacts/extra/base_sha') != '' }}
+        run: |
+          base_sha=$(cat artifacts/extra/base_sha)
+          re='[0-9a-f]{40}'
+          if [[ $base_sha =~ $re ]] ; then
+            echo "BASE_SHA=$base_sha" >> $GITHUB_ENV
+          fi
+
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }} # not required for forks of public repos
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+          override_branch: ${{ github.event.workflow_run.head_branch}}
+          override_commit: ${{ github.event.workflow_run.head_sha}}
+          commit_parent: ${{ env.BASE_SHA }}
+          override_pr: ${{ env.PR_NUMBER }}

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -35,3 +35,10 @@ jobs:
           commit: ${{ github.event.workflow_run.head_sha }}
           check_name: "Test results"
           files: artifacts/**/*-results.xml
+
+      - name: "Upload coverage to Codecov"
+        if: github.repository_owner == 'Uninett'
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for forks of public repos

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -10,8 +10,7 @@ jobs:
   publish-test-results:
     name: "Publish test results"
     runs-on: ubuntu-latest
-    if: >
-      github.event.workflow_run.conclusion != 'skipped'
+    if: github.event.workflow_run.conclusion != 'skipped' && github.repository_owner == 'Uninett'
 
     steps:
       - name: Download and Extract Artifacts
@@ -37,7 +36,6 @@ jobs:
           files: artifacts/**/*-results.xml
 
       - name: "Upload coverage to Codecov"
-        if: github.repository_owner == 'Uninett'
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true


### PR DESCRIPTION


Since upgrading the codecov action to version 4 uploading coverage reports without a token (so when creating a PR from a fork) is severely rate limited, which resulted often enough in our tests seemingly failing, even though it was only the coverage upload failing. (Reference: https://docs.codecov.com/docs/codecov-uploader#supporting-token-less-uploads-for-forks-of-open-source-repos-using-codecov)

Workflows that are triggered by other workflows are always run within the context of the main repository, instead of within the fork (except for workflows triggered by pushes to main in a fork, they are run within the context of the fork). This means that that way we can have access to the secret CODECOV_TOKEN and avoid the rate limitations.

Since we already upload our coverage results as artifacts in the Upload test reports step of the tests workflow, we decided to move the uploading coverage step to the same workflow where we publish the test results: publish-test-results. This workflow is triggered by the completion of the tests workflow, which means it is run within the context of the main repository.

Moving the uploading coverage step to the publish-test-results worked great in the way that we have access to the CODECOV_TOKEN, but due to the context switch codecov could not properly tell anymore which branch, commit and pull request that coverage information belongs to.

That is why we override the pull request, commit, base and branch information.

Getting the associated pull request number and base SHA is quite a bit more complicated and it involves saving them in a file, then uploading it as an artifact, then downloading that artifact and after validation using them in configuring codecov.

This also upgrades various actions used in these workflows.
Reference for why we need to rename the artifacts after upgrading the upload artifacts action: https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/
