### PR TITLE
Remove Python 3.7 from default test matrix and Sonarcloud rules

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.7", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -11,7 +11,7 @@ sonar.sources=bin, python
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
 
-sonar.python.version=3.7, 3.8, 3.9
+sonar.python.version=3.8, 3.9
 sonar.tests=tests
 
 sonar.exclusions=python/nav/smidumps/**, python/nav/enterprise/ids.py, python/nav/etc/geomap/config.py

--- a/changelog.d/+python37-testmatrix.removed.md
+++ b/changelog.d/+python37-testmatrix.removed.md
@@ -1,0 +1,1 @@
+Removed Python 3.7 from default test matrix

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,11 @@
 # of the documentation in hacking.rst
 [tox]
 envlist =
-    {unit,integration,functional}-py{37,39,310}-django{32}
+    {unit,integration,functional}-py{39,310}-django{32}
     javascript
     docs
 skipsdist = True
-basepython = python3.7
+basepython = python3.9
 
 [pytest]
 addopts = --failed-first
@@ -20,7 +20,6 @@ markers =
 
 [gh-actions]
 python =
-    3.7: py37
     3.9: py39
     3.10: py310
 


### PR DESCRIPTION
The next NAV release will not support Python 3.7, so there is no longer any reason to test on Python 3.7 by default.

Closes #2891 