### PR TITLE
Pin snmpsim to older version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,7 +49,7 @@ jobs:
       - name: "Install test runner dependencies"
         run: |
           set -xe
-          python3 -m pip install --upgrade 'pip==23.1.0' setuptools wheel 'tox<4' tox-gh-actions coverage virtualenv snmpsim 'pyasn1<0.5.0'
+          python3 -m pip install --upgrade 'pip==23.1.0' setuptools wheel 'tox<4' tox-gh-actions coverage virtualenv 'snmpsim<1.0' 'pyasn1<0.5.0'
           sudo apt-get install -y nbtscan
 
       # virtualenv seems to currently be embedding a broken version of

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -67,7 +67,7 @@ RUN cd /tmp && \
     mv chromedriver /usr/local/bin/
 
 # Install our primary test runner
-RUN python3.9 -m pip install 'tox<4' snmpsim 'pyasn1<0.5.0' virtualenv
+RUN python3.9 -m pip install 'tox<4' 'snmpsim<1.0' 'pyasn1<0.5.0' virtualenv
 
 # Add a build user
 ENV USER build


### PR DESCRIPTION
same issue as we had to Zino

> A new version of snmpsim was released about 6 hours ago (the first new version in 5 years), and it seems to have changed to be incompatible with how our test suite uses it.
> 
> In particular, our test suite expects snmpsimd.py to be available on the search PATH, but the executable's name may have changed, and I don't have the luxury of time to figure out how to adapt our test suite
> 
> I assume there may be many more changes, as the original maintainer died a while back, and someone else has taken over, which is why I think it's best to pin to an older version for now.