### PR TITLE
Replace docker-compose in workflow with docker compose

### DIFF
--- a/.github/workflows/dockercompose.yml
+++ b/.github/workflows/dockercompose.yml
@@ -1,4 +1,4 @@
-name: Build docker-compose dev environment
+name: Build docker compose dev environment
 on:
   schedule:
     - cron: '6 6 * * *'
@@ -14,25 +14,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: docker-compose build
+      - name: docker compose build
         run: |
           echo "UID=$(id -u)" >> .env
           echo "GID=$(id -g)" >> .env
-          docker-compose build
+          docker compose build
 
       - name: Verify containers stay running at least 1 minute
         run: |
-          docker-compose up -d
+          docker compose up -d
           sleep 60
-          docker-compose ps
+          docker compose ps
           echo "Verifying service states"
-          docker-compose ps -q | xargs docker inspect -f '{{.State.Running}}' | grep -q false && exit 1
+          docker compose ps -q | xargs docker inspect -f '{{.State.Running}}' | grep -q false && exit 1
           echo "Looks ok"
 
-      - name: Print docker-compose logs
+      - name: Print docker compose logs
         if: failure()
         run: |
-          docker-compose logs
+          docker compose logs
 
       - name: Send GitHub Action trigger data to Slack workflow
         id: slack

--- a/doc/hacking/snmp-tunnels.rst
+++ b/doc/hacking/snmp-tunnels.rst
@@ -21,7 +21,7 @@ Course of action - with docker
 ==============================
 
 1. Copy the content of :file:`docker-compose.snmp.yml` into
-   :file:`docker-compose.override.yml` or later run docker-compose like this:
+   :file:`docker-compose.override.yml` or later run docker compose like this:
    ``docker compose -f docker-compose.yml -f docker-compose.snmp.yml up``.
 
 2. Change the line ``command: 192.168.0.1 user@my-hop-host 10000`` to the ip
@@ -61,7 +61,7 @@ When starting docker:
 When adding IP device in SeedDB:
 
 - if an error message appears go into the docker container using
-  ``docker-compose exec nav /bin/bash`` and do ``ping mydevice.mydomain``. If that
+  ``docker compose exec nav /bin/bash`` and do ``ping mydevice.mydomain``. If that
   works, then make sure you're using the right management profile, because
   tunneling works.
 

--- a/doc/hacking/using-docker.rst
+++ b/doc/hacking/using-docker.rst
@@ -8,7 +8,7 @@ Docker is a lightweight "virtualization" framework for creating isolated
 environments, useful both in development and production.
 For more information on Docker visit their homepage_ or read the documentation_.
 
-Installing Docker and docker-compose
+Installing Docker and docker compose
 ------------------------------------
 
 Docker provides up-to-date documentation on how to install it for most popular
@@ -202,7 +202,7 @@ The ``nav`` and ``web`` containers share a common configuration volume named
 ``nav_config``. This volume should persist even between rebuilds of the
 containers themselves. If you want NAV to install a completely new set of
 config files from scratch, you may need to manually trash this volume using the
-``-v`` option to the :kbd:`docker-compose down` command.
+``-v`` option to the :kbd:`docker compose down` command.
 
 
 Overriding the compose services


### PR DESCRIPTION
GitHub Actions no longer supports the v1 Docker Compose command docker-compose, so we need to switch over to docker compose.

Reference: https://github.com/orgs/community/discussions/116610