### PR TITLE
Use nodejs version 18 instead of version 14 in when building test docker image

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update && \
 
 
 # Now install NodeJS and NPM for Javascript testing needs -
-RUN curl -sL https://deb.nodesource.com/setup_14.x  | bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_18.x  | bash - && \
     apt-get install -y --no-install-recommends nodejs
 
 # Install geckodriver to properly run Selenium tests in Firefox versions>=47


### PR DESCRIPTION
why: nodejs version 14 gives a deprecation warning when building the test docker image. Version 18 is the oldest nodejs version that is not deprecated.