### PR TITLE
Run tests on schedule (daily)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,9 @@
 name: Build NAV and run full test suite
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule: # Run daily at 08:00 CEST (06:00 UST)
+    - cron: '0 6 * * *'
 
 jobs:
   build-and-test:


### PR DESCRIPTION
To make sure that all dependencies still work. We already build the docker image daily, but as we've seen with `snmpsim` (#2946) that was not enough. 