### PR TITLE
Update snmpsim to newer version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,7 +49,7 @@ jobs:
       - name: "Install test runner dependencies"
         run: |
           set -xe
-          python3 -m pip install --upgrade 'pip==23.1.0' setuptools wheel 'tox<4' tox-gh-actions coverage virtualenv 'snmpsim<1.0' 'pyasn1<0.5.0'
+          python3 -m pip install --upgrade 'pip==23.1.0' setuptools wheel 'tox<4' tox-gh-actions coverage virtualenv 'snmpsim>=1.0'
           sudo apt-get install -y nbtscan
 
       # virtualenv seems to currently be embedding a broken version of

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -67,7 +67,7 @@ RUN cd /tmp && \
     mv chromedriver /usr/local/bin/
 
 # Install our primary test runner
-RUN python3.9 -m pip install 'tox<4' 'snmpsim<1.0' 'pyasn1<0.5.0' virtualenv
+RUN python3.9 -m pip install 'tox<4' 'snmpsim>=1.0' virtualenv
 
 # Add a build user
 ENV USER build

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -313,7 +313,7 @@ def snmpsim():
     by the test that declares a dependency to this fixture. Data fixtures are loaded
     from the snmp_fixtures subdirectory.
     """
-    snmpsimd = which('snmpsimd.py')
+    snmpsimd = which('snmpsim-command-responder')
     assert snmpsimd, "Could not find snmpsimd.py"
     workspace = os.getenv('WORKSPACE', os.getenv('HOME', '/source'))
     proc = subprocess.Popen(


### PR DESCRIPTION
`snmpsimd.py` was renamed to `snmpsim-command-responder`(reference:  https://docs.lextudio.com/snmpsim/changelog#revision-1-0-0-released-on-nov-13-2022)

The lock on pyasn1 can also be removed since the never versions of snmpsim are compatible with it.

This reverts parts of #2622 and #2946.