### PR TITLE
 Use `return` instead of `twisted.defer.returnValue`

### DIFF
--- a/changelog.d/2955.changed.md
+++ b/changelog.d/2955.changed.md
@@ -1,0 +1,1 @@
+Replace twisted.internet.defer.returnValue with return due to deprecation in newest twisted version

--- a/doc/hacking/adding-environment-probe-support.rst
+++ b/doc/hacking/adding-environment-probe-support.rst
@@ -219,7 +219,7 @@ Let's hardcode an example result for a single temperature sensor, based on the
 		    'mib': 'SPAGENT-MIB',
 		}
 	    ]
-	    defer.returnValue(result)
+	    return result
 
 This returns a list of a single item: A dictionary describing the first
 temperature sensor from the snmpwalk from above. The dictionary should contain
@@ -284,8 +284,8 @@ Let's rewrite ``SPAgentMib`` to collect actual temperature sensors:
    :emphasize-lines: 9, 20
 
     from nav.models.manage import Sensor
-    
-		     
+
+
     class SPAgentMib(MibRetriever):
 	mib = get_mib('SPAGENT-MIB')
 
@@ -300,7 +300,7 @@ Let's rewrite ``SPAgentMib`` to collect actual temperature sensors:
 	    sensors = (self._temp_row_to_sensor(index, row)
 		       for index, row in result.iteritems())
 
-	    defer.returnValue([s for s in sensors if s])
+	    return [s for s in sensors if s]
 
 	def _temp_row_to_sensor(self, index, row):
 	    online = row.get('sensorProbeTempOnline', 'offline')

--- a/python/nav/bin/naventity.py
+++ b/python/nav/bin/naventity.py
@@ -70,11 +70,11 @@ def collect_entities(netbox, portnumber):
     """Collects the entPhysicalTable"""
     agent = _create_agentproxy(netbox, portnumber)
     if not agent:
-        defer.returnValue(None)
+        return None
 
     mib = EntityMib(agent)
     result = yield mib.get_entity_physical_table()
-    defer.returnValue(result)
+    return result
 
 
 def make_graph(entities, netbox):

--- a/python/nav/bin/navoidverify.py
+++ b/python/nav/bin/navoidverify.py
@@ -72,7 +72,7 @@ def verify(netbox, oid):
     """Verifies a GETNEXT response from below the oid subtree"""
     agent = _create_agentproxy(netbox)
     if not agent:
-        defer.returnValue(False)
+        return False
 
     result = yield agent.walk(str(oid))
     agent.close()
@@ -82,8 +82,8 @@ def verify(netbox, oid):
     for key, _value in result:
         if oid.is_a_prefix_of(key):
             print(netbox.sysname)
-            defer.returnValue(True)
-    defer.returnValue(False)
+            return True
+    return False
 
 
 def endit(_result):

--- a/python/nav/ipdevpoll/jobs.py
+++ b/python/nav/ipdevpoll/jobs.py
@@ -153,9 +153,9 @@ class JobHandler(object):
         ]
 
         if not plugins:
-            defer.returnValue(None)
+            return None
 
-        defer.returnValue(plugins)
+        return plugins
 
     def _get_valid_plugins(self):
         valid_plugins, invalid_plugins = splitby(
@@ -201,7 +201,7 @@ class JobHandler(object):
             else:
                 self._logger.debug("no %s plugins", willingness)
 
-        defer.returnValue(willing_plugins)
+        return willing_plugins
 
     def _iterate_plugins(self, plugins):
         """Iterates plugins."""
@@ -278,7 +278,7 @@ class JobHandler(object):
         self._reset_timers()
         if not plugins:
             self._destroy_agentproxy()
-            defer.returnValue(False)
+            return False
 
         self._logger.debug("Starting job %r for %s", self.name, self.netbox.sysname)
 
@@ -353,7 +353,7 @@ class JobHandler(object):
         df.addBoth(cleanup)
         df.addCallbacks(log_externally_success, log_externally_failure)
         yield df
-        defer.returnValue(True)
+        return True
 
     def cancel(self):
         """Cancels a running job.

--- a/python/nav/ipdevpoll/plugins/arp.py
+++ b/python/nav/ipdevpoll/plugins/arp.py
@@ -113,10 +113,10 @@ class Arp(Plugin):
     @defer.inlineCallbacks
     def _get_ip_mib(self):
         if not self.is_arista():
-            defer.returnValue(IpMib(self.agent))  # regular IpMib for regular folks
+            return IpMib(self.agent)  # regular IpMib for regular folks
         else:
             instances = yield get_arista_vrf_instances(self.agent)
-            defer.returnValue(MultiIpMib(self.agent, instances=instances))
+            return MultiIpMib(self.agent, instances=instances)
 
     def is_arista(self):
         """Returns True if this is an Arista device"""
@@ -182,7 +182,7 @@ class Arp(Plugin):
         open_mappings = dict(
             ((IP(arp['ip']), arp['mac']), arp['id']) for arp in open_arp_records
         )
-        defer.returnValue(open_mappings)
+        return open_mappings
 
     @classmethod
     def _update_prefix_cache(cls):

--- a/python/nav/ipdevpoll/plugins/bgp.py
+++ b/python/nav/ipdevpoll/plugins/bgp.py
@@ -14,7 +14,7 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """BGP peer state monitor plugin for ipdevpoll"""
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 from nav.ipdevpoll import Plugin
 from nav.ipdevpoll.shadows import GatewayPeerSession, Netbox
@@ -40,7 +40,7 @@ class BGP(Plugin):
 
         if not mib:
             self._logger.debug("No BGP MIBs are supported")
-            returnValue(None)
+            return None
 
         self._logger.debug("Collect BGP peers from %s", mib.mib['moduleName'])
         data = yield mib.get_bgp_peer_states()
@@ -73,4 +73,4 @@ class BGP(Plugin):
             mib = mibclass(self.agent)
             support = yield mib.is_supported()
             if support:
-                returnValue(mib)
+                return mib

--- a/python/nav/ipdevpoll/plugins/bridge.py
+++ b/python/nav/ipdevpoll/plugins/bridge.py
@@ -41,7 +41,7 @@ class Bridge(Plugin):
         if bridge_address:
             self._save_bridge_address(bridge_address)
         baseports = yield bridge.get_baseport_ifindex_map()
-        defer.returnValue(self._set_port_numbers(baseports))
+        return self._set_port_numbers(baseports)
 
     def _save_bridge_address(self, bridge_address):
         info = self.containers.factory(

--- a/python/nav/ipdevpoll/plugins/cam.py
+++ b/python/nav/ipdevpoll/plugins/cam.py
@@ -57,7 +57,7 @@ class Cam(Plugin):
     def can_handle(cls, netbox):
         daddy_says_ok = super(Cam, cls).can_handle(netbox)
         has_ifcs = yield db.run_in_thread(cls._has_interfaces, netbox)
-        defer.returnValue(has_ifcs and daddy_says_ok)
+        return has_ifcs and daddy_says_ok
 
     @classmethod
     def _has_interfaces(cls, netbox):
@@ -102,7 +102,7 @@ class Cam(Plugin):
                 ifindex = baseports[port]
                 mapping[ifindex].add(mac)
 
-        defer.returnValue(dict(mapping))
+        return dict(mapping)
 
     @defer.inlineCallbacks
     def _get_dot1q_mac_port_mapping(self):
@@ -116,27 +116,27 @@ class Cam(Plugin):
                 ifindex = baseports[port]
                 mapping[ifindex].add(mac)
 
-        defer.returnValue(dict(mapping))
+        return dict(mapping)
 
     @defer.inlineCallbacks
     def _get_baseports(self):
         if not self.baseports:
             bridge = yield self._get_bridge()
             self.baseports = yield bridge.get_baseport_ifindex_map()
-        defer.returnValue(self.baseports)
+        return self.baseports
 
     @defer.inlineCallbacks
     def _get_bridge(self):
         if not self.bridge:
             instances = yield self._get_dot1d_instances()
             self.bridge = MultiBridgeMib(self.agent, instances)
-        defer.returnValue(self.bridge)
+        return self.bridge
 
     @defer.inlineCallbacks
     def _get_dot1d_instances(self):
         if not self.dot1d_instances:
             self.dot1d_instances = yield utils.get_dot1d_instances(self.agent)
-        defer.returnValue(self.dot1d_instances)
+        return self.dot1d_instances
 
     def _log_fdb_stats(self, prefix, fdb):
         mac_count = sum(len(v) for v in fdb.values())
@@ -230,7 +230,7 @@ class Cam(Plugin):
         if translated:
             self._log_blocking_ports(translated)
             self._store_blocking_ports(translated)
-        defer.returnValue(translated)
+        return translated
 
     def _log_blocking_ports(self, blocking):
         ifc_count = len(set(ifc for ifc, vlan in blocking))

--- a/python/nav/ipdevpoll/plugins/cdp.py
+++ b/python/nav/ipdevpoll/plugins/cdp.py
@@ -50,7 +50,7 @@ class CDP(Plugin):
     def can_handle(cls, netbox):
         daddy_says_ok = super(CDP, cls).can_handle(netbox)
         has_ifcs = yield run_in_thread(cls._has_interfaces, netbox)
-        defer.returnValue(has_ifcs and daddy_says_ok)
+        return has_ifcs and daddy_says_ok
 
     @classmethod
     def _has_interfaces(cls, netbox):
@@ -97,7 +97,7 @@ class CDP(Plugin):
         yield stampcheck.load()
         yield stampcheck.collect([mib.get_neighbors_last_change()])
 
-        defer.returnValue(stampcheck)
+        return stampcheck
 
     @defer.inlineCallbacks
     def _get_cached_neighbors(self):
@@ -108,7 +108,7 @@ class CDP(Plugin):
             INFO_KEY_NAME,
             INFO_VAR_NEIGHBORS_CACHE,
         )
-        defer.returnValue(value)
+        return value
 
     @defer.inlineCallbacks
     def _save_cached_neighbors(self, neighbors):

--- a/python/nav/ipdevpoll/plugins/ciscovlan.py
+++ b/python/nav/ipdevpoll/plugins/ciscovlan.py
@@ -72,7 +72,7 @@ class CiscoVlan(Plugin):
     def _get_ifindexes(self):
         ifmib = IfMib(self.agent)
         indexes = yield ifmib.get_ifindexes()
-        defer.returnValue(set(indexes))
+        return set(indexes)
 
     def _store_access_ports(self, vlan_membership):
         """Store vlan memberships for all ports."""

--- a/python/nav/ipdevpoll/plugins/dot1q.py
+++ b/python/nav/ipdevpoll/plugins/dot1q.py
@@ -27,7 +27,7 @@ interfaces, as well as set the list of enabled VLANs on trunks.
 
 from collections import defaultdict
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 from nav.util import mergedicts
 from nav.mibs.bridge_mib import BridgeMib
@@ -122,7 +122,7 @@ class Dot1q(Plugin):
             egress = yield query.get_vlan_static_egress_ports()
             untagged = yield query.get_vlan_static_untagged_ports()
 
-        returnValue((egress, untagged))
+        return (egress, untagged)
 
     def _find_trunkports(self, egress, untagged):
         trunkports = defaultdict(list)

--- a/python/nav/ipdevpoll/plugins/entity.py
+++ b/python/nav/ipdevpoll/plugins/entity.py
@@ -65,7 +65,7 @@ class Entity(Plugin):
         yield self.stampcheck.collect([self.entitymib.get_last_change_time()])
 
         result = yield self.stampcheck.is_changed()
-        defer.returnValue(result)
+        return result
 
     def _process_entities(self, result):
         """Process the list of collected entities."""

--- a/python/nav/ipdevpoll/plugins/extremevlan.py
+++ b/python/nav/ipdevpoll/plugins/extremevlan.py
@@ -19,7 +19,7 @@ Uses information from EXTREME-VLAN-MIB and BRIDGE-MIB.
 
 """
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 from nav.enterprise.ids import VENDOR_ID_EXTREME_NETWORKS
 from nav.mibs.extreme_vlan_mib import ExtremeVlanMib
@@ -60,7 +60,7 @@ class ExtremeVlan(Plugin):
         vlan_ports = yield self.extremevlan.get_vlan_ports()
         if not vlan_ports:
             # Doesn't appear to have VLAN data in EXTREME MIBs, get out now.
-            returnValue(None)
+            return None
         ifindex_vlan = yield self.extremevlan.get_ifindex_vlan_map()
         self.baseport_ifindex = yield self.bridge.get_baseport_ifindex_map()
 

--- a/python/nav/ipdevpoll/plugins/interfaces.py
+++ b/python/nav/ipdevpoll/plugins/interfaces.py
@@ -165,7 +165,7 @@ class Interfaces(Plugin):
         stack = yield self.ifmib.get_stack_status().addCallback(_stackify)
         self._get_ifalias_from_lower_layers(stack)
         self._create_stack_containers(stack)
-        defer.returnValue(interfaces)
+        return interfaces
 
     def _get_ifalias_from_lower_layers(self, stack):
         """For each interface without an ifAlias value, attempts to find

--- a/python/nav/ipdevpoll/plugins/juniperdot1q.py
+++ b/python/nav/ipdevpoll/plugins/juniperdot1q.py
@@ -37,7 +37,7 @@ https://www.juniper.net/documentation/en_US/junos12.3/topics/reference/general/s
 
 """
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from nav.enterprise.ids import VENDOR_ID_JUNIPER_NETWORKS_INC
 from nav.oids import OID
 from . import dot1q
@@ -84,12 +84,12 @@ class JuniperDot1q(dot1q.Dot1q):
         """
         (egress, untagged) = yield super(JuniperDot1q, self)._retrieve_vlan_ports()
         if not self.jnx_vlan_map:
-            returnValue((egress, untagged))
+            return (egress, untagged)
 
         new_egress = {self._remap_vlan(key): value for key, value in egress.items()}
         new_untagged = {self._remap_vlan(key): value for key, value in untagged.items()}
 
-        returnValue((new_egress, new_untagged))
+        return (new_egress, new_untagged)
 
     def __is_a_moronic_juniper_device(self):
         if self.netbox.type:
@@ -103,4 +103,4 @@ class JuniperDot1q(dot1q.Dot1q):
         mappings = result.get(_jnxExVlanTag, {})
         mappings = {OID(key)[-1]: value for key, value in mappings.items()}
         self._logger.debug("got jnxExVlanTag map: %r", mappings)
-        returnValue(mappings)
+        return mappings

--- a/python/nav/ipdevpoll/plugins/linkaggregate.py
+++ b/python/nav/ipdevpoll/plugins/linkaggregate.py
@@ -15,7 +15,7 @@
 #
 import logging
 from collections import defaultdict
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 from nav.ipdevpoll import Plugin
 from nav.ipdevpoll import shadows
@@ -47,7 +47,7 @@ class LinkAggregate(Plugin):
             for if_idx in aggregates:
                 interface = yield self._get_interface(if_idx)
                 result.append((interface, aggregator))
-        returnValue(result)
+        return result
 
     @inlineCallbacks
     def _get_interface(self, ifindex):
@@ -56,7 +56,7 @@ class LinkAggregate(Plugin):
             # In case no other plugins ran before us to collect this:
             self._logger.debug("retrieving ifName.%s", ifindex)
             ifc.ifname = yield self.ifmib.retrieve_column_by_index('ifName', (ifindex,))
-        returnValue(ifc)
+        return ifc
 
     def _log_aggregates(self, aggregates):
         if not self._logger.isEnabledFor(logging.DEBUG):

--- a/python/nav/ipdevpoll/plugins/linkstate.py
+++ b/python/nav/ipdevpoll/plugins/linkstate.py
@@ -14,7 +14,7 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Collects interface link states and dispatches NAV events on changes"""
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 from nav.mibs import reduce_index
 from nav.mibs.if_mib import IfMib
@@ -32,7 +32,7 @@ class LinkState(Plugin):
             self._logger.debug(
                 "this is a virtual instance of %s, not polling", self.netbox.master
             )
-            returnValue(None)
+            return None
 
         ifmib = IfMib(self.agent)
         result = yield ifmib.retrieve_columns(

--- a/python/nav/ipdevpoll/plugins/lldp.py
+++ b/python/nav/ipdevpoll/plugins/lldp.py
@@ -53,7 +53,7 @@ class LLDP(Plugin):
     def can_handle(cls, netbox):
         daddy_says_ok = super(LLDP, cls).can_handle(netbox)
         has_ifcs = yield run_in_thread(cls._has_interfaces, netbox)
-        defer.returnValue(has_ifcs and daddy_says_ok)
+        return has_ifcs and daddy_says_ok
 
     @classmethod
     def _has_interfaces(cls, netbox):
@@ -102,7 +102,7 @@ class LLDP(Plugin):
             INFO_KEY_LLDP_INFO,
             INFO_VAR_REMOTES_CACHE,
         )
-        defer.returnValue(value)
+        return value
 
     @defer.inlineCallbacks
     def _save_cached_remote_table(self, remote_table):
@@ -149,7 +149,7 @@ class LLDP(Plugin):
         yield stampcheck.load()
         yield stampcheck.collect([mib.get_remote_last_change()])
 
-        defer.returnValue(stampcheck)
+        return stampcheck
 
     def _process_remote(self):
         """Tries to synchronously identify LLDP entries in NAV's database"""

--- a/python/nav/ipdevpoll/plugins/modules.py
+++ b/python/nav/ipdevpoll/plugins/modules.py
@@ -69,7 +69,7 @@ class Modules(Plugin):
         yield self.stampcheck.collect([self.entitymib.get_last_change_time()])
 
         result = yield self.stampcheck.is_changed()
-        defer.returnValue(result)
+        return result
 
     def _device_from_entity(self, ent):
         serial_column = 'entPhysicalSerialNum'

--- a/python/nav/ipdevpoll/plugins/paloaltoarp.py
+++ b/python/nav/ipdevpoll/plugins/paloaltoarp.py
@@ -27,7 +27,6 @@ import xml.etree.ElementTree as ET
 
 from IPy import IP
 from twisted.internet import defer, reactor, ssl
-from twisted.internet.defer import returnValue
 from twisted.web import client
 from twisted.web.client import Agent
 from twisted.web.http_headers import Headers
@@ -44,7 +43,7 @@ class PaloaltoArp(Arp):
     def can_handle(cls, netbox):
         """Return True if this plugin can handle the given netbox."""
         has_configurations = yield cls._has_paloalto_configurations(netbox)
-        returnValue(has_configurations)
+        return has_configurations
 
     @defer.inlineCallbacks
     def handle(self):
@@ -90,7 +89,7 @@ class PaloaltoArp(Arp):
         """
         arptable = yield self._do_request(address, key)
         mappings = _parse_arp(arptable) if arptable else []
-        returnValue(mappings)
+        return mappings
 
     @defer.inlineCallbacks
     def _do_request(self, address: IP, key: str):
@@ -121,10 +120,10 @@ class PaloaltoArp(Arp):
                 "Error when making HTTP request to Paloalto API endpoint. "
                 "Make sure the device is reachable and the API key is correct."
             )
-            returnValue(None)
+            return None
 
         response = yield client.readBody(response)
-        returnValue(response)
+        return response
 
 
 def _parse_arp(arpbytes: bytes) -> list[tuple[str, IP, str]]:

--- a/python/nav/ipdevpoll/plugins/poe.py
+++ b/python/nav/ipdevpoll/plugins/poe.py
@@ -15,7 +15,7 @@
 #
 """Collects power over ethernet information"""
 from collections import defaultdict
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 from nav.mibs.power_ethernet_mib import PowerEthernetMib
 from nav.mibs.cisco_power_ethernet_ext_mib import CiscoPowerEthernetExtMib
@@ -41,7 +41,7 @@ class Poe(Plugin):
             self._logger.debug(
                 "this is a virtual instance of %s, not polling", self.netbox.master
             )
-            returnValue(None)
+            return None
 
         poemib = PowerEthernetMib(self.agent)
         if self._is_cisco():
@@ -90,7 +90,7 @@ class Poe(Plugin):
         entity_mib = EntityMib(self.agent)
         alias_mapping = yield entity_mib.get_alias_mapping()
         port_ifindices = self._resolve_ifindex(port_phy_index, alias_mapping)
-        returnValue((group_phy_index, port_ifindices))
+        return (group_phy_index, port_ifindices)
 
     def _process_groups(self, groups, phy_indices):
         netbox = self.containers.factory(None, shadows.Netbox)

--- a/python/nav/ipdevpoll/plugins/prefix.py
+++ b/python/nav/ipdevpoll/plugins/prefix.py
@@ -134,7 +134,7 @@ class Prefix(Plugin):
         ifmib = IfMib(self.agent)
         statuses = yield ifmib.get_admin_status()
         result = set(ifindex for ifindex, status in statuses.items() if status == 'up')
-        defer.returnValue(result)
+        return result
 
     def create_containers(
         self, netbox, ifindex, net_prefix, ip, vlan_interfaces, ifc_aliases=None
@@ -193,7 +193,7 @@ class Prefix(Plugin):
                 vlan = int(match.group('vlan'))
                 vlan_ifs[ifindex] = vlan
 
-        defer.returnValue(vlan_ifs)
+        return vlan_ifs
 
     def _ignore_timeout(self, failure, result=None):
         """Ignores a TimeoutError in an errback chain.

--- a/python/nav/ipdevpoll/plugins/psuwatch.py
+++ b/python/nav/ipdevpoll/plugins/psuwatch.py
@@ -64,7 +64,7 @@ class PowerSupplyOrFanStateWatcher(Plugin):
             if old_state != new_state:
                 yield self._handle_state_change(unit, new_state)
 
-        defer.returnValue(True)
+        return True
 
     @defer.inlineCallbacks
     def _retrieve_current_unit_state(self, unit):
@@ -79,11 +79,11 @@ class PowerSupplyOrFanStateWatcher(Plugin):
                 method = getattr(mib, method_name, None)
                 if method:
                     state = yield method(unit.internal_id)
-                    defer.returnValue(state or STATE_UNKNOWN)
+                    return state or STATE_UNKNOWN
         else:
             self._logger.debug("unit has no internal id: %r", unit)
 
-        defer.returnValue(STATE_UNKNOWN)
+        return STATE_UNKNOWN
 
     @defer.inlineCallbacks
     def _handle_state_change(self, unit, new_state):

--- a/python/nav/ipdevpoll/plugins/sensors.py
+++ b/python/nav/ipdevpoll/plugins/sensors.py
@@ -96,7 +96,7 @@ class Sensors(Plugin):
 
         classes = self.mib_map.get(vendor_id, ()) or self.mib_map.get('*', ())
         mibs = [cls(self.agent) for cls in classes]
-        defer.returnValue(mibs)
+        return mibs
 
     def _store_sensors(self, result):
         """Stores sensor records in the current job's container dictionary, so

--- a/python/nav/ipdevpoll/plugins/snmpcheck.py
+++ b/python/nav/ipdevpoll/plugins/snmpcheck.py
@@ -16,7 +16,6 @@
 """snmp check plugin"""
 from pynetsnmp.netsnmp import SnmpTimeoutError
 from twisted.internet import error, defer
-from twisted.internet.defer import returnValue
 
 from django.db import transaction
 
@@ -71,10 +70,10 @@ class SnmpCheck(Plugin):
             result = yield self.agent.walk(SYSTEM_OID)
         except (defer.TimeoutError, error.TimeoutError, SnmpTimeoutError):
             self._logger.debug("SNMP v%s timed out", self.agent.snmpVersion)
-            returnValue(False)
+            return False
 
         self._logger.debug("SNMP response: %r", result)
-        returnValue(bool(result))
+        return bool(result)
 
     @defer.inlineCallbacks
     def _mark_as_down(self):

--- a/python/nav/ipdevpoll/plugins/statports.py
+++ b/python/nav/ipdevpoll/plugins/statports.py
@@ -78,7 +78,7 @@ class StatPorts(Plugin):
     def handle(self):
         if self.netbox.master:
             yield self._log_instance_details()
-            defer.returnValue(None)
+            return None
 
         timestamp = time.time()
         stats = yield self._get_stats()
@@ -105,7 +105,7 @@ class StatPorts(Plugin):
                 stats[ifindex][IF_IN_OCTETS_IPV6] = in_octets
                 stats[ifindex][IF_OUT_OCTETS_IPV6] = out_octets
 
-        defer.returnValue(stats)
+        return stats
 
     def _make_metrics(self, stats, netboxes, timestamp=None):
         timestamp = timestamp or time.time()

--- a/python/nav/ipdevpoll/plugins/statsensors.py
+++ b/python/nav/ipdevpoll/plugins/statsensors.py
@@ -46,8 +46,8 @@ class StatSensors(Plugin):
         )
         if base_can_handle:
             i_can_handle = yield run_in_thread(cls._has_sensors, netbox)
-            defer.returnValue(i_can_handle)
-        defer.returnValue(base_can_handle)
+            return i_can_handle
+        return base_can_handle
 
     @classmethod
     def _has_sensors(cls, netbox):
@@ -56,7 +56,7 @@ class StatSensors(Plugin):
     @defer.inlineCallbacks
     def handle(self):
         if self.netbox.master:
-            defer.returnValue(None)
+            return None
         netboxes = yield db.run_in_thread(self._get_netbox_list)
         sensors = yield run_in_thread(self._get_sensors)
         self._logger.debug("retrieving data from %d sensors", len(sensors))

--- a/python/nav/ipdevpoll/plugins/statsystem.py
+++ b/python/nav/ipdevpoll/plugins/statsystem.py
@@ -75,7 +75,7 @@ class StatSystem(Plugin):
     @defer.inlineCallbacks
     def handle(self):
         if self.netbox.master:
-            defer.returnValue(None)
+            return None
         netboxes = yield db.run_in_thread(self._get_netbox_list)
         bandwidth = yield self._collect_bandwidth(netboxes)
         cpu = yield self._collect_cpu(netboxes)
@@ -98,8 +98,8 @@ class StatSystem(Plugin):
                 )
             else:
                 if metrics:
-                    defer.returnValue(metrics)
-        defer.returnValue([])
+                    return metrics
+        return []
 
     @defer.inlineCallbacks
     def _collect_bandwidth_from_mib(self, mib, netboxes):
@@ -129,7 +129,7 @@ class StatSystem(Plugin):
                         (timestamp, bandwidth_peak),
                     ),
                 ]
-            defer.returnValue(metrics)
+            return metrics
 
     @defer.inlineCallbacks
     def _collect_cpu(self, netboxes):
@@ -142,8 +142,8 @@ class StatSystem(Plugin):
                     "collect_cpu: ignoring timeout in %s", mib.mib['moduleName']
                 )
             else:
-                defer.returnValue(load + utilization)
-        defer.returnValue([])
+                return load + utilization
+        return []
 
     @defer.inlineCallbacks
     def _get_cpu_loadavg(self, mib, netboxes):
@@ -160,7 +160,7 @@ class StatSystem(Plugin):
                     for netbox in netboxes:
                         path = metric_path_for_cpu_load(netbox, cpuname, interval)
                         metrics.append((path, (timestamp, value)))
-        defer.returnValue(metrics)
+        return metrics
 
     @defer.inlineCallbacks
     def _get_cpu_utilization(self, mib, netboxes):
@@ -176,7 +176,7 @@ class StatSystem(Plugin):
                 for netbox in netboxes:
                     path = metric_path_for_cpu_utilization(netbox, cpuname)
                     metrics.append((path, (timestamp, value)))
-        defer.returnValue(metrics)
+        return metrics
 
     def _mibs_for_me(self, mib_class_dict):
         vendor = self.netbox.type.get_enterprise_id() if self.netbox.type else None
@@ -196,9 +196,9 @@ class StatSystem(Plugin):
             for netbox in netboxes:
                 path = metric_path_for_sysuptime(netbox)
                 metrics.append((path, (timestamp, uptime)))
-            defer.returnValue(metrics)
+            return metrics
         else:
-            defer.returnValue([])
+            return []
 
     @defer.inlineCallbacks
     def _collect_power(self, netboxes):
@@ -218,9 +218,9 @@ class StatSystem(Plugin):
                 for index, value in power.items():
                     path = metric_path_for_power(netbox, index)
                     metrics.append((path, (timestamp, value)))
-            defer.returnValue(metrics)
+            return metrics
         else:
-            defer.returnValue([])
+            return []
 
     @defer.inlineCallbacks
     def _collect_memory(self, netboxes):
@@ -250,4 +250,4 @@ class StatSystem(Plugin):
                         (prefix + '.free', (timestamp, free)),
                     ]
                 )
-        defer.returnValue(result)
+        return result

--- a/python/nav/ipdevpoll/plugins/typeoid.py
+++ b/python/nav/ipdevpoll/plugins/typeoid.py
@@ -67,7 +67,7 @@ class TypeOid(Plugin):
             )
         oid = OID(result)
         self._logger.debug("sysObjectID is %s", oid)
-        defer.returnValue(oid)
+        return oid
 
     def _is_sysobjectid_changed(self, oid):
         current_oid = OID(self.netbox.type.sysobjectid) if self.netbox.type else None
@@ -129,7 +129,7 @@ class TypeOid(Plugin):
             return type_
 
         new_type = yield db.run_in_thread(_create)
-        defer.returnValue(new_type)
+        return new_type
 
     @classmethod
     def _get_vendor(cls, sysobjectid):

--- a/python/nav/ipdevpoll/plugins/uptime.py
+++ b/python/nav/ipdevpoll/plugins/uptime.py
@@ -18,7 +18,7 @@
 """Collects uptime ticks and interprets discontinuities as cold boots"""
 from datetime import timedelta, datetime
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 from nav.ipdevpoll import Plugin, shadows
 from nav.ipdevpoll.timestamps import TimestampChecker
@@ -54,7 +54,7 @@ class Uptime(Plugin):
             "last sysuptime reset/rollover reported by device: %s", upsince
         )
         stampcheck.save()
-        returnValue((changed, upsince))
+        return (changed, upsince)
 
 
 def get_upsince(timestamp, ticks):

--- a/python/nav/ipdevpoll/pool.py
+++ b/python/nav/ipdevpoll/pool.py
@@ -24,7 +24,7 @@ import logging
 
 from twisted.protocols import amp
 from twisted.internet import reactor, protocol
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from twisted.internet.endpoints import ProcessEndpoint, StandardIOEndpoint
 import twisted.internet.endpoints
 
@@ -273,7 +273,7 @@ class Worker(object):
                 now=False,
             )
 
-        returnValue(self)
+        return self
 
     @property
     def pid(self):
@@ -366,7 +366,7 @@ class Worker(object):
         deferred = self.process.callRemote(Ping)
         response = yield deferred.addTimeout(timeout, clock=reactor)
         self._logger.debug("PING: Response from %r: %r", self, response)
-        returnValue(response.get("result") == "pong")
+        return response.get("result") == "pong"
 
     def cancel(self, serial):
         """Cancels a job running on this worker"""

--- a/python/nav/ipdevpoll/timestamps.py
+++ b/python/nav/ipdevpoll/timestamps.py
@@ -84,7 +84,7 @@ class TimestampChecker(object):
             else:
                 value.raiseException()
         self.collected_times = tuple(tup)
-        defer.returnValue(self.collected_times)
+        return self.collected_times
 
     # We must ignore deserialization failures by catching the Exception base class
     # pylint: disable=W0703
@@ -107,7 +107,7 @@ class TimestampChecker(object):
                 return None
 
         self.loaded_times = yield db.run_in_thread(_deserialize)
-        defer.returnValue(self.loaded_times)
+        return self.loaded_times
 
     def save(self):
         """Saves timestamps to a ContainerRepository"""

--- a/python/nav/ipdevpoll/utils.py
+++ b/python/nav/ipdevpoll/utils.py
@@ -139,7 +139,7 @@ def get_multibridgemib(agentproxy):
     from nav.mibs.bridge_mib import MultiBridgeMib
 
     instances = yield get_dot1d_instances(agentproxy)
-    defer.returnValue(MultiBridgeMib(agentproxy, instances))
+    return MultiBridgeMib(agentproxy, instances)
 
 
 @defer.inlineCallbacks
@@ -182,9 +182,9 @@ def get_dot1d_instances(agentproxy):
                 modified_by,
                 result,
             )
-            defer.returnValue(result)
+            return result
 
-    defer.returnValue([])
+    return []
 
 
 @defer.inlineCallbacks
@@ -202,7 +202,7 @@ def get_arista_vrf_instances(agentproxy) -> Deferred:
     states = yield vrf_mib.get_vrf_states(only='active')
     vrfs = [('', agentproxy.community)]
     vrfs.extend((vrf, f"{agentproxy.community}@{vrf}") for vrf in states)
-    defer.returnValue(vrfs)
+    return vrfs
 
 
 _VLAN_RE = re.compile('^vlan([0-9]+)', re.IGNORECASE)

--- a/python/nav/mibs/alcatel_ind1_port_mib.py
+++ b/python/nav/mibs/alcatel_ind1_port_mib.py
@@ -18,7 +18,6 @@
 """A class for getting DDM values for ALE equipment"""
 
 from twisted.internet import defer
-from twisted.internet.defer import returnValue
 from nav.smidumps import get_mib
 from nav.mibs.mibretriever import MibRetriever
 from nav.models.manage import Sensor
@@ -68,7 +67,7 @@ class AlcatelInd1PortMib(MibRetriever):
         sensors = []
         for column, config in COLUMNS.items():
             sensors += yield self.handle_column(column, config)
-        returnValue(sensors)
+        return sensors
 
     @defer.inlineCallbacks
     def handle_column(self, column, config):
@@ -88,4 +87,4 @@ class AlcatelInd1PortMib(MibRetriever):
             print(sensor)
             sensor.update(config)
             result.append(sensor)
-        returnValue(result)
+        return result

--- a/python/nav/mibs/arista_vrf_mib.py
+++ b/python/nav/mibs/arista_vrf_mib.py
@@ -13,7 +13,7 @@
 # more details.  You should have received a copy of the GNU General Public
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
-from twisted.internet.defer import inlineCallbacks, returnValue, Deferred
+from twisted.internet.defer import inlineCallbacks, Deferred
 
 from nav.mibs import mibretriever
 from nav.oids import OID
@@ -40,7 +40,7 @@ class AristaVrfMib(mibretriever.MibRetriever):
             for k, v in states.items()
             if only is None or v['aristaVrfState'] == only
         }
-        returnValue(states)
+        return states
 
 
 def _vrf_index_to_string(index: OID) -> str:

--- a/python/nav/mibs/bgp4_mib.py
+++ b/python/nav/mibs/bgp4_mib.py
@@ -21,7 +21,6 @@ from pprint import pformat
 import logging
 
 from twisted.internet import defer
-from twisted.internet.defer import returnValue
 
 from nav.oidparsers import oid_to_ipv4
 from nav.smidumps import get_mib
@@ -49,7 +48,7 @@ class BGP4Mib(mibretriever.MibRetriever):
 
         """
         reply = yield self.get_next(self.SUPPORTED_ROOT)
-        returnValue(bool(reply))
+        return bool(reply)
 
     @defer.inlineCallbacks
     def get_bgp_peer_states(self):
@@ -90,7 +89,7 @@ class BGP4Mib(mibretriever.MibRetriever):
 
         if self._logger.isEnabledFor(logging.DEBUG):
             self._logger.debug("Found BGP peers:\n%s", pformat(result))
-        returnValue(result)
+        return result
 
     @staticmethod
     def _bgp_row_to_remote_ip(row_index):

--- a/python/nav/mibs/bridge_mib.py
+++ b/python/nav/mibs/bridge_mib.py
@@ -37,7 +37,7 @@ class BridgeMib(mibretriever.MibRetriever):
     @defer.inlineCallbacks
     def get_base_bridge_address(self):
         addr = yield self.get_next('dot1dBaseBridgeAddress')
-        defer.returnValue(addr)
+        return addr
 
     @defer.inlineCallbacks
     def get_forwarding_database(self):
@@ -55,14 +55,14 @@ class BridgeMib(mibretriever.MibRetriever):
             mac = ':'.join("%02x" % o for o in mac[-6:])
             port = row['dot1dTpFdbPort']
             result.append((mac, port))
-        defer.returnValue(result)
+        return result
 
     @defer.inlineCallbacks
     def get_stp_blocking_ports(self):
         """Retrieves a list of numbers of STP blocking ports"""
         states = yield self.__get_stp_port_states()
         blocked = [port for port, state in states if state == 'blocking']
-        defer.returnValue(blocked)
+        return blocked
 
     @defer.inlineCallbacks
     def get_stp_port_states(self):
@@ -70,7 +70,7 @@ class BridgeMib(mibretriever.MibRetriever):
         states = yield self.retrieve_columns(['dot1dStpPortState'])
         states = reduce_index(self.translate_result(states))
         result = [(k, v['dot1dStpPortState']) for k, v in states.items()]
-        defer.returnValue(result)
+        return result
 
     __get_stp_port_states = get_stp_port_states
 

--- a/python/nav/mibs/cd6c_mib.py
+++ b/python/nav/mibs/cd6c_mib.py
@@ -34,7 +34,7 @@ class CD6CMib(MibRetriever):
         supported = yield self.get_next('main')
         if not supported:
             self._logger.debug('CD6C mib not supported - returned %s', supported)
-            defer.returnValue([])
+            return []
 
         self._logger.debug('CD6C mib supported because main returned %s', supported)
 
@@ -52,7 +52,7 @@ class CD6CMib(MibRetriever):
 
         all_sensors = temp_sensors + pressure_sensors + flow_sensors
 
-        defer.returnValue(all_sensors)
+        return all_sensors
 
     def create_sensor(self, sensor, precision=0, uom=''):
         """Creates sensor object based on name"""

--- a/python/nav/mibs/cisco_cdp_mib.py
+++ b/python/nav/mibs/cisco_cdp_mib.py
@@ -49,7 +49,7 @@ class CiscoCDPMib(mibretriever.MibRetriever):
             neighbor = self._make_cache_tuple(index, row)
             if neighbor:
                 neighbors.append(neighbor)
-        defer.returnValue(neighbors)
+        return neighbors
 
     @defer.inlineCallbacks
     def _get_cdp_cache_table(self):
@@ -61,7 +61,7 @@ class CiscoCDPMib(mibretriever.MibRetriever):
                 'cdpCacheDevicePort',
             ]
         )
-        defer.returnValue(reduce_index(cache))
+        return reduce_index(cache)
 
     @staticmethod
     def _make_cache_tuple(index, row):

--- a/python/nav/mibs/cisco_enhanced_memory_pool_mib.py
+++ b/python/nav/mibs/cisco_enhanced_memory_pool_mib.py
@@ -36,4 +36,4 @@ class CiscoEnhancedMemoryPoolMib(mibretriever.MibRetriever):
         result = dict(
             (row[NAME], (row[USED], row[FREE])) for row in pools.values() if row[VALID]
         )
-        defer.returnValue(result)
+        return result

--- a/python/nav/mibs/cisco_entity_fru_control_mib.py
+++ b/python/nav/mibs/cisco_entity_fru_control_mib.py
@@ -101,7 +101,7 @@ class CiscoEntityFruControlMib(mibretriever.MibRetriever):
             "cefcFanTrayOperStatus", (int(internal_id),)
         )
         self._logger.debug("cefcFanTrayOperStatus.%s = %r", internal_id, oper_status)
-        defer.returnValue(self._translate_fan_status(oper_status))
+        return self._translate_fan_status(oper_status)
 
     @defer.inlineCallbacks
     def get_power_supply_status(self, internal_id):
@@ -110,21 +110,21 @@ class CiscoEntityFruControlMib(mibretriever.MibRetriever):
             "cefcFRUPowerOperStatus", (int(internal_id),)
         )
         self._logger.debug("cefcFRUPowerOperStatus.%s = %r", internal_id, oper_status)
-        defer.returnValue(self._translate_power_supply_status_value(oper_status))
+        return self._translate_power_supply_status_value(oper_status)
 
     @defer.inlineCallbacks
     def get_fan_status_table(self):
         """Retrieve the whole table of fan-sensors and cache the result."""
         if not self.fan_status_table:
             self.fan_status_table = yield self._get_fantray_status_table()
-        defer.returnValue(self.fan_status_table)
+        return self.fan_status_table
 
     @defer.inlineCallbacks
     def get_psu_status_table(self):
         """Retrieve the whole table of PSU-sensors and cache the result."""
         if not self.psu_status_table:
             self.psu_status_table = yield self._get_power_status_table()
-        defer.returnValue(self.psu_status_table)
+        return self.psu_status_table
 
     def get_power_supplies(self):
         """Retrieves a list of power supply objects"""
@@ -144,4 +144,4 @@ class CiscoEntityFruControlMib(mibretriever.MibRetriever):
             "found %d/%d field-replaceable fan entities", len(status), len(fans)
         )
         fans = [fan for fan in fans if fan.internal_id in status]
-        defer.returnValue(fans)
+        return fans

--- a/python/nav/mibs/cisco_envmon_mib.py
+++ b/python/nav/mibs/cisco_envmon_mib.py
@@ -209,4 +209,4 @@ class CiscoEnvMonMib(mibretriever.MibRetriever):
         result.extend(self._get_powersupply_sensor_params(powersupply_sensors))
 
         self._logger.debug('get_all_sensors: result=%s', result)
-        defer.returnValue(result)
+        return result

--- a/python/nav/mibs/cisco_hsrp_mib.py
+++ b/python/nav/mibs/cisco_hsrp_mib.py
@@ -33,4 +33,4 @@ class CiscoHSRPMib(mibretriever.MibRetriever):
         addr_map = dict(
             (IP(ip), ifindex) for (ifindex, group), ip in index_addrs.items()
         )
-        defer.returnValue(addr_map)
+        return addr_map

--- a/python/nav/mibs/cisco_ietf_ip_mib.py
+++ b/python/nav/mibs/cisco_ietf_ip_mib.py
@@ -71,7 +71,7 @@ class CiscoIetfIpMib(IpMib):
             column='cInetNetToMediaPhysAddress'
         )
 
-        defer.returnValue(mappings)
+        return mappings
 
     @defer.inlineCallbacks
     def get_interface_addresses(self):
@@ -89,7 +89,7 @@ class CiscoIetfIpMib(IpMib):
             prefix_entry='cIpAddressPfxOrigin',
         )
 
-        defer.returnValue(addresses)
+        return addresses
 
     @staticmethod
     def _binary_mac_to_hex(mac):

--- a/python/nav/mibs/cisco_memory_pool_mib.py
+++ b/python/nav/mibs/cisco_memory_pool_mib.py
@@ -38,4 +38,4 @@ class CiscoMemoryPoolMib(mibretriever.MibRetriever):
         result = dict(
             (row[NAME], (row[USED], row[FREE])) for row in pools.values() if row[VALID]
         )
-        defer.returnValue(result)
+        return result

--- a/python/nav/mibs/cisco_process_mib.py
+++ b/python/nav/mibs/cisco_process_mib.py
@@ -50,12 +50,12 @@ class CiscoProcessMib(mibretriever.MibRetriever):
         for index, row in load.items():
             name = names.get(row[PHYSICAL_INDEX], str(index[-1]))
             result[name] = [(5, row[TOTAL_5_MIN_REV]), (1, row[TOTAL_1_MIN_REV])]
-        defer.returnValue(result)
+        return result
 
     @defer.inlineCallbacks
     def _get_cpu_names(self, indexes):
         if not indexes:
-            defer.returnValue({})
+            return {}
         self._logger.debug("getting cpu names from ENTITY-MIB")
         base_oid = EntityMib.nodes['entPhysicalName'].oid
         oids = [str(base_oid + (index,)) for index in indexes]
@@ -64,7 +64,7 @@ class CiscoProcessMib(mibretriever.MibRetriever):
         names = {
             OID(oid)[-1]: smart_str(value) for oid, value in names.items() if value
         }
-        defer.returnValue(names)
+        return names
 
     def get_cpu_utilization(self):
         return defer.succeed(None)

--- a/python/nav/mibs/cisco_vlan_iftable_relationship_mib.py
+++ b/python/nav/mibs/cisco_vlan_iftable_relationship_mib.py
@@ -41,7 +41,7 @@ class CiscoVlanIftableRelationshipMib(mibretriever.MibRetriever):
             RoutedVlan(vlan, physical, virtual)
             for (vlan, physical), virtual in routed_vlans.items()
         ]
-        defer.returnValue(result)
+        return result
 
 
 # pylint: disable=C0103

--- a/python/nav/mibs/cisco_vlan_membership_mib.py
+++ b/python/nav/mibs/cisco_vlan_membership_mib.py
@@ -30,4 +30,4 @@ class CiscoVlanMembershipMib(mibretriever.MibRetriever):
         vlans = yield self.retrieve_column('vmVlan')
 
         result = {index[0]: vlan for index, vlan in vlans.items()}
-        defer.returnValue(result)
+        return result

--- a/python/nav/mibs/cisco_vtp_mib.py
+++ b/python/nav/mibs/cisco_vtp_mib.py
@@ -14,7 +14,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 from twisted.internet import defer
-from twisted.internet.defer import returnValue
 
 from nav.bitvector import BitVector
 from nav.smidumps import get_mib
@@ -38,7 +37,7 @@ class CiscoVTPMib(mibretriever.MibRetriever):
             for index, row in trunkports.items()
             if row['vlanTrunkPortDynamicState'] in ('on', 'onNoNegotiate')
         }
-        returnValue(result)
+        return result
 
     @defer.inlineCallbacks
     def get_trunk_enabled_vlans(self, as_bitvector=False):
@@ -77,7 +76,7 @@ class CiscoVTPMib(mibretriever.MibRetriever):
             for index, row in trunkports.items()
             if row['vlanTrunkPortDynamicState'] in ('on', 'onNoNegotiate')
         }
-        returnValue(result)
+        return result
 
     @defer.inlineCallbacks
     def get_ethernet_vlan_states(self):
@@ -91,15 +90,13 @@ class CiscoVTPMib(mibretriever.MibRetriever):
             for (_domain, vlan), row in states.items()
             if row['vtpVlanType'] == 'ethernet'
         }
-        defer.returnValue(result)
+        return result
 
     @defer.inlineCallbacks
     def get_operational_vlans(self):
         """Retrieves a set of operational ethernet VLANs on this device"""
         states = yield self.get_ethernet_vlan_states()
-        defer.returnValue(
-            set(vlan for vlan, state in states.items() if state == 'operational')
-        )
+        return set(vlan for vlan, state in states.items() if state == 'operational')
 
     @defer.inlineCallbacks
     def retrieve_alternate_bridge_mibs(self):
@@ -111,6 +108,4 @@ class CiscoVTPMib(mibretriever.MibRetriever):
         """
         vlans = yield self.get_operational_vlans()
         community = self.agent_proxy.community
-        defer.returnValue(
-            [("vlan%s" % vlan, "%s@%s" % (community, vlan)) for vlan in vlans]
-        )
+        return [("vlan%s" % vlan, "%s@%s" % (community, vlan)) for vlan in vlans]

--- a/python/nav/mibs/comet.py
+++ b/python/nav/mibs/comet.py
@@ -22,7 +22,6 @@ implementation for multiple MIBs must be implemented.
 """
 
 from twisted.internet import defer
-from twisted.internet.defer import returnValue
 
 from nav.Snmp import safestring
 from nav.smidumps import get_mib
@@ -49,7 +48,7 @@ class Comet(MibRetriever):
         """
         channels = yield self.get_channels()
         bin_inputs = yield self.get_binary_inputs()
-        returnValue(channels + bin_inputs)
+        return channels + bin_inputs
 
     @defer.inlineCallbacks
     def get_channels(self):
@@ -81,7 +80,7 @@ class Comet(MibRetriever):
                     mib=self.get_module_name(),
                 )
             )
-        returnValue(result)
+        return result
 
     @defer.inlineCallbacks
     def get_binary_inputs(self):
@@ -131,7 +130,7 @@ class Comet(MibRetriever):
                     on_state=1,
                 )
             )
-        returnValue(result)
+        return result
 
 
 class CometMS(MibRetriever):
@@ -145,7 +144,7 @@ class CometMS(MibRetriever):
         device.
         """
         channels = yield self.get_channels()
-        returnValue(channels)
+        return channels
 
     @defer.inlineCallbacks
     def get_channels(self):
@@ -172,4 +171,4 @@ class CometMS(MibRetriever):
                     mib=self.get_module_name(),
                 )
             )
-        returnValue(result)
+        return result

--- a/python/nav/mibs/comet_t3611.py
+++ b/python/nav/mibs/comet_t3611.py
@@ -17,7 +17,6 @@
 """A class for retrieving temperature and humidity data from a Comet T3611"""
 
 from twisted.internet import defer
-from twisted.internet.defer import returnValue
 
 from nav.smidumps import get_mib
 from nav.mibs import mibretriever, reduce_index
@@ -42,7 +41,7 @@ class CometT3611(mibretriever.MibRetriever):
             .addCallback(reduce_index)
         )
 
-        returnValue(self._data_to_sensor(result))
+        return self._data_to_sensor(result)
 
     def _data_to_sensor(self, result):
         """Processes MIB data and returns a humidity and temperature sensor pair"""
@@ -57,27 +56,25 @@ class CometT3611(mibretriever.MibRetriever):
         hum_mibobject = self.nodes.get("hum")
         hum_readout_oid = str(hum_mibobject.oid + str(0))
 
-        returnValue(
-            [
-                dict(
-                    oid=temp_readout_oid,
-                    unit_of_measurement=temp_unit,
-                    precision=0,
-                    scale=None,
-                    description=temp_name,
-                    name=temp_name,
-                    internal_name=temp_internal_name,
-                    mib="T3611-MIB",
-                ),
-                dict(
-                    oid=hum_readout_oid,
-                    unit_of_measurement=Sensor.UNIT_PERCENT_RELATIVE_HUMIDITY,
-                    precision=0,
-                    scale=None,
-                    description=hum_name,
-                    name=hum_name,
-                    internal_name=hum_internal_name,
-                    mib="T3611-MIB",
-                ),
-            ]
-        )
+        return [
+            dict(
+                oid=temp_readout_oid,
+                unit_of_measurement=temp_unit,
+                precision=0,
+                scale=None,
+                description=temp_name,
+                name=temp_name,
+                internal_name=temp_internal_name,
+                mib="T3611-MIB",
+            ),
+            dict(
+                oid=hum_readout_oid,
+                unit_of_measurement=Sensor.UNIT_PERCENT_RELATIVE_HUMIDITY,
+                precision=0,
+                scale=None,
+                description=hum_name,
+                name=hum_name,
+                internal_name=hum_internal_name,
+                mib="T3611-MIB",
+            ),
+        ]

--- a/python/nav/mibs/coriant_groove_mib.py
+++ b/python/nav/mibs/coriant_groove_mib.py
@@ -16,7 +16,6 @@
 """A class for getting DOM values from Coriant Groove equipment"""
 
 from twisted.internet import defer
-from twisted.internet.defer import returnValue
 from nav.smidumps import get_mib
 from nav.mibs.mibretriever import MibRetriever
 from nav.models.manage import Sensor
@@ -153,7 +152,7 @@ class CoriantGrooveMib(MibRetriever):
                 filter_columns=group.get("filter_columns"),
             )
             sensors.extend(response)
-        returnValue(sensors)
+        return sensors
 
     @defer.inlineCallbacks
     def _discover_sensors(
@@ -226,7 +225,7 @@ class CoriantGrooveMib(MibRetriever):
                 ]
             )
         self._logger.debug("Returning sensor list: %r", sensors)
-        returnValue(sensors)
+        return sensors
 
     def _make_sensor(self, index, name, alias, column, config):
         value_oid = self.nodes[column].oid

--- a/python/nav/mibs/cpqpower_mib.py
+++ b/python/nav/mibs/cpqpower_mib.py
@@ -182,7 +182,7 @@ class CPQPowerMib(mibretriever.MibRetriever):
         for config in SENSORS:
             r = yield self._get_sensors(names, **config)
             result.extend(r)
-        defer.returnValue(result)
+        return result
 
     def _get_oid(self, column, index):
         return self.mib['nodes'][column]['oid'] + index
@@ -199,7 +199,7 @@ class CPQPowerMib(mibretriever.MibRetriever):
             name = name.strip()
             name = name.replace('\0', '')
             result[index] = name
-        defer.returnValue(result)
+        return result
 
     @defer.inlineCallbacks
     def _get_sensors(self, names, sensors, extra_columns=None, filter=lambda x: True):
@@ -213,7 +213,7 @@ class CPQPowerMib(mibretriever.MibRetriever):
             if not filter(row):
                 continue
             result.extend(self._mksensors(index, row, sensors, names))
-        defer.returnValue(result)
+        return result
 
     def _mksensors(self, index, row, table, names):
         result = []

--- a/python/nav/mibs/eltek_distributed_mib.py
+++ b/python/nav/mibs/eltek_distributed_mib.py
@@ -14,7 +14,7 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """MibRetriever implementation for Eltek 48V rectifier devices"""
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from nav.smidumps import get_mib
 from nav.mibs.mibretriever import MibRetriever
 from nav.models.manage import Sensor
@@ -54,7 +54,7 @@ class EltekDistributedMib(MibRetriever):
             if sensor:
                 sensors.append(sensor)
 
-        returnValue(sensors)
+        return sensors
 
     @inlineCallbacks
     def _verify_sensor(self, object_name):
@@ -81,4 +81,4 @@ class EltekDistributedMib(MibRetriever):
                 sensor['on_state'] = 1
                 sensor['on_message'] = "{} alarm".format(description)
                 sensor['off_message'] = "{} normal".format(description)
-            returnValue(sensor)
+            return sensor

--- a/python/nav/mibs/entity_mib.py
+++ b/python/nav/mibs/entity_mib.py
@@ -89,13 +89,13 @@ class EntityMib(mibretriever.MibRetriever):
         df.addCallback(self.translate_result)
         ret_table = yield df
         named_table = EntityTable(ret_table)
-        defer.returnValue(named_table)
+        return named_table
 
     @defer.inlineCallbacks
     def get_entity_physical_table(self):
         """Retrieves the full entPhysicalTable contents"""
         phy_sensor_table = yield self._get_named_table('entPhysicalTable')
-        defer.returnValue(phy_sensor_table)
+        return phy_sensor_table
 
     @defer.inlineCallbacks
     def get_useful_physical_table_columns(self):
@@ -115,12 +115,12 @@ class EntityMib(mibretriever.MibRetriever):
                 'entPhysicalIsFRU',
             ]
         )
-        defer.returnValue(self.translate_result(columns))
+        return self.translate_result(columns)
 
     @defer.inlineCallbacks
     def get_alias_mapping(self):
         alias_mapping = yield self.retrieve_column('entAliasMappingIdentifier')
-        defer.returnValue(self._process_alias_mapping(alias_mapping))
+        return self._process_alias_mapping(alias_mapping)
 
     def _process_alias_mapping(self, alias_mapping):
         mapping = defaultdict(list)
@@ -154,7 +154,7 @@ class EntityMib(mibretriever.MibRetriever):
             for e in table.values()
             if filter_function(e)
         ]
-        defer.returnValue(objects)
+        return objects
 
 
 class EntityTable(dict):

--- a/python/nav/mibs/entity_sensor_mib.py
+++ b/python/nav/mibs/entity_sensor_mib.py
@@ -137,4 +137,4 @@ class EntitySensorMib(mibretriever.MibRetriever):
                     }
                 )
         self._logger.debug('get_all_sensors: result=%s', result)
-        defer.returnValue(result)
+        return result

--- a/python/nav/mibs/esswitch_mib.py
+++ b/python/nav/mibs/esswitch_mib.py
@@ -46,4 +46,4 @@ class ESSwitchMib(mibretriever.MibRetriever):
                 self.nodes[self.BANDWIDTH_USAGE_CURRENT_PEAK].oid + (peak_index,)
             )
             rsp = yield self.agent_proxy.get([peak_oid])
-            defer.returnValue(rsp.get(peak_oid, None))
+            return rsp.get(peak_oid, None)

--- a/python/nav/mibs/etherlike_mib.py
+++ b/python/nav/mibs/etherlike_mib.py
@@ -34,4 +34,4 @@ class EtherLikeMib(mibretriever.MibRetriever):
         result = {
             index[0]: row['dot3StatsDuplexStatus'] for index, row in duplex.items()
         }
-        defer.returnValue(result)
+        return result

--- a/python/nav/mibs/hp_httpmanageable_mib.py
+++ b/python/nav/mibs/hp_httpmanageable_mib.py
@@ -30,4 +30,4 @@ class HPHTTPManageableMib(MibRetriever):
         if serial:
             if isinstance(serial, bytes):
                 serial = serial.decode("utf-8")
-            defer.returnValue(serial)
+            return serial

--- a/python/nav/mibs/hpicf_fan_mib.py
+++ b/python/nav/mibs/hpicf_fan_mib.py
@@ -57,7 +57,7 @@ class HpIcfFanMib(mibretriever.MibRetriever):
         df.addCallback(reduce_index)
         fan_table = yield df
         self._logger.debug("fan_table: %r", fan_table)
-        defer.returnValue(fan_table)
+        return fan_table
 
     @staticmethod
     def _translate_fan_status(psu_status):
@@ -79,7 +79,7 @@ class HpIcfFanMib(mibretriever.MibRetriever):
         fan_status = fan_status_row.get("hpicfFanState")
 
         self._logger.debug("hpicfFanState.%s = %r", index, fan_status)
-        defer.returnValue(self._translate_fan_status(fan_status))
+        return self._translate_fan_status(fan_status)
 
     @defer.inlineCallbacks
     def get_fans(self):
@@ -102,4 +102,4 @@ class HpIcfFanMib(mibretriever.MibRetriever):
         ):
             ent.internal_id = "{}:{}".format(ent.internal_id, index)
 
-        defer.returnValue(entities)
+        return entities

--- a/python/nav/mibs/hpicf_powersupply_mib.py
+++ b/python/nav/mibs/hpicf_powersupply_mib.py
@@ -54,7 +54,7 @@ class HpIcfPowerSupplyMib(mibretriever.MibRetriever):
         df.addCallback(reduce_index)
         psu_table = yield df
         self._logger.debug("psu_table: %r", psu_table)
-        defer.returnValue(psu_table)
+        return psu_table
 
     @staticmethod
     def _translate_psu_status(psu_status):
@@ -76,7 +76,7 @@ class HpIcfPowerSupplyMib(mibretriever.MibRetriever):
         psu_status = psu_status_row.get("hpicfPsState")
 
         self._logger.debug("hpicfPsState.%s = %r", index, psu_status)
-        defer.returnValue(self._translate_psu_status(psu_status))
+        return self._translate_psu_status(psu_status)
 
     @defer.inlineCallbacks
     def get_power_supplies(self):
@@ -100,7 +100,7 @@ class HpIcfPowerSupplyMib(mibretriever.MibRetriever):
         ):
             ent.internal_id = "{}:{}".format(ent.internal_id, index)
 
-        defer.returnValue(entities)
+        return entities
 
 
 def _psu_index_from_internal_id(internal_id):

--- a/python/nav/mibs/ibm_pdu_mib.py
+++ b/python/nav/mibs/ibm_pdu_mib.py
@@ -15,7 +15,7 @@
 #
 """MibRetriever implementation for IBM-PDU-MIB"""
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 from nav.mibs import reduce_index
 from nav.smidumps import get_mib
@@ -46,7 +46,7 @@ class IbmPduMib(MibRetriever):
         """
         phases = yield self._get_phase_sensors()
         outlets = yield self._get_outlet_sensors()
-        returnValue(phases + outlets)
+        return phases + outlets
 
     @inlineCallbacks
     def _get_phase_sensors(self):
@@ -78,7 +78,7 @@ class IbmPduMib(MibRetriever):
                 )
             )
 
-        returnValue(result)
+        return result
 
     @inlineCallbacks
     def _get_outlet_sensors(self):
@@ -99,7 +99,7 @@ class IbmPduMib(MibRetriever):
         for index, row in outlets.items():
             result.extend(self._outlet_row_to_sensors(index, row))
 
-        returnValue(result)
+        return result
 
     def _outlet_row_to_sensors(self, index, row):
         name = row.get(OUTLET_NAME)

--- a/python/nav/mibs/ieee8023_lag_mib.py
+++ b/python/nav/mibs/ieee8023_lag_mib.py
@@ -15,7 +15,7 @@
 #
 """ "A MibRetriever to retrieve IEEE 802.3ad info from the IEEE8023-LAG-MIB"""
 from collections import defaultdict
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from nav.smidumps import get_mib
 from nav.mibs import mibretriever, reduce_index
 
@@ -36,9 +36,9 @@ class IEEE8023LagMib(mibretriever.MibRetriever):
         result = yield self.retrieve_column('dot3adAggPortSelectedAggID').addCallback(
             reduce_index
         )
-        returnValue(
-            {port: aggregator for port, aggregator in result.items() if aggregator != 0}
-        )
+        return {
+            port: aggregator for port, aggregator in result.items() if aggregator != 0
+        }
 
     @inlineCallbacks
     def retrieve_attached_aggregators(self):
@@ -51,9 +51,9 @@ class IEEE8023LagMib(mibretriever.MibRetriever):
         result = yield self.retrieve_column('dot3adAggPortAttachedAggID').addCallback(
             reduce_index
         )
-        returnValue(
-            {port: aggregator for port, aggregator in result.items() if aggregator != 0}
-        )
+        return {
+            port: aggregator for port, aggregator in result.items() if aggregator != 0
+        }
 
     @inlineCallbacks
     def retrieve_aggregations_by_operational_key(self):
@@ -81,4 +81,4 @@ class IEEE8023LagMib(mibretriever.MibRetriever):
             if opervalue in by_opervalue
         }
 
-        returnValue(result)
+        return result

--- a/python/nav/mibs/if_mib.py
+++ b/python/nav/mibs/if_mib.py
@@ -34,7 +34,7 @@ class IfMib(mibretriever.MibRetriever):
         df.addCallback(self.translate_result)
         df.addCallback(reduce_index)
         if_table = yield df
-        defer.returnValue(if_table)
+        return if_table
 
     @defer.inlineCallbacks
     def get_ifnames(self):
@@ -49,7 +49,7 @@ class IfMib(mibretriever.MibRetriever):
         result = dict(
             (index, (row['ifName'], row['ifDescr'])) for index, row in table.items()
         )
-        defer.returnValue(result)
+        return result
 
     @defer.inlineCallbacks
     def get_ifaliases(self):
@@ -59,13 +59,13 @@ class IfMib(mibretriever.MibRetriever):
 
         """
         aliases = yield self.retrieve_column('ifAlias').addCallback(reduce_index)
-        defer.returnValue(aliases)
+        return aliases
 
     @defer.inlineCallbacks
     def get_ifindexes(self):
         "Retrieves a list of current ifIndexes"
         indexes = yield self.retrieve_column('ifIndex')
-        defer.returnValue(indexes.values())
+        return indexes.values()
 
     @defer.inlineCallbacks
     def get_admin_status(self):
@@ -80,7 +80,7 @@ class IfMib(mibretriever.MibRetriever):
         status = yield df
 
         result = dict((index, row['ifAdminStatus']) for index, row in status.items())
-        defer.returnValue(result)
+        return result
 
     @defer.inlineCallbacks
     def get_stack_status(self):
@@ -97,4 +97,4 @@ class IfMib(mibretriever.MibRetriever):
             for higher, lower in status.keys()
             if higher > 0 and lower > 0
         ]
-        defer.returnValue(result)
+        return result

--- a/python/nav/mibs/ip_forward_mib.py
+++ b/python/nav/mibs/ip_forward_mib.py
@@ -19,7 +19,7 @@ from collections import defaultdict
 from itertools import chain
 from collections import namedtuple
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 from nav.smidumps import get_mib
 from nav.oidparsers import consume
@@ -77,9 +77,9 @@ class IpForwardMib(mibretriever.MibRetriever):
 
         if protocols:
             result = chain(*[by_proto.get(proto, []) for proto in protocols])
-            returnValue(list(result))
+            return list(result)
         else:
-            returnValue(dict(by_proto))
+            return dict(by_proto)
 
     @inlineCallbacks
     def get_decoded_routes(self, protocols=None):
@@ -114,7 +114,7 @@ class IpForwardMib(mibretriever.MibRetriever):
                     for entry in (decode_route_entry(r) for r in result[proto])
                     if entry
                 ]
-        returnValue(result)
+        return result
 
     def get_cidr_route_column(self, column, index):
         """Retrieves the value of a specific column for a given route index"""

--- a/python/nav/mibs/ip_mib.py
+++ b/python/nav/mibs/ip_mib.py
@@ -17,7 +17,7 @@
 #
 """MibRetriever implementation for IP-MIB"""
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 from nav.oids import OID
 from nav.oidparsers import IPV4_ID, IPV6_ID, oid_to_ipv6, oid_to_ipv4
@@ -160,7 +160,7 @@ class IpMib(mibretriever.MibRetriever):
         self._logger.debug(
             "ip/mac pairs: Got %d rows from %s", len(all_phys_addrs), column
         )
-        returnValue(mappings)
+        return mappings
 
     @inlineCallbacks
     def _get_ifindex_ipv4_mac_mappings(self, column='ipNetToMediaPhysAddress'):
@@ -193,7 +193,7 @@ class IpMib(mibretriever.MibRetriever):
         self._logger.debug(
             "ip/mac pairs: Got %d rows from %s", len(ipv4_phys_addrs), column
         )
-        returnValue(mappings)
+        return mappings
 
     @staticmethod
     def _binary_mac_to_hex(mac):
@@ -218,7 +218,7 @@ class IpMib(mibretriever.MibRetriever):
         mappings_new = yield self._get_ifindex_ip_mac_mappings()
         mappings_deprecated = yield self._get_ifindex_ipv4_mac_mappings()
 
-        returnValue(mappings_new | mappings_deprecated)
+        return mappings_new | mappings_deprecated
 
     @inlineCallbacks
     def _get_interface_ipv4_addresses(
@@ -266,7 +266,7 @@ class IpMib(mibretriever.MibRetriever):
             len(address_rows),
             ifindex_column,
         )
-        returnValue(addresses)
+        return addresses
 
     @inlineCallbacks
     def _get_interface_addresses(
@@ -310,7 +310,7 @@ class IpMib(mibretriever.MibRetriever):
             len(address_rows),
             ifindex_column,
         )
-        returnValue(addresses)
+        return addresses
 
     @inlineCallbacks
     def get_interface_addresses(self):
@@ -328,7 +328,7 @@ class IpMib(mibretriever.MibRetriever):
         addrs_from_new_table = yield self._get_interface_addresses()
         addrs_from_deprecated_table = yield self._get_interface_ipv4_addresses()
 
-        returnValue(addrs_from_new_table | addrs_from_deprecated_table)
+        return addrs_from_new_table | addrs_from_deprecated_table
 
     @inlineCallbacks
     def get_ipv6_octet_counters(self):
@@ -343,7 +343,7 @@ class IpMib(mibretriever.MibRetriever):
             for index, row in octets.items()
             if index[-2] == IPV6_ID
         )
-        returnValue(result)
+        return result
 
 
 class MultiIpMib(IpMib, mibretriever.MultiMibMixIn):

--- a/python/nav/mibs/ipv6_mib.py
+++ b/python/nav/mibs/ipv6_mib.py
@@ -88,7 +88,7 @@ class Ipv6Mib(mibretriever.MibRetriever):
         self._logger.debug(
             "ip/mac pairs: Got %d rows from %s", len(ipv6_phys_addrs), column
         )
-        defer.returnValue(mappings)
+        return mappings
 
     @defer.inlineCallbacks
     def get_interface_addresses(self):
@@ -120,4 +120,4 @@ class Ipv6Mib(mibretriever.MibRetriever):
             prefixlen_column,
         )
 
-        defer.returnValue(addresses)
+        return addresses

--- a/python/nav/mibs/itw_mib.py
+++ b/python/nav/mibs/itw_mib.py
@@ -397,7 +397,7 @@ class BaseITWatchDogsMib(mibretriever.MibRetriever):
             for sensor_group in sensor_groups:
                 result.extend(self._handle_sensor_group(sensor_group, sensors))
 
-        defer.returnValue(result)
+        return result
 
 
 UNITS = {

--- a/python/nav/mibs/itw_mibv3.py
+++ b/python/nav/mibs/itw_mibv3.py
@@ -516,4 +516,4 @@ class ItWatchDogsMibV3(BaseITWatchDogsMib):
             self._logger.debug('get_all_sensors: %s = %s', table, sensors)
             result.extend(handler(sensors))
 
-        defer.returnValue(result)
+        return result

--- a/python/nav/mibs/juniper_alarm_mib.py
+++ b/python/nav/mibs/juniper_alarm_mib.py
@@ -40,4 +40,4 @@ class JuniperAlarmMib(MibRetriever):
             count = int(count) or 0
         except (ValueError, TypeError):
             count = 0
-        defer.returnValue(count)
+        return count

--- a/python/nav/mibs/juniper_dom_mib.py
+++ b/python/nav/mibs/juniper_dom_mib.py
@@ -16,7 +16,6 @@
 """A class for getting DOM values for juniper equipment"""
 
 from twisted.internet import defer
-from twisted.internet.defer import returnValue
 from nav.smidumps import get_mib
 from nav.mibs.mibretriever import MibRetriever
 from nav.models.manage import Sensor
@@ -63,7 +62,7 @@ class JuniperDomMib(MibRetriever):
         sensors = []
         for column, config in COLUMNS.items():
             sensors += yield self.handle_column(column, config)
-        returnValue(sensors)
+        return sensors
 
     @defer.inlineCallbacks
     def handle_column(self, column, config):
@@ -81,4 +80,4 @@ class JuniperDomMib(MibRetriever):
             )
             sensor.update(config)
             result.append(sensor)
-        returnValue(result)
+        return result

--- a/python/nav/mibs/juniper_mib.py
+++ b/python/nav/mibs/juniper_mib.py
@@ -70,7 +70,7 @@ class JuniperMib(MibRetriever):
         if serial:
             if isinstance(serial, bytes):
                 serial = serial.decode("utf-8")
-            defer.returnValue(serial)
+            return serial
 
     @defer.inlineCallbacks
     def get_cpu_loadavg(self):
@@ -98,7 +98,7 @@ class JuniperMib(MibRetriever):
                         (1, row[LOAD_AVG_1MIN]),
                     ]
                     result[name] = values
-            defer.returnValue(result)
+            return result
 
     @defer.inlineCallbacks
     def get_cpu_utilization(self):
@@ -119,7 +119,7 @@ class JuniperMib(MibRetriever):
                 if row[OPERATING_CPU]:
                     name = row[OPERATING_DESCR]
                     result[name] = row[OPERATING_CPU]
-            defer.returnValue(result)
+            return result
 
     def get_power_supplies(self):
         """Retrieves a list of field-replaceable power supply units"""
@@ -147,7 +147,7 @@ class JuniperMib(MibRetriever):
             for row in response.values()
             if row.get("jnxFruState") != "empty" and row.get("jnxFruType") == fru_type
         ]
-        defer.returnValue(units)
+        return units
 
     @defer.inlineCallbacks
     def get_fru_status(self, internal_id):
@@ -156,7 +156,7 @@ class JuniperMib(MibRetriever):
             "jnxFruState", OID(internal_id)
         )
         self._logger.debug("jnxFruState.%s = %r", internal_id, oper_status)
-        defer.returnValue(self._translate_fru_status_value(oper_status))
+        return self._translate_fru_status_value(oper_status)
 
     get_fan_status = get_fru_status
     get_power_supply_status = get_fru_status
@@ -168,7 +168,7 @@ class JuniperMib(MibRetriever):
         for table, config in SENSOR_TABLES.items():
             sensors = yield self._get_sensors(config)
             result.extend(sensors)
-        defer.returnValue(result)
+        return result
 
     @defer.inlineCallbacks
     def _get_sensors(self, config):
@@ -189,7 +189,7 @@ class JuniperMib(MibRetriever):
             self._row_to_sensor(config, index, row) for index, row in result.items()
         )
 
-        defer.returnValue([s for s in sensors if s])
+        return [s for s in sensors if s]
 
     def _row_to_sensor(self, config, index, row):
         """
@@ -246,7 +246,7 @@ class JuniperMib(MibRetriever):
                 used = (row[OPERATING_BUF] / 100) * total
                 free = total - used
                 result[row[OPERATING_DESCR]] = (used, free)
-        defer.returnValue(result)
+        return result
 
 
 def _fru_row_to_powersupply_or_fan(fru_row):

--- a/python/nav/mibs/lldp_mib.py
+++ b/python/nav/mibs/lldp_mib.py
@@ -18,7 +18,7 @@
 import socket
 from collections import namedtuple
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 from nav.ip import IP
 from nav.mibs.if_mib import IfMib
@@ -49,7 +49,7 @@ class LLDPMib(mibretriever.MibRetriever):
         else:
             result = []
 
-        returnValue(result)
+        return result
 
     def _retrieve_rem_table(self):
         return self.retrieve_columns(
@@ -92,7 +92,7 @@ class LLDPMib(mibretriever.MibRetriever):
         """
         if self._is_remote_table_index_broken(remote_table):
             self._logger.warning("lldpRemTable has broken row indexes on this device")
-            returnValue([])
+            return []
 
         remotes = remote_table.values()
         local_ports = yield self._retrieve_local_ports()
@@ -141,7 +141,7 @@ class LLDPMib(mibretriever.MibRetriever):
             _timemark, local_portnum, _index = remote[0]
             remote[0] = lookup.get(local_portnum, local_portnum)
 
-        returnValue(remotes)
+        return remotes
 
     @staticmethod
     def _is_remote_table_index_broken(remote_table):
@@ -164,7 +164,7 @@ class LLDPMib(mibretriever.MibRetriever):
             index: IdSubtypes.get(row['lldpLocPortIdSubtype'], row['lldpLocPortId'])
             for index, row in ports.items()
         }
-        returnValue(result)
+        return result
 
     @inlineCallbacks
     def _make_interface_lookup_dict(self):
@@ -174,7 +174,7 @@ class LLDPMib(mibretriever.MibRetriever):
         for ifindex, (ifname, ifdescr) in ifnames.items():
             lookup[ifdescr] = ifindex
             lookup[ifname] = ifindex
-        returnValue(lookup)
+        return lookup
 
 
 # pylint: disable=C0103

--- a/python/nav/mibs/mibretriever.py
+++ b/python/nav/mibs/mibretriever.py
@@ -35,7 +35,6 @@ import logging
 
 from pynetsnmp.netsnmp import SnmpTimeoutError
 from twisted.internet import defer, reactor
-from twisted.internet.defer import returnValue
 from twisted.internet.error import TimeoutError
 from twisted.python.failure import Failure
 
@@ -390,7 +389,7 @@ class MibRetriever(object, metaclass=MibRetrieverMaker):
             if oid.is_a_prefix_of(key):
                 if translate_result:
                     value = self.nodes[object_name].to_python(value)
-                defer.returnValue(value)
+                return value
 
     def retrieve_column(self, column_name):
         """Retrieve the contents of a single MIB table column.
@@ -574,7 +573,7 @@ class MibRetriever(object, metaclass=MibRetrieverMaker):
         result = yield self.agent_proxy._get([oid])
         for obj, value in result:
             assert obj == oid
-            returnValue(node.to_python(value))
+            return node.to_python(value)
 
 
 class MultiMibMixIn(MibRetriever):
@@ -654,7 +653,7 @@ class MultiMibMixIn(MibRetriever):
                 self.agent_proxy = self._base_agent
             results.append((descr, one_result))
             yield lambda thing: fire_eventually(thing)
-        defer.returnValue(integrator(results))
+        return integrator(results)
 
     def __timeout_handler(self, failure, descr):
         """Handles timeouts while processing alternate MIB instances.

--- a/python/nav/mibs/netswitch_mib.py
+++ b/python/nav/mibs/netswitch_mib.py
@@ -47,4 +47,4 @@ class NetswitchMib(mibretriever.MibRetriever):
             slots = yield self.retrieve_columns([slot_oid, free_oid, used_oid])
             for row in slots.values():
                 result[kind + str(row[slot_oid])] = (row[used_oid], row[free_oid])
-        defer.returnValue(result)
+        return result

--- a/python/nav/mibs/old_cisco_cpu_mib.py
+++ b/python/nav/mibs/old_cisco_cpu_mib.py
@@ -27,7 +27,7 @@ class OldCiscoCpuMib(mibretriever.MibRetriever):
         avgbusy1 = yield self.get_next('avgBusy1')
         if avgbusy5 or avgbusy1:
             result = dict(cpu=[(5, avgbusy5), (1, avgbusy1)])
-            defer.returnValue(result)
+            return result
 
     def get_cpu_utilization(self):
         return defer.succeed(None)

--- a/python/nav/mibs/pdu2_mib.py
+++ b/python/nav/mibs/pdu2_mib.py
@@ -16,7 +16,6 @@
 """A class for getting sensor information from Raritan PDU2 devices"""
 
 from twisted.internet import defer
-from twisted.internet.defer import returnValue
 from nav.smidumps import get_mib
 from nav.mibs.mibretriever import MibRetriever
 from nav.models.manage import Sensor
@@ -74,7 +73,7 @@ class PDU2Mib(MibRetriever):
         result += sensors
         result += yield self.get_inlet_pole_sensors(inlets)
         result += yield self.get_over_current_protection_sensors()
-        returnValue(result)
+        return result
 
     def retrieve_sensor_columns(self, table):
         columns = [fmt.format(table=table) for fmt in SENSOR_COLUMNS]
@@ -127,7 +126,7 @@ class PDU2Mib(MibRetriever):
             )
             sensor = self.get_sensor(table, index, row, name, name, internal_name)
             result.append(sensor)
-        returnValue((result, inlets))
+        return (result, inlets)
 
     @defer.inlineCallbacks
     def get_inlet_pole_sensors(self, inlets):
@@ -154,7 +153,7 @@ class PDU2Mib(MibRetriever):
             )
             sensor = self.get_sensor(table, index, row, name, name, internal_name)
             result.append(sensor)
-        returnValue(result)
+        return result
 
     @defer.inlineCallbacks
     def get_over_current_protection_sensors(self):
@@ -182,4 +181,4 @@ class PDU2Mib(MibRetriever):
             if sensor_type == 'trip':
                 sensor['unit_of_measurement'] = Sensor.UNIT_TRUTHVALUE
             result.append(sensor)
-        returnValue(result)
+        return result

--- a/python/nav/mibs/power_ethernet_mib.py
+++ b/python/nav/mibs/power_ethernet_mib.py
@@ -27,10 +27,10 @@ class PowerEthernetMib(mibretriever.MibRetriever):
         cols = yield self.retrieve_columns(
             ["pethMainPsePower", "pethMainPseOperStatus", "pethMainPseConsumptionPower"]
         )
-        defer.returnValue(cols)
+        return cols
 
     @defer.inlineCallbacks
     def get_ports_table(self):
         """Retrieves PoE port information"""
         cols = yield self.retrieve_table("pethPsePortTable")
-        defer.returnValue(cols)
+        return cols

--- a/python/nav/mibs/powernet_mib.py
+++ b/python/nav/mibs/powernet_mib.py
@@ -84,7 +84,7 @@ class PowerNetMib(UpsMib):
         ups_sensors = yield super(PowerNetMib, self).get_all_sensors()
         pdu_sensors = yield self._get_pdu_bank_load_sensors()
         result = ups_sensors + pdu_sensors
-        defer.returnValue(result)
+        return result
 
     @defer.inlineCallbacks
     def _get_pdu_bank_load_sensors(self):
@@ -123,7 +123,7 @@ class PowerNetMib(UpsMib):
                     mib=self.get_module_name(),
                 )
             )
-        defer.returnValue(result)
+        return result
 
     @defer.inlineCallbacks
     def get_serial_number(self):
@@ -134,4 +134,4 @@ class PowerNetMib(UpsMib):
             if serial:
                 if isinstance(serial, bytes):
                     serial = serial.decode("utf-8")
-                defer.returnValue(serial)
+                return serial

--- a/python/nav/mibs/pwt_3phase_mibv1.py
+++ b/python/nav/mibs/pwt_3phase_mibv1.py
@@ -237,4 +237,4 @@ class Pwt3PhaseV1Mib(mibretriever.MibRetriever):
                 method = getattr(self, handler)
                 result.extend(method(sensors))
 
-        defer.returnValue(result)
+        return result

--- a/python/nav/mibs/qbridge_mib.py
+++ b/python/nav/mibs/qbridge_mib.py
@@ -104,7 +104,7 @@ class QBridgeMib(mibretriever.MibRetriever):
             mac = ':'.join("%02x" % o for o in mac[-6:])
             port = row['dot1qTpFdbPort']
             result.append((mac, port))
-        defer.returnValue(result)
+        return result
 
     @defer.inlineCallbacks
     def get_vlan_static_names(self):
@@ -115,7 +115,7 @@ class QBridgeMib(mibretriever.MibRetriever):
         for key, value in names.items():
             if isinstance(value, str) and "\x00" in value:
                 names[key] = value.replace("\x00", "")
-        defer.returnValue(names)
+        return names
 
 
 def filter_newest_current_entries(dot1qvlancurrenttable):

--- a/python/nav/mibs/rittal_cmc_iii.py
+++ b/python/nav/mibs/rittal_cmc_iii.py
@@ -19,7 +19,6 @@ from collections import defaultdict
 import math
 
 from twisted.internet import defer
-from twisted.internet.defer import returnValue
 from nav.smidumps import get_mib
 from nav.mibs.mibretriever import MibRetriever
 from nav.models.manage import Sensor
@@ -79,7 +78,7 @@ class RittalCMCIIIMib(MibRetriever):
         """Discovers and returns all eligible sensors from the device."""
         devices = yield self.get_devices()
         sensors = yield self.get_sensors(devices)
-        returnValue(sensors)
+        return sensors
 
     @defer.inlineCallbacks
     def get_devices(self):
@@ -87,7 +86,7 @@ class RittalCMCIIIMib(MibRetriever):
             ['cmcIIIDevName', 'cmcIIIDevAlias', 'cmcIIIDevNumberOfVars']
         )
         devices = self.translate_result(devices)
-        returnValue(devices)
+        return devices
 
     @defer.inlineCallbacks
     def get_sensors(self, devices):
@@ -147,4 +146,4 @@ class RittalCMCIIIMib(MibRetriever):
                     mib=self.get_module_name(),
                 )
                 result.append(sensor)
-        returnValue(result)
+        return result

--- a/python/nav/mibs/snmpv2_mib.py
+++ b/python/nav/mibs/snmpv2_mib.py
@@ -42,13 +42,13 @@ class Snmpv2Mib(mibretriever.MibRetriever):
         oid = self.nodes[var].oid
         result = yield self.get_next(var)
         if result:
-            defer.returnValue(result)
+            return result
         else:
             oid = oid + OID('0')
             result = yield self.agent_proxy.get([str(oid)])
             for key, value in result.items():
                 if oid == OID(key):
-                    defer.returnValue(value)
+                    return value
 
     # pylint: disable=C0103
 
@@ -76,7 +76,7 @@ class Snmpv2Mib(mibretriever.MibRetriever):
         """
         sysuptime = yield self._get_sysvariable('sysUpTime')
         timestamp = time.mktime(time.localtime())
-        defer.returnValue((timestamp, sysuptime))
+        return (timestamp, sysuptime)
 
     @staticmethod
     def get_uptime_deviation(first_uptime, second_uptime):

--- a/python/nav/mibs/spagent_mib.py
+++ b/python/nav/mibs/spagent_mib.py
@@ -111,7 +111,7 @@ class SPAgentMib(MibRetriever):
         for table, config in TABLES[model_id].items():
             sensors = yield self._get_sensors(config)
             result.extend(sensors)
-        defer.returnValue(result)
+        return result
 
     @defer.inlineCallbacks
     def _get_sensors(self, config):
@@ -135,7 +135,7 @@ class SPAgentMib(MibRetriever):
             self._row_to_sensor(config, index, row) for index, row in result.items()
         )
 
-        defer.returnValue([s for s in sensors if s])
+        return [s for s in sensors if s]
 
     def _row_to_sensor(self, config, index, row):
         """

--- a/python/nav/mibs/statistics_mib.py
+++ b/python/nav/mibs/statistics_mib.py
@@ -35,7 +35,7 @@ class StatisticsMib(mibretriever.MibRetriever):
         """Returns the current switch CPU utilization in percent"""
         util = yield self.get_next('hpSwitchCpuStat')
         if util is not None:
-            defer.returnValue(dict(cpu=util))
+            return dict(cpu=util)
 
     def get_cpu_loadavg(self):
         return defer.succeed(None)
@@ -64,4 +64,4 @@ class StatisticsMib(mibretriever.MibRetriever):
                 IP('.'.join(str(i) for i in group)), ifindex, vlan, access
             )
 
-        defer.returnValue([_split(i) for i in ports.items()])
+        return [_split(i) for i in ports.items()]

--- a/python/nav/mibs/ups_mib.py
+++ b/python/nav/mibs/ups_mib.py
@@ -115,7 +115,7 @@ class UpsMib(mibretriever.MibRetriever):
             sensor_params = yield self._get_named_column(sensor)
             result.extend(self._get_sensors(sensor, sensor_params))
 
-        defer.returnValue(result)
+        return result
 
     def _get_sensors(self, object_name, sensor_params):
         result = []

--- a/python/nav/mibs/vrrp_mib.py
+++ b/python/nav/mibs/vrrp_mib.py
@@ -35,4 +35,4 @@ class VRRPMib(mibretriever.MibRetriever):
             ifindex, vrrp_id = index[:2]
             ipaddr = IP(".".join(str(o) for o in index[2:]))
             addr_map[ipaddr] = ifindex
-        defer.returnValue(addr_map)
+        return addr_map

--- a/python/nav/mibs/wlsx_systemext_mib.py
+++ b/python/nav/mibs/wlsx_systemext_mib.py
@@ -30,4 +30,4 @@ class WLSXSystemextMib(MibRetriever):
         if serial:
             if isinstance(serial, bytes):
                 serial = serial.decode("utf-8")
-            defer.returnValue(serial)
+            return serial

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ psycopg2==2.9.9  # requires libpq to build
 IPy==1.01
 pyaml
 
-twisted>=23.8.0,<24.0
+twisted>=24.7
 
 networkx==2.6.3
 # Cannot be removed as long as qrcode is included


### PR DESCRIPTION
In the last week when running the tests I got a lot of a similar warning:
```
DeprecationWarning: twisted.internet.defer.returnValue was deprecated in Twisted 24.7.0; please use standard return statement instead
    defer.returnValue(serial)
```
I replaced all occurrences of `defer.returnValue` with `return`.
Reference: https://github.com/twisted/twisted/blob/HEAD/NEWS.rst#deprecations-and-removals, https://github.com/twisted/twisted/issues/9930