### PR TITLE
Disable towncrier check on dependabot PRs

### DIFF
--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 jobs:
   towncrier:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     name: Towncrier check
     steps:


### PR DESCRIPTION
Since dependabot only updates the GitHub actions these pull requests do not need a changelog fragment.