### PR TITLE
Upgrade pre-commit to towncrier 24.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/twisted/towncrier
-    rev: 24.7.1
+    rev: 24.8.0
     hooks:
       - id: towncrier-check
         files: $changelog\.d/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ underlines = ["", "", ""]
 title_format = "## [{version}] - {project_date}"
 issue_format = "[#{issue}](https://github.com/Uninett/nav/issues/{issue})"
 wrap = true
-ignore = [".gitkeep"]
 
 [[tool.towncrier.type]]
 directory = "security"


### PR DESCRIPTION
This version automatically ignores .gitkeep files. It reverts #2942.