### PR TITLE
Fix more snmpsim problems

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: "Install test runner dependencies"
         run: |
           set -xe
-          python3 -m pip install --upgrade 'pip==23.1.0' setuptools wheel 'tox<4' tox-gh-actions coverage virtualenv 'snmpsim>=1.0'
+          python3 -m pip install --upgrade 'pip==23.1.0' setuptools wheel 'tox<4' tox-gh-actions coverage virtualenv
           sudo apt-get install -y nbtscan
 
       # virtualenv seems to currently be embedding a broken version of

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -67,7 +67,7 @@ RUN cd /tmp && \
     mv chromedriver /usr/local/bin/
 
 # Install our primary test runner
-RUN python3.9 -m pip install 'tox<4' 'snmpsim>=1.0' virtualenv
+RUN python3.9 -m pip install 'tox<4' virtualenv
 
 # Add a build user
 ENV USER build

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -13,6 +13,7 @@ pytest-twisted~=1.13.0
 pytidylib==0.3.2
 selenium==3.141.0
 snmpsim>=1.0
+pyasn1<0.6.0  # Really just a constraint because of incompatibility with snmpsim
 toml
 whisper>=0.9.9
 whitenoise==4.1.4

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -12,6 +12,7 @@ pytest-timeout
 pytest-twisted~=1.13.0
 pytidylib==0.3.2
 selenium==3.141.0
+snmpsim>=1.0
 toml
 whisper>=0.9.9
 whitenoise==4.1.4


### PR DESCRIPTION
snmpsim belongs inside the tox test environments, and is required for several tests.  Not sure why it was being installed explicitly in the Dockerfiles and workflows, when the correct approach is to name it in the test requirements (I'm guessing because it is used as a command and not as a library by the test suite).  This way, it doesn't need to be referenced multiple times.

Also, it appears that snmpsim is once again incompatible with pyasn1, so this also introduces a version constraint for that.
