### PR TITLE
Fix various issues with running test suite on "non-standard" platforms

### DIFF
--- a/changelog.d/+macos-testsuite-fixes.fixed.md
+++ b/changelog.d/+macos-testsuite-fixes.fixed.md
@@ -1,0 +1,1 @@
+Make the test suite easier to run under MacOS

--- a/python/nav/Snmp/__init__.py
+++ b/python/nav/Snmp/__init__.py
@@ -21,6 +21,8 @@ multiple implementations
 
 """
 from __future__ import absolute_import
+import os
+import sys
 
 BACKEND = None
 
@@ -35,6 +37,12 @@ else:
 # These wildcard imports are informed, not just accidents.
 # pylint: disable=W0401
 if BACKEND == 'pynetsnmp':
+    if sys.platform == "darwin" and not os.getenv("DYLD_LIBRARY_PATH"):
+        # horrible workaround for MacOS problems, described at length at
+        # https://hynek.me/articles/macos-dyld-env/
+        os.environ["DYLD_LIBRARY_PATH"] = os.getenv(
+            "LD_LIBRARY_PATH", "/usr/local/opt/openssl/lib"
+        )
     from .pynetsnmp import *
 else:
     raise ImportError("No supported SNMP backend was found")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import os
 import importlib.util
 import io
+import platform
 import re
 import shlex
 from itertools import cycle
@@ -41,10 +42,11 @@ def pytest_configure(config):
 
     bootstrap_django('pytest')
 
-    # Install custom reactor for Twisted tests
-    from nav.ipdevpoll.epollreactor2 import install
+    if platform.system() == 'Linux':
+        # Install custom reactor for Twisted tests
+        from nav.ipdevpoll.epollreactor2 import install
 
-    install()
+        install()
 
     # Setup test environment for Django
     from django.test.utils import setup_test_environment

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,8 @@ passenv =
     PGPASSWORD
     WORKSPACE
     DISPLAY
+    DYLD_LIBRARY_PATH
+    LD_LIBRARY_PATH
 allowlist_externals =
                       sh
                       sed

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ setenv =
     django32: DJANGO_VER=32
     django40: DJANGO_VER=40
 passenv =
+    C_INCLUDE_PATH
     GITHUB_ACTIONS
     GITHUB_RUN_ID
     USER


### PR DESCRIPTION
This extracts MacOS and NixOS-related commits from #2675 .  They should not affect the test suite on Debian-derived or FHS-compatible Linux OS-es, but will aid in making it run properly on MacOS or NixOS.