### PR TITLE
Remove obsolete future imports

### DIFF
--- a/python/nav/Snmp/__init__.py
+++ b/python/nav/Snmp/__init__.py
@@ -20,7 +20,6 @@ This interface only supports pynetsnmp, but is designed to allow
 multiple implementations
 
 """
-from __future__ import absolute_import
 
 BACKEND = None
 

--- a/python/nav/Snmp/pynetsnmp.py
+++ b/python/nav/Snmp/pynetsnmp.py
@@ -16,7 +16,6 @@
 #
 """High level synchronouse NAV API for NetSNMP"""
 
-from __future__ import absolute_import, unicode_literals
 
 from collections import namedtuple
 from ctypes import (

--- a/python/nav/arnold.py
+++ b/python/nav/arnold.py
@@ -19,7 +19,6 @@
 Provides helpfunctions for Arnold web and script
 """
 
-from __future__ import absolute_import
 
 import re
 import os

--- a/python/nav/asyncdns.py
+++ b/python/nav/asyncdns.py
@@ -24,7 +24,6 @@ support.
 
 """
 
-from __future__ import absolute_import
 
 import socket
 from itertools import cycle

--- a/python/nav/auditlog/__init__.py
+++ b/python/nav/auditlog/__init__.py
@@ -15,8 +15,6 @@
 # more details.  You should have received a copy of the GNU General Public
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
-
 
 def find_modelname(obj):
     return obj._meta.db_table

--- a/python/nav/auditlog/models.py
+++ b/python/nav/auditlog/models.py
@@ -15,7 +15,6 @@
 # more details.  You should have received a copy of the GNU General Public
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals, absolute_import
 
 import logging
 from django.utils.encoding import force_str

--- a/python/nav/auditlog/urls.py
+++ b/python/nav/auditlog/urls.py
@@ -13,7 +13,6 @@
 # more details.  You should have received a copy of the GNU General Public
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals, absolute_import
 
 from django.urls import re_path
 

--- a/python/nav/auditlog/utils.py
+++ b/python/nav/auditlog/utils.py
@@ -14,7 +14,6 @@
 # details.  You should have received a copy of the GNU General Public License
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
-from __future__ import unicode_literals
 
 from django.utils.encoding import force_str
 from django.db.models import Q

--- a/python/nav/auditlog/views.py
+++ b/python/nav/auditlog/views.py
@@ -14,7 +14,6 @@
 # more details.  You should have received a copy of the GNU General Public
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals, absolute_import
 
 import json
 

--- a/python/nav/bin/alertengine.py
+++ b/python/nav/bin/alertengine.py
@@ -22,7 +22,6 @@ This background process polls the alert queue for new alerts from the
 eventengine and sends put alerts to users based on user defined profiles.
 """
 
-from __future__ import print_function
 
 # FIXME missing detailed usage
 

--- a/python/nav/bin/collect_active_ip.py
+++ b/python/nav/bin/collect_active_ip.py
@@ -17,7 +17,6 @@
 #
 """A wrapper for prefix_ip_collector"""
 
-from __future__ import print_function
 
 import argparse
 import logging

--- a/python/nav/bin/mailin.py
+++ b/python/nav/bin/mailin.py
@@ -16,7 +16,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import print_function
 
 import re
 import sys

--- a/python/nav/bin/navcheckservice.py
+++ b/python/nav/bin/navcheckservice.py
@@ -22,7 +22,6 @@ host. Useful for testing or debugging individual servicemon plugins.
 
 """
 
-from __future__ import print_function
 
 import argparse
 import sys

--- a/python/nav/bin/navdf.py
+++ b/python/nav/bin/navdf.py
@@ -18,7 +18,6 @@
 A command line interface to list and filter IP devices monitored by NAV
 """
 
-from __future__ import print_function
 
 import argparse
 

--- a/python/nav/bin/naventity.py
+++ b/python/nav/bin/naventity.py
@@ -20,7 +20,6 @@ A command line program to output an entity hierarchy graph from a device's
 ENTITY-MIB::entPhysicalTable.
 """
 
-from __future__ import print_function
 
 import sys
 import argparse

--- a/python/nav/bin/navmain.py
+++ b/python/nav/bin/navmain.py
@@ -16,7 +16,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Command line program to control NAV processes"""
-from __future__ import print_function
 import sys
 import os
 import os.path

--- a/python/nav/bin/navoidverify.py
+++ b/python/nav/bin/navoidverify.py
@@ -21,7 +21,6 @@ A command line program to verify support for SNMP subtrees in sets of
 NAV-monitored devices.
 """
 
-from __future__ import print_function
 
 import platform
 import sys

--- a/python/nav/bin/navsnmp.py
+++ b/python/nav/bin/navsnmp.py
@@ -18,7 +18,6 @@
 line arguments.
 
 """
-from __future__ import print_function
 import argparse
 import sys
 

--- a/python/nav/bin/navuser.py
+++ b/python/nav/bin/navuser.py
@@ -18,7 +18,6 @@
 """
 A command line interface to list and modify NAV web user accounts
 """
-from __future__ import print_function
 import sys
 import argparse
 from getpass import getpass

--- a/python/nav/bin/pping.py
+++ b/python/nav/bin/pping.py
@@ -21,7 +21,6 @@
 Pings multiple hosts in parallel
 """
 
-from __future__ import print_function
 
 import os
 import sys

--- a/python/nav/bin/radiusparser.py
+++ b/python/nav/bin/radiusparser.py
@@ -29,7 +29,6 @@ server.  It has been written to not require any NAV libraries.
 It will require psycopg, a PostgreSQL driver for Python.
 """
 
-from __future__ import print_function
 
 import psycopg2
 import sys

--- a/python/nav/bin/smsd.py
+++ b/python/nav/bin/smsd.py
@@ -17,7 +17,6 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """The NAV SMS daemon"""
-from __future__ import print_function
 
 import argparse
 import logging

--- a/python/nav/bin/snmptrapd.py
+++ b/python/nav/bin/snmptrapd.py
@@ -17,7 +17,6 @@
 #
 """NAV daemon to receive and act upon SNMP traps."""
 
-from __future__ import print_function
 
 import logging
 import os

--- a/python/nav/bin/start_arnold.py
+++ b/python/nav/bin/start_arnold.py
@@ -32,7 +32,6 @@ Always uses the last interface the ip was seen on whether the ip is active
 there or not.
 
 """
-from __future__ import print_function
 
 import getpass
 import logging

--- a/python/nav/bitvector.py
+++ b/python/nav/bitvector.py
@@ -15,7 +15,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Bit vector manipulation."""
-from __future__ import absolute_import
 import array
 import re
 

--- a/python/nav/bootstrap.py
+++ b/python/nav/bootstrap.py
@@ -13,7 +13,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import absolute_import
 
 from os.path import dirname, realpath
 import os

--- a/python/nav/bulkimport.py
+++ b/python/nav/bulkimport.py
@@ -18,7 +18,6 @@
 # no importer implementations have public methods, disable R0903 warning
 # pylint: disable=R0903
 
-from __future__ import absolute_import
 
 import json
 

--- a/python/nav/bulkparse.py
+++ b/python/nav/bulkparse.py
@@ -16,7 +16,6 @@
 #
 """Bulk import format parsers."""
 
-from __future__ import absolute_import
 
 import csv
 import re

--- a/python/nav/colors.py
+++ b/python/nav/colors.py
@@ -16,7 +16,6 @@
 #
 """Simple tools for terminal color support"""
 
-from __future__ import print_function, absolute_import
 
 import os
 import sys

--- a/python/nav/config.py
+++ b/python/nav/config.py
@@ -15,7 +15,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Utility functions for NAV configuration file discovery and parsing."""
-from __future__ import absolute_import
 
 import errno
 import grp

--- a/python/nav/db/__init__.py
+++ b/python/nav/db/__init__.py
@@ -17,7 +17,6 @@
 """
 Provides common database functionality for NAV.
 """
-from __future__ import absolute_import
 import atexit
 from functools import wraps
 import logging

--- a/python/nav/debug.py
+++ b/python/nav/debug.py
@@ -15,7 +15,6 @@
 #
 """This module provides some useful debugging tools for NAV developers"""
 
-from __future__ import absolute_import, print_function
 import logging
 import pprint
 from traceback import print_stack

--- a/python/nav/django/forms.py
+++ b/python/nav/django/forms.py
@@ -16,7 +16,6 @@
 #
 """Django form field types for NAV"""
 
-from __future__ import unicode_literals, absolute_import
 
 import json
 

--- a/python/nav/django/validators.py
+++ b/python/nav/django/validators.py
@@ -15,7 +15,6 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import unicode_literals, absolute_import
 
 import json
 from decimal import Decimal, InvalidOperation

--- a/python/nav/event.py
+++ b/python/nav/event.py
@@ -16,7 +16,6 @@
 #
 """Simple API to interface with NAVs event queue."""
 
-from __future__ import absolute_import
 
 from django.db import transaction
 

--- a/python/nav/event2.py
+++ b/python/nav/event2.py
@@ -18,7 +18,6 @@
 Next generation event factory functionality for NAV, based on the Django ORM
 models from nav.models.event.
 """
-from __future__ import absolute_import
 
 from nav.models.event import EventQueue
 

--- a/python/nav/eventengine/config.py
+++ b/python/nav/eventengine/config.py
@@ -15,7 +15,6 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """eventengine config"""
-from __future__ import unicode_literals
 from configparser import NoSectionError, NoOptionError
 
 from nav.config import NAVConfigParser

--- a/python/nav/eventengine/plugin.py
+++ b/python/nav/eventengine/plugin.py
@@ -15,7 +15,6 @@
 #
 "event engine plugin handling"
 
-from __future__ import absolute_import
 import os
 import logging
 

--- a/python/nav/ipdevpoll/control.py
+++ b/python/nav/ipdevpoll/control.py
@@ -15,7 +15,6 @@
 #
 "Process control for multi-process invocation of ipdevpoll"
 
-from __future__ import print_function
 
 import sys
 

--- a/python/nav/ipdevpoll/daemon.py
+++ b/python/nav/ipdevpoll/daemon.py
@@ -20,7 +20,6 @@ This is the daemon program that runs the IP device poller.
 
 """
 
-from __future__ import print_function
 
 import sys
 import os

--- a/python/nav/ipdevpoll/pool.py
+++ b/python/nav/ipdevpoll/pool.py
@@ -15,7 +15,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Handle sending jobs to worker processes."""
-from __future__ import print_function
 
 import datetime
 import os

--- a/python/nav/ipdevpoll/shadows/entity.py
+++ b/python/nav/ipdevpoll/shadows/entity.py
@@ -16,7 +16,6 @@
 #
 """NetboxEntity shadow and manager classes for ipdevpoll"""
 
-from __future__ import absolute_import
 from collections import defaultdict
 from datetime import datetime
 

--- a/python/nav/ipdevpoll/shadows/gwpeers.py
+++ b/python/nav/ipdevpoll/shadows/gwpeers.py
@@ -15,7 +15,6 @@
 #
 """Handling of gateway protocol state changes"""
 
-from __future__ import absolute_import
 
 from functools import partial
 

--- a/python/nav/ipdevpoll/snmp/__init__.py
+++ b/python/nav/ipdevpoll/snmp/__init__.py
@@ -15,7 +15,6 @@
 #
 """selects a proper SNMP backend for ipdevpoll"""
 
-from __future__ import absolute_import
 
 try:
     import pynetsnmp.twistedsnmp

--- a/python/nav/ipdevpoll/snmp/pynetsnmp.py
+++ b/python/nav/ipdevpoll/snmp/pynetsnmp.py
@@ -17,7 +17,6 @@
 """pynetsnmp compatibility"""
 # pylint: disable=C0103,C0111,W0703,R0903,W0611
 
-from __future__ import absolute_import
 import inspect
 import os
 

--- a/python/nav/logengine.py
+++ b/python/nav/logengine.py
@@ -42,7 +42,6 @@ files, one of which this program will have exclusive access to.
 # TODO: Possible future enhancement is the ability to tail a log file
 # continually, instead of reading and truncating as a cron job.
 
-from __future__ import absolute_import, print_function
 
 import re
 import fcntl

--- a/python/nav/logs.py
+++ b/python/nav/logs.py
@@ -17,7 +17,6 @@
 #
 """NAV related logging functionality."""
 
-from __future__ import unicode_literals
 import sys
 import os
 import logging

--- a/python/nav/macaddress.py
+++ b/python/nav/macaddress.py
@@ -29,7 +29,6 @@ order.
 
 """
 
-from __future__ import absolute_import
 
 import re
 

--- a/python/nav/maintengine.py
+++ b/python/nav/maintengine.py
@@ -21,7 +21,6 @@ the state of registered maintenance tasks and dispatching maintenance events
 to the event queue.
 
 """
-from __future__ import absolute_import
 import datetime
 import logging
 

--- a/python/nav/mibs/__init__.py
+++ b/python/nav/mibs/__init__.py
@@ -16,7 +16,6 @@
 #
 """MIB parsing and MIB-aware data retrieval."""
 
-from __future__ import absolute_import
 
 from . import mibretriever
 

--- a/python/nav/mibs/bgp4_mib.py
+++ b/python/nav/mibs/bgp4_mib.py
@@ -16,7 +16,6 @@
 #
 """Implements a BGP4-MIB MibRetriever and associated functionality."""
 
-from __future__ import absolute_import
 from collections import namedtuple
 from pprint import pformat
 import logging

--- a/python/nav/mibs/bgp4_v2_mib_juniper.py
+++ b/python/nav/mibs/bgp4_v2_mib_juniper.py
@@ -16,7 +16,6 @@
 #
 """Implements a BGP4-V2-MIB-JUNIPER MibRetriever w/associated functionality."""
 
-from __future__ import absolute_import
 
 from nav.oidparsers import consume, TypedFixedInetAddress, Unsigned32
 from nav.smidumps import get_mib

--- a/python/nav/mibs/bridge_mib.py
+++ b/python/nav/mibs/bridge_mib.py
@@ -14,7 +14,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Implements a BRIDGE-MIB MibRetriever and associated functionality."""
-from __future__ import absolute_import
 from twisted.internet import defer
 
 from nav.smidumps import get_mib

--- a/python/nav/mibs/cisco_bgp4_mib.py
+++ b/python/nav/mibs/cisco_bgp4_mib.py
@@ -16,7 +16,6 @@
 #
 """Implements a CISCO-BGP4-MIB MibRetriever w/associated functionality."""
 
-from __future__ import absolute_import
 
 from nav.oidparsers import consume, TypedInetAddress
 from nav.smidumps import get_mib

--- a/python/nav/mibs/cisco_cdp_mib.py
+++ b/python/nav/mibs/cisco_cdp_mib.py
@@ -14,7 +14,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """"CISCO-CDP-MIB handling"""
-from __future__ import absolute_import
 import socket
 from collections import namedtuple
 

--- a/python/nav/mibs/cisco_hsrp_mib.py
+++ b/python/nav/mibs/cisco_hsrp_mib.py
@@ -14,7 +14,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """CISCO-HSRP-MIB handling"""
-from __future__ import absolute_import
 
 from IPy import IP
 from twisted.internet import defer

--- a/python/nav/mibs/cisco_ietf_ip_mib.py
+++ b/python/nav/mibs/cisco_ietf_ip_mib.py
@@ -14,7 +14,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Implements a MibRetriever for the CISCO-IETF-IP-MIB."""
-from __future__ import absolute_import
 from twisted.internet import defer
 
 from nav.smidumps import get_mib

--- a/python/nav/mibs/cisco_vlan_iftable_relationship_mib.py
+++ b/python/nav/mibs/cisco_vlan_iftable_relationship_mib.py
@@ -14,7 +14,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """"handling of CISCO-VLAN-IFTABLE-RELATIONSHIP-MIB"""
-from __future__ import absolute_import
 
 from collections import namedtuple
 

--- a/python/nav/mibs/cisco_vlan_membership_mib.py
+++ b/python/nav/mibs/cisco_vlan_membership_mib.py
@@ -14,7 +14,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """MibRetriever for CISCO-VLAN-MEMBERSHIP-MIB"""
-from __future__ import absolute_import
 from twisted.internet import defer
 from nav.smidumps import get_mib
 from . import mibretriever

--- a/python/nav/mibs/cisco_vtp_mib.py
+++ b/python/nav/mibs/cisco_vtp_mib.py
@@ -13,7 +13,6 @@
 # more details.  You should have received a copy of the GNU General Public
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
-from __future__ import absolute_import
 from twisted.internet import defer
 from twisted.internet.defer import returnValue
 

--- a/python/nav/mibs/cpqpower_mib.py
+++ b/python/nav/mibs/cpqpower_mib.py
@@ -15,7 +15,6 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """A class for extracting information from HPE power devices devices"""
-from __future__ import unicode_literals
 from twisted.internet import defer
 from nav.smidumps import get_mib
 from nav.mibs import reduce_index

--- a/python/nav/mibs/etherlike_mib.py
+++ b/python/nav/mibs/etherlike_mib.py
@@ -15,7 +15,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Implements a EtherLike-MIB MibRetriever and associated functionality."""
-from __future__ import absolute_import
 from twisted.internet import defer
 from nav.smidumps import get_mib
 from . import mibretriever

--- a/python/nav/mibs/extreme_vlan_mib.py
+++ b/python/nav/mibs/extreme_vlan_mib.py
@@ -14,7 +14,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Implements an EXTREME-VLAN-MIB MibRetriever"""
-from __future__ import absolute_import
 from nav.smidumps import get_mib
 from nav.mibs.qbridge_mib import portlist
 from nav.mibs import reduce_index

--- a/python/nav/mibs/ip_forward_mib.py
+++ b/python/nav/mibs/ip_forward_mib.py
@@ -15,7 +15,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """A MibRetriever implementation for IP-FORWARD-MIB"""
-from __future__ import absolute_import
 from collections import defaultdict
 from itertools import chain
 from collections import namedtuple

--- a/python/nav/mibs/ip_mib.py
+++ b/python/nav/mibs/ip_mib.py
@@ -16,7 +16,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """MibRetriever implementation for IP-MIB"""
-from __future__ import absolute_import
 
 from twisted.internet.defer import inlineCallbacks, returnValue
 

--- a/python/nav/mibs/ipv6_mib.py
+++ b/python/nav/mibs/ipv6_mib.py
@@ -19,7 +19,6 @@ Although IPV6-MIB has been obsoleted by a revised version of IP-MIB,
 some vendors still only provide IPv6 data in this MIB.
 
 """
-from __future__ import absolute_import
 
 from twisted.internet import defer
 

--- a/python/nav/mibs/snmpv2_mib.py
+++ b/python/nav/mibs/snmpv2_mib.py
@@ -14,7 +14,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Implements a MibRetriever for the SNMPV2-MIB"""
-from __future__ import absolute_import
 import time
 
 from twisted.internet import defer

--- a/python/nav/mibs/vrrp_mib.py
+++ b/python/nav/mibs/vrrp_mib.py
@@ -14,7 +14,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """VRRP-MIB handling"""
-from __future__ import absolute_import
 
 from IPy import IP
 from twisted.internet import defer

--- a/python/nav/models/rack.py
+++ b/python/nav/models/rack.py
@@ -15,7 +15,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Models for racks and rack items"""
-from __future__ import unicode_literals
 
 import json
 from itertools import chain

--- a/python/nav/oids.py
+++ b/python/nav/oids.py
@@ -15,7 +15,6 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """OID manipulation"""
-from __future__ import absolute_import
 
 SEPARATOR = '.'
 SEPARATOR_B = b'.'

--- a/python/nav/pgsync.py
+++ b/python/nav/pgsync.py
@@ -16,7 +16,6 @@
 #
 """Program to synchronize NAV database schema changes"""
 
-from __future__ import print_function
 
 import sys
 import os

--- a/python/nav/pwhash.py
+++ b/python/nav/pwhash.py
@@ -15,7 +15,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Provides password hashing algorithms for NAV."""
-from __future__ import absolute_import
 
 import os
 import random

--- a/python/nav/report/generator.py
+++ b/python/nav/report/generator.py
@@ -14,7 +14,6 @@
 # details.  You should have received a copy of the GNU General Public License
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 """Generates the query and makes the report."""
-from __future__ import unicode_literals
 
 import io
 import re

--- a/python/nav/smidumps/__init__.py
+++ b/python/nav/smidumps/__init__.py
@@ -3,7 +3,6 @@
 As dumped by smidump dump using the python format option.
 
 """
-from __future__ import absolute_import
 
 from itertools import chain
 import importlib

--- a/python/nav/startstop.py
+++ b/python/nav/startstop.py
@@ -15,7 +15,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """NAV Service start/stop library."""
-from __future__ import absolute_import, print_function
 
 import errno
 import os

--- a/python/nav/statemon/RunQueue.py
+++ b/python/nav/statemon/RunQueue.py
@@ -22,7 +22,6 @@
 """
 This module provides a threadpool and fair scheduling.
 """
-from __future__ import absolute_import
 
 from collections import deque
 import heapq

--- a/python/nav/statemon/checker/OracleChecker.py
+++ b/python/nav/statemon/checker/OracleChecker.py
@@ -15,7 +15,6 @@
 #
 """Oracle database service checker"""
 
-from __future__ import print_function
 
 from nav.statemon.abstractchecker import AbstractChecker
 from nav.statemon.event import Event

--- a/python/nav/statemon/checkermap.py
+++ b/python/nav/statemon/checkermap.py
@@ -18,7 +18,6 @@
 # along with NAV; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
-from __future__ import absolute_import
 import os
 import importlib
 import logging

--- a/python/nav/statemon/db.py
+++ b/python/nav/statemon/db.py
@@ -21,7 +21,6 @@ by the service monitor.
 It implements the singleton pattern, ensuring only one instance
 is used at a time.
 """
-from __future__ import absolute_import
 
 import atexit
 from collections import defaultdict

--- a/python/nav/tableformat.py
+++ b/python/nav/tableformat.py
@@ -15,7 +15,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Formatting of table data to readable text."""
-from __future__ import absolute_import
 
 
 class SimpleTableFormatter(object):

--- a/python/nav/thresholdmon.py
+++ b/python/nav/thresholdmon.py
@@ -16,7 +16,6 @@
 #
 """Threshold monitoring program"""
 
-from __future__ import absolute_import
 
 import logging
 from optparse import OptionParser

--- a/python/nav/topology/detector.py
+++ b/python/nav/topology/detector.py
@@ -15,7 +15,6 @@
 #
 """NAV network topology detection program"""
 
-from __future__ import print_function
 
 from argparse import ArgumentParser
 from functools import wraps

--- a/python/nav/topology/diff.py
+++ b/python/nav/topology/diff.py
@@ -15,8 +15,6 @@
 #
 """Diff stored and current topology"""
 
-from __future__ import print_function
-from __future__ import absolute_import
 
 from nav.models.manage import Interface
 

--- a/python/nav/util.py
+++ b/python/nav/util.py
@@ -15,7 +15,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """General utility functions for Network Administration Visualized"""
-from __future__ import absolute_import
 import os
 import re
 import stat

--- a/python/nav/web/__init__.py
+++ b/python/nav/web/__init__.py
@@ -15,7 +15,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """This package encompasses modules with web functionality for NAV"""
-from __future__ import unicode_literals
 
 import logging
 import sys

--- a/python/nav/web/auth/ldap.py
+++ b/python/nav/web/auth/ldap.py
@@ -17,7 +17,6 @@
 Contains ldap authentication functionality for NAV web.
 """
 
-from __future__ import print_function, unicode_literals
 
 import logging
 from os.path import join

--- a/python/nav/web/business/reportengine.py
+++ b/python/nav/web/business/reportengine.py
@@ -15,7 +15,6 @@
 #
 """Module for emailing status reports"""
 
-from __future__ import print_function
 
 import logging
 from collections import namedtuple

--- a/python/nav/web/ipam/prefix_tree.py
+++ b/python/nav/web/ipam/prefix_tree.py
@@ -20,7 +20,6 @@ contains ad-hoc serializer methods (self.fields) for API purposes.
 
 """
 
-from __future__ import unicode_literals, absolute_import
 import bisect
 import json
 import functools

--- a/python/nav/web/netmap/api.py
+++ b/python/nav/web/netmap/api.py
@@ -13,7 +13,6 @@
 # details.  You should have received a copy of the GNU General Public License
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
-from __future__ import absolute_import
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q

--- a/python/nav/web/portadmin/utils.py
+++ b/python/nav/web/portadmin/utils.py
@@ -14,7 +14,6 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """Util functions for the PortAdmin"""
-from __future__ import unicode_literals
 from typing import Any, Optional, Sequence
 import re
 import logging

--- a/python/nav/web/radius/db.py
+++ b/python/nav/web/radius/db.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import re
 import time
 import uuid

--- a/python/nav/web/radius/radiuslib.py
+++ b/python/nav/web/radius/radiuslib.py
@@ -20,7 +20,6 @@
 #
 """Helper functions and classes for radius accounting in NAV"""
 
-from __future__ import division, absolute_import
 from socket import gethostbyaddr, herror, gaierror
 from re import match, sub
 import time

--- a/python/nav/wsgi.py
+++ b/python/nav/wsgi.py
@@ -14,7 +14,6 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """A NAV wsgi application"""
-from __future__ import absolute_import
 
 from nav.bootstrap import bootstrap_django
 from nav.web import loginit

--- a/tests/integration/api_test.py
+++ b/tests/integration/api_test.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 from django.utils.encoding import force_str
 
 from datetime import datetime, timedelta

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import importlib.util
 import io

--- a/tests/integration/report/generator_test.py
+++ b/tests/integration/report/generator_test.py
@@ -6,7 +6,6 @@ These tests simply enumerate all known reports and ensure that the dbresult is
 error free. This only ensures that the SQL can be run, no further verification
 is performed.
 """
-from __future__ import unicode_literals
 import pytest
 
 from django.http import QueryDict

--- a/tests/integration/seeddb_test.py
+++ b/tests/integration/seeddb_test.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from django.urls import reverse
 from django.http import Http404
 from django.test.client import RequestFactory

--- a/tests/integration/snmptrapd_test.py
+++ b/tests/integration/snmptrapd_test.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, unicode_literals
-
 import configparser
 import pytest
 import signal

--- a/tests/integration/web/alertprofiles_test.py
+++ b/tests/integration/web/alertprofiles_test.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from random import randint
 
 from mock import MagicMock, patch

--- a/tests/integration/web/crawler_test.py
+++ b/tests/integration/web/crawler_test.py
@@ -14,8 +14,6 @@ URLs that report a Content-Type of text/html.
 
 """
 
-from __future__ import print_function
-
 from collections import namedtuple
 from http.client import BadStatusLine
 from lxml.html import fromstring

--- a/tests/integration/web/devicehistory_test.py
+++ b/tests/integration/web/devicehistory_test.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 from nav.models.event import EventQueue, EventQueueVar
 

--- a/tests/integration/web/info_test.py
+++ b/tests/integration/web/info_test.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 import os
 

--- a/tests/integration/web/ipdevinfo_test.py
+++ b/tests/integration/web/ipdevinfo_test.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 
 from django.urls import reverse
 from django.utils.encoding import smart_str

--- a/tests/integration/web/netboxtype_test.py
+++ b/tests/integration/web/netboxtype_test.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 from nav.models.manage import NetboxType
 from nav.web.seeddb.forms import SEPARATOR

--- a/tests/unittests/django/forms_test.py
+++ b/tests/unittests/django/forms_test.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from unittest import TestCase
 import json
 

--- a/tests/unittests/django/templatetags/info_test.py
+++ b/tests/unittests/django/templatetags/info_test.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import unittest
 
 from datetime import timedelta, datetime

--- a/tests/unittests/django/templatetags/string_manipulation_test.py
+++ b/tests/unittests/django/templatetags/string_manipulation_test.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import unittest
 
 from nav.django.templatetags.string_manipulation import deep_urlize

--- a/tests/unittests/eventengine/plugin_test.py
+++ b/tests/unittests/eventengine/plugin_test.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import pytest
 from mock import Mock
 

--- a/tests/unittests/general/config_test.py
+++ b/tests/unittests/general/config_test.py
@@ -13,7 +13,6 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import unicode_literals
 from io import StringIO
 from os import makedirs, remove, rmdir, listdir
 from os.path import join

--- a/tests/unittests/ipdevpoll/config_test.py
+++ b/tests/unittests/ipdevpoll/config_test.py
@@ -15,7 +15,6 @@
 #
 # pylint:  disable=C0111
 """Tests for config module"""
-from __future__ import unicode_literals
 
 import unittest
 from configparser import NoOptionError

--- a/tests/unittests/ipdevpoll/shadows_test.py
+++ b/tests/unittests/ipdevpoll/shadows_test.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from unittest import TestCase
 from nav.ipdevpoll.storage import ContainerRepository
 from nav.ipdevpoll.shadows import Vlan, Prefix, Netbox, Interface

--- a/tests/unittests/netmap/multidigraph_to_undirect_test.py
+++ b/tests/unittests/netmap/multidigraph_to_undirect_test.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 
 from nav.netmap import topology

--- a/tests/unittests/smsd/dispatcher_test.py
+++ b/tests/unittests/smsd/dispatcher_test.py
@@ -16,7 +16,6 @@
 #
 """Unit tests for the dispatcher module."""
 
-from __future__ import print_function
 
 import types
 

--- a/tools/buglog.py
+++ b/tools/buglog.py
@@ -18,7 +18,6 @@
 Extracts closed issues from a NAV milestone on GitHub to produce a list of
 fixed issues for a release changelog entry.
 """
-from __future__ import print_function, unicode_literals
 
 import re
 import sys

--- a/tools/eventgenerators/boxevent.py
+++ b/tools/eventgenerators/boxevent.py
@@ -16,7 +16,6 @@
 #
 """Script to simulate up/down events from pping"""
 
-from __future__ import print_function
 import argparse
 import sys
 

--- a/tools/eventgenerators/linkevent.py
+++ b/tools/eventgenerators/linkevent.py
@@ -16,7 +16,6 @@
 #
 """Script to simulate link up/down events from snmptrapd / ipdevpoll"""
 
-from __future__ import print_function
 import argparse
 
 from nav.bootstrap import bootstrap_django

--- a/tools/eventgenerators/moduleevent.py
+++ b/tools/eventgenerators/moduleevent.py
@@ -16,7 +16,6 @@
 #
 "Script to simulate up/down module events from moduleMon"
 
-from __future__ import print_function
 
 import sys
 from nav import db
@@ -24,7 +23,7 @@ from nav import db
 
 def handler(cursor, boxlist, state):
 
-    for (deviceid, netboxid, subid) in boxlist:
+    for deviceid, netboxid, subid in boxlist:
         sql = """INSERT INTO eventq
                    (source, target, deviceid, netboxid, subid, eventtypeid,
                     state,severity)
@@ -65,7 +64,7 @@ def main():
 
         box, module = spec.split(":")
         cursor.execute(sql, (box, module))
-        for (deviceid, netboxid, moduleid, sysname, modulename) in cursor.fetchall():
+        for deviceid, netboxid, moduleid, sysname, modulename in cursor.fetchall():
             if not deviceid in device_dupes:
                 netboxes.append((deviceid, netboxid, moduleid))
                 sysnames.append((sysname, modulename))

--- a/tools/eventgenerators/servicestate.py
+++ b/tools/eventgenerators/servicestate.py
@@ -21,7 +21,6 @@ testing purposes only.
 
 """
 
-from __future__ import print_function
 
 import sys
 from optparse import OptionParser

--- a/tools/eventgenerators/snmpevent.py
+++ b/tools/eventgenerators/snmpevent.py
@@ -16,7 +16,6 @@
 #
 "Script to simulate snmpAgentState events from ipdevpoll"
 
-from __future__ import print_function
 
 import sys
 from nav import db

--- a/tools/eventgenerators/thresholdstate.py
+++ b/tools/eventgenerators/thresholdstate.py
@@ -21,7 +21,6 @@ testing purposes only.
 
 """
 
-from __future__ import print_function
 
 import sys
 

--- a/tools/iana-enterprise.py
+++ b/tools/iana-enterprise.py
@@ -19,7 +19,6 @@
 Retrieves IANAs current list of assigned enterprise numbers, and outputs
 the data NAV wants, as Python code.
 """
-from __future__ import print_function
 import sys
 import os
 from collections import namedtuple, Counter


### PR DESCRIPTION
These future imports became obsolete years ago, when we dropped support for Python 2.