### PR TITLE
Constrain snmpsim to not use broken version 1.1.6

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -12,8 +12,7 @@ pytest-timeout
 pytest-twisted~=1.13.0
 pytidylib==0.3.2
 selenium==3.141.0
-snmpsim>=1.0
-pyasn1<0.6.0  # Really just a constraint because of incompatibility with snmpsim
+snmpsim>=1.0,!=1.1.6
 toml
 whisper>=0.9.9
 whitenoise==4.1.4


### PR DESCRIPTION
1.0.0 to 1.1.5 and 1.1.7 work and we can remove the lock for the pyasn1 version as well. Reverts parts of #2964.