### PR TITLE
Replace session fakery by login simulation in Selenium functional tests

### DIFF
--- a/python/nav/web/auth/utils.py
+++ b/python/nav/web/auth/utils.py
@@ -19,9 +19,6 @@ login method.
 """
 import logging
 
-from django.conf import settings
-from django.contrib.sessions.backends.db import SessionStore
-
 from nav.models.profiles import Account
 
 
@@ -87,24 +84,3 @@ def authorization_not_required(fullpath):
         if fullpath.startswith(url):
             _logger.debug('authorization_not_required: %s', url)
             return True
-
-
-def create_session_cookie(username):
-    """Creates an active session for username and returns the resulting
-    session cookie.
-
-    This is useful to fake login sessions during testing.
-
-    """
-    user = Account.objects.get(login=username)
-    session = SessionStore()
-    session[ACCOUNT_ID_VAR] = user.id
-    session.save()
-
-    cookie = {
-        'name': settings.SESSION_COOKIE_NAME,
-        'value': session.session_key,
-        'secure': False,
-        'path': '/',
-    }
-    return cookie

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""pytest setup and fixtures common for all tests, regardless of suite"""
+
+import os
+
+import pytest
+
+
+@pytest.fixture(scope='session')
+def admin_username():
+    return os.environ.get('ADMINUSERNAME', 'admin')
+
+
+@pytest.fixture(scope='session')
+def admin_password():
+    return os.environ.get('ADMINPASSWORD', 'admin')

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -29,6 +29,11 @@ def pytest_configure(config):
     subprocess.check_call([SCRIPT_CREATE_DB])
     start_gunicorn()
 
+    # Bootstrap Django config
+    from nav.bootstrap import bootstrap_django
+
+    bootstrap_django('pytest')
+
 
 def pytest_unconfigure(config):
     stop_gunicorn()
@@ -62,10 +67,6 @@ def selenium(selenium, base_url):
     in as the admin user.
 
     """
-    from nav.bootstrap import bootstrap_django
-
-    bootstrap_django(__file__)
-
     from nav.web.auth.utils import create_session_cookie
 
     selenium.implicitly_wait(10)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -380,13 +380,3 @@ def admin_account(db):
     from nav.models.profiles import Account
 
     yield Account.objects.get(id=Account.ADMIN_ACCOUNT)
-
-
-@pytest.fixture(scope='session')
-def admin_username():
-    return os.environ.get('ADMINUSERNAME', 'admin')
-
-
-@pytest.fixture(scope='session')
-def admin_password():
-    return os.environ.get('ADMINPASSWORD', 'admin')


### PR DESCRIPTION
Instead of creating a "fake" admin session directly in the database, this changes the overloaded `selenium` fixture to log in to the NAV interface as an admin, using a username and password, before handing the selenium driver to the calling test.

It seems as though our recent fixes to avoid session fixation may cause the whole "session fakery" to become flaky, as the session cookie might be reset by loading a page, causing the old selenium fixture to time out waiting for the expected cookie.

There's also the old issue of whether the faked session will be properly committed to the database and be visible to the web server process that runs outside of the test session.

These issues can all be circumvented by just simulating a "normal" login.
