### PR TITLE
Restrict which branch pushes cause a full CI run

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,9 @@
 name: Build NAV and run full test suite
 on:
   push:
+    branches:
+      - master
+      - '[1-9].[0-9]+.x'
   pull_request:
   schedule: # Run daily at 08:00 CEST (06:00 UST)
     - cron: '0 6 * * *'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - '[1-9].[0-9]+.x'
+      - '[1-9][0-9]*.[0-9]+.x'
   pull_request:
   schedule: # Run daily at 08:00 CEST (06:00 UST)
     - cron: '0 6 * * *'


### PR DESCRIPTION
Currently, if a PR is made from a repo-local branch, the full test suite runs twice, because it triggers on both the branch push and the PR event.

We do not usually keep long-lived feature branches, so it should be ok to restrict full test runs to the important branches: `master` and any branch that matches the stable branch pattern.

As discussed with @johannaengland 