### PR TITLE
Remove space in div class name in filter form

### DIFF
--- a/python/nav/web/templates/seeddb/_filter_form.html
+++ b/python/nav/web/templates/seeddb/_filter_form.html
@@ -4,7 +4,7 @@
                 <div class="row">
                   <div class="columns medium-8">
                     {% for field in filter_form %}
-                    <div id="div_id_{{ field.name }}" class="ctrlHolder {% if field.errors %}error {% endif %}">
+                    <div id="div_id_{{ field.name }}" class="ctrlHolder{% if field.errors %} error {% endif %}">
                       {{ field.label_tag }}
                       {{ field }}
                       {% for error in field.errors %}


### PR DESCRIPTION
A little fix to #2981 that I found while comparing the html of old and new filter forms. 
Before it was `<div id="div_id_net_type" class="ctrlHolder ">` and now it is `<div id="div_id_net_type" class="ctrlHolder">`

Not sure if it actually makes a difference? 