### PR TITLE
Remove crispy-forms from `VlanFilterForm`

### DIFF
--- a/python/nav/web/seeddb/page/vlan.py
+++ b/python/nav/web/seeddb/page/vlan.py
@@ -18,13 +18,10 @@
 
 from django import forms
 
-from crispy_forms.helper import FormHelper
-from crispy_forms_foundation.layout import Layout, Row, Column, Fieldset
-from nav.web.crispyforms import LabelSubmit
-
 from nav.models.manage import Vlan, NetType, Organization, Usage
 
 from nav.web.seeddb import SeeddbInfo, reverse_lazy
+from nav.web.seeddb.forms import set_filter_form_attributes
 from nav.web.seeddb.utils.list import render_list
 from nav.web.seeddb.utils.edit import render_edit
 
@@ -42,34 +39,18 @@ class VlanInfo(SeeddbInfo):
 
 class VlanFilterForm(forms.Form):
     net_type = forms.ModelChoiceField(
-        NetType.objects.order_by('id').all(), required=False
+        NetType.objects.order_by('id').all(), required=False, label_suffix=""
     )
     organization = forms.ModelChoiceField(
-        Organization.objects.order_by('id').all(), required=False
+        Organization.objects.order_by('id').all(), required=False, label_suffix=""
     )
-    usage = forms.ModelChoiceField(Usage.objects.order_by('id').all(), required=False)
-
-    def __init__(self, *args, **kwargs):
-        super(VlanFilterForm, self).__init__(*args, **kwargs)
-        col_class = 'medium-3'
-        self.helper = FormHelper()
-        self.helper.form_action = ''
-        self.helper.form_method = 'GET'
-        self.helper.form_class = 'custom'
-        self.helper.layout = Layout(
-            Fieldset(
-                'Filter vlans',
-                Row(
-                    Column('net_type', css_class=col_class),
-                    Column('organization', css_class=col_class),
-                    Column('usage', css_class=col_class),
-                    Column(
-                        LabelSubmit('submit', 'Filter', css_class='postfix'),
-                        css_class=col_class,
-                    ),
-                ),
-            )
-        )
+    usage = forms.ModelChoiceField(
+        Usage.objects.order_by('id').all(), required=False, label_suffix=""
+    )
+    net_type.widget.attrs.update({"class": "select"})
+    organization.widget.attrs.update({"class": "select"})
+    usage.widget.attrs.update({"class": "select"})
+    no_crispy = set_filter_form_attributes('Filter vlans')
 
 
 class VlanForm(forms.ModelForm):

--- a/python/nav/web/templates/seeddb/_filter_form_columns.html
+++ b/python/nav/web/templates/seeddb/_filter_form_columns.html
@@ -1,0 +1,24 @@
+            <form class="{{attrs.form_class }}" method="{{ attrs.method }}"{% if attrs.action %} action="{{ attrs.action }}"{% endif %}>
+              <fieldset>
+                <legend>{{ attrs.legend }}</legend>
+                <div class="row">
+                  {% for field in filter_form %}
+                    <div class="columns medium-3">
+                      <div id="div_id_{{ field.name }}" class="ctrlHolder{% if field.errors %} error {% endif %}">
+                        {{ field.label_tag }}
+                        {{ field }}
+                        {% for error in field.errors %}
+                        <small id="error_{{ forloop.counter}}_id_{{ field.name }}" class="error">
+                          {{ error }}
+                        </small>
+                        {% endfor %}
+                      </div>
+                    </div>
+                  {% endfor %}
+                  <div class="columns medium-3">
+                    <label>&nbsp;</label>
+                    <input type="submit" name="submit" value="{{ attrs.submit_value }}" class="submit button postfix" id="submit-id-submit">
+                  </div>
+                </div>
+              </fieldset>
+            </form>

--- a/python/nav/web/templates/seeddb/list.html
+++ b/python/nav/web/templates/seeddb/list.html
@@ -5,7 +5,11 @@
 
   {% if filter_form %}
     {% if filter_form.base_fields|length >= 3 %}
-      {% crispy filter_form %}
+      {% if filter_form.no_crispy %}
+        {% include "seeddb/_filter_form_columns.html" with attrs=filter_form.no_crispy %}
+      {% else %}
+        {% crispy filter_form %}
+      {% endif %}
     {% else %}
       <div class="row">
         <div class="medium-6 column">


### PR DESCRIPTION
Closes #2991.

Using pattern established by the `RoomFilterForm` refactor (#2981). 

I added another template. If there is a nicer way of fixing it, please let me know!