### PR TITLE
Change test suite web server (gunicorn) launch to a proper pytest fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,30 @@
 """pytest setup and fixtures common for all tests, regardless of suite"""
 
 import os
+import platform
 import subprocess
 
 import pytest
 import requests
 from requests.adapters import HTTPAdapter, Retry
+
+
+def pytest_configure(config):
+    # Bootstrap Django config
+    from nav.bootstrap import bootstrap_django
+
+    bootstrap_django('pytest')
+
+    # Setup test environment for Django
+    from django.test.utils import setup_test_environment
+
+    setup_test_environment()
+
+    if platform.system() == 'Linux':
+        # Install custom reactor for Twisted tests
+        from nav.ipdevpoll.epollreactor2 import install
+
+        install()
 
 
 @pytest.fixture(scope='session')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 """pytest setup and fixtures common for all tests, regardless of suite"""
 
 import os
+import subprocess
 
 import pytest
+import requests
+from requests.adapters import HTTPAdapter, Retry
 
 
 @pytest.fixture(scope='session')
@@ -13,3 +16,36 @@ def admin_username():
 @pytest.fixture(scope='session')
 def admin_password():
     return os.environ.get('ADMINPASSWORD', 'admin')
+
+
+@pytest.fixture(scope='session')
+def gunicorn():
+    """Sets up NAV to be served by a gunicorn instance.
+
+    Useful for tests that need to make external HTTP requests to NAV.
+
+    Returns the (expected) base URL of the gunicorn instance.
+    """
+    workspace = os.path.join(os.environ.get('WORKSPACE', ''), 'reports')
+    errorlog = os.path.join(workspace, 'gunicorn-error.log')
+    accesslog = os.path.join(workspace, 'gunicorn-access.log')
+    gunicorn = subprocess.Popen(
+        [
+            'gunicorn',
+            '--error-logfile',
+            errorlog,
+            '--access-logfile',
+            accesslog,
+            'navtest_wsgi:application',
+        ]
+    )
+    # Allow for gunicorn to become ready to serve requests before handing off to a test
+    session = requests.Session()
+    retries = Retry(total=5, backoff_factor=0.1, status_forcelist=[500, 502, 503, 504])
+    base_url = "http://localhost:8000"
+    session.mount(base_url, HTTPAdapter(max_retries=retries))
+    session.get(base_url)
+
+    yield base_url
+
+    gunicorn.terminate()

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -27,11 +27,6 @@ SCRIPT_CREATE_DB = os.path.join(SCRIPT_PATH, 'create-db.sh')
 def pytest_configure(config):
     subprocess.check_call([SCRIPT_CREATE_DB])
 
-    # Bootstrap Django config
-    from nav.bootstrap import bootstrap_django
-
-    bootstrap_django('pytest')
-
 
 ############
 #          #

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -7,7 +7,6 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
 USERNAME = 'admin'
-gunicorn = None
 
 ########################################################################
 #                                                                      #
@@ -27,31 +26,11 @@ SCRIPT_CREATE_DB = os.path.join(SCRIPT_PATH, 'create-db.sh')
 
 def pytest_configure(config):
     subprocess.check_call([SCRIPT_CREATE_DB])
-    start_gunicorn()
 
     # Bootstrap Django config
     from nav.bootstrap import bootstrap_django
 
     bootstrap_django('pytest')
-
-
-def pytest_unconfigure(config):
-    stop_gunicorn()
-
-
-def start_gunicorn():
-    global gunicorn
-    gunicorn_log = open("reports/gunicorn.log", "ab")
-    gunicorn = subprocess.Popen(
-        ['gunicorn', 'navtest_wsgi:application'],
-        stdout=gunicorn_log,
-        stderr=subprocess.STDOUT,
-    )
-
-
-def stop_gunicorn():
-    if gunicorn:
-        gunicorn.terminate()
 
 
 ############

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -72,8 +72,11 @@ class _session_cookie_is_present(object):
 
 
 @pytest.fixture(scope="session")
-def base_url():
-    return os.environ.get('TARGETURL', 'http://localhost:8000')
+def base_url(gunicorn):
+    """Used as shorthand for the base URL of the test web server, but really just
+    invokes the gunicorn fixture.
+    """
+    yield gunicorn
 
 
 @pytest.fixture

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,6 @@
 import os
 import importlib.util
 import io
-import platform
 import re
 import shlex
 from itertools import cycle
@@ -32,23 +31,6 @@ SCRIPT_CREATE_DB = os.path.join(SCRIPT_PATH, 'create-db.sh')
 
 def pytest_configure(config):
     subprocess.check_call([SCRIPT_CREATE_DB])
-    os.environ['TARGETURL'] = "http://localhost:8000/"
-
-    # Bootstrap Django config
-    from nav.bootstrap import bootstrap_django
-
-    bootstrap_django('pytest')
-
-    if platform.system() == 'Linux':
-        # Install custom reactor for Twisted tests
-        from nav.ipdevpoll.epollreactor2 import install
-
-        install()
-
-    # Setup test environment for Django
-    from django.test.utils import setup_test_environment
-
-    setup_test_environment()
 
 
 ########################################################################

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,7 +13,6 @@ import toml
 import pytest
 from django.test import Client
 
-gunicorn = None
 
 ########################################################################
 #                                                                      #
@@ -34,7 +33,6 @@ SCRIPT_CREATE_DB = os.path.join(SCRIPT_PATH, 'create-db.sh')
 def pytest_configure(config):
     subprocess.check_call([SCRIPT_CREATE_DB])
     os.environ['TARGETURL'] = "http://localhost:8000/"
-    start_gunicorn()
 
     # Bootstrap Django config
     from nav.bootstrap import bootstrap_django
@@ -51,32 +49,6 @@ def pytest_configure(config):
     from django.test.utils import setup_test_environment
 
     setup_test_environment()
-
-
-def pytest_unconfigure(config):
-    stop_gunicorn()
-
-
-def start_gunicorn():
-    global gunicorn
-    workspace = os.path.join(os.environ.get('WORKSPACE', ''), 'reports')
-    errorlog = os.path.join(workspace, 'gunicorn-error.log')
-    accesslog = os.path.join(workspace, 'gunicorn-access.log')
-    gunicorn = subprocess.Popen(
-        [
-            'gunicorn',
-            '--error-logfile',
-            errorlog,
-            '--access-logfile',
-            accesslog,
-            'navtest_wsgi:application',
-        ]
-    )
-
-
-def stop_gunicorn():
-    if gunicorn:
-        gunicorn.terminate()
 
 
 ########################################################################

--- a/tests/integration/web/crawler_test.py
+++ b/tests/integration/web/crawler_test.py
@@ -14,32 +14,28 @@ all reachable pages.
 from collections import namedtuple
 from http.client import BadStatusLine
 from lxml.html import fromstring
-import os
 
 import pytest
 
 from tidylib import tidy_document
 from urllib.request import (
-    urlopen,
-    build_opener,
-    install_opener,
     HTTPCookieProcessor,
     Request,
+    build_opener,
+    install_opener,
+    urlopen,
 )
 from urllib.error import HTTPError, URLError
 from urllib.parse import (
-    urlsplit,
-    urlencode,
-    urlunparse,
-    urlparse,
     quote,
+    urlencode,
+    urljoin,
+    urlparse,
+    urlsplit,
+    urlunparse,
 )
-from mock import Mock
 
 
-HOST_URL = os.environ.get('TARGETURL', None)
-USERNAME = os.environ.get('ADMINUSERNAME', 'admin')
-PASSWORD = os.environ.get('ADMINPASSWORD', 'admin')
 TIMEOUT = 90  # seconds?
 
 TIDY_OPTIONS = {
@@ -72,14 +68,6 @@ BLACKLISTED_PATHS = [
 #
 
 Page = namedtuple('Page', 'url response content_type content')
-
-if not HOST_URL:
-    pytest.skip(
-        msg="Missing environment variable TARGETURL "
-        "(ADMINUSERNAME, ADMINPASSWORD) , skipping crawler "
-        "tests!",
-        allow_module_level=True,
-    )
 
 
 def normalize_path(url):
@@ -226,8 +214,8 @@ def _quote_url(url):
 
 
 @pytest.fixture(scope="session")
-def webcrawler():
-    crawler = WebCrawler(HOST_URL, USERNAME, PASSWORD)
+def webcrawler(gunicorn, admin_username, admin_password):
+    crawler = WebCrawler(gunicorn, admin_username, admin_password)
     yield crawler
 
 

--- a/tests/integration/web/crawler_test.py
+++ b/tests/integration/web/crawler_test.py
@@ -165,7 +165,7 @@ class WebCrawler(object):
                 self.queue.append('%s://%s%s' % (url.scheme, url.netloc, url.path))
 
     def login(self):
-        login_url = '%sindex/login/' % self.base_url
+        login_url = urljoin(self.base_url, '/index/login/')
         opener = build_opener(HTTPCookieProcessor())
         data = urlencode({'username': self.username, 'password': self.password})
         opener.open(login_url, data.encode('utf-8'), TIMEOUT)


### PR DESCRIPTION
This cleans up the test suite somewhat, by changing how gunicorn is launched to provide a fully operational NAV web ui for the test suite.

Gunicorn is needed both by the integration and the functional test suites, but its launch was duplicated in both suites' `conftest.py` files.  Also, as part of the `pytest_configure()` and `pytest_unconfigure()` functions of those modules, the gunicorn server would *always* be launches on every test session, regardless of which tests were selected.

This changes the mechanism to properly function as a pytest fixture, which means that tests can now explicitly declare a dependency on the gunicorn test web server.   This ensures it will only ever be launched when tests that use it are selected.

The PR ensures existing tests that need the web server are made dependent on the new fixture, and removes a bit of cruft in the surrounding code as well.

Anti-cruft measures include removing test suite redundancies by factoring out redundant setup code and moving it to the top-level `tests/conftest.py` file.  This was in some ways necessary for the test suite to continue working.


This was extracted and adapted from #2675. 