### PR TITLE
Fix typo in ipdevinfo tooltip

### DIFF
--- a/changelog.d/+ipdevinfo-tooltip-typo.fixed.md
+++ b/changelog.d/+ipdevinfo-tooltip-typo.fixed.md
@@ -1,0 +1,1 @@
+Fixed grammar of an ipdevinfo mouseover-tooltip on degraded aggregate links

--- a/python/nav/web/templates/ipdevinfo/port-details-main-frag.html
+++ b/python/nav/web/templates/ipdevinfo/port-details-main-frag.html
@@ -35,7 +35,7 @@
         (Disabled by <a href="{% url 'arnold-details' detention.id %}" title="Link to detention">Arnold</a>)
       {% endif %}
       {% if port.is_degraded %}
-          <small class="label warning" title="One more of the interfaces aggregated under {{ port.ifname }} is down.">Degraded</small>
+          <small class="label warning" title="One or more of the interfaces aggregated under {{ port.ifname }} is down.">Degraded</small>
       {% endif %}
     </td>
   </tr>


### PR DESCRIPTION
When an aggregate link is downgraded, a special mouseover/tooltip is added to the "Degraded" label.  This fixes a slight grammar/typo issue with this sentence.