### PR TITLE
Only lint whole codebase on pushes to master

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -31,8 +31,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Validate whole codebase on pushes and only changes on pull requests
-          # Change this to VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' }}
-          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' }}
 
       # Upload MegaLinter artifacts
       - name: Archive production artifacts


### PR DESCRIPTION
Otherwise only changes in a PR will be checked.

This was forgotten to change back when merging #2941, but it is convenient, now we can wait until #3045 is merged.