### PR TITLE
Remove `reverse_lazy` helper function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ exclude = [
 force-exclude = true
 
 [tool.ruff.lint]
-select = ["E9", "F63", "F7", "F82"]
+select = ["E9", "F63", "F7", "F81", "F82"]
 
 [tool.towncrier]
 directory = "changelog.d"

--- a/python/nav/web/seeddb/__init__.py
+++ b/python/nav/web/seeddb/__init__.py
@@ -15,24 +15,8 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 
-from django.urls import reverse
 
 from nav.web.seeddb.constants import TITLE_DEFAULT, NAVPATH_DEFAULT
-
-
-def reverse_lazy(*args, **kwargs):
-    # Lazy reverse will become part of the Django framework in future releases.
-    class Proxy(object):
-        def __init__(self, *args, **kwargs):
-            self.args = args
-            self.kwargs = kwargs
-
-        def __str__(self):
-            if not hasattr(self, 'reverse_url'):
-                self.reverse_url = reverse(*self.args, **self.kwargs)
-            return self.reverse_url
-
-    return Proxy(*args, **kwargs)
 
 
 class SeeddbInfo(object):

--- a/python/nav/web/seeddb/page/cabling.py
+++ b/python/nav/web/seeddb/page/cabling.py
@@ -15,12 +15,14 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from django.urls import reverse_lazy
+
 from nav.models.cabling import Cabling
 from nav.models.manage import Room
 from nav.bulkparse import CablingBulkParser
 from nav.bulkimport import CablingImporter
 
-from nav.web.seeddb import SeeddbInfo, reverse_lazy
+from nav.web.seeddb import SeeddbInfo
 from nav.web.seeddb.constants import SEEDDB_EDITABLE_MODELS
 from nav.web.seeddb.page import view_switcher, not_implemented
 from nav.web.seeddb.utils.list import render_list

--- a/python/nav/web/seeddb/page/location.py
+++ b/python/nav/web/seeddb/page/location.py
@@ -17,12 +17,13 @@
 #
 
 from django.shortcuts import render
+from django.urls import reverse_lazy
 
 from nav.models.manage import Location
 from nav.bulkparse import LocationBulkParser
 from nav.bulkimport import LocationImporter
 
-from nav.web.seeddb import SeeddbInfo, reverse_lazy
+from nav.web.seeddb import SeeddbInfo
 from nav.web.seeddb.constants import SEEDDB_EDITABLE_MODELS
 from nav.web.seeddb.forms import LocationForm
 from nav.web.seeddb.page import view_switcher, not_implemented

--- a/python/nav/web/seeddb/page/management_profile/__init__.py
+++ b/python/nav/web/seeddb/page/management_profile/__init__.py
@@ -26,7 +26,7 @@ from nav.bulkparse import ManagementProfileBulkParser
 from nav.bulkimport import ManagementProfileImporter
 from nav.web.message import new_message, Messages
 
-from nav.web.seeddb import SeeddbInfo, reverse_lazy
+from nav.web.seeddb import SeeddbInfo
 from nav.web.seeddb.constants import SEEDDB_EDITABLE_MODELS
 from nav.web.seeddb.page import view_switcher
 from nav.web.seeddb.utils.list import render_list

--- a/python/nav/web/seeddb/page/netbox/__init__.py
+++ b/python/nav/web/seeddb/page/netbox/__init__.py
@@ -18,12 +18,13 @@
 import datetime
 from django.db import transaction
 from django.contrib.postgres.aggregates import ArrayAgg
+from django.urls import reverse_lazy
 
 from nav.models.manage import Netbox
 from nav.bulkparse import NetboxBulkParser
 from nav.bulkimport import NetboxImporter
 
-from nav.web.seeddb import SeeddbInfo, reverse_lazy
+from nav.web.seeddb import SeeddbInfo
 from nav.web.seeddb.constants import SEEDDB_EDITABLE_MODELS
 from nav.web.seeddb.page import view_switcher
 from nav.web.seeddb.utils.list import render_list

--- a/python/nav/web/seeddb/page/netbox/edit.py
+++ b/python/nav/web/seeddb/page/netbox/edit.py
@@ -23,11 +23,11 @@ import socket
 from socket import error as SocketError
 import logging
 
-from django.urls import reverse
-from django.http import HttpResponse, JsonResponse, Http404
-from django.shortcuts import get_object_or_404, redirect, render
 from django.db import transaction
 from django.contrib import messages
+from django.http import HttpResponse, JsonResponse, Http404
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse, reverse_lazy
 
 from nav.auditlog.models import LogEntry
 from nav.models.manage import Netbox, NetboxCategory, NetboxType, NetboxProfile
@@ -37,7 +37,6 @@ from nav.Snmp.errors import SnmpError
 from nav.Snmp.profile import get_snmp_session_for_profile
 from nav import napalm
 from nav.util import is_valid_ip
-from nav.web.seeddb import reverse_lazy
 from nav.web.seeddb.utils.edit import resolve_ip_and_sysname
 from nav.web.seeddb.page.netbox import NetboxInfo as NI
 from nav.web.seeddb.page.netbox.forms import NetboxModelForm

--- a/python/nav/web/seeddb/page/netboxgroup.py
+++ b/python/nav/web/seeddb/page/netboxgroup.py
@@ -34,12 +34,14 @@
 #
 
 import logging
-from django.http import JsonResponse
+
+from django.urls import reverse_lazy
+
 from nav.models.manage import NetboxGroup, Netbox
 from nav.bulkparse import NetboxGroupBulkParser
 from nav.bulkimport import NetboxGroupImporter
 
-from nav.web.seeddb import SeeddbInfo, reverse_lazy
+from nav.web.seeddb import SeeddbInfo
 from nav.web.seeddb.constants import SEEDDB_EDITABLE_MODELS
 from nav.web.seeddb.page import view_switcher, not_implemented
 from nav.web.seeddb.utils.list import render_list

--- a/python/nav/web/seeddb/page/netboxtype.py
+++ b/python/nav/web/seeddb/page/netboxtype.py
@@ -15,11 +15,13 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from django.urls import reverse_lazy
+
 from nav.models.manage import NetboxType
 from nav.bulkparse import NetboxTypeBulkParser
 from nav.bulkimport import NetboxTypeImporter
 
-from nav.web.seeddb import SeeddbInfo, reverse_lazy
+from nav.web.seeddb import SeeddbInfo
 from nav.web.seeddb.constants import SEEDDB_EDITABLE_MODELS
 from nav.web.seeddb.page import view_switcher, not_implemented
 from nav.web.seeddb.utils.list import render_list

--- a/python/nav/web/seeddb/page/organization.py
+++ b/python/nav/web/seeddb/page/organization.py
@@ -16,12 +16,13 @@
 #
 
 from django.shortcuts import render
+from django.urls import reverse_lazy
 
 from nav.models.manage import Organization
 from nav.bulkparse import OrgBulkParser
 from nav.bulkimport import OrgImporter
 
-from nav.web.seeddb import SeeddbInfo, reverse_lazy
+from nav.web.seeddb import SeeddbInfo
 from nav.web.seeddb.constants import SEEDDB_EDITABLE_MODELS
 from nav.web.seeddb.page import view_switcher
 from nav.web.seeddb.utils.edit import render_edit

--- a/python/nav/web/seeddb/page/patch/__init__.py
+++ b/python/nav/web/seeddb/page/patch/__init__.py
@@ -21,6 +21,7 @@ import logging
 from django import forms
 from django.http import HttpResponse
 from django.shortcuts import render, get_object_or_404
+from django.urls import reverse_lazy
 from django.views.decorators.http import require_POST
 
 from nav.models.cabling import Patch, Cabling
@@ -28,7 +29,7 @@ from nav.models.manage import Netbox, Interface, Room
 from nav.bulkparse import PatchBulkParser
 from nav.bulkimport import PatchImporter
 
-from nav.web.seeddb import SeeddbInfo, reverse_lazy
+from nav.web.seeddb import SeeddbInfo
 from nav.web.seeddb.constants import SEEDDB_EDITABLE_MODELS
 from nav.web.seeddb.page import view_switcher, not_implemented
 from nav.web.seeddb.utils.list import render_list

--- a/python/nav/web/seeddb/page/prefix.py
+++ b/python/nav/web/seeddb/page/prefix.py
@@ -23,7 +23,7 @@ from django import forms
 from django.db import transaction
 from django.shortcuts import render
 from django.http import HttpResponseRedirect
-from django.urls import reverse
+from django.urls import reverse, reverse_lazy
 
 from nav.web.message import new_message, Messages
 
@@ -32,7 +32,7 @@ from nav.django.forms import CIDRField
 from nav.bulkparse import PrefixBulkParser
 from nav.bulkimport import PrefixImporter
 
-from nav.web.seeddb import SeeddbInfo, reverse_lazy
+from nav.web.seeddb import SeeddbInfo
 from nav.web.seeddb.constants import SEEDDB_EDITABLE_MODELS
 from nav.web.seeddb.page import view_switcher, not_implemented
 from nav.web.seeddb.utils.list import render_list

--- a/python/nav/web/seeddb/page/room.py
+++ b/python/nav/web/seeddb/page/room.py
@@ -17,13 +17,13 @@
 #
 """Forms and view functions for SeedDB's Room view"""
 
-from django.urls import reverse
+from django.urls import reverse_lazy
 
 from nav.models.manage import Room
 from nav.bulkparse import RoomBulkParser
 from nav.bulkimport import RoomImporter
 
-from nav.web.seeddb import SeeddbInfo, reverse_lazy
+from nav.web.seeddb import SeeddbInfo
 from nav.web.seeddb.constants import SEEDDB_EDITABLE_MODELS
 from nav.web.seeddb.page import view_switcher
 from nav.web.seeddb.utils.list import render_list

--- a/python/nav/web/seeddb/page/service/__init__.py
+++ b/python/nav/web/seeddb/page/service/__init__.py
@@ -15,11 +15,13 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from django.urls import reverse_lazy
+
 from nav.models.service import Service
 from nav.bulkparse import ServiceBulkParser
 from nav.bulkimport import ServiceImporter
 
-from nav.web.seeddb import SeeddbInfo, reverse_lazy
+from nav.web.seeddb import SeeddbInfo
 from nav.web.seeddb.constants import SEEDDB_EDITABLE_MODELS
 from nav.web.seeddb.page import view_switcher, not_implemented
 from nav.web.seeddb.utils.list import render_list

--- a/python/nav/web/seeddb/page/usage.py
+++ b/python/nav/web/seeddb/page/usage.py
@@ -17,12 +17,13 @@
 """Module containing all things regarding usages in seeddb"""
 
 from django import forms
+from django.urls import reverse_lazy
 
 from nav.models.manage import Usage
 from nav.bulkparse import UsageBulkParser
 from nav.bulkimport import UsageImporter
 
-from nav.web.seeddb import SeeddbInfo, reverse_lazy
+from nav.web.seeddb import SeeddbInfo
 from nav.web.seeddb.constants import SEEDDB_EDITABLE_MODELS
 from nav.web.seeddb.page import view_switcher, not_implemented
 from nav.web.seeddb.utils.list import render_list

--- a/python/nav/web/seeddb/page/vendor.py
+++ b/python/nav/web/seeddb/page/vendor.py
@@ -17,12 +17,13 @@
 """Module containing everything regarding vendors in SeedDB"""
 
 from django import forms
+from django.urls import reverse_lazy
 
 from nav.models.manage import Vendor
 from nav.bulkparse import VendorBulkParser
 from nav.bulkimport import VendorImporter
 
-from nav.web.seeddb import SeeddbInfo, reverse_lazy
+from nav.web.seeddb import SeeddbInfo
 from nav.web.seeddb.constants import SEEDDB_EDITABLE_MODELS
 from nav.web.seeddb.page import view_switcher, not_implemented
 from nav.web.seeddb.utils.list import render_list

--- a/python/nav/web/seeddb/page/vlan.py
+++ b/python/nav/web/seeddb/page/vlan.py
@@ -17,10 +17,11 @@
 #
 
 from django import forms
+from django.urls import reverse_lazy
 
 from nav.models.manage import Vlan, NetType, Organization, Usage
 
-from nav.web.seeddb import SeeddbInfo, reverse_lazy
+from nav.web.seeddb import SeeddbInfo
 from nav.web.seeddb.forms import set_filter_form_attributes
 from nav.web.seeddb.utils.list import render_list
 from nav.web.seeddb.utils.edit import render_edit

--- a/tests/unittests/models/fields_test.py
+++ b/tests/unittests/models/fields_test.py
@@ -4,8 +4,6 @@ from datetime import datetime as dt
 from decimal import Decimal
 import pickle
 
-from decimal import Decimal
-
 from django.core import exceptions
 from django.db import connection
 


### PR DESCRIPTION
This is leftover from before Django had its build-in `reverse_lazy` function. Now we can simply use Django's own function.

Also removes another duplicate import from a test. And adds "F81" to ruff's ruleset. 