### PR TITLE
Enable HTML validation warnings as failures

### DIFF
--- a/tests/integration/web/crawler_test.py
+++ b/tests/integration/web/crawler_test.py
@@ -46,7 +46,7 @@ TIDY_OPTIONS = {
     'doctype': 'auto',
     'output_xhtml': True,
     'input_encoding': 'utf8',
-    'show-warnings': False,
+    'show-warnings': True,
 }
 
 TIDY_IGNORE = [


### PR DESCRIPTION
Most problems that tidy detects appears to be classed as warnings, not errors, as HTML5 validation rules can be quite lax.

This turns on warnings in our validation results just to see how many we actually get.