### PR TITLE
Add `noqa` for unused imports in tests

### DIFF
--- a/tests/unittests/Snmp/Snmp_test.py
+++ b/tests/unittests/Snmp/Snmp_test.py
@@ -1,3 +1,5 @@
+# ruff: noqa: F401 - importing to test availability
+
 import unittest
 from mock import Mock, patch
 import pytest

--- a/tests/unittests/buildconf_test.py
+++ b/tests/unittests/buildconf_test.py
@@ -1,3 +1,5 @@
+# ruff: noqa: F401 - importing to test availability
+
 from unittest import TestCase
 
 


### PR DESCRIPTION
These tests import to test availability. It would be possible to also use `importlib.util.find_spec`, but this was easier. 

Similar to #3018 to later add rule `F401` to ruff. 