### PR TITLE
Remove unused Django imports

### DIFF
--- a/python/nav/bin/navdump.py
+++ b/python/nav/bin/navdump.py
@@ -28,8 +28,6 @@ from nav.bootstrap import bootstrap_django
 
 bootstrap_django(__file__)
 
-import django
-
 from nav.models import manage
 import nav.models.service
 

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -22,7 +22,6 @@ import sys
 import copy
 import warnings
 
-import django
 from django.utils.log import DEFAULT_LOGGING
 
 from nav.config import NAV_CONFIG, getconfig, find_config_dir

--- a/python/nav/models/fields.py
+++ b/python/nav/models/fields.py
@@ -21,7 +21,6 @@ import json
 from datetime import datetime
 from decimal import Decimal
 
-import django
 from django import forms
 from django.db import models
 from django.db.models import signals

--- a/python/nav/report/matrixIPv6.py
+++ b/python/nav/report/matrixIPv6.py
@@ -17,8 +17,6 @@
 
 import logging
 
-from django.urls import reverse
-
 from nav.django.templatetags.report import report
 from nav.report import IPtools, metaIP
 from nav.report.matrix import Matrix, Link

--- a/python/nav/web/seeddb/page/prefix.py
+++ b/python/nav/web/seeddb/page/prefix.py
@@ -21,7 +21,6 @@ Forms and controllers for the prefix functionality in SeedDB
 
 from django import forms
 from django.db import transaction
-from django.shortcuts import render
 from django.http import HttpResponseRedirect
 from django.urls import reverse, reverse_lazy
 

--- a/tools/eventgenerators/devicenotice.py
+++ b/tools/eventgenerators/devicenotice.py
@@ -24,8 +24,6 @@ bootstrap_django()
 from nav.event2 import EventFactory
 from nav.models.manage import Device
 
-from django.db import transaction
-
 
 def main():
     """Main controller"""


### PR DESCRIPTION
Most of these were from when  switching from Django version 1 to 2, where checks like `if django.VERSION[:2] == (1, 8):` were done. This was introduced in e.g. #1899. Since we are currently only supporting Django 3.2 and the adaptations have been removed these imports are not necessary any longer. 

Other Django imports are also from code that has been removed by now. 