### PR TITLE
Simplify Xvfb bootstrap in test suite

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,6 +10,7 @@ pytest-cov==2.7.1
 pytest-selenium==4.1.0
 pytest-timeout
 pytest-twisted~=1.13.0
+pytest-xvfb
 pytidylib==0.3.2
 selenium<4.11.0
 snmpsim>=1.0,!=1.1.6

--- a/tox.ini
+++ b/tox.ini
@@ -86,11 +86,8 @@ commands =
          integration: pytest -o junit_suite_name="{envname} integration tests" --cov-config {toxinidir}/tests/.coveragerc --cov={toxinidir}/python --cov-report=xml:reports/{envname}/coverage.xml --html reports/{envname}/integration-report.html --junitxml=reports/{envname}/integration-results.xml --verbose --showlocals {posargs:tests/integration}
 
          functional: sed -i 's/^nav.*=.*INFO/root=DEBUG/' {envdir}/etc/logging.conf
-         functional: /sbin/start-stop-daemon -o --stop --quiet --pidfile /var/tmp/xvfb.pid
-         functional: /sbin/start-stop-daemon --start --quiet --pidfile /var/tmp/xvfb.pid --make-pidfile --background --exec /usr/bin/Xvfb -- {env:DISPLAY} -screen 0 1024x768x24 -fbdir /var/tmp -ac
          functional: django-admin collectstatic --noinput
          functional: pytest -o junit_suite_name="{envname} functional tests" --junitxml=reports/{envname}/functional-results.xml --verbose --driver Chrome --driver-path=/usr/local/bin/chromedriver --sensitive-url "nothing to see here" --html reports/{envname}/functional-report.html {posargs:tests/functional}
-         functional: /sbin/start-stop-daemon --stop --quiet --pidfile /var/tmp/xvfb.pid
 
 
 [testenv:javascript]

--- a/tox.ini
+++ b/tox.ini
@@ -93,12 +93,10 @@ commands =
 [testenv:javascript]
 usedevelop=True
 deps = libsass==0.15.1
+allowlist_externals = xvfb-run
 commands_pre =
 commands =
-         /sbin/start-stop-daemon -o --stop --quiet --pidfile /var/tmp/xvfb.pid
-         /sbin/start-stop-daemon --start --quiet --pidfile /var/tmp/xvfb.pid --make-pidfile --background --exec /usr/bin/Xvfb -- {env:DISPLAY} -screen 0 1024x768x24 -fbdir /var/tmp -ac
-         {toxinidir}/tests/javascript-test.sh "{toxinidir}"
-         /sbin/start-stop-daemon --stop --quiet --pidfile /var/tmp/xvfb.pid
+         xvfb-run {toxinidir}/tests/javascript-test.sh "{toxinidir}"
 
 [testenv:pylint]
 deps = pip-tools


### PR DESCRIPTION
This adds the `pytest-xvfb` plugin as a test requirement and removes the now redundant tox commands to set up an Xvfb server before the functional test suite runs.  Additionally, it simplifies the bootstrap of Xvfb in the javascript test environment.

This is part of wider strategy to make running the test suite more independent of tox: Tox is there to help us set up test matrices as separate environments, but the test suite itself should really be able to run on manually built environments.