### PR TITLE
Remove unused third party imports

### DIFF
--- a/python/nav/ipdevpoll/snmp/pynetsnmp.py
+++ b/python/nav/ipdevpoll/snmp/pynetsnmp.py
@@ -33,6 +33,8 @@ from pynetsnmp.twistedsnmp import snmpprotocol
 
 from . import common
 
+__all__ = ["snmpprotocol", "pynetsnmp_limits_results", "AgentProxy"]
+
 
 def pynetsnmp_limits_results():
     """Returns True if the available pynetsnmp version limits the number of

--- a/python/nav/web/seeddb/page/netbox/forms.py
+++ b/python/nav/web/seeddb/page/netbox/forms.py
@@ -24,7 +24,6 @@ from crispy_forms_foundation.layout import (
     Layout,
     Row,
     Column,
-    Submit,
     Fieldset,
     Field,
     Div,


### PR DESCRIPTION
Another part to adding `F401` to the ruff rules. 

Also add `__all__` to `pynetsnmp` to make ruff happy-