### PR TITLE
Add `F401` (unused imports) rule to ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ exclude = [
 force-exclude = true
 
 [tool.ruff.lint]
-select = ["E711", "E713", "E721", "E9", "F541", "F63", "F7", "F81", "F82"]
+select = ["E711", "E713", "E721", "E9", "F401", "F541", "F63", "F7", "F81", "F82"]
 
 [tool.towncrier]
 directory = "changelog.d"


### PR DESCRIPTION
This is just my suggestion. so please add your opinion if and why you think this is not a great idea. 