### PR TITLE
Remove unused test variables

### DIFF
--- a/tests/unittests/django/templatetags/info_test.py
+++ b/tests/unittests/django/templatetags/info_test.py
@@ -30,7 +30,6 @@ class TemplateTagsTest(unittest.TestCase):
             return datetime.now() - timedelta(*args, **kwargs)
 
         minute = 60
-        hour = minute * 60
 
         self.assertEqual(time_since(None), "Never")
         self.assertEqual(

--- a/tests/unittests/general/bulkparse_test.py
+++ b/tests/unittests/general/bulkparse_test.py
@@ -1,7 +1,6 @@
 """Tests for bulkparse"""
 
 # pylint: disable=C0111, C0103, W0614
-
 import pytest
 
 from nav import bulkparse
@@ -84,7 +83,7 @@ class TestNetboxBulkParser(object):
             b"room1:10.0.0.187:myorg:OTHER:SNMP v2c read profile::\n"
         )
         b = bulkparse.NetboxBulkParser(data)
-        out_data = list(b)
+        list(b)  # Generator needs to be consumed for this test to succeed
         assert b.line_num == 3
 
     def test_short_line_should_raise_error(self):

--- a/tests/unittests/ipdevpoll/prefix_test.py
+++ b/tests/unittests/ipdevpoll/prefix_test.py
@@ -78,7 +78,7 @@ class PrefixPluginTest(TestCase):
     def test_instantiation(self):
         netbox = Mock('Netbox')
         netbox.sysname = 'foo-sw.example.org'
-        plugin = prefix.Prefix(netbox, None, None)
+        prefix.Prefix(netbox, None, None)
 
 
 class VlanPatternTest(TestCase):

--- a/tests/unittests/models/fields_test.py
+++ b/tests/unittests/models/fields_test.py
@@ -60,7 +60,7 @@ class TestCIDRField(object):
         field = CIDRField()
         ip6 = u'1234:dead:beef::63/23'
         with pytest.raises(exceptions.ValidationError):
-            result6 = field.to_python(ip6)
+            field.to_python(ip6)
 
 
 class TestDateTimeInfinityField(object):

--- a/tests/unittests/netmap/metadata_nx_test.py
+++ b/tests/unittests/netmap/metadata_nx_test.py
@@ -8,7 +8,7 @@ from .metaclass_testcase import MetaClassTestCase
 
 class MetaClassesTests(MetaClassTestCase):
     def test_group_does_not_raise_exception_when_interface_is_none(self):
-        foo = Group(Mock(name='netbox', spec=Netbox), None)
+        Group(Mock(name='netbox', spec=Netbox), None)
 
     def test_edge_allows_both_interface_linkspeed_in_group_to_be_none(self):
         netbox_a = Mock(name='netbox a', sepc=Netbox)
@@ -21,7 +21,7 @@ class MetaClassesTests(MetaClassTestCase):
         b = Mock(name='interface b', spec=Interface)
         b.speed = None
 
-        foo = Edge((netbox_a, netbox_b), (a, b))
+        Edge((netbox_a, netbox_b), (a, b))
 
 
 class Layer2NetworkXMetadataTests(TopologyLayer2TestCase):

--- a/tests/unittests/netmap/topology_layer2_testcase.py
+++ b/tests/unittests/netmap/topology_layer2_testcase.py
@@ -64,9 +64,6 @@ class TopologyLayer2TestCase(TopologyTestCase):
         )
         self.build_l2.start()
 
-        bar = vlan.build_layer2_graph()
-        # foo = topology._get_vlans_map_layer2(bar)
-
         vlan_by_interfaces, vlan_by_netbox = topology._get_vlans_map_layer2(
             self.nav_graph
         )

--- a/tests/unittests/netmap/topology_layer3_testcase.py
+++ b/tests/unittests/netmap/topology_layer3_testcase.py
@@ -36,19 +36,19 @@ class TopologyLayer3TestCase(TopologyTestCase):
         self.e = e = self._netbox_factory('e')
         self.f = f = self._netbox_factory('f')
 
-        self.a1 = a1 = self._interface_factory('a1', a)
-        self.a3 = a3 = self._interface_factory('a3', a)
+        self.a1 = self._interface_factory('a1', a)
+        self.a3 = self._interface_factory('a3', a)
 
-        self.b1 = b1 = self._interface_factory('b1', b)
-        self.b4 = b4 = self._interface_factory('b4', b)
+        self.b1 = self._interface_factory('b1', b)
+        self.b4 = self._interface_factory('b4', b)
 
-        self.c3 = c3 = self._interface_factory('c3', c)
+        self.c3 = self._interface_factory('c3', c)
 
-        self.d4 = d4 = self._interface_factory('d4', d)
+        self.d4 = self._interface_factory('d4', d)
 
-        self.e4 = e4 = self._interface_factory('e4', e)
+        self.e4 = self._interface_factory('e4', e)
 
-        self.f5 = f5 = self._interface_factory('f5', f)
+        self.f5 = self._interface_factory('f5', f)
 
         self.prefix_foo = Prefix(
             id=1111,

--- a/tests/unittests/web/ldapauth_test.py
+++ b/tests/unittests/web/ldapauth_test.py
@@ -56,7 +56,7 @@ debug=true
 
 @patch('nav.web.auth.ldap._config', LdapOpenTestConfig())
 def test_open_ldap_should_run_without_error():
-    with patch('ldap.initialize') as initialize:
+    with patch('ldap.initialize'):
         assert open_ldap()
 
 
@@ -74,5 +74,5 @@ debug=true
 
 @patch('nav.web.auth.ldap._config', LdapOpenTestInvalidEncryptionConfig())
 def test_when_encryption_setting_is_invalid_open_ldap_should_run_without_encryption():
-    with patch('ldap.initialize') as initialize:
+    with patch('ldap.initialize'):
         assert open_ldap()


### PR DESCRIPTION
Just like #3028 and #3029 another part in adding `F841` to ruff. 