### PR TITLE
Adds unused variable rule (`F841`) to ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ exclude = [
 force-exclude = true
 
 [tool.ruff.lint]
-select = ["E711", "E713", "E721", "E9", "F401", "F541", "F63", "F7", "F81", "F82"]
+select = ["E711", "E713", "E721", "E9", "F401", "F541", "F63", "F7", "F8"]
 
 [tool.towncrier]
 directory = "changelog.d"


### PR DESCRIPTION
As #3026, up for discussion. This also adds `F842` - Local variable {name} is annotated but never used.