### PR TITLE
Use is instead of == to compare to True/False in tests

### DIFF
--- a/tests/unittests/general/util_test.py
+++ b/tests/unittests/general/util_test.py
@@ -150,7 +150,7 @@ class TestIPRangeString(object):
 class TestFirstTrue(object):
     def test_first_true_should_find_true_element(self):
         elems = [False, False, True, False]
-        assert first_true(elems) == True
+        assert first_true(elems) is True
 
     def test_first_true_should_return_default_value_when_no_true_found(self):
         elems = [False, False, False]

--- a/tests/unittests/general/webfront_test.py
+++ b/tests/unittests/general/webfront_test.py
@@ -77,7 +77,7 @@ class TestRemoteUserAuthenticate(object):
             ):
                 with patch("nav.web.auth.LogEntry.add_log_entry"):
                     with patch("nav.web.auth.Account.locked", return_value=True):
-                        assert remote_user.authenticate(request) == False
+                        assert remote_user.authenticate(request) is False
 
 
 class TestGetStandardUrls(object):


### PR DESCRIPTION
As preparation to add `E712` to ruff rules. 