### PR TITLE
Use default rules for ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,8 @@ exclude = [
 force-exclude = true
 
 [tool.ruff.lint]
-select = ["E711", "E713", "E721", "E9", "F401", "F541", "F63", "F7", "F8"]
+select = ["E4", "E7", "E9", "F"]
+ignore = ["E402", "E722", "E731", "F403"]
 
 [tool.towncrier]
 directory = "changelog.d"


### PR DESCRIPTION
Ignored rules: Module level import not at top of cell, bare except, lambda assignments, star imports

As usual, this is up for discussion which rules we would like to have and which not. 

Dependent on #3035.
After this is merged #3005 can be merged as well. 