### PR TITLE
Remove adaptation for Django 1.8

### DIFF
--- a/python/nav/models/fields.py
+++ b/python/nav/models/fields.py
@@ -45,10 +45,7 @@ class DateTimeInfinityField(models.DateTimeField):
             return super(DateTimeInfinityField, self).get_db_prep_value(
                 value, connection, prepared=prepared
             )
-        try:
-            return connection.ops.value_to_db_datetime(value)  # <= 1.8
-        except AttributeError:
-            return connection.ops.adapt_datetimefield_value(value)  # >= 1.9
+        return connection.ops.adapt_datetimefield_value(value)
 
 
 class VarcharField(models.TextField):


### PR DESCRIPTION
While cleaning up other things in order to add new rules to ruff I stumbled over this adaptation that was introduced in #1752, but never removed. Since we're running on Django 3.2, this can be removed. 