### PR TITLE
Add noncrispy help form field

### DIFF
--- a/python/nav/web/crispyforms.py
+++ b/python/nav/web/crispyforms.py
@@ -53,6 +53,20 @@ class HelpField(Field):
     template = 'custom_crispy_templates/field_helptext_as_icon.html'
 
 
+class HelpFormField:
+    """Field that displays an icon with tooltip as helptext
+
+    :param field: A field to render as a help field.
+    :param css_classes: Additional CSS classes to apply to the field. Defaults to an empty string.
+    """
+
+    def __init__(self, field, css_classes: str = ''):
+        """Constructor method"""
+        self.field = field
+        self.css_classes = css_classes
+        self.template = 'custom_crispy_templates/_help_form_field.html'
+
+
 class NumberInput(forms.TextInput):
     """Input widget with type set to number"""
 

--- a/python/nav/web/templates/custom_crispy_templates/_help_form_field.html
+++ b/python/nav/web/templates/custom_crispy_templates/_help_form_field.html
@@ -1,0 +1,3 @@
+{% with field=field.field %}
+{% include 'custom_crispy_templates/field_helptext_as_icon.html' %}
+{% endwith %}


### PR DESCRIPTION
Both #3050 and #3053 need a noncrispy HelpField, so this is a common fix for those.
When this PR and both of those are merged, `field_helptext_as_icon` and `_help_form_field` can be merged into one and the Crispy `HelpForm`can be removed entirely