### PR TITLE
Make sure that general form errors are rendered if present

### DIFF
--- a/python/nav/web/templates/custom_crispy_templates/_form_content.html
+++ b/python/nav/web/templates/custom_crispy_templates/_form_content.html
@@ -1,5 +1,7 @@
 {# NB! This template can be used directly (without form template wrapper) for cases where form.helper.form_tag is set to False. #}
 
+{% include 'foundation-5/errors.html' %}
+
 {% if form.attrs.form_fields %}
   {% include 'custom_crispy_templates/_form_fields.html' with fields=form.attrs.form_fields %}
 {% else %}


### PR DESCRIPTION
@stveit discovered that general form errors were not rendered while working on #3058. This PR fixes the issue for #3058 in particular and for forms from #2794 in general.

The template used for rendering general form errors is uncrispyfied, even though it is located in foundation-5 dir.

This PR ensures 1:1 behaviour with crispy forms in NAV, ref https://github.com/django-crispy-forms/django-crispy-forms/blob/baf94397a011b3f15a9899097234caa68b86a65e/crispy_forms/templates/uni_form/display_form.html#L4 which always executes in NAV since `form_show_errors` is `True` by default in crispy's `FormHelper` and we never set it to `False` in code or context.