### PR TITLE
Make it possible to use SubmitField for LabelSubmit

### DIFF
--- a/python/nav/web/crispyforms.py
+++ b/python/nav/web/crispyforms.py
@@ -140,17 +140,23 @@ class SubmitField:
     :param name: The name attribute of the submit field.
     :param value: The display text of the submit button.
     :param css_classes: Additional CSS classes to apply to the submit button.
+    :param has_empty_label: If an empty label is added above the submit button to align it within a row.
     :ivar input_type: The type of input, which is 'submit' for this class.
     :type input_type: str
     """
 
     def __init__(
-        self, name: str = 'submit', value: str = 'Submit', css_classes: str = ''
+        self,
+        name: str = 'submit',
+        value: str = 'Submit',
+        css_classes: str = '',
+        has_empty_label: bool = False,
     ):
         """Constructor method"""
         self.name = name
         self.value = value
         self.css_classes = css_classes
+        self.has_empty_label = has_empty_label
         self.input_type = 'submit'
 
 

--- a/python/nav/web/templates/custom_crispy_templates/submit_field.html
+++ b/python/nav/web/templates/custom_crispy_templates/submit_field.html
@@ -1,5 +1,7 @@
-{# NB! This field can be used as a replacement of crispy's Submit #}
-
+{# NB! This field can be used as a replacement of crispy's Submit and our custom LabelSubmit #}
+{% if input.has_empty_label %}
+   <label>&nbsp;</label>
+{% endif %}
 <input type="submit"
        name="{% if input.name|wordcount > 1 %}{{ input.name|slugify }}{% else %}{{ input.name }}{% endif %}"
        value="{{ input.value }}"


### PR DESCRIPTION
Some forms in NAV currently use [LabelSubmit](https://github.com/Uninett/nav/blob/6c83dcfb135099f92b347c1344ac6172a95128c1/python/nav/web/crispyforms.py#L38-L41), which is a submit button with a label with the content `&nbsp;` in it to align it within a row. [Template of LabelSubmit](https://github.com/Uninett/nav/blob/6c83dcfb135099f92b347c1344ac6172a95128c1/python/nav/web/templates/custom_crispy_templates/submit_field.html)

I stumbled over it while working on #2991, because it is used in `VlanFilterForm`.

I simply added a boolean attribute `label` to the `SubmitField` class and when that one is set to true this label is added above the submit button.

If I should handle this differently, e.g. adding a new template/class, please let me know.