### PR TITLE
Ensure field errors are always rendered in template for HelpField

### DIFF
--- a/python/nav/web/templates/custom_crispy_templates/field_helptext_as_icon.html
+++ b/python/nav/web/templates/custom_crispy_templates/field_helptext_as_icon.html
@@ -3,7 +3,7 @@
 {% if field.is_hidden %}
   {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="ctrlHolder{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.errors and form_show_errors %} error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="ctrlHolder{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.errors %} error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
       {% if field.label %}
         {% if field|is_checkbox %}
           {{ field }}
@@ -23,14 +23,12 @@
         {{ field }}
       {% endif %}
 
-      {% if form_show_errors %}
-        {% for error in field.errors %}
-          <small id="error_{{ forloop.counter }}_{{ field.auto_id }}"
-                 class="errorField">
-            {{ error }}
-          </small>
-        {% endfor %}
-      {% endif %}
+      {% for error in field.errors %}
+        <small id="error_{{ forloop.counter }}_{{ field.auto_id }}"
+               class="errorField">
+          {{ error }}
+        </small>
+      {% endfor %}
 
     </div>
 {% endif %}


### PR DESCRIPTION
While reviewing #3052 I noticed that `field.errors` did not render in non-crispy version of HelpField:
![Screenshot 2024-10-01 at 16 29 42](https://github.com/user-attachments/assets/3d90c617-6739-4aca-80e2-020df1a06335)


This PR ensures that both the non-crispy version of HelpField and the crispy HelpField (any not yet uncrispyfied form with HelpField) will render errors if any are present. This PR will not change the functionality of yet uncrispyfied helpfields since show_form_errors is set to True by default in crispy's FormHelper and never changed to False in NAV code or any context.