### PR TITLE
Add spaceless wrapper around helpfield template

### DIFF
--- a/python/nav/web/templates/custom_crispy_templates/field_helptext_as_icon.html
+++ b/python/nav/web/templates/custom_crispy_templates/field_helptext_as_icon.html
@@ -1,34 +1,35 @@
 {% load forms %}
+{% spaceless %}
+  {% if field.is_hidden %}
+    {{ field }}
+  {% else %}
+      <div id="div_{{ field.auto_id }}" class="ctrlHolder{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.errors %} error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+        {% if field.label %}
+          {% if field|is_checkbox %}
+            {{ field }}
+          {% endif %}
 
-{% if field.is_hidden %}
-  {{ field }}
-{% else %}
-    <div id="div_{{ field.auto_id }}" class="ctrlHolder{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.errors %} error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
-      {% if field.label %}
-        {% if field|is_checkbox %}
+            <label for="{{ field.id_for_label }}" {% if field.field.required %}class="requiredField"{% endif %}>
+              {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+              {% if field.help_text %}
+                  &nbsp;<i id="hint_{{ field.auto_id }}" class="fa fa-info-circle" data-tooltip title="
+                  {{ field.help_text }}
+                  "></i>
+              {% endif %}
+            </label>
+        {% endif %}
+
+        {% if not field|is_checkbox %}
           {{ field }}
         {% endif %}
 
-          <label for="{{ field.id_for_label }}" {% if field.field.required %}class="requiredField"{% endif %}>
-            {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
-            {% if field.help_text %}
-                &nbsp;<i id="hint_{{ field.auto_id }}" class="fa fa-info-circle" data-tooltip title="
-                {{ field.help_text }}
-                "></i>
-            {% endif %}
-          </label>
-      {% endif %}
+        {% for error in field.errors %}
+          <small id="error_{{ forloop.counter }}_{{ field.auto_id }}"
+                class="errorField">
+            {{ error }}
+          </small>
+        {% endfor %}
 
-      {% if not field|is_checkbox %}
-        {{ field }}
-      {% endif %}
-
-      {% for error in field.errors %}
-        <small id="error_{{ forloop.counter }}_{{ field.auto_id }}"
-               class="errorField">
-          {{ error }}
-        </small>
-      {% endfor %}
-
-    </div>
-{% endif %}
+      </div>
+  {% endif %}
+{% endspaceless %}


### PR DESCRIPTION
Whitespace showed up on checkboxes without this.

Diff is large cause of indentation changes