### PR TITLE
Uncrispify `ActivityIntervalForm` in ipdevinfo

### DIFF
--- a/python/nav/web/ipdevinfo/forms.py
+++ b/python/nav/web/ipdevinfo/forms.py
@@ -16,13 +16,11 @@
 #
 
 from django import forms
-from crispy_forms.helper import FormHelper
-from crispy_forms_foundation.layout import Layout, Row, Column
+
 from nav.models.manage import Sensor
 from nav.web.crispyforms import (
     FormColumn,
     FormRow,
-    LabelSubmit,
     SubmitField,
     set_flat_form_attributes,
 )
@@ -62,17 +60,26 @@ class ActivityIntervalForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         super(ActivityIntervalForm, self).__init__(*args, **kwargs)
-        self.helper = FormHelper()
-        self.helper.form_tag = False
-        self.helper.layout = Layout(
-            Row(
-                Column('interval', css_class='small-4'),
-                Column(
-                    LabelSubmit('submit', 'Recheck activity', css_class='postfix'),
-                    css_class='small-8',
-                ),
-                css_class='collapse',
-            )
+
+        self.attrs = set_flat_form_attributes(
+            form_fields=[
+                FormRow(
+                    fields=[
+                        FormColumn(fields=[self["interval"]], css_classes="small-4"),
+                        FormColumn(
+                            fields=[
+                                SubmitField(
+                                    value="Recheck activity",
+                                    css_classes="postfix",
+                                    has_empty_label=True,
+                                )
+                            ],
+                            css_classes="small-8",
+                        ),
+                    ],
+                    css_classes="collapse",
+                )
+            ]
         )
 
 

--- a/python/nav/web/templates/ipdevinfo/modules.html
+++ b/python/nav/web/templates/ipdevinfo/modules.html
@@ -9,7 +9,11 @@
   <div class="row">
     <div class="medium-6 column">
       <form id="switchport_activity_recheck" action="" method="get">
-        {% crispy activity_interval_form %}
+        {% if activity_interval_form.attrs %}
+          {% include 'custom_crispy_templates/_form_content.html' with form=activity_interval_form %}
+        {% else %}
+          {% crispy activity_interval_form %}
+        {% endif %}
       </form>
     </div>
     <div class="medium-6 column">

--- a/python/nav/web/templates/ipdevinfo/modules.html
+++ b/python/nav/web/templates/ipdevinfo/modules.html
@@ -1,5 +1,3 @@
-{% load crispy_forms_tags %}
-
 {% if port_view.perspective == 'swportactive' %}
   <h5>
     Activity based on CAM records since
@@ -12,7 +10,7 @@
         {% if activity_interval_form.attrs %}
           {% include 'custom_crispy_templates/_form_content.html' with form=activity_interval_form %}
         {% else %}
-          {% crispy activity_interval_form %}
+          {{ activity_interval_form }}
         {% endif %}
       </form>
     </div>


### PR DESCRIPTION
Closes #3060.

Url: ipdevinfo/<netbox_sysname>/modules/\<perspective> (where perspective is `swportstatus`, `swportactive`, or `gwportstatus`