### PR TITLE
Fix branch specification for test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - '[1-9][0-9]*.[0-9]+.x'
+      - '[1-9][0-9]?.[0-9]+.x'
   pull_request:
   schedule: # Run daily at 08:00 CEST (06:00 UST)
     - cron: '0 6 * * *'


### PR DESCRIPTION
GitHub uses `?` to indicate zero or more characters instead of the regex `+`. 

Reference: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet