### PR TITLE
Uncrispify AlertAddressForm

### DIFF
--- a/python/nav/web/alertprofiles/forms.py
+++ b/python/nav/web/alertprofiles/forms.py
@@ -99,7 +99,7 @@ class AlertAddressForm(forms.ModelForm):
         super(AlertAddressForm, self).__init__(*args, **kwargs)
         self.fields['type'].widget.attrs.update({"class": "select2"})
         self.attrs = set_flat_form_attributes(
-            form_fields={
+            form_fields=[
                 self['id'],
                 FormRow(
                     fields=[
@@ -117,7 +117,7 @@ class AlertAddressForm(forms.ModelForm):
                         ),
                     ]
                 ),
-            }
+            ]
         )
 
     class Meta(object):

--- a/python/nav/web/alertprofiles/forms.py
+++ b/python/nav/web/alertprofiles/forms.py
@@ -24,7 +24,7 @@ from django import forms
 from django.db.models import Q
 
 from crispy_forms.helper import FormHelper
-from crispy_forms_foundation.layout import Layout, Row, Column, Field, Submit, HTML
+from crispy_forms_foundation.layout import Layout, Row, Column, Field, Submit
 
 from nav.alertengine.dispatchers.email_dispatcher import Email
 from nav.alertengine.dispatchers.slack_dispatcher import Slack
@@ -97,15 +97,27 @@ class AlertAddressForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(AlertAddressForm, self).__init__(*args, **kwargs)
-        self.helper = FormHelper()
-        self.helper.form_tag = False
-        self.helper.layout = Layout(
-            'id',
-            Row(
-                Column(Field('type', css_class='select2'), css_class='medium-4'),
-                Column('address', css_class='medium-4'),
-                Column(HTML(''), css_class='medium-4'),
-            ),
+        self.fields['type'].widget.attrs.update({"class": "select2"})
+        self.attrs = set_flat_form_attributes(
+            form_fields={
+                self['id'],
+                FormRow(
+                    fields=[
+                        FormColumn(
+                            fields=[self['type']],
+                            css_classes='medium-4',
+                        ),
+                        FormColumn(
+                            fields=[self['address']],
+                            css_classes='medium-4',
+                        ),
+                        FormColumn(
+                            fields=[],
+                            css_classes='medium-4',
+                        ),
+                    ]
+                ),
+            }
         )
 
     class Meta(object):


### PR DESCRIPTION
Fixes #3076 

I assume that the column containing `HTML('')` was there to act as a fake column so the formatting of the other columns was correct. If this is removed, then one of the columns get sent far to the right.

A `FormColumn` with an empty `fields` argument seems to accomplish the exact same thing.

URL: http://localhost/alertprofiles/address/