### PR TITLE
Uncrispify ColumnsForm

### DIFF
--- a/python/nav/web/templates/webfront/preferences.html
+++ b/python/nav/web/templates/webfront/preferences.html
@@ -63,7 +63,11 @@
         </div>
 
         <div class="column medium-6 large-7">
-          {% crispy columns_form %}
+            {% if columns_form.attrs %}
+                {% include 'custom_crispy_templates/flat_form.html' with form=columns_form %}
+            {% else %}
+                {{ columns_form }}
+            {% endif %}
         </div>
 
     </div>

--- a/python/nav/web/webfront/forms.py
+++ b/python/nav/web/webfront/forms.py
@@ -17,13 +17,11 @@
 
 from django import forms
 from django.forms.models import modelformset_factory
-from django.urls import reverse
 from crispy_forms.helper import FormHelper
-from crispy_forms_foundation.layout import Layout, Fieldset, Row, Column, HTML
+from crispy_forms_foundation.layout import Layout, Row, Column, HTML
 from nav.models.profiles import NavbarLink, Account
 from nav.web.crispyforms import (
     CheckBox,
-    NavSubmit,
     SubmitField,
     set_flat_form_attributes,
     FlatFieldset,
@@ -150,13 +148,16 @@ class ColumnsForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         super(ColumnsForm, self).__init__(*args, **kwargs)
-        self.helper = FormHelper()
-        self.helper.form_action = reverse('webfront-preferences-setwidgetcolumns')
 
-        self.helper.layout = Layout(
-            Fieldset(
-                'Number of columns for widgets',
-                'num_columns',
-                NavSubmit('submit', 'Save'),
-            )
+        self.attrs = set_flat_form_attributes(
+            form_action='webfront-preferences-setwidgetcolumns',
+            form_fields=[
+                FlatFieldset(
+                    legend='Number of columns for widgets',
+                    fields=[
+                        self['num_columns'],
+                        SubmitField(value='Save', css_classes='small'),
+                    ],
+                )
+            ],
         )


### PR DESCRIPTION
Fixes #3100 

Not sure if the `form_action` value is correct. tried to set it to `reverse('webfront-preferences-setwidgetcolumns')` directly but that created some errors, but just giving the string without reversing seems to have worked fine?

We dont have a separate uncrispy class for `NavSubmit`, but it seems a `NavSubmit` button is pretty much just a smaller submit button using the css classes `button small`, so I just used a `SubmitField` with the additional css. 
Is it even necessary to include `button` as a class? It seems to look and behave exactly the same with just `small`