### PR TITLE
Remove unused `load crispy_form_tags` from netbox list in seedDB

### DIFF
--- a/python/nav/web/templates/seeddb/list_netbox.html
+++ b/python/nav/web/templates/seeddb/list_netbox.html
@@ -1,5 +1,4 @@
 {% extends "seeddb/list.html" %}
-{% load crispy_forms_tags %}
 {% load info %}
 
 {% block row %}


### PR DESCRIPTION
Url: http://localhost/seeddb/netbox/

This was added in #1492, but from what it looks like was never actually used. 