### PR TITLE
Remove unused block in `edit_vlan` template in seedDB

### DIFF
--- a/changelog.d/+remove-block-template-vlan.removed.md
+++ b/changelog.d/+remove-block-template-vlan.removed.md
@@ -1,0 +1,1 @@
+Remove unused block in edit vlan template in seedDB

--- a/python/nav/web/templates/seeddb/edit_vlan.html
+++ b/python/nav/web/templates/seeddb/edit_vlan.html
@@ -1,20 +1,4 @@
 {% extends "seeddb/edit.html" %}
-
-{% block formfields %}
-<tr>
-    <th>Net type</th>
-    <td>{{ object.net_type }}</td>
-</tr>
-<tr>
-    <th>Net ident</th>
-    <td>{{ object.net_ident }}</td>
-</tr>
-<tr>
-    <th>Description</th>
-    <td>{{ object.description }}</td>
-</tr>
-{{ block.super }}
-{% endblock %}
 {% block crispyfields %}
 <div>
     <p>Net type<br/>


### PR DESCRIPTION
This was added in https://github.com/Uninett/nav/commit/78f3127fa5eea1eb33a4854e099f29f0e3df1cfe and https://github.com/Uninett/nav/commit/b74c30689d47beae6332a6c001e2dcff1237403c, but when this block was removed in https://github.com/Uninett/nav/pull/2153/ it was forgotten. 

So now we can remove it!