### PR TITLE
Switch `DeviceGroupForm` in seeddb to new uncrispy way

### DIFF
--- a/python/nav/web/seeddb/forms/__init__.py
+++ b/python/nav/web/seeddb/forms/__init__.py
@@ -33,6 +33,7 @@ from nav.models.manage import (
 )
 from nav.models.cabling import Cabling
 from nav.oids import OID
+from nav.web.crispyforms import set_flat_form_attributes
 
 _logger = logging.getLogger(__name__)
 
@@ -312,7 +313,6 @@ class DeviceGroupForm(forms.ModelForm):
         queryset=Netbox.objects.all(), required=False
     )
     netboxes.widget.attrs.update({"class": "select2"})
-    no_crispy = True
 
     def __init__(self, *args, **kwargs):
         # If the form is based on an existing model instance, populate the
@@ -321,6 +321,8 @@ class DeviceGroupForm(forms.ModelForm):
             initial = kwargs.setdefault('initial', {})
             initial['netboxes'] = [n.pk for n in kwargs['instance'].netboxes.all()]
         forms.ModelForm.__init__(self, *args, **kwargs)
+
+        self.attrs = set_flat_form_attributes()
 
     class Meta(object):
         model = NetboxGroup

--- a/python/nav/web/templates/seeddb/_form_fields.html
+++ b/python/nav/web/templates/seeddb/_form_fields.html
@@ -1,3 +1,0 @@
-{% for field in form %}
-	{% include "foundation-5/field.html" %}
-{% endfor %}

--- a/python/nav/web/templates/seeddb/edit.html
+++ b/python/nav/web/templates/seeddb/edit.html
@@ -41,10 +41,8 @@
       <form class="seeddb-edit" action="" method="post">
         <fieldset>
           <legend>Attributes</legend>
-	        {% if form.no_crispy %}
-		        {% block formfields %}
-			        {% include "seeddb/_form_fields.html" %}
-		        {% endblock %}
+	        {% if form.attrs %}
+		        {% include 'custom_crispy_templates/_form_content.html' %}
 	        {% else %}
 		        {% block crispyfields %}
 			        {{ form|crispy }}


### PR DESCRIPTION
Changes again most changes done in #2994 and instead uses our newest way of uncrispifying forms.

Urls:
http://localhost/seeddb/netboxgroup/add/
http://localhost/seeddb/netboxgroup/edit/<id\>