### PR TITLE
Uncrispyfy NavbarlinkForm and NavbarLinkFormSet

### DIFF
--- a/python/nav/web/sass/nav/my_account.scss
+++ b/python/nav/web/sass/nav/my_account.scss
@@ -1,11 +1,19 @@
 @import "../navsettings";
 
-#navigation-preferences { 
+#navigation-preferences {
 	.asteriskField {
 		display:none;
 	}
 
 	.link-delete label{
 		color:$alert-color;
+	}
+
+	.row {
+		display: flex;
+	}
+
+	.row .link-delete {
+		align-self: center;
 	}
 }

--- a/python/nav/web/templates/webfront/_navbar_link_form.html
+++ b/python/nav/web/templates/webfront/_navbar_link_form.html
@@ -1,0 +1,17 @@
+{% load forms %}
+<div class="row">
+  {% for field in form %}
+    {% if field in form.attrs.form_fields %}
+      <div class="columns medium-5">
+        {% show_field field %}
+      </div>
+    {% elif field.name == 'DELETE' and navbar_formset.can_delete %}
+      <div class="columns link-delete medium-2">
+        <label>&nbsp;</label>
+        {% include 'custom_crispy_templates/horizontal_checkbox.html' %}
+      </div>
+    {% elif form.render_unmentioned_fields %}
+      {{ field }}
+    {% endif %}
+  {% endfor %}
+</div>

--- a/python/nav/web/templates/webfront/_navbar_link_form.html
+++ b/python/nav/web/templates/webfront/_navbar_link_form.html
@@ -7,7 +7,6 @@
       </div>
     {% elif field.name == 'DELETE' and navbar_formset.can_delete %}
       <div class="columns link-delete medium-2">
-        <label>&nbsp;</label>
         {% include 'custom_crispy_templates/horizontal_checkbox.html' %}
       </div>
     {% elif form.render_unmentioned_fields %}

--- a/python/nav/web/templates/webfront/preferences.html
+++ b/python/nav/web/templates/webfront/preferences.html
@@ -1,7 +1,5 @@
 {% extends "base.html" %}
 
-{% load crispy_forms_tags %}
-
 {% block base_header_additional_head %}
 <link rel="stylesheet"  href="{{ STATIC_URL }}css/nav/my_account.css" />
 <script>require(['src/navigation_preferences']);</script>
@@ -95,7 +93,14 @@
                 <fieldset>
                     <legend>'My stuff' quick links</legend>
                     <p>A quick link requires both link text and URL.</p>
-                    {% crispy navbar_formset navbar_formset.form.helper %}
+                    {% csrf_token %}
+                    <div>{{ navbar_formset.management_form }}</div>
+                    {% include 'foundation-5/errors_formset.html' %}
+                    {% for form in navbar_formset %}
+                      {% include 'webfront/_navbar_link_form.html' %}
+                      {% empty %}
+                      {{ navbar_formset }}
+                    {% endfor %}
                     <input type="submit" class="button primary small" name="submit" value="Save changes" />
                 </fieldset>
 

--- a/python/nav/web/webfront/forms.py
+++ b/python/nav/web/webfront/forms.py
@@ -17,11 +17,8 @@
 
 from django import forms
 from django.forms.models import modelformset_factory
-from crispy_forms.helper import FormHelper
-from crispy_forms_foundation.layout import Layout, Row, Column, HTML
 from nav.models.profiles import NavbarLink, Account
 from nav.web.crispyforms import (
-    CheckBox,
     SubmitField,
     set_flat_form_attributes,
     FlatFieldset,
@@ -48,20 +45,12 @@ class NavbarlinkForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(NavbarlinkForm, self).__init__(*args, **kwargs)
         self.empty_permitted = True
-        self.helper = FormHelper()
-        self.helper.form_tag = False
         self.render_unmentioned_fields = True
-
-        self.helper.layout = Layout(
-            Row(
-                Column('name', css_class='medium-5'),
-                Column('uri', css_class='medium-5'),
-                Column(
-                    HTML('<label>&nbsp;</label>'),
-                    CheckBox('DELETE'),
-                    css_class='link-delete medium-2',
-                ),
-            ),
+        self.attrs = set_flat_form_attributes(
+            form_fields=[
+                self['name'],
+                self['uri'],
+            ]
         )
 
 


### PR DESCRIPTION
Closes #3099, #3107

http://localhost/preferences/ under 'My stuff' quick links

Difference from the original implementation: the `hidden` input in each form became a part of the `<row>`. Functionally and visually it bears no difference whatsoever, yet simplifies the form template considerably.