### PR TITLE
Add check to handle empty form attributes in general non-crispy template

### DIFF
--- a/python/nav/web/templates/custom_crispy_templates/_form_content.html
+++ b/python/nav/web/templates/custom_crispy_templates/_form_content.html
@@ -21,5 +21,7 @@
     {% endif %}
   {% endblock form_fields %}
 {% else %}
-  {{ form }}
+  {% for field in form %}
+    {% show_field field %}
+  {% endfor %}
 {% endif %}


### PR DESCRIPTION
Originally mentioned in https://github.com/Uninett/nav/pull/3105#pullrequestreview-2359625996

@lunkwill42 har suggested IRL to add the check to the general template.

A general failsafe for #2794