### PR TITLE
Fix PhantomJS test problems

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -136,7 +136,7 @@ jobs:
       - run: chrome --version
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
 
       - name: npm install
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -144,7 +144,7 @@ jobs:
           npm ci
 
       - name: npm test
-        run: xvfb-run -a npm test
+        run: OPENSSL_CONF=/dev/null xvfb-run -a npm test
         working-directory: ./python/nav/web/static/js
 
       - name: Upload JavaScript test reports


### PR DESCRIPTION
PhantomJS development has ceased.  Our CI test suite currently fails because the outdated version of PhantomJS we're using for the JS tests is trying to use OpenSSL features that are no longer present in more recent versions of OpenSSL:

```

15 10 2024 05:25:09.525:ERROR [launcher]: PhantomJS stdout: 
15 10 2024 05:25:09.525:ERROR [launcher]: PhantomJS stderr: Auto configuration failed
140546702575424:error:25066067:DSO support routines:DLFCN_LOAD:could not load the shared library:dso_dlfcn.c:185:filename(libproviders.so): libproviders.so: cannot open shared object file: No such file or directory
140546702575424:error:25070067:DSO support routines:DSO_load:could not load the shared library:dso_lib.c:244:
140546702575424:error:0E07506E:configuration file routines:MODULE_LOAD_DSO:error loading dso:conf_mod.c:285:module=providers, path=providers
140546702575424:error:0E076071:configuration file routines:MODULE_RUN:unknown module name:conf_mod.c:222:module=providers
```

This PR fixes the problem by temporarily disabling OpenSSL during the running of the test suite on GitHub actions (specifically).  The test suite still runs fine on the Docker test image supplied with NAV, since it is based on a slightly older Ubuntu.

For good measure, the PR also updates the workflow to use Node 18, just as the Docker image does.

### The future of PhantomJS

We should consider removing PhantomJS from our test suite entirely.  It is debatable whether is serves any purpose, since we also test on real JS engines like Firefox and Chrome.
