### PR TITLE
Upgrade linter versions to same as MegaLinter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,11 @@ repos:
     -   id: end-of-file-fixer
         exclude: &exclude_pattern '^changelog.d/'
 -   repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
     -   id: black
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.1
+    rev: v0.6.9
     hooks:
       - id: ruff
 -   repo: https://github.com/twisted/towncrier


### PR DESCRIPTION
The newest release of [MegaLinter](https://github.com/oxsecurity/megalinter/releases/tag/v8.1.0) has upgraded the black and ruff to the newest versions (black 24.10.0, ruff 0.6.9). This PR changes the pre-commit accordingly. 

No actual formatting/linting changes necessary. 