### PR TITLE
Configure HTTP-based ARP information fetching from Palo Alto PAN-OS firewalls using management profiles 

### DIFF
--- a/NOTES.rst
+++ b/NOTES.rst
@@ -20,6 +20,37 @@ to be able to upgrade to Python 3.11:
 * :mod:`django-crispy-forms`
 * :mod:`crispy-forms-foundation`
 
+
+NAV 5.12
+========
+Deprecation warnings
+--------------------
+.. warning:: The ``[paloaltoarp]`` section of :file:`ipdevpoll.conf`, used for
+             configuring HTTP-based ARP fetching from Palo Alto firewalls, is
+             deprecated and will be ignored in NAV 5.12 and future versions.
+             HTTP-based ARP fetching from Palo Alto
+             firewalls *must* now be configured using management profiles,
+             analogous to configuration of SNMP-based fetching.  :ref:`See below
+             for more details<5.12-new-http-rest-api-management-profile-type>`.
+
+.. _5.12-new-http-rest-api-management-profile-type:
+New way to configure fetching of Palo Alto firewall ARP cache data
+------------------------------------------------------------------
+.. NOTE:: See
+          :ref:`management profile reference documentation<http-rest-api-management-profile>`
+          for instructions on how to reconfigure your Palo Alto firewall
+          devices in NAV 5.12 to enable support for fetching of their
+          ARP information.
+
+Starting with NAV 5.12, a new ``HTTP API`` management profile type has been
+added to NAV for configuring HTTP API specific parameters used in fetching of
+ARP information from Palo Alto firewalls running PAN-OS. Currently, this
+management profile type is only used to configure Palo Alto firewall devices. If
+support for other devices that similarly can be managed using a HTTP API is
+added to NAV in future releases, you can expect to be able to configure API
+parameters for these devices by using management profiles as well.
+
+
 NAV 5.11
 ========
 

--- a/changelog.d/3147.changed.md
+++ b/changelog.d/3147.changed.md
@@ -1,0 +1,3 @@
+The ipdevpoll plugin to fetch ARP cache data from a netbox's Palo Alto firewall
+API is now configured through a new management profile type assigned to that
+netbox.

--- a/doc/reference/ipdevpoll.rst
+++ b/doc/reference/ipdevpoll.rst
@@ -106,35 +106,6 @@ Section [linkstate]
   The value ``any`` will generate alerts for all link state changes, but
   **this is not recommended** for performance reasons.
 
-Section [paloaltoarp]
----------------------
-
-This section configures the Palo Alto ARP plugin.  Palo Alto firewalls do
-support SNMP.  They do not, however, support fetching ARP cache data using
-SNMP.  This plugin enables fetching ARP records from Palo Alto firewalls using
-their built-in REST API.
-
-Currently, there is no management profile type for this type of REST APIs, so
-credentials to access a Palo Alto firewall's API must be configured in this
-section.
-
-If you have a Palo Alto firewall named ``example-fw.example.org``, with an IP
-address of ``10.0.42.42`` and a secret API token of
-``762e87e0ec051a1c5211a08dd48e7a93720eee63``, you can configure this in this
-section by adding::
-
-  example-fw.example.org = 762e87e0ec051a1c5211a08dd48e7a93720eee63
-
-Or, alternatively::
-
-  10.0.42.42 = 762e87e0ec051a1c5211a08dd48e7a93720eee63
-
-
-.. warning:: The Palo Alto ARP plugin does not currently verify TLS
-             certificates when accessing a Palo Alto API.  This will be changed
-             at a later date, but if it worries you, you should not use the
-             plugin yet.
-
 
 Job sections
 ------------

--- a/doc/reference/management-profiles.rst
+++ b/doc/reference/management-profiles.rst
@@ -86,7 +86,38 @@ Use keys
 Alternate port
   If access to the switch is not on the default port (22, in the case of the
   JunOS driver), put the alternate port here.
-  
+
 
 .. _`NAPALM`: https://napalm.readthedocs.io/en/latest/
 .. _`NETCONF`: https://en.wikipedia.org/wiki/NETCONF
+
+.. _http-rest-api-management-profile:
+HTTP APIs
+--------------
+As of NAV 5.12, HTTP API profiles are used to configure access to
+services of the following devices.
+
+`Palo Alto PAN-OS firewalls`_
+  A HTTP API profile is needed for NAV to access the firewall's ARP information.
+
+.. warning:: The Palo Alto ARP implementation in NAV does not currently verify TLS
+             certificates when accessing a Palo Alto API.  This will be changed
+             at a later date, but if it worries you, you should not configure
+             any netboxes to use the Palo Alto Arp service yet.
+
+.. image:: http-rest-api-profile-example.png
+
+If you have a Palo Alto firewall running on a netbox managed by NAV,
+with a secret API key of ``762e87e0ec051a1c5211a08dd48e7a93720eee63``,
+you can configure NAV to fetch ARP information from this firewall by
+creating a new management profile with
+
+* protocol set to ``HTTP API``,
+
+* API key set to ``762e87e0ec051a1c5211a08dd48e7a93720eee63``,
+
+* service set to ``Palo Alto ARP``,
+
+and then add this management profile to the netbox.
+
+.. _`Palo Alto PAN-OS firewalls`: https://docs.paloaltonetworks.com/pan-os/11-0/pan-os-panorama-api/pan-os-xml-api-request-types/configuration-api/get-active-configuration/use-xpath-to-get-arp-information

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -131,10 +131,12 @@ class ManagementProfile(models.Model):
     PROTOCOL_SNMP = 1
     PROTOCOL_NAPALM = 2
     PROTOCOL_SNMPV3 = 3
+    PROTOCOL_HTTP_API = 4
     PROTOCOL_CHOICES = [
         (PROTOCOL_SNMP, "SNMP"),
         (PROTOCOL_NAPALM, "NAPALM"),
         (PROTOCOL_SNMPV3, "SNMPv3"),
+        (PROTOCOL_HTTP_API, "HTTP API"),
     ]
     if settings.DEBUG:
         PROTOCOL_CHOICES.insert(0, (PROTOCOL_DEBUG, 'debug'))

--- a/python/nav/web/seeddb/page/management_profile/forms.py
+++ b/python/nav/web/seeddb/page/management_profile/forms.py
@@ -62,6 +62,28 @@ class ProtocolSpecificMixIn(object):
                 cfg[field] = self.cleaned_data.get(field)
 
 
+class HttpApiForm(ProtocolSpecificMixIn, forms.ModelForm):
+    PROTOCOL = ManagementProfile.PROTOCOL_HTTP_API
+    PROTOCOL_NAME = PROTOCOL_CHOICES.get(PROTOCOL)
+
+    class Meta(object):
+        model = ManagementProfile
+        configuration_fields = ['api_key', 'service']
+        fields = []
+
+    api_key = forms.CharField(
+        label="API key",
+        help_text="Key/token to authenticate to the service",
+        required=True,
+    )
+
+    service = forms.ChoiceField(
+        choices=(("Palo Alto ARP", "Palo Alto ARP"),),
+        help_text="",
+        required=True,
+    )
+
+
 class DebugForm(ProtocolSpecificMixIn, forms.ModelForm):
     PROTOCOL = ManagementProfile.PROTOCOL_DEBUG
     PROTOCOL_NAME = PROTOCOL_CHOICES.get(PROTOCOL)

--- a/tests/integration/ipdevpoll/plugins/paloaltoarp_test.py
+++ b/tests/integration/ipdevpoll/plugins/paloaltoarp_test.py
@@ -1,0 +1,357 @@
+from unittest.mock import Mock
+
+from django.urls import reverse
+import pytest
+import pytest_twisted
+from twisted.internet import defer
+
+from nav.models.manage import ManagementProfile, Netbox, NetboxProfile
+from nav.ipdevpoll.jobs import JobHandler
+from nav.ipdevpoll.plugins.paloaltoarp import PaloaltoArp
+from nav.ipdevpoll.plugins import plugin_registry
+
+
+class TestCanHandleNetbox:
+    """
+    Check that the PaloaltoArp plugin signifies it can handle netboxes with at
+    least one management profile containing a paloalto configuration.
+    """
+
+    @pytest.mark.parametrize(
+        "netbox",
+        ["paloalto_netbox_1234", "paloalto_netbox_5678"],
+    )
+    @pytest.mark.twisted
+    @pytest_twisted.inlineCallbacks
+    def test_it_should_accept_netbox_having_some_paloalto_http_api_management_profile(
+        self, netbox, request
+    ):
+        netbox = request.getfixturevalue(netbox)
+
+        can_handle = yield PaloaltoArp.can_handle(netbox)
+        assert can_handle
+
+    @pytest.mark.parametrize(
+        "netbox",
+        ["no_paloalto_http_api_netbox", "no_http_api_netbox"],
+    )
+    @pytest.mark.twisted
+    @pytest_twisted.inlineCallbacks
+    def test_it_should_not_accept_netbox_without_any_paloalto_http_api_management_profile(
+        self, netbox, request
+    ):
+        netbox = request.getfixturevalue(netbox)
+
+        can_handle = yield PaloaltoArp.can_handle(netbox)
+        assert not can_handle
+
+
+class TestGetArpMappings:
+    """
+    Run the PaloaltoArp plugin on disparate pre-configured netboxes, then check
+    that the expected arp mappings are assigned afterwards.
+    """
+
+    @pytest.mark.parametrize(
+        "netbox",
+        ["paloalto_netbox_1234"],
+    )
+    @pytest.mark.twisted
+    @pytest_twisted.inlineCallbacks
+    def test_it_should_get_arp_mappings_of_netbox_having_some_paloalto_management_profile_with_valid_api_key(
+        self, netbox, monkeypatch, request
+    ):
+        netbox = request.getfixturevalue(netbox)
+
+        # Set up a single ipdevpoll job for this netbox:
+        # Assure PaloAltoArp is a known ipdevpoll plugin
+        plugin_registry['paloaltoarp'] = PaloaltoArp
+        job = JobHandler('paloaltoarp', netbox.pk, plugins=['paloaltoarp'])
+        # Disable implicit SNMP requests done during job.run()
+        job._create_agentproxy = Mock()
+        job._destroy_agentproxy = Mock()
+
+        monkeypatch.setattr(PaloaltoArp, "_do_request", _only_accept_1234)
+
+        assert netbox.arp_set.count() == 0
+
+        yield job.run()
+
+        actual = [(arp.ip, arp.mac) for arp in netbox.arp_set.all()]
+        expected = [
+            ('192.168.0.1', '00:00:00:00:00:01'),
+            ('192.168.0.2', '00:00:00:00:00:02'),
+            ('192.168.0.3', '00:00:00:00:00:03'),
+        ]
+        assert sorted(actual) == sorted(expected)
+
+    @pytest.mark.parametrize(
+        "netbox",
+        ["paloalto_netbox_5678", "no_paloalto_http_api_netbox", "no_http_api_netbox"],
+    )
+    @pytest.mark.twisted
+    @pytest_twisted.inlineCallbacks
+    def test_it_should_not_get_arp_mappings_of_netbox_without_any_paloalto_http_api_management_profile_with_valid_api_key(
+        self, netbox, monkeypatch, request
+    ):
+        netbox = request.getfixturevalue(netbox)
+
+        plugin_registry['paloaltoarp'] = PaloaltoArp
+        job = JobHandler('paloaltoarp', netbox.pk, plugins=['paloaltoarp'])
+        job._create_agentproxy = Mock()
+        job._destroy_agentproxy = Mock()
+
+        monkeypatch.setattr(PaloaltoArp, "_do_request", _only_accept_1234)
+
+        assert netbox.arp_set.count() == 0
+        yield job.run()
+        assert netbox.arp_set.count() == 0
+
+
+class TestEndToEnd:
+    """Tests that mimic actual usage of the plugin"""
+
+    @pytest.mark.twisted
+    @pytest_twisted.inlineCallbacks
+    def test_it_should_get_arp_mappings_of_netbox_configured_with_paloalto_management_profile_using_seeddb(
+        self, client, no_http_api_netbox, blank_management_profile, monkeypatch
+    ):
+        """
+        Manually configure a netbox for use with the PaloaltoArp plugin, using
+        SeedDB. Then run the PaloaltoArp plugin on this netbox and check that the
+        expected arp mappings are assigned afterwards.
+        """
+
+        # Using SeedDB, edit a blank profile so that it now configures access to Palo Alto ARP
+        profile = blank_management_profile
+        management_profile_url = reverse(
+            "seeddb-management-profile-edit", args=(profile.id,)
+        )
+        client.post(
+            management_profile_url,
+            follow=True,
+            data={
+                "name": profile.name,
+                "description": "",
+                "protocol": ManagementProfile.PROTOCOL_HTTP_API,
+                "service": "Palo Alto ARP",
+                "api_key": "1234",
+            },
+        )
+
+        # Using SeedDB, add the profile to a netbox with no prior Palo Alto ARP management profile
+        netbox = no_http_api_netbox
+        netbox_url = reverse("seeddb-netbox-edit", args=(netbox.id,))
+        client.post(
+            netbox_url,
+            follow=True,
+            data={
+                "ip": netbox.ip,
+                "room": netbox.room_id,
+                "category": netbox.category_id,
+                "organization": netbox.organization_id,
+                "profiles": [profile.id],
+            },
+        )
+        profile.refresh_from_db()
+        netbox.refresh_from_db()
+
+        # Now check that the plugin correctly fetches arp mappings from this netbox
+        plugin_registry['paloaltoarp'] = PaloaltoArp
+        job = JobHandler('paloaltoarp', netbox.pk, plugins=['paloaltoarp'])
+
+        job._create_agentproxy = Mock()
+        job._destroy_agentproxy = Mock()
+
+        monkeypatch.setattr(PaloaltoArp, "_do_request", _only_accept_1234)
+
+        assert netbox.arp_set.count() == 0
+
+        yield job.run()
+
+        actual = [(arp.ip, arp.mac) for arp in netbox.arp_set.all()]
+        expected = [
+            ('192.168.0.1', '00:00:00:00:00:01'),
+            ('192.168.0.2', '00:00:00:00:00:02'),
+            ('192.168.0.3', '00:00:00:00:00:03'),
+        ]
+        assert sorted(actual) == sorted(expected)
+
+
+valid_http_response_body = b'''
+    <response status="success">
+    <result>
+            <max>132000</max>
+            <total>3</total>
+            <timeout>1800</timeout>
+            <dp>s3dp1</dp>
+            <entries>
+                <entry>
+                    <status>  s  </status>
+                    <ip>192.168.0.1</ip>
+                    <mac>00:00:00:00:00:01</mac>
+                    <ttl>100</ttl>
+                    <interface>ae2</interface>
+                    <port>ae2</port>
+                </entry>
+                <entry>
+                    <status>  e  </status>
+                    <ip>192.168.0.2</ip>
+                    <mac>00:00:00:00:00:02</mac>
+                    <ttl>200</ttl>
+                    <interface>ae2</interface>
+                    <port>ae2</port>
+                </entry>
+                <entry>
+                    <status>  c  </status>
+                    <ip>192.168.0.3</ip>
+                    <mac>00:00:00:00:00:03</mac>
+                    <ttl>300</ttl>
+                    <interface>ae3.61</interface>
+                    <port>ae3</port>
+                </entry>
+                <entry>
+                    <status>  i  </status>
+                    <ip>192.168.0.4</ip>
+                    <mac>00:00:00:00:00:04</mac>
+                    <ttl>400</ttl>
+                    <interface>ae3.61</interface>
+                    <port>ae3</port>
+                </entry>
+            </entries>
+        </result>
+    </response>
+    '''
+
+
+def _only_accept_1234(self, address, key, *args, **kwargs):
+    """Mimic PaloaltoArp._do_request() but only succeed if supplied key is '1234'"""
+    if key == "1234":
+        return defer.succeed(valid_http_response_body)
+    return defer.succeed(None)
+
+
+@pytest.fixture
+def paloalto_netbox_1234():
+    """
+    Netbox with a PaloAlto HTTP
+    """
+    netbox = Netbox(
+        ip="10.0.0.1",
+        sysname="fw1.example.org",
+        organization_id="myorg",
+        room_id="myroom",
+        category_id="SRV",
+    )
+    netbox.save()
+
+    profile = ManagementProfile(
+        name="PaloAlto Profile 1",
+        protocol=ManagementProfile.PROTOCOL_HTTP_API,
+        configuration={
+            "api_key": "1234",
+            "service": "Palo Alto ARP",
+        },
+    )
+    profile.save()
+    NetboxProfile(netbox=netbox, profile=profile).save()
+
+    yield netbox
+    netbox.delete()
+    profile.delete()
+
+
+@pytest.fixture
+def paloalto_netbox_5678():
+    netbox = Netbox(
+        ip="10.0.0.2",
+        sysname="fw2.example.org",
+        organization_id="myorg",
+        room_id="myroom",
+        category_id="SRV",
+    )
+    netbox.save()
+
+    profile = ManagementProfile(
+        name="PaloAlto Profile 2",
+        protocol=ManagementProfile.PROTOCOL_HTTP_API,
+        configuration={
+            "api_key": "5678",
+            "service": "Palo Alto ARP",
+        },
+    )
+    profile.save()
+    NetboxProfile(netbox=netbox, profile=profile).save()
+
+    yield netbox
+    netbox.delete()
+    profile.delete()
+
+
+@pytest.fixture
+def no_http_api_netbox():
+    netbox = Netbox(
+        ip="10.0.0.3",
+        sysname="gw1.example.org",
+        organization_id="myorg",
+        room_id="myroom",
+        category_id="GW",
+    )
+    netbox.save()
+
+    profile = ManagementProfile(
+        name="SNMP v1 write profile",
+        protocol=ManagementProfile.PROTOCOL_SNMP,
+        configuration={
+            "community": "secret",
+            "version": 1,
+            "write": True,
+            "api_key": "1234",
+            "service": "Palo Alto ARP",
+        },
+    )
+    profile.save()
+    NetboxProfile(netbox=netbox, profile=profile).save()
+
+    yield netbox
+    netbox.delete()
+    profile.delete()
+
+
+@pytest.fixture
+def no_paloalto_http_api_netbox():
+    netbox = Netbox(
+        ip="10.0.0.4",
+        sysname="dns.example.org",
+        organization_id="myorg",
+        room_id="myroom",
+        category_id="SRV",
+    )
+    netbox.save()
+
+    profile = ManagementProfile(
+        name="PaloAlto Test Management Profile",
+        protocol=ManagementProfile.PROTOCOL_HTTP_API,
+        configuration={
+            "api_key": "1234",
+            "service": "DNS",
+        },
+    )
+    profile.save()
+    NetboxProfile(netbox=netbox, profile=profile).save()
+
+    yield netbox
+    netbox.delete()
+    profile.delete()
+
+
+@pytest.fixture
+def blank_management_profile():
+    profile = ManagementProfile(
+        name="Manually Configured Paloaltoarp Profile",
+        protocol=ManagementProfile.PROTOCOL_DEBUG,
+        configuration={},
+    )
+    profile.save()
+    yield profile
+    profile.delete()

--- a/tests/unittests/ipdevpoll/plugins_paloaltoarp_test.py
+++ b/tests/unittests/ipdevpoll/plugins_paloaltoarp_test.py
@@ -1,12 +1,14 @@
 from unittest.mock import patch, Mock
 
+import pytest_twisted
+import pytest
+
 from IPy import IP
-from nav.ipdevpoll.plugins.paloaltoarp import PaloaltoArp, parse_arp
+from nav.ipdevpoll.plugins.paloaltoarp import PaloaltoArp, _parse_arp
 from twisted.internet import defer
-from twisted.internet.defer import inlineCallbacks, succeed
 from twisted.web.client import Agent, Response
 
-mock_data = b'''
+valid_http_response_body = b'''
     <response status="success">
     <result>
             <max>132000</max>
@@ -52,59 +54,83 @@ mock_data = b'''
     '''
 
 
-def test_parse_mappings():
-    assert parse_arp(mock_data) == [
+def test_parse_arp_should_correctly_parse_valid_http_response_body():
+    assert _parse_arp(valid_http_response_body) == [
         ('ifindex', IP('192.168.0.1'), '00:00:00:00:00:01'),
         ('ifindex', IP('192.168.0.2'), '00:00:00:00:00:02'),
         ('ifindex', IP('192.168.0.3'), '00:00:00:00:00:03'),
     ]
 
 
-@inlineCallbacks
-def test_get_mappings():
-    # Mocking the __init__ method
-    with patch.object(PaloaltoArp, "__init__", lambda x: None):
-        instance = PaloaltoArp()
-        instance.config = {'paloaltoarp': {'abcdefghijklmnop': '0.0.0.0'}}
-
-        # Mocking _do_request to return the mock_data when called
-        with patch.object(
-            PaloaltoArp, "_do_request", return_value=defer.succeed(mock_data)
-        ):
-            mappings = yield instance._get_paloalto_arp_mappings(
-                "0.0.0.0", "abcdefghijklmnop"
-            )
-
-            assert mappings == [
-                ('ifindex', IP('192.168.0.1'), '00:00:00:00:00:01'),
-                ('ifindex', IP('192.168.0.2'), '00:00:00:00:00:02'),
-                ('ifindex', IP('192.168.0.3'), '00:00:00:00:00:03'),
-            ]
+@pytest.mark.twisted
+@pytest_twisted.inlineCallbacks
+def test_get_paloalto_arp_mappings_should_return_arp_mappings_on_valid_http_response(
+    paloaltoarp,
+):
+    with patch.object(
+        PaloaltoArp, "_do_request", return_value=defer.succeed(valid_http_response_body)
+    ):
+        assert paloaltoarp._do_request.call_count == 0
+        mappings = yield paloaltoarp._get_paloalto_arp_mappings(
+            IP("0.0.0.0"), "abcdefghijklmnop"
+        )
+        assert sorted(mappings) == [
+            ('ifindex', IP('192.168.0.1'), '00:00:00:00:00:01'),
+            ('ifindex', IP('192.168.0.2'), '00:00:00:00:00:02'),
+            ('ifindex', IP('192.168.0.3'), '00:00:00:00:00:03'),
+        ]
+        assert paloaltoarp._do_request.call_count == 1
 
 
-@inlineCallbacks
-def test_do_request():
+@pytest.mark.twisted
+@pytest_twisted.inlineCallbacks
+def test_get_paloalto_arp_mappings_should_return_empty_list_on_request_error(
+    paloaltoarp,
+):
+    with patch.object(PaloaltoArp, "_do_request", return_value=defer.succeed(None)):
+        mappings = yield paloaltoarp._get_paloalto_arp_mappings(
+            IP("10.0.0.0"), "incorrect_key"
+        )
+        assert mappings == []
+
+
+@pytest.mark.twisted
+@pytest_twisted.inlineCallbacks
+def test_do_request_should_form_correct_api_query_url(paloaltoarp):
     mock_response = Mock(spec=Response)
     mock_agent = Mock(spec=Agent)
-    mock_agent.request.return_value = succeed(mock_response)
+    mock_agent.request.return_value = defer.succeed(mock_response)
+
+    sentinel = object()
 
     with (
         patch('nav.ipdevpoll.plugins.paloaltoarp.Agent', return_value=mock_agent),
-        patch('twisted.web.client.readBody', return_value="test content"),
+        patch('twisted.web.client.readBody', return_value=sentinel),
     ):
-        mock_address = "paloalto.example.org"
-        mock_key = "secret"
+        address = IP("127.0.0.1")
+        key = "secret"
 
-        mock_netbox = Mock(sysname=mock_address, ip="127.0.0.1")
+        result = yield paloaltoarp._do_request(address, key)
 
-        plugin = PaloaltoArp(netbox=mock_netbox, agent=Mock(), containers=Mock())
-        result = yield plugin._do_request(mock_address, mock_key)
-
-        expected_url = f"https://{mock_address}/api/?type=op&cmd=<show><arp><entry+name+=+'all'/></arp></show>&key={mock_key}".encode(
+        expected_url = f"https://{address}/api/?type=op&cmd=<show><arp><entry+name+=+'all'/></arp></show>&key={key}".encode(
             "utf-8"
         )
+
         mock_agent.request.assert_called()
         args, kwargs = mock_agent.request.call_args
         assert expected_url in args
 
-        assert result == "test content"
+        assert result == sentinel
+
+
+@pytest.fixture
+def paloaltoarp():
+    """
+    No method in PaloaltoArp except PaloaltoArp.handle() utilize the state of an
+    instance, so as long as we defer testing PaloaltoArp.handle() to integration
+    tests, we can make do with a fully mocked internal state for the unit
+    tests. (The reason we do not declare the methods as static, so that we can
+    skip this mocking step when testing, is to not mess with logging
+    granularity.)
+    """
+    return PaloaltoArp(Mock(), Mock(), Mock())


### PR DESCRIPTION
Deprecate the `[paloaltoarp]` section of `ipdevpoll.conf` in favor of using management profiles to configure HTTP-based fetching of ARP information from Palo Alto PIO-OS firewalls, analogous to how configuration of SNMP-based fetching is done.

The new management profile protocol to configure HTTP-based fetching has been given the name `HTTP API`~~`HTTP REST API` for now, but this name might be missing the mark since there really isn't anything REST-related about the management profile type.~~ Perhaps `HTTP WITH API KEY`, would be a more fitting name?

Fixes #2894