### PR TITLE
Add class representing a Div

### DIFF
--- a/python/nav/web/crispyforms.py
+++ b/python/nav/web/crispyforms.py
@@ -195,3 +195,18 @@ def set_flat_form_attributes(
         form_id=form_id,
         form_class=form_class,
     )
+
+
+class FormDiv:
+    """A class representing a div in a form layout.
+
+    :param fields: A list of fields to include in the div.
+    :param css_classes: Additional CSS classes to apply to the div.
+    """
+
+    def __init__(
+        self, fields: Optional[list] = None, css_classes: Optional[str] = None
+    ):
+        self.fields = fields
+        self.css_classes = css_classes
+        self.template = 'custom_crispy_templates/form_div.html'

--- a/python/nav/web/templates/custom_crispy_templates/form_div.html
+++ b/python/nav/web/templates/custom_crispy_templates/form_div.html
@@ -1,0 +1,11 @@
+{# NB! This form div can only render fields that are supported by custom_crispy_templates/_form_field.html #}
+
+<div
+  {% if field.css_classes %} class="{{ field.css_classes }}" {% endif %}
+>
+  {% block formdiv_content %}
+    {% for field in field.fields %}
+      {% include 'custom_crispy_templates/_form_field.html' %}
+    {% endfor %}
+  {% endblock %}
+</div>


### PR DESCRIPTION
Adds a blank div as replacement for the crispyforms `Div` class.
Part of the uncrispyfication (#2794).

Arnold `ManualDetentionForm` and `DetentionProfileForm` use `Div`s with a specific class added to it
to make it hide and reappear. Tried to recreate the effect using widget manipulation, changes to `arnold.scss `etc etc..

Using a `FormRow` worked the best, but still wasnt perfect (it messed up the margins for some reason). As a `FormRow` is just a div with the "row" css class added to it, it seems reasonable to have a class for blank div that you can do whatever you want with.