### PR TITLE
Remove `setup.py` once and for all

### DIFF
--- a/changelog.d/3176.changed.md
+++ b/changelog.d/3176.changed.md
@@ -1,0 +1,1 @@
+The old-style `setup.py` script was removed and installation docs were updated

--- a/doc/howto/generic-install-from-source.rst
+++ b/doc/howto/generic-install-from-source.rst
@@ -217,7 +217,7 @@ Building the documentation
 
 If you wish, this HTML documentation can be built separately using this step::
 
-  python setup.py build_sphinx
+  sphinx-build
 
 The resulting files will typically be placed in :file:`build/sphinx/html/`.
 

--- a/doc/howto/generic-install-from-source.rst
+++ b/doc/howto/generic-install-from-source.rst
@@ -43,11 +43,14 @@ To run NAV, these software packages are required:
 PostgreSQL and Graphite are services that do not necessarily need to run on
 the same server as NAV.
 
-The required Python modules can be installed either from your OS package
-manager, or from the Python Package Index (PyPI_) using the regular ``setup.py``
-method described below. The packages can also be installed from PyPI_ in a
-separate step, using the pip_ tool and the provided requirements and constraints
-files::
+While the required Python modules can be installed from your OS package
+manager, most distributions do not provide all of them, or cannot provide them
+in the required versions.  We recommend creating a Python virtual environment
+(virtualenv), which will ensure NAV's Python requirements do not interfere with
+your system Python libraries. Use pip_ to install all Python requirements
+from the Python Package Index (PyPI_), using the method described below. The
+packages can also be installed from PyPI_ in a separate step, using the pip_
+tool and the provided requirements and constraints files::
 
   pip install -r requirements.txt -c constraints.txt
 
@@ -90,13 +93,25 @@ the following command to build the CSS assets::
 This will build the CSS assets and place them in the :file:`python/nav/web/static/css`
 directory.
 
-To build and install NAV and all its Python dependencies::
+We recommend installing NAV into a Python virtual environment, to avoid
+interfering with your system-wide Python libraries.  Pick a suitable path for
+the virtual environment (e.g. :file:`/opt/nav`), create it and activate it in
+your shell before installing NAV::
+
+  python3 -m venv /opt/nav
+  source /opt/nav/bin/activate
+
+To build and install NAV and all its Python dependencies in the activated
+virtual environment, run::
 
   pip install -r requirements.txt -c constraints.txt .
 
-This will build and install NAV in the default system-wide directories for your
-system. If you wish to customize the install locations, please consult the
-output of ``python setup.py install --help``.
+If you want to make sure you can run all NAV programs without first explicitly
+activating the virtual environment in a shell, you can add the virtual
+environment's :file:`bin` directory to your system's :envvar:`PATH` variable,
+e.g.::
+
+  export PATH=$PATH:/opt/nav/bin
 
 
 .. _initializing-the-configuration-files:

--- a/doc/howto/manual-install-on-debian.rst
+++ b/doc/howto/manual-install-on-debian.rst
@@ -59,7 +59,7 @@ actually find :file:`nav.conf`::
 
 If you like, you can build the complete HTML documentation thus::
 
-    python setup.py build_sphinx
+    sphinx-build
 
 
 6. Initialize the database

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,0 @@
-from setuptools import setup
-
-setup(
-    setup_requires=['setuptools_scm'],
-)

--- a/tools/docker/build.sh
+++ b/tools/docker/build.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-if [[ ! -f "/source/setup.py" ]]; then
+if [[ ! -f "/source/pyproject.toml" ]]; then
   echo NAV source code does not appear to be mounted at /source
   exit 1
 fi


### PR DESCRIPTION
With `libsass` out of the way, and `setuptools_scm` long since updated, we no longer rely on having a minimal `setup.py` present.  It can be removed to complete the transition to `pyproject.toml`.

This PR removes the script and updates documentation and some scripts that referenced the old `setup.py` ways (which means this also fixes #3141)
