### PR TITLE
Uncrispify `StyleFormTwo` in styleguide

### DIFF
--- a/python/nav/web/styleguide.py
+++ b/python/nav/web/styleguide.py
@@ -17,8 +17,13 @@
 
 from django.shortcuts import render
 from django import forms
-from crispy_forms.helper import FormHelper
-from crispy_forms_foundation.layout import Layout, Column, Row, Fieldset
+
+from nav.web.crispyforms import (
+    FlatFieldset,
+    FormColumn,
+    FormRow,
+    set_flat_form_attributes,
+)
 
 
 class StyleFormOne(forms.Form):
@@ -36,17 +41,25 @@ class StyleFormTwo(forms.Form):
 
     def __init__(self, *args, **kwargs):
         super(StyleFormTwo, self).__init__(*args, **kwargs)
-        self.helper = FormHelper()
-        self.helper.form_action = ''
-        self.helper.form_method = 'POST'
-        self.helper.layout = Layout(
-            Fieldset(
-                'Address form',
-                Row(
-                    Column('name', css_class='small-6'),
-                    Column('address', css_class='small-6'),
-                ),
-            )
+
+        self.attrs = set_flat_form_attributes(
+            form_fields=[
+                FlatFieldset(
+                    legend="Address form",
+                    fields=[
+                        FormRow(
+                            fields=[
+                                FormColumn(
+                                    fields=[self["name"]], css_classes="small-6"
+                                ),
+                                FormColumn(
+                                    fields=[self["address"]], css_classes="small-6"
+                                ),
+                            ]
+                        )
+                    ],
+                )
+            ]
         )
 
 

--- a/python/nav/web/templates/styleguide.html
+++ b/python/nav/web/templates/styleguide.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-{% load crispy_forms_tags %}
 
 {% block base_header_additional_head %}
   <style>
@@ -416,8 +415,8 @@
         need to create forms - ask on mail/jabber/irc.
       </p>
 
-      {% crispy form1 %}
-      {% crispy form2 %}
+      {% include 'custom_crispy_templates/flat_form.html' with form=form1 %}
+      {% include 'custom_crispy_templates/flat_form.html' with form=form2 %}
 
     </div>
 


### PR DESCRIPTION
Closes #3179. 

Url: http://localhost/styleguide/

It looks slightly different now, but I think this is okay given it's the styleguide and this can be adapted in #3180. 