### PR TITLE
Add non-crispy checkbox

### DIFF
--- a/python/nav/web/crispyforms.py
+++ b/python/nav/web/crispyforms.py
@@ -27,6 +27,17 @@ class CheckBox(Field):
     template = 'custom_crispy_templates/horizontal_checkbox.html'
 
 
+class FormCheckBox:
+    """Checkbox suited for the NAV layout
+
+    :param field: A field to render as a checkbox field.
+    """
+
+    def __init__(self, field):
+        self.field = field
+        self.input_type = 'checkbox'
+
+
 class HelpField(Field):
     """Field that displays an icon with tooltip as helptext"""
 

--- a/python/nav/web/templates/custom_crispy_templates/_form_field.html
+++ b/python/nav/web/templates/custom_crispy_templates/_form_field.html
@@ -6,6 +6,8 @@
   {% include 'custom_crispy_templates/submit_field.html' with input=field %}
 {% elif field.input_type == 'helpfield' %}
   {% include 'custom_crispy_templates/field_helptext_as_icon.html' with field=field.field %}
+{% elif field.input_type == 'checkbox' %}
+  {% include 'custom_crispy_templates/form_checkbox.html' with field=field.field %}
 {% else %}
   {% show_field field %}
 {% endif %}

--- a/python/nav/web/templates/custom_crispy_templates/form_checkbox.html
+++ b/python/nav/web/templates/custom_crispy_templates/form_checkbox.html
@@ -1,0 +1,11 @@
+<div id="div_{{ field.auto_id }}" class="ctrlHolder{% if field.errors %} error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <label for="{{ field.id_for_label }}">
+        {{ field.label}}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+        {{ field }}
+    </label>
+    {% for error in field.errors %}
+        <small id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="errorField">
+            {{ error }}
+        </small>
+    {% endfor %}
+</div>


### PR DESCRIPTION
Replacement for the crispy-reliant `Checkbox`. Needed for #3174 

I think only `DetentionProfileForm` uses this, so once that is uncrispified this new checbox should probably be renamed to just "CheckBox" and the old be removed

