### PR TITLE
Remove fallback form rendering from uncrispified forms

### DIFF
--- a/python/nav/web/templates/alertprofiles/base_detail.html
+++ b/python/nav/web/templates/alertprofiles/base_detail.html
@@ -14,11 +14,7 @@
   </h4>
 
   <form action="{% block url_edit %}{% endblock %}" method="post" >
-    {% if form.attrs %}
-      {% include 'custom_crispy_templates/_form_content.html' %}
-    {% else %}
-      {{ form }}
-    {% endif %}
+    {% include 'custom_crispy_templates/_form_content.html' %}
 
     {% block form_additional_fields %}
     {% endblock %}

--- a/python/nav/web/templates/alertprofiles/subscription_form.html
+++ b/python/nav/web/templates/alertprofiles/subscription_form.html
@@ -83,11 +83,7 @@
               <a href="{% url 'alertprofiles-filter_groups-new' %}">Add your first filter group</a> to fix this problem.
             </div>
         {% endif %}
-          {% if form.attrs %}
-            {% include 'custom_crispy_templates/_form_content.html' %}
-          {% else %}
-            {{ form }}
-          {% endif %}
+          {% include 'custom_crispy_templates/_form_content.html' %}
           <input type="submit" value="{{ editing|yesno:"Save,Add" }}" class="button small"/>
         </div>
     </form>

--- a/python/nav/web/templates/alertprofiles/timeperiod_edit.html
+++ b/python/nav/web/templates/alertprofiles/timeperiod_edit.html
@@ -4,10 +4,6 @@
 
 <form action="{% url 'alertprofiles-profile-timeperiod-add' %}" method="post">
     <input type="hidden" name="valid_during" value="{{ time_period.valid_during }}" />
-    {% if time_period_form.attrs %}
-        {% include 'custom_crispy_templates/_form_content.html' with form=time_period_form %}
-    {% else %}
-        {{ time_period_form }}
-    {% endif %}
+    {% include 'custom_crispy_templates/_form_content.html' with form=time_period_form %}
 </form>
 {% endblock %}

--- a/python/nav/web/templates/alertprofiles/timeperiod_form.html
+++ b/python/nav/web/templates/alertprofiles/timeperiod_form.html
@@ -4,8 +4,4 @@
     <h4>Add new time period</h4>
 {% endif %}
 
-{% if time_period_form.attrs %}
-    {% include 'custom_crispy_templates/_form_content.html' with form=time_period_form %}
-{% else %}
-    {{ time_period_form }}
-{% endif %}
+{% include 'custom_crispy_templates/_form_content.html' with form=time_period_form %}

--- a/python/nav/web/templates/arnold/justifications.html
+++ b/python/nav/web/templates/arnold/justifications.html
@@ -50,11 +50,7 @@
 
         {% comment %} Form for creating new justifications {% endcomment %}
         <div class="medium-6 column">
-            {% if form.attrs %}
-                {% include 'custom_crispy_templates/flat_form.html' %}
-            {% else %}
-                {{ form }}
-            {% endif %}
+            {% include 'custom_crispy_templates/flat_form.html' %}
         </div>
 
     </div>

--- a/python/nav/web/templates/devicehistory/history_search.html
+++ b/python/nav/web/templates/devicehistory/history_search.html
@@ -10,11 +10,7 @@
     <form action="{% url 'devicehistory-search' %}" method="get">
         <div class="row">
             <div class="large-8 column">
-              {% if form.attrs %}
-                {% include 'custom_crispy_templates/_form_content.html' %}
-              {% else %}
-                {{ form }}
-              {% endif %}
+              {% include 'custom_crispy_templates/_form_content.html' %}
             </div>
         </div>
         <div class="row">

--- a/python/nav/web/templates/devicehistory/history_view.html
+++ b/python/nav/web/templates/devicehistory/history_view.html
@@ -11,11 +11,7 @@
             <input type="hidden" name="{{ type }}" value="{{ id }}" />
           {% endfor %}
         {% endfor %}
-        {% if form.attrs %}
-          {% include 'custom_crispy_templates/_form_content.html' %}
-        {% else %}
-          {{ form }}
-        {% endif %}
+        {% include 'custom_crispy_templates/_form_content.html' %}
         <input type="submit" class="button small" value="Filter">
       </form>
     </div>

--- a/python/nav/web/templates/ipdevinfo/modules.html
+++ b/python/nav/web/templates/ipdevinfo/modules.html
@@ -7,11 +7,7 @@
   <div class="row">
     <div class="medium-6 column">
       <form id="switchport_activity_recheck" action="" method="get">
-        {% if activity_interval_form.attrs %}
-          {% include 'custom_crispy_templates/_form_content.html' with form=activity_interval_form %}
-        {% else %}
-          {{ activity_interval_form }}
-        {% endif %}
+        {% include 'custom_crispy_templates/_form_content.html' with form=activity_interval_form %}
       </form>
     </div>
     <div class="medium-6 column">

--- a/python/nav/web/templates/ipdevinfo/search.html
+++ b/python/nav/web/templates/ipdevinfo/search.html
@@ -6,11 +6,7 @@
 
 <div class="row">
     <div class="column medium-6">
-        {% if search_form.attrs %}
-            {% include 'custom_crispy_templates/flat_form.html' with form=search_form %}
-        {% else %}
-            {{ search_form }}
-        {% endif %}
+        {% include 'custom_crispy_templates/flat_form.html' with form=search_form %}
     </div>
 </div>
 

--- a/python/nav/web/templates/ipdevinfo/sensor-details.html
+++ b/python/nav/web/templates/ipdevinfo/sensor-details.html
@@ -104,11 +104,7 @@
             Add to dashboard
           </button>
           <form method="post">
-            {% if form.attrs %}
-              {% include 'custom_crispy_templates/_form_content.html' %}
-            {% else %}
-              {{ form }}
-            {% endif %}
+            {% include 'custom_crispy_templates/_form_content.html' %}
             <button type="submit" class="button small">Update settings</button>
           </form>
         {% else %}

--- a/python/nav/web/templates/macwatch/addmacwatch.html
+++ b/python/nav/web/templates/macwatch/addmacwatch.html
@@ -5,11 +5,7 @@
     <div class="row">
         <div class="large-4 column">
             <a href="{% url 'listwatch' %}" class="button small secondary">Back</a>
-            {% if form.attrs %}
-                {% include 'custom_crispy_templates/flat_form.html' %}
-            {% else %}
-                {{ form }}
-            {% endif %}
+            {% include 'custom_crispy_templates/flat_form.html' %}
         </div>
     </div>
 

--- a/python/nav/web/templates/maintenance/new_task.html
+++ b/python/nav/web/templates/maintenance/new_task.html
@@ -35,11 +35,7 @@
         <div class="large-4 columns">
           <fieldset>
             <legend>Details</legend>
-            {% if task_form.attrs %}
-              {% include 'custom_crispy_templates/_form_content.html' with form=task_form %}
-            {% else %}
-              {{ task_form }}
-            {% endif %}
+            {% include 'custom_crispy_templates/_form_content.html' with form=task_form %}
           </fieldset>
         </div>
 

--- a/python/nav/web/templates/messages/save.html
+++ b/python/nav/web/templates/messages/save.html
@@ -23,11 +23,7 @@
 
   <div class="row">
     <div class="column medium-6">
-      {% if form.attrs %}
-        {% include 'custom_crispy_templates/flat_form.html' %}
-      {% else %}
-        {{ form }}
-      {% endif %}
+      {% include 'custom_crispy_templates/flat_form.html' %}
     </div>
   </div>
 

--- a/python/nav/web/templates/navlets/alert_edit.html
+++ b/python/nav/web/templates/navlets/alert_edit.html
@@ -12,11 +12,7 @@
   </p>
 
   <form action="{% url 'get-user-navlet' navlet.navlet_id %}" method="post">
-    {% if form.attrs %}
-      {% include 'custom_crispy_templates/_form_content.html' %}
-    {% else %}
-      {{ form }}
-    {% endif %}
+    {% include 'custom_crispy_templates/_form_content.html' %}
     <input type="submit" class="button tiny" value="Save">
     <a class="button tiny secondary cancel-button">Cancel</a>
   </form>

--- a/python/nav/web/templates/portadmin/base.html
+++ b/python/nav/web/templates/portadmin/base.html
@@ -22,11 +22,7 @@
 
   {% block page_content %}
 
-    {% if form.attrs %}
-      {% include 'custom_crispy_templates/flat_form.html' %}
-    {% else %}
-      {{ form }}
-    {% endif %}
+    {% include 'custom_crispy_templates/flat_form.html' %}
 
     {% block content %}
       {% if form.is_bound %}

--- a/python/nav/web/templates/seeddb/netbox_wizard.html
+++ b/python/nav/web/templates/seeddb/netbox_wizard.html
@@ -40,11 +40,7 @@
   </div>
 
   <form  id="seeddb-netbox-form" method="post">
-    {% if form.attrs %}
-      {% include 'seeddb/_seeddb_netbox_form_content.html' %}
-    {% else %}
-      {{ form }}
-    {% endif %}
+    {% include 'seeddb/_seeddb_netbox_form_content.html' %}
     <input type="submit" name="save_ip_device" value="Save IP device" class="submit button small left" id="submit-id-save_ip_device" />
   </form>
 

--- a/python/nav/web/templates/sortedstats/sortedstats.html
+++ b/python/nav/web/templates/sortedstats/sortedstats.html
@@ -22,11 +22,7 @@
     </div>
   {% endif %}
 
-  {% if form.attrs %}
-    {% include 'custom_crispy_templates/flat_form.html' %}
-  {% else %}
-    {{ form }}
-  {% endif %}
+  {% include 'custom_crispy_templates/flat_form.html' %}
 
   {# Display view if exists #}
   {% if result %}

--- a/python/nav/web/templates/status2/status.html
+++ b/python/nav/web/templates/status2/status.html
@@ -29,11 +29,7 @@
     {# Form for filtering events #}
     <a href="javascript:void(0);" class="button small secondary toggle-panel"></a>
     <div id="status-panel" class="hidden panel">
-      {% if form.attrs %}
-        {% include 'custom_crispy_templates/flat_form.html' %}
-      {% else %}
-        {{ form }}
-      {% endif %}
+      {% include 'custom_crispy_templates/flat_form.html' %}
     <hr>
       <a href="javascript:void(0);" class="button small secondary set-default">Save as my default status filter</a>
       <button id="clear-status-form" class="small secondary">Clear form</button>

--- a/python/nav/web/templates/threshold/set_threshold.html
+++ b/python/nav/web/templates/threshold/set_threshold.html
@@ -20,11 +20,7 @@
            data-url="{% url 'threshold-search' %}"
            data-renderurl="{% url 'threshold-graph' %}"
            data-metric="{{ metric|default_if_none:'' }}">
-        {% if form.attrs %}
-          {% include 'custom_crispy_templates/flat_form.html' %}
-        {% else %}
-          {{ form }}
-        {% endif %}
+        {% include 'custom_crispy_templates/flat_form.html' %}
       </div>
       {% if id %}
       <a href="#" data-dropdown="confirm-delete" class="button alert">Delete</a>

--- a/python/nav/web/templates/useradmin/group_detail.html
+++ b/python/nav/web/templates/useradmin/group_detail.html
@@ -77,11 +77,7 @@
             {% endif %}
 
             <h6>Add group member</h6>
-            {% if account_form.attrs %}
-              {% include 'custom_crispy_templates/flat_form.html' with form=account_form %}
-            {% else %}
-              {{ account_form }}
-            {% endif %}
+            {% include 'custom_crispy_templates/flat_form.html' with form=account_form %}
           </fieldset>
         </div>
         {# END GROUP MEMBERS #}

--- a/python/nav/web/templates/webfront/login.html
+++ b/python/nav/web/templates/webfront/login.html
@@ -48,11 +48,7 @@
         </div>
       {% endif %}
 
-      {% if form.attrs %}
-        {% include 'custom_crispy_templates/flat_form.html' %}
-      {% else %}
-        {{ form }}
-      {% endif %}
+      {% include 'custom_crispy_templates/flat_form.html' %}
 
       <small>
         <a href="#" data-reveal-id="auditlog-information">About audit logging in NAV</a>

--- a/python/nav/web/templates/webfront/preferences.html
+++ b/python/nav/web/templates/webfront/preferences.html
@@ -61,11 +61,7 @@
         </div>
 
         <div class="column medium-6 large-7">
-            {% if columns_form.attrs %}
-                {% include 'custom_crispy_templates/flat_form.html' with form=columns_form %}
-            {% else %}
-                {{ columns_form }}
-            {% endif %}
+            {% include 'custom_crispy_templates/flat_form.html' with form=columns_form %}
         </div>
 
     </div>
@@ -79,11 +75,7 @@
         </p>
     {% else %}
         <form method="post" id="change-password-form" action="{% url 'webfront-preferences-changepassword' %}">
-          {% if password_form.attrs %}
-            {% include 'custom_crispy_templates/_form_content.html' with form=password_form %}
-          {% else %}
-            {{ password_form }}
-          {% endif %}
+          {% include 'custom_crispy_templates/_form_content.html' with form=password_form %}
         </form>
     {% endif %}
 


### PR DESCRIPTION
We decided that the template [`web/templates/custom_crispy_templates/_form_content.html`](https://github.com/Uninett/nav/blob/10fe3c60ff833c8b130f1016cd5c8be0152fb02d/python/nav/web/templates/custom_crispy_templates/_form_content.html) has enough fallback by itself

For more information see #3140 and #3157.