### PR TITLE
Remove unused loading of crispy_forms_tags in templates

### DIFF
--- a/python/nav/web/templates/auditlog/base.html
+++ b/python/nav/web/templates/auditlog/base.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load crispy_forms_tags %}
 {% load tools %}
 
 {% block base_header_additional_head %}

--- a/python/nav/web/templates/info/location/upload.html
+++ b/python/nav/web/templates/info/location/upload.html
@@ -1,5 +1,4 @@
 {% extends "info/location/base.html" %}
-{% load crispy_forms_tags %}
 
 {% block base_header_additional_head %}
   <link href="{{ STATIC_URL }}css/nav/info_room.css" rel="stylesheet">

--- a/python/nav/web/templates/info/room/upload.html
+++ b/python/nav/web/templates/info/room/upload.html
@@ -1,5 +1,4 @@
 {% extends "info/room/base.html" %}
-{% load crispy_forms_tags %}
 
 {% block base_header_additional_head %}
   <link href="{{ STATIC_URL }}css/nav/info_room.css" rel="stylesheet">

--- a/python/nav/web/templates/webfront/login.html
+++ b/python/nav/web/templates/webfront/login.html
@@ -1,4 +1,3 @@
-{% load crispy_forms_tags %}
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
Another thing in preparation of completely removing crispy forms. These were forgotten in previous uncrispify PRs.