### PR TITLE
Make `css_classes` argument optional for `FormRow`

### DIFF
--- a/python/nav/web/crispyforms.py
+++ b/python/nav/web/crispyforms.py
@@ -96,7 +96,7 @@ class FormRow:
     :param css_classes: Additional CSS classes to apply to the row. Defaults to an empty string.
     """
 
-    def __init__(self, fields: list, css_classes: str = ''):
+    def __init__(self, fields: list, css_classes: Optional[str] = None):
         """Constructor method"""
         self.fields = fields
         self.css_classes = css_classes

--- a/python/nav/web/templates/custom_crispy_templates/form_row.html
+++ b/python/nav/web/templates/custom_crispy_templates/form_row.html
@@ -1,7 +1,7 @@
 {# NB! This form row can only render fields that are supported by custom_crispy_templates/_form_field.html #}
 
 <div
-    class="row {{ field.css_classes|default:'' }}"
+    class="row{% if field.css_classes %} {{ field.css_classes }}{% endif %}"
 >
   {% block formrow_content %}
     {% for field in field.fields %}


### PR DESCRIPTION
As discussed in #3169. This makes it a bit tidier. 