### PR TITLE
Allow periods in room/location IDs in API

### DIFF
--- a/changelog.d/3186.fixed.md
+++ b/changelog.d/3186.fixed.md
@@ -1,0 +1,1 @@
+Rooms and locations with periods in their IDs can now be properly retrieved from the corresponding API endpoints

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -330,6 +330,7 @@ class RoomViewSet(LoggerMixin, NAVAPIMixin, viewsets.ModelViewSet):
     queryset = manage.Room.objects.all()
     serializer_class = serializers.RoomSerializer
     filterset_fields = ('location', 'description')
+    lookup_value_regex = '[^/]+'
 
 
 class LocationViewSet(LoggerMixin, NAVAPIMixin, viewsets.ModelViewSet):
@@ -349,6 +350,7 @@ class LocationViewSet(LoggerMixin, NAVAPIMixin, viewsets.ModelViewSet):
     serializer_class = serializers.LocationSerializer
     filterset_fields = ('id', 'parent')
     search_fields = ('description',)
+    lookup_value_regex = '[^/]+'
 
 
 class UnrecognizedNeighborViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):

--- a/tests/integration/api_test.py
+++ b/tests/integration/api_test.py
@@ -192,6 +192,32 @@ def test_get_new_room(db, api_client, token):
     assert response.status_code == 200
 
 
+def test_when_room_has_dot_in_id_the_api_should_still_find_it(db, api_client, token):
+    create_token_endpoint(token, "room")
+    from nav.models.manage import Room
+
+    room = Room(id="foo.bar", location_id="mylocation")
+    room.save()
+
+    response = api_client.get(f"/api/1/room/{room.id}/")
+    print(response)
+    assert response.status_code == 200
+
+
+def test_when_location_has_dot_in_id_the_api_should_still_find_it(
+    db, api_client, token
+):
+    create_token_endpoint(token, "location")
+    from nav.models.manage import Location
+
+    location = Location(id="foo.bar")
+    location.save()
+
+    response = api_client.get(f"/api/1/location/{location.id}/")
+    print(response)
+    assert response.status_code == 200
+
+
 def test_patch_room_not_found(db, api_client, token):
     create_token_endpoint(token, 'room')
     data = {'location': 'mylocation'}


### PR DESCRIPTION
Django REST Framework's default regexp pattern for matching object primary keys explicitly disallowed `.` characters in IDs.  Periods are perfectly acceptable in room and location identifiers, and should be allowed.

This changes the lookup regex used for rooms and locations.

Fixes #3186 