### PR TITLE
Uncrispify portadmin navlet html template

### DIFF
--- a/python/nav/web/templates/navlets/portadmin_view.html
+++ b/python/nav/web/templates/navlets/portadmin_view.html
@@ -1,8 +1,7 @@
 {% extends 'navlets/base.html' %}
-{% load crispy_forms_tags %}
 
 {% block navlet-content %}
 
-  {% crispy form %}
+  {% include 'custom_crispy_templates/flat_form.html' %}
 
 {% endblock %}


### PR DESCRIPTION
This was forgotten in #3113.

How to get there:
Add a widget with the type "Portadmin" to the dashboard