### PR TITLE
Remove now unused crispy `HelpField`

### DIFF
--- a/python/nav/web/crispyforms.py
+++ b/python/nav/web/crispyforms.py
@@ -39,12 +39,6 @@ class FormCheckBox:
         self.template = 'custom_crispy_templates/form_checkbox.html'
 
 
-class HelpField(Field):
-    """Field that displays an icon with tooltip as helptext"""
-
-    template = 'custom_crispy_templates/field_helptext_as_icon.html'
-
-
 class HelpFormField:
     """Field that displays an icon with tooltip as helptext
 


### PR DESCRIPTION
After #3057, #3052 and #3058 were merged nothing uses `HelpField` anymore, so we can remove it. 