### PR TITLE
Remove unused crispy `CheckBox`

### DIFF
--- a/python/nav/web/arnold/forms.py
+++ b/python/nav/web/arnold/forms.py
@@ -20,8 +20,8 @@ from django import forms
 
 from nav.util import is_valid_ip, is_valid_mac
 from nav.web.crispyforms import (
+    CheckBox,
     FlatFieldset,
-    FormCheckBox,
     FormColumn,
     FormDiv,
     FormRow,
@@ -243,7 +243,7 @@ class DetentionProfileForm(forms.Form):
                                     fields=[self['keep_closed']], css_classes='medium-4'
                                 ),
                                 FormColumn(
-                                    fields=[FormCheckBox(self['exponential'])],
+                                    fields=[CheckBox(self['exponential'])],
                                     css_classes='medium-4',
                                 ),
                                 FormDiv(css_classes='medium-4 columns'),
@@ -254,7 +254,7 @@ class DetentionProfileForm(forms.Form):
                     ],
                     css_class='secondary',
                 ),
-                FormCheckBox(self['active']),
+                CheckBox(self['active']),
             ],
             submit_field=SubmitField(value='Save'),
         )

--- a/python/nav/web/crispyforms.py
+++ b/python/nav/web/crispyforms.py
@@ -20,7 +20,7 @@ from typing import Optional
 from django import forms
 
 
-class FormCheckBox:
+class CheckBox:
     """Checkbox suited for the NAV layout
 
     :param field: A field to render as a checkbox field.

--- a/python/nav/web/crispyforms.py
+++ b/python/nav/web/crispyforms.py
@@ -18,13 +18,6 @@ from types import SimpleNamespace
 from typing import Optional
 
 from django import forms
-from crispy_forms_foundation.layout import Field
-
-
-class CheckBox(Field):
-    """Checkbox suited for the NAV layout"""
-
-    template = 'custom_crispy_templates/horizontal_checkbox.html'
 
 
 class FormCheckBox:


### PR DESCRIPTION
Closes #3191. Its template `custom_crispy_templates/horizontal_checkbox.html` is still in use in `web/templates/webfront/_navbar_link_form.html`, so not removing that one. 