### PR TITLE
Remove `crispy-forms-foundation` and `django-crispy-forms` from requirements

### DIFF
--- a/NOTES.rst
+++ b/NOTES.rst
@@ -8,6 +8,18 @@ existing bug reports, go to https://github.com/uninett/nav/issues .
 To see an overview of upcoming release milestones and the issues they resolve,
 please go to https://github.com/uninett/nav/milestones .
 
+Unreleased
+==========
+
+Dependency changes
+------------------
+
+These Python modules are no longer required due to us rewriting forms in order
+to be able to upgrade to Python 3.11:
+
+* :mod:`django-crispy-forms`
+* :mod:`crispy-forms-foundation`
+
 NAV 5.11
 ========
 

--- a/changelog.d/2794.removed.md
+++ b/changelog.d/2794.removed.md
@@ -1,0 +1,1 @@
+Removed dependencies django-crispy-forms and crispy-forms-foundation

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -211,8 +211,6 @@ NAVLETS = (
     'nav.web.navlets.env_rack.EnvironmentRackWidget',
 )
 
-CRISPY_ALLOWED_TEMPLATE_PACKS = 'foundation-5'
-CRISPY_TEMPLATE_PACK = 'foundation-5'
 
 INSTALLED_APPS = (
     'nav.models',

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -222,8 +222,6 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.humanize',
     'django_filters',
-    'crispy_forms',
-    'crispy_forms_foundation',
     'rest_framework',
     'nav.auditlog',
     'nav.web.macwatch',

--- a/python/nav/web/crispyforms.py
+++ b/python/nav/web/crispyforms.py
@@ -13,7 +13,7 @@
 # more details.  You should have received a copy of the GNU General Public
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
-"""A collection of forms using the django crispy forms framework"""
+"""A collection of forms inspired by the django crispy forms framework"""
 from types import SimpleNamespace
 from typing import Optional
 
@@ -54,9 +54,6 @@ class NumberField(forms.IntegerField):
     """Input field with type set to number"""
 
     widget = NumberInput
-
-
-# For uncrispyfied forms:
 
 
 class FlatFieldset:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,8 +24,6 @@ dnspython<3.0.0,>=2.1.0
 
 django-filter>=2
 djangorestframework>=3.12,<3.13
-django-crispy-forms>=1.8,<1.9
-crispy-forms-foundation>=0.7,<0.8
 
 # REST framework
 iso8601


### PR DESCRIPTION
Removes `crispy-forms-foundation` and `django-crispy-forms` from requirements and necessary settings for those. Also changes some wording to not directly reference crispy