### PR TITLE
Refactor maintenance task views to improve display of deleted components

### DIFF
--- a/python/nav/models/fields.py
+++ b/python/nav/models/fields.py
@@ -20,6 +20,7 @@ import pickle
 import json
 from datetime import datetime
 from decimal import Decimal
+from typing import Optional
 
 from django import forms
 from django.db import models
@@ -234,11 +235,11 @@ class LegacyGenericForeignKey(object):
         setattr(instance, self.cache_attr, value)
 
     @staticmethod
-    def get_model_name(obj):
+    def get_model_name(obj) -> str:
         return obj._meta.db_table
 
     @staticmethod
-    def get_model_class(table_name):
+    def get_model_class(table_name) -> Optional[models.Model]:
         """Returns a Model class based on a database table name"""
         classmap = {model._meta.db_table: model for model in apps.get_models()}
         if table_name in classmap:

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -282,8 +282,8 @@ class Netbox(models.Model):
 
     class Meta(object):
         db_table = 'netbox'
-        verbose_name = 'ip device'
-        verbose_name_plural = 'ip devices'
+        verbose_name = 'IP device'
+        verbose_name_plural = 'IP devices'
         ordering = ('sysname',)
 
     def __str__(self):

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -1155,6 +1155,9 @@ class Location(models.Model, TreeMixin):
         locations = self.get_descendants(True)
         return Room.objects.filter(location__in=locations)
 
+    def get_absolute_url(self):
+        return reverse('location-info', kwargs={'locationid': self.pk})
+
 
 class Organization(models.Model, TreeMixin):
     """From NAV Wiki: The org table defines an organization which is in charge

--- a/python/nav/models/msgmaint.py
+++ b/python/nav/models/msgmaint.py
@@ -181,6 +181,7 @@ class MaintenanceComponent(models.Model):
     )
     key = VarcharField()
     value = VarcharField()
+    description = VarcharField(null=True, blank=True)
     component = LegacyGenericForeignKey('key', 'value')
 
     class Meta(object):

--- a/python/nav/models/msgmaint.py
+++ b/python/nav/models/msgmaint.py
@@ -191,6 +191,10 @@ class MaintenanceComponent(models.Model):
     def __str__(self):
         return u'%s=%s' % (self.key, self.value)
 
+    def get_component_class(self) -> models.Model:
+        """Returns a Model class based on the database table name stored in key"""
+        return LegacyGenericForeignKey.get_model_class(self.key)
+
 
 class MessageToMaintenanceTask(models.Model):
     """From NAV Wiki: The connection between messages and related maintenance

--- a/python/nav/models/sql/changes/sc.05.12.0001.sql
+++ b/python/nav/models/sql/changes/sc.05.12.0001.sql
@@ -1,0 +1,7 @@
+-- Add column to maint_component table to keep descriptions of components that can no longer referenced
+ALTER TABLE maint_component ADD COLUMN description VARCHAR;
+
+UPDATE maint_component c
+SET description = n.sysname
+FROM netbox n
+WHERE c.key = 'netbox' AND c.value = n.netboxid::text;

--- a/python/nav/web/maintenance/utils.py
+++ b/python/nav/web/maintenance/utils.py
@@ -24,6 +24,7 @@ from django.db import models
 from django.urls import reverse
 from django.utils.html import conditional_escape
 
+from nav.models.fields import LegacyGenericForeignKey
 from nav.models.manage import Netbox, Room, Location, NetboxGroup
 from nav.models.service import Service
 from nav.models.msgmaint import MaintenanceTask, MaintenanceComponent
@@ -191,68 +192,37 @@ def get_component_keys(post):
     return component_keys, errors
 
 
-def components_for_keys(component_keys):
-    component_data = {}
+def get_components_from_keydict(
+    component_keys: dict[str, List[Union[int, str]]]
+) -> tuple[List[ComponentType], List[str]]:
+    """Fetches components from a dictionary of component keys, typically as created
+    from POST data.
+
+    Returns a list of matched components and a list of errors encountered during the
+    process.  Again, this would be better handled by a Django Form class.
+    """
+    components = []
     component_data_errors = []
-    if component_keys['service']:
-        component_data['service'] = Service.objects.filter(
-            id__in=component_keys['service']
-        ).values(
-            'id',
-            'handler',
-            'netbox__id',
-            'netbox__sysname',
-            'netbox__ip',
-            'netbox__room__id',
-            'netbox__room__description',
-            'netbox__room__location__id',
-            'netbox__room__location__description',
+
+    for key, values in component_keys.items():
+        if not values:
+            continue
+        model_class = (
+            LegacyGenericForeignKey.get_model_class(key)
+            if key in ALLOWED_COMPONENTS
+            else None
         )
-        if not component_data['service']:
+        if not model_class:
+            component_data_errors.append(f"{key}: invalid component type")
+            continue
+
+        objects = model_class.objects.filter(id__in=component_keys[key])
+        components.extend(objects)
+        if not objects:
             component_data_errors.append(
-                "service: no elements with the given identifiers found"
+                f"{key}: no elements with the given identifiers found"
             )
-    if component_keys['netbox']:
-        component_data['netbox'] = Netbox.objects.filter(
-            id__in=component_keys['netbox']
-        ).values(
-            'id',
-            'sysname',
-            'ip',
-            'room__id',
-            'room__description',
-            'room__location__id',
-            'room__location__description',
-        )
-        if not component_data['netbox']:
-            component_data_errors.append(
-                "netbox: no elements with the given identifiers found"
-            )
-    if component_keys['room']:
-        component_data['room'] = Room.objects.filter(
-            id__in=component_keys['room']
-        ).values('id', 'description', 'location__id', 'location__description')
-        if not component_data['room']:
-            component_data_errors.append(
-                "room: no elements with the given identifiers found"
-            )
-    if component_keys['location']:
-        component_data['location'] = Location.objects.filter(
-            id__in=component_keys['location']
-        ).values('id', 'description')
-        if not component_data['location']:
-            component_data_errors.append(
-                "location: no elements with the given identifiers found"
-            )
-    if component_keys['netboxgroup']:
-        component_data['netboxgroup'] = NetboxGroup.objects.filter(
-            id__in=component_keys['netboxgroup']
-        ).values('id', 'description')
-        if not component_data['netboxgroup']:
-            component_data_errors.append(
-                "netboxgroup: no elements with the given identifiers found"
-            )
-    return component_data, component_data_errors
+    return components, component_data_errors
 
 
 def structure_component_data(component_data):

--- a/python/nav/web/maintenance/utils.py
+++ b/python/nav/web/maintenance/utils.py
@@ -21,6 +21,7 @@ from time import strftime
 from typing import Union, List, Iterator
 
 from django.db import models
+from django.db.models import IntegerField
 from django.urls import reverse
 from django.utils.html import conditional_escape
 
@@ -31,7 +32,14 @@ from nav.models.msgmaint import MaintenanceTask, MaintenanceComponent
 
 ALLOWED_COMPONENTS = ('service', 'netbox', 'room', 'location', 'netboxgroup')
 
-PRIMARY_KEY_INTEGER = ('netbox', 'service')
+PRIMARY_KEY_INTEGER = [
+    table
+    for table in ALLOWED_COMPONENTS
+    if isinstance(
+        LegacyGenericForeignKey.get_model_class(table)._meta.get_field('id'),
+        IntegerField,
+    )
+]
 
 NAVPATH = [
     ('Home', '/'),

--- a/python/nav/web/maintenance/views.py
+++ b/python/nav/web/maintenance/views.py
@@ -273,11 +273,11 @@ def edit(request, task_id=None, start_time=None, **_):
         component_data, component_data_errors = components_for_keys(component_keys)
         components = structure_component_data(component_data)
         component_trail = task_component_trails(component_keys, components)
-        if component_data_errors:
-            new_message(request, ",".join(component_data_errors), Messages.ERROR)
+        for error in component_data_errors:
+            new_message(request, error, Messages.ERROR)
 
-    if component_keys_errors:
-        new_message(request, ",".join(component_keys_errors), Messages.ERROR)
+    for error in component_keys_errors:
+        new_message(request, error, Messages.ERROR)
 
     if request.method == 'POST':
         if 'save' in request.POST:

--- a/python/nav/web/maintenance/views.py
+++ b/python/nav/web/maintenance/views.py
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2011 Uninett AS
+# Copyright (C) 2024 Sikt
 #
 # This file is part of Network Administration Visualized (NAV).
 #
@@ -15,36 +16,41 @@
 #
 
 import logging
-
 import time
 from datetime import datetime
 
-from django.db import transaction, connection
+from django.db import connection, transaction
 from django.db.models import Count, Q
-from django.shortcuts import render, get_object_or_404, redirect
 from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 
+import nav.maintengine
 from nav.django.utils import get_account
 from nav.models.manage import Netbox
-from nav.models.msgmaint import MaintenanceTask, MaintenanceComponent
-from nav.web.message import new_message, Messages
-from nav.web.quickselect import QuickSelect
-
-from nav.web.maintenance.utils import (
-    components_for_keys,
-    get_components,
-    component_to_trail,
+from nav.models.msgmaint import MaintenanceComponent, MaintenanceTask
+from nav.web.maintenance.forms import (
+    MaintenanceAddSingleNetbox,
+    MaintenanceCalendarForm,
+    MaintenanceTaskForm,
 )
-from nav.web.maintenance.utils import task_component_trails
-from nav.web.maintenance.utils import get_component_keys, PRIMARY_KEY_INTEGER
-from nav.web.maintenance.utils import structure_component_data
-from nav.web.maintenance.utils import task_form_initial, infodict_by_state
-from nav.web.maintenance.utils import MaintenanceCalendar, NAVPATH, TITLE
-from nav.web.maintenance.forms import MaintenanceTaskForm, MaintenanceCalendarForm
-from nav.web.maintenance.forms import MaintenanceAddSingleNetbox
-import nav.maintengine
+from nav.web.maintenance.utils import (
+    NAVPATH,
+    PRIMARY_KEY_INTEGER,
+    TITLE,
+    MaintenanceCalendar,
+    component_to_trail,
+    components_for_keys,
+    get_component_keys,
+    get_components,
+    infodict_by_state,
+    structure_component_data,
+    task_component_trails,
+    task_form_initial,
+)
+from nav.web.message import Messages, new_message
+from nav.web.quickselect import QuickSelect
 
 INFINITY = datetime.max
 

--- a/python/nav/web/maintenance/views.py
+++ b/python/nav/web/maintenance/views.py
@@ -36,6 +36,7 @@ from nav.web.maintenance.forms import (
     MaintenanceTaskForm,
 )
 from nav.web.maintenance.utils import (
+    ALLOWED_COMPONENTS,
     NAVPATH,
     PRIMARY_KEY_INTEGER,
     TITLE,
@@ -255,13 +256,7 @@ def edit(request, task_id=None, start_time=None, **_):
         component_keys, component_keys_errors = get_component_keys(request.POST)
 
     elif task:
-        component_keys = {
-            'service': [],
-            'netbox': [],
-            'room': [],
-            'location': [],
-            'netboxgroup': [],
-        }
+        component_keys = {key: [] for key in ALLOWED_COMPONENTS}
         for key, value in task.maintenance_components.values_list('key', 'value'):
             if key in PRIMARY_KEY_INTEGER:
                 value = int(value)

--- a/python/nav/web/maintenance/views.py
+++ b/python/nav/web/maintenance/views.py
@@ -32,7 +32,11 @@ from nav.models.msgmaint import MaintenanceTask, MaintenanceComponent
 from nav.web.message import new_message, Messages
 from nav.web.quickselect import QuickSelect
 
-from nav.web.maintenance.utils import components_for_keys
+from nav.web.maintenance.utils import (
+    components_for_keys,
+    get_components,
+    component_to_trail,
+)
 from nav.web.maintenance.utils import task_component_trails
 from nav.web.maintenance.utils import get_component_keys, PRIMARY_KEY_INTEGER
 from nav.web.maintenance.utils import structure_component_data
@@ -189,25 +193,8 @@ def historic(request):
 
 def view(request, task_id):
     task = get_object_or_404(MaintenanceTask, pk=task_id)
-    maint_components = MaintenanceComponent.objects.filter(
-        maintenance_task=task.id
-    ).values_list('key', 'value')
-
-    component_keys = {
-        'service': [],
-        'netbox': [],
-        'room': [],
-        'location': [],
-        'netboxgroup': [],
-    }
-    for key, value in maint_components:
-        if key in PRIMARY_KEY_INTEGER:
-            value = int(value)
-        component_keys[key].append(value)
-
-    component_data, _ = components_for_keys(component_keys)
-    components = structure_component_data(component_data)
-    component_trail = task_component_trails(component_keys, components)
+    components = get_components(task)
+    component_trail = [component_to_trail(c) for c in components]
 
     heading = 'Task "%s"' % task.description
     infodict = infodict_by_state(task)

--- a/python/nav/web/templates/maintenance/details.html
+++ b/python/nav/web/templates/maintenance/details.html
@@ -1,4 +1,5 @@
 {% extends "maintenance/base.html" %}
+{% load maintenance %}
 
 {% block content %}
 
@@ -43,20 +44,13 @@
           <td>
             {% if components %}
               <ul class="no-bullet">
-                {% for comp in components %}
-                  <li>
-                    {{ comp.title|capfirst }}:
-                    {% for elem in comp.trail %}
-                      {% if elem.url %}
-                        <a href="{{ elem.url }}" title="{{ elem.title }}">{{ elem.name }}</a>
-                      {% else %}
-                        {{ elem.name }}
-                      {% endif %}
-                      {% if not forloop.last %}
-                        &rarr;
-                      {% endif %}
-                    {% endfor %}
-                  </li>
+                {% for trail in components %}
+                    <li>
+                        {% with trail|last as component %}
+                            {{ component|model_verbose_name }}:
+                            {% include "maintenance/frag-component-trail.html" %}
+                        {% endwith %}
+                    </li>
                 {% endfor %}
               </ul>
             {% else %}

--- a/python/nav/web/templates/maintenance/frag-component-trail.html
+++ b/python/nav/web/templates/maintenance/frag-component-trail.html
@@ -1,0 +1,11 @@
+{% load maintenance %}
+{% for element in trail %}
+    {% with element|component_name as title %}
+        {% if element.get_absolute_url %}
+            <a href="{{ element.get_absolute_url }}" title="{{ title }}">{{ title }}</a>
+        {% else %}
+            {{ title }}
+        {% endif %}
+    {% endwith %}
+    {% if not forloop.last %} → {% endif %}
+{% endfor %}

--- a/python/nav/web/templates/maintenance/new_task.html
+++ b/python/nav/web/templates/maintenance/new_task.html
@@ -1,4 +1,5 @@
 {% extends "maintenance/base.html" %}
+{% load maintenance %}
 
 {% block base_header_additional_head %}
   {{ block.super }}
@@ -57,26 +58,19 @@
 
             {% if components %}
               <ul id="component-list" class="no-bullet">
-                {% for comp in components %}
-                  <li>
-                    <div>
-                      <input type="hidden" name="{{ comp.type }}" value="{{ comp.id }}"/>
-                      <input type="checkbox" name="remove_{{ comp.type }}" value="{{ comp.id }}"/>
-                      {{ comp.title|capfirst }}:
-                    </div>
-                    <div>
-                      {% for elem in comp.trail %}
-                        {% if elem.url %}
-                          <a href="{{ elem.url }}" title="{{ elem.title }}">{{ elem.name }}</a>
-                        {% else %}
-                          {{ elem.name }}
-                        {% endif %}
-                        {% if not forloop.last %}
-                          &rarr;
-                        {% endif %}
-                      {% endfor %}
-                    </div>
-                  </li>
+                {% for trail in components %}
+                    {% with trail|last as component %}
+                      <li>
+                        <div>
+                          <input type="hidden" name="{{ component|component_db_table }}" value="{{ component.pk }}"/>
+                          <input type="checkbox" name="remove_{{ component|component_db_table }}" value="{{ component.pk }}"/>
+                            {{ component|model_verbose_name }}:
+                        </div>
+                        <div>
+                          {% include "maintenance/frag-component-trail.html" %}
+                        </div>
+                      </li>
+                    {% endwith %}
                 {% endfor %}
               </ul>
               <input type="submit" name="remove"


### PR DESCRIPTION
This fixes #3228, but it was not feasible without a significant refactoring of the maintenance task UI codebase.

The codebase originally stems from a time before Django was added to NAV, and was significantly convoluted compared to what it needs to be.  This PR makes it slightly less so, but there is still some way to go:

There was a lot of processing and custom validation code for the component fields of the maintenance task forms, which ended up producing large hierarchies of dicts and lists (some of which were fed directly to templates), instead of re-using ORM functionality.  While much of the processing would be best encapsulated in Django Forms, this refactor mostly concerns itself with using ORM objects where we can.

The ultimate goal was really only to be able to display deleted components in a better way, by utilizing a new component `description` field.  This is achieved in this PR by replacing the template render data witch actual lists of Django model objects, and by replacing the missing objects with a special `MissingComponent` class.

Please do ask for clarifications if necessary.