### PR TITLE
Show error message on trying to delete last dashboard

### DIFF
--- a/python/nav/web/static/js/src/webfront.js
+++ b/python/nav/web/static/js/src/webfront.js
@@ -289,7 +289,7 @@ require([
                     window.location = '/';
                 });
                 request.fail(function (response) {
-                    feedback.addFeedback(response, 'error');
+                    feedback.addFeedback(response.responseText, 'error');
                 });
             }
         });

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -24,6 +24,7 @@ from operator import attrgetter
 from urllib.parse import quote as urlquote
 
 from django.http import (
+    HttpResponseBadRequest,
     HttpResponseForbidden,
     HttpResponseRedirect,
     HttpResponse,
@@ -428,7 +429,7 @@ def delete_dashboard(request, did):
     """Delete this dashboard and all widgets on it"""
     is_last = AccountDashboard.objects.filter(account=request.account).count() == 1
     if is_last:
-        return HttpResponse('Can not delete last dashboard', status=400)
+        return HttpResponseBadRequest('Cannot delete last dashboard')
 
     dash = get_object_or_404(AccountDashboard, pk=did, account=request.account)
     dash.delete()

--- a/tests/integration/web/webfront_test.py
+++ b/tests/integration/web/webfront_test.py
@@ -68,6 +68,20 @@ def test_set_default_dashboard_with_multiple_previous_defaults_should_succeed(
     )
 
 
+def test_delete_last_dashboard_should_fail(db, client, admin_account):
+    """Tests that the last dashboard cannot be deleted"""
+    dashboard = AccountDashboard.objects.get(
+        is_default=True,
+        account=admin_account,
+    )
+    url = reverse("delete-dashboard", args=(dashboard.pk,))
+    response = client.post(url, follow=True)
+
+    assert response.status_code == 400
+    assert "Cannot delete last dashboard" in smart_str(response.content)
+    assert AccountDashboard.objects.filter(id=dashboard.id).exists()
+
+
 def test_when_logging_in_it_should_change_the_session_id(
     db, client, admin_username, admin_password
 ):


### PR DESCRIPTION
This is not an actual bug, but something I noticed when working on #3150. 

The "Delete dashboard" button is already not shown when there is only one dashboard, so it is not possible for a user to try to delete their last dashboard.

So to reproduce this you need to change this line to actually show that button:
https://github.com/Uninett/nav/blob/27b12b527aac40a9702cc515981346e21eab89bf/python/nav/web/templates/webfront/index.html#L147

After that when trying to delete the last dashboard an alert box will be added with the content `[Object object]` instead of showing the correct error message `Cannot delete last dashboard`.

Before: 
![image](https://github.com/user-attachments/assets/f0ec672e-b736-4a6f-9c9e-bf3b2cb59247)

After:
![image](https://github.com/user-attachments/assets/9de65f6b-aa4b-4f90-9452-802d066ac517)
