### PR TITLE
Disable deleting of default dashboard

### DIFF
--- a/changelog.d/3150.fixed.md
+++ b/changelog.d/3150.fixed.md
@@ -1,0 +1,1 @@
+Disable deletion of the default dashboard

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -432,6 +432,10 @@ def delete_dashboard(request, did):
         return HttpResponseBadRequest('Cannot delete last dashboard')
 
     dash = get_object_or_404(AccountDashboard, pk=did, account=request.account)
+
+    if dash.is_default:
+        return HttpResponseBadRequest('Cannot delete default dashboard')
+
     dash.delete()
 
     return HttpResponse('Dashboard deleted')

--- a/tests/integration/web/webfront_test.py
+++ b/tests/integration/web/webfront_test.py
@@ -82,6 +82,27 @@ def test_delete_last_dashboard_should_fail(db, client, admin_account):
     assert AccountDashboard.objects.filter(id=dashboard.id).exists()
 
 
+def test_delete_default_dashboard_should_fail(db, client, admin_account):
+    """Tests that the default dashboard cannot be deleted"""
+    # Creating another dashboard, so that default is not the last one
+    AccountDashboard.objects.create(
+        name="non_default",
+        is_default=False,
+        account=admin_account,
+    )
+
+    default_dashboard = AccountDashboard.objects.get(
+        is_default=True,
+        account=admin_account,
+    )
+    url = reverse("delete-dashboard", args=(default_dashboard.pk,))
+    response = client.post(url, follow=True)
+
+    assert response.status_code == 400
+    assert "Cannot delete default dashboard" in smart_str(response.content)
+    assert AccountDashboard.objects.filter(id=default_dashboard.id).exists()
+
+
 def test_when_logging_in_it_should_change_the_session_id(
     db, client, admin_username, admin_password
 ):


### PR DESCRIPTION
This will disable deleting of a dashboard if it is the default on and show an alert box why it was not possible to delete the dashboard. 

![image](https://github.com/user-attachments/assets/9e519cc3-ef2b-46aa-944a-66e706dc9810)
