### PR TITLE
Hide "Delete dashboard" button for default dashboard

### DIFF
--- a/python/nav/web/static/js/src/webfront.js
+++ b/python/nav/web/static/js/src/webfront.js
@@ -210,7 +210,8 @@ require([
     function addDefaultDashboardListener(feedback) {
         var defaultDashboardContainer = $('#default-dashboard-container'),
             setDefaultDashboardForm = $('#form-set-default-dashboard'),
-            isDefaultDashboardAlert = defaultDashboardContainer.find('.alert-box');
+            isDefaultDashboardAlert = defaultDashboardContainer.find('.alert-box'),
+            deleteDashboardForm = $('#form-delete-dashboard');
 
         if (defaultDashboardContainer.data('is-default-dashboard')) {
             setDefaultDashboardForm.hide();
@@ -226,6 +227,7 @@ require([
                 feedback.addFeedback(responseText);
                 setDefaultDashboardForm.hide();
                 isDefaultDashboardAlert.show();
+                deleteDashboardForm.hide();
                 $dashboardNavigator.find('.fa-star').addClass('hidden');
                 $dashboardNavigator.find('.current .fa-star').removeClass('hidden');
             });

--- a/python/nav/web/templates/webfront/index.html
+++ b/python/nav/web/templates/webfront/index.html
@@ -144,7 +144,7 @@
         </div>
 
         <div class="column medium-4">
-          {% if request.account.account_dashboards.count > 1 %}
+          {% if request.account.account_dashboards.count > 1 and not dashboard.is_default %}
             <form id="form-delete-dashboard" method="post" action="{% url 'delete-dashboard' dashboard.pk %}">
               <input type="submit" class="small button alert expand" value="Delete dashboard">
             </form>


### PR DESCRIPTION
Dependent on #3233. Another potential part of the fix for #3150.

This hides the "Delete dashboard" button for the default dashboard. Up for discussion if this is how we want to prevent the user from trying to delete the default dashboard.

But this is how it is done for the case where the current dashboard is the last dashboard. 

Before:
![image](https://github.com/user-attachments/assets/d6f351a3-ed7b-4212-88a0-02563a082c6c)

After: 
![image](https://github.com/user-attachments/assets/6584a429-4846-4cdf-99f6-0c2813bd19e0)
