### PR TITLE
Ensure every account has exactly one default dashboard

### DIFF
--- a/changelog.d/+migration-one-default-dashboard.fixed.md
+++ b/changelog.d/+migration-one-default-dashboard.fixed.md
@@ -1,0 +1,1 @@
+Ensure that each account has exactly one default dashboard

--- a/python/nav/models/sql/changes/sc.05.12.0001.sql
+++ b/python/nav/models/sql/changes/sc.05.12.0001.sql
@@ -1,0 +1,20 @@
+-- This migration is to ensure that for accounts that don't have a default
+-- dashboard we set a default dashboard
+
+-- This part finds the row with the lowest id for any account that does not
+-- have a default dashboard
+WITH CTE AS (
+  SELECT MIN(id) as id
+  FROM account_dashboard a
+  WHERE NOT EXISTS (
+    SELECT 1 
+    FROM account_dashboard b 
+    WHERE a.account_id = b.account_id 
+    AND b.is_default = TRUE
+  )
+  GROUP BY account_id
+)
+-- And this part sets is_default for that row to true
+UPDATE account_dashboard
+SET is_default = TRUE
+WHERE id IN (SELECT id FROM CTE);

--- a/python/nav/models/sql/changes/sc.05.12.0002.sql
+++ b/python/nav/models/sql/changes/sc.05.12.0002.sql
@@ -1,0 +1,21 @@
+-- This migration is to ensure that for accounts that have more than one
+-- default dashboard we set is_default to false for all except for one
+
+UPDATE account_dashboard
+SET is_default = FALSE
+WHERE id NOT IN (
+  -- This part finds the lowest id of the default dashboards for each
+  -- account_id 
+  SELECT MIN(id)
+  FROM account_dashboard
+  WHERE is_default = TRUE
+  GROUP BY account_id
+)
+AND account_id IN (
+  -- This part finds all account_ids that have more than one default dashboard
+  SELECT account_id
+  FROM account_dashboard
+  WHERE is_default = TRUE
+  GROUP BY account_id
+  HAVING COUNT(account_id) > 1
+)


### PR DESCRIPTION
Another part of fixing #3150.

As mentioned in there it is possible to delete ones default dashboard and no other is set to be default instead, essentially meaning a user can have no default dashboards. We also observed that it has somehow been possible to set multiple dashboards as default (see #2680), we still don't know how that has been possible and if it is still possible. 

This PR adds two migrations:
- the first one will find all accounts that have no default dashboard and set one to default
- the second one will find all accounts that have more than one default dashboard and remove the default marker from all but one 

Since it has not been possible to delete the last dashboard (as seen in #3232) we can assume that each account has at least one dashboard. 