### PR TITLE
Update list limits for alert profiles dropdowns

### DIFF
--- a/changelog.d/2908.fixed.md
+++ b/changelog.d/2908.fixed.md
@@ -1,0 +1,1 @@
+Alert profiles filter match value dropdowns now support more than the old hard limit of 1000 choices

--- a/python/nav/models/sql/changes/sc.05.12.0100.sql
+++ b/python/nav/models/sql/changes/sc.05.12.0100.sql
@@ -1,0 +1,5 @@
+-- Increase alertprofiles dropdown list limits
+UPDATE matchfield
+SET list_limit = 10000
+WHERE show_list
+  AND list_limit = 1000;


### PR DESCRIPTION
For some long-forgotten reason, there are limits configured on the length of dropdown lists in Alert Profiles: One value per match field is set in the database.  The limits are set to 1000 for all fields, but some users do in fact have more than 1000 communication rooms registered in their NAV installations.

The code does not allow unlimited lengths, so a quickfix for now is to increase the limit ten-fold.  A more long-term fix would be to look into why there are limitations at all (aside from the fact that selecting from a dropdown with > 1000 values and no search functionality is bad UX)

Fixes #2908