### PR TITLE
Make alert profiles match value dropdown lists searchable using `select2`

### DIFF
--- a/changelog.d/3238.added.md
+++ b/changelog.d/3238.added.md
@@ -1,0 +1,1 @@
+Alert profiles filter match value dropdowns now support interactive value searches

--- a/python/nav/web/alertprofiles/forms.py
+++ b/python/nav/web/alertprofiles/forms.py
@@ -734,6 +734,7 @@ class ExpressionForm(forms.ModelForm):
 
                 # At last we acctually add the multiple choice field.
                 self.fields['value'] = forms.MultipleChoiceField(choices=choices)
+                self.fields['value'].widget.attrs['class'] = 'select2'
             else:
                 self.fields['value'] = forms.CharField(required=True)
 


### PR DESCRIPTION
This makes multiple choice drop down lists in Alert Profiles filter searchable using `select2`, which makes it a lot easier to find desired values when the choice lists become huge.

Fixes #3238

Url: http://localhost/alertprofiles/filters/add-expression/

### Screenshot

![image](https://github.com/user-attachments/assets/a218a6f2-a152-48f3-8c7e-8966951e9f3f)
