### PR TITLE
Upgrade ruff to 0.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.4
+    rev: v0.8.0
     hooks:
       - id: ruff
 -   repo: https://github.com/twisted/towncrier


### PR DESCRIPTION
This is the same as in the newest MegaLinter release ([8.3.0](https://github.com/oxsecurity/megalinter/releases/tag/v8.3.0))