### PR TITLE
Lock Github workflows to `ubuntu-22.04` image

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-and-test:
     name: "Test on Python ${{ matrix.python-version}}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       max-parallel: 4
@@ -128,7 +128,7 @@ jobs:
 
   javascript:
     name: "Test Javascript code"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: browser-actions/setup-chrome@latest
@@ -157,7 +157,7 @@ jobs:
 
   upload-pr-number-base-sha:
     name: Save PR number and base SHA in artifact
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.event.number && always() }}
     env:
       PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/dockercompose.yml
+++ b/.github/workflows/dockercompose.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-docker-compose:
     name: "Build docker-compose-based development environment"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   megalinter:
     name: MegaLinter
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       # Give the linter write permission to comment on PRs (if PR is not from fork)
       issues: write

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   publish-test-results:
     name: "Publish test results"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.workflow_run.conclusion != 'skipped' && github.repository_owner == 'Uninett'
 
     steps:

--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   towncrier:
     if: ${{ github.actor != 'dependabot[bot]' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Towncrier check
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
ubuntu-latest has moved to 24.04 and there seems to be problems with running the CI workflows on that version.  This locks all workflows to ubuntu-22.04 until we can figure out the issues.