### PR TITLE
Upgrade test container image to Ubuntu 24.04

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -10,8 +10,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ### Installing packages
 RUN sed -ie 's/^# *deb-src/deb-src/' /etc/apt/sources.list  # Enable source repos
 RUN apt-get update && \
-    apt-get install -y software-properties-common gosu sudo && \
-    chmod u+s /usr/sbin/gosu
+    apt-get install -y software-properties-common gosu sudo
 
 RUN echo "build   ALL =(ALL: ALL) NOPASSWD: ALL" > /etc/sudoers.d/navbuild
 

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ### Installing packages
 RUN sed -ie 's/^# *deb-src/deb-src/' /etc/apt/sources.list  # Enable source repos
 RUN apt-get update && \
-    apt-get install -y software-properties-common gosu sudo
+    apt-get install -y software-properties-common gosu sudo unzip
 
 RUN echo "build   ALL =(ALL: ALL) NOPASSWD: ALL" > /etc/sudoers.d/navbuild
 
@@ -61,8 +61,6 @@ RUN cd /tmp && \
 # Ref: https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json
 ENV CHROMEDRIVERVERSION=131.0.6778.69
 RUN cd /tmp && \
-    apt-get update && \
-    apt-get -y --no-install-recommends install unzip && \
     wget https://storage.googleapis.com/chrome-for-testing-public/$CHROMEDRIVERVERSION/linux64/chromedriver-linux64.zip && \
     unzip chromedriver-linux64.zip && \
     mv chromedriver-linux64/chromedriver /usr/local/bin/

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Full integration test image for NAV
 #
-FROM ubuntu:focal
+FROM ubuntu:24.04
 
 ENV DISTRO=noble
 ENV DISPLAY=:99
@@ -8,7 +8,7 @@ ENV ADMINPASSWORD=omicronpersei8
 ENV DEBIAN_FRONTEND=noninteractive
 
 ### Installing packages
-RUN sed -ie 's/^# *deb-src/deb-src/' /etc/apt/sources.list  # Enable source repos
+RUN sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources  # Enable source repos
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
@@ -24,9 +24,9 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     apt-get update && \
     apt-get -y install --no-install-recommends \
       curl git build-essential \
-      python3.9-dbg python3.9-dev \
-      python3.10-dbg python3.10-dev \
-      python3.11-dbg python3.11-dev \
+      python3.9-dbg python3.9-dev python3.9-venv \
+      python3.10-dbg python3.10-dev python3.10-venv \
+      python3.11-dbg python3.11-dev python3.11-venv \
       python3-pip
 
 RUN echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
@@ -43,7 +43,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     apt-get update && \
     apt-get -y --no-install-recommends install \
-	libsnmp35 \
+	libsnmp40 \
 	cron \
 	libjpeg62 \
 	postgresql postgresql-contrib postgresql-client \
@@ -76,8 +76,10 @@ RUN cd /tmp && \
     unzip chromedriver-linux64.zip && \
     mv chromedriver-linux64/chromedriver /usr/local/bin/
 
-# Install our primary test runner
-RUN python3.9 -m pip install tox virtualenv
+# Install required Python tools in a virtualenv, as required by Ubuntu
+ENV PATH=/opt/venvs/nav/bin:$PATH
+RUN python3.9 -m venv /opt/venvs/nav && \
+    /opt/venvs/nav/bin/pip install --upgrade pip setuptools tox
 
 # Add a build user
 ENV USER=build

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -2,10 +2,10 @@
 #
 FROM ubuntu:focal
 
-ENV DISTRO focal
-ENV DISPLAY :99
-ENV ADMINPASSWORD omicronpersei8
-ENV DEBIAN_FRONTEND noninteractive
+ENV DISTRO=noble
+ENV DISPLAY=:99
+ENV ADMINPASSWORD=omicronpersei8
+ENV DEBIAN_FRONTEND=noninteractive
 
 ### Installing packages
 RUN sed -ie 's/^# *deb-src/deb-src/' /etc/apt/sources.list  # Enable source repos
@@ -71,13 +71,13 @@ RUN cd /tmp && \
 RUN python3.9 -m pip install tox virtualenv
 
 # Add a build user
-ENV USER build
+ENV USER=build
 RUN adduser --system --group --home=/source --shell=/bin/bash $USER && \
     mkdir -p /usr/share/nav/var/uploads && \
     chown -R $USER /usr/share/nav
 
-ENV WORKSPACE /source
-ENV HOME /source
+ENV WORKSPACE=/source
+ENV HOME=/source
 
 COPY scripts/ /
 WORKDIR /source

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -9,13 +9,18 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 ### Installing packages
 RUN sed -ie 's/^# *deb-src/deb-src/' /etc/apt/sources.list  # Enable source repos
-RUN apt-get update && \
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+    --mount=target=/var/cache/apt,type=cache,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && \
     apt-get install -y software-properties-common gosu sudo unzip
 
 RUN echo "build   ALL =(ALL: ALL) NOPASSWD: ALL" > /etc/sudoers.d/navbuild
 
 
-RUN add-apt-repository ppa:deadsnakes/ppa && \
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+    --mount=target=/var/cache/apt,type=cache,sharing=locked \
+    add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get -y install --no-install-recommends \
       curl git build-essential \
@@ -28,11 +33,15 @@ RUN echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sou
 # 78BD65473CB3BD13 Google signing key for chrome (for selenium, functional tests)
 RUN apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys 78BD65473CB3BD13
 
-RUN apt-get update && \
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+    --mount=target=/var/cache/apt,type=cache,sharing=locked \
+    apt-get update && \
     apt-get -y --no-install-recommends build-dep \
 	python3-psycopg2 python3-lxml python3-pil python3-ldap
 
-RUN apt-get update && \
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+    --mount=target=/var/cache/apt,type=cache,sharing=locked \
+    apt-get update && \
     apt-get -y --no-install-recommends install \
 	libsnmp35 \
 	cron \
@@ -47,7 +56,9 @@ RUN apt-get update && \
 
 
 # Now install NodeJS and NPM for Javascript testing needs -
-RUN curl -sL https://deb.nodesource.com/setup_18.x  | bash - && \
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+    --mount=target=/var/cache/apt,type=cache,sharing=locked \
+    curl -sL https://deb.nodesource.com/setup_18.x  | bash - && \
     apt-get install -y --no-install-recommends nodejs
 
 # Install geckodriver to properly run Selenium tests in Firefox versions>=47

--- a/tests/docker/Makefile
+++ b/tests/docker/Makefile
@@ -1,8 +1,6 @@
 mkfile_dir := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 top_srcdir := $(mkfile_dir)../..
 uname := $(shell uname)
-uid := $(shell id -u)
-gid := $(shell id -g)
 dockerfile := Dockerfile
 
 name := navtest:$(shell git describe --tags)-$(dockerfile)
@@ -16,14 +14,14 @@ buildnocache:
 	docker build --no-cache -t $(name) -f $(dockerfile) $(mkfile_dir)
 
 check: build
-	docker run -t -u $(uid):$(gid) -v $(top_srcdir):/source --tmpfs /var/lib/postgresql $(name) /source/tests/docker/test.sh
+	docker run -t -v $(top_srcdir):/source --tmpfs /var/lib/postgresql $(name) /source/tests/docker/test.sh
 
 lint: build
-	docker run -t -u $(uid):$(gid) -v $(top_srcdir):/source --tmpfs /var/lib/postgresql $(name) tox -e pylint
+	docker run -t -v $(top_srcdir):/source --tmpfs /var/lib/postgresql $(name) tox -e pylint
 
 # Runs an ephemeral container with core dumping capabilities and PostgreSQL on an in-memory tmpfs
 shell:
-	docker run -ti --rm --ulimit core=-1 -u $(uid):$(gid) -v $(top_srcdir):/source --tmpfs /var/lib/postgresql $(name) /bin/bash
+	docker run -ti --rm --ulimit core=-1 -v $(top_srcdir):/source --tmpfs /var/lib/postgresql $(name) /bin/bash
 
 name:
 	echo Image name: $(name)

--- a/tests/docker/scripts/entrypoint.sh
+++ b/tests/docker/scripts/entrypoint.sh
@@ -1,9 +1,24 @@
 #!/bin/bash
-# Remap the container's build user entry to the currently running UID
-gosu root usermod -u $UID build
+
+# Function to get the owner UID and GID of the /source directory
+get_source_uid_gid() {
+    stat -c "%u %g" /source
+}
+
+# Get the UID and GID of the /source directory
+SOURCE_UID_GID=$(get_source_uid_gid)
+SOURCE_UID=$(echo "$SOURCE_UID_GID" | cut -d ' ' -f 1)
+SOURCE_GID=$(echo "$SOURCE_UID_GID" | cut -d ' ' -f 2)
+
+# Modify the build user's UID and GID to match the /source directory's UID and GID
+usermod -u $SOURCE_UID build
+groupmod -g $SOURCE_GID build
+
 if [ -n "$WORKSPACE" ]; then
     export HOME="$WORKSPACE"
 fi
-mkdir -p "$HOME/.cache/pip"
-gosu root mkdir -p /usr/share/nav ; gosu root chown build /usr/share/nav
-exec "$@"
+mkdir -p "$HOME/.cache/pip" && chown -R build "$HOME/.cache"
+mkdir -p /usr/share/nav ; chown build /usr/share/nav
+
+# Execute the command as the build user using gosu
+exec gosu build "$@"


### PR DESCRIPTION
This upgrades the test container image used for local integration testing to Ubuntu 24.04, which brings it more in line with the current `ubuntu-latest` tag used on Github Actions.

It also fixes some problems with the image, highlighted by the upgrade to Ubuntu 24: 

- The way privilege escalation for management inside the container works has been turned on its head.  The container now starts privileged and drops to a non-privileged user after startup-maintenance has been performed.  The main way to elevate privileges inside the container is now through `sudo`, not `gosu` (which claims it was never intended for privilege escalation and will not not work if you try it).

- Cache mounts for APT packages are added to the definition, in an attempt to make image builds faster.

- Syntax problems/deprecations highlighted by newer Docker versions have been fixed

- Just as newer Debian versions have started to do, newer Ubuntu versions will refuse to let `pip` install site-wide packages, in order to avoid breaking the OS' own Python packages.  The image therefore switches to using a virtualenv for the few Python commands we need to drive tox and the test suite.