### PR TITLE
Add tests for device history search

### DIFF
--- a/changelog.d/3261.added.md
+++ b/changelog.d/3261.added.md
@@ -1,0 +1,1 @@
+Added tests for device history search

--- a/tests/integration/web/devicehistory_test.py
+++ b/tests/integration/web/devicehistory_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from nav.models.event import EventQueue, EventQueueVar
+from nav.models.manage import Device, Module, NetboxGroup
 
 from django.urls import reverse
 from django.utils.encoding import smart_str
@@ -87,3 +88,53 @@ def test_post_device_error_without_comment_should_succeed_with_confirmation(
     assert eventvars
     assert eventvars.filter(variable="alerttype", value="deviceError")
     assert eventvars.filter(variable="comment", value="")
+
+
+def test_get_location_history_should_succeed(client, localhost):
+    url = reverse('devicehistory-view')
+    response = client.get(
+        f"{url}?from_date=2023-01-01&to_date=2025-01-01&eventtype=all&loc={localhost.room.location.id}&submit_module=View+location+history"
+    )
+
+    assert response.status_code == 200
+
+
+def test_get_room_history_should_succeed(client, localhost):
+    url = reverse('devicehistory-view')
+    response = client.get(
+        f"{url}?from_date=2023-01-01&to_date=2025-01-01&eventtype=all&room={localhost.room.id}&submit_module=View+room+history"
+    )
+
+    assert response.status_code == 200
+
+
+def test_get_ip_device_history_should_succeed(client, localhost):
+    url = reverse('devicehistory-view')
+    response = client.get(
+        f"{url}?from_date=2023-01-01&to_date=2025-01-01&eventtype=all&netbox={localhost.id}&submit_module=View+IP+device+history"
+    )
+
+    assert response.status_code == 200
+
+
+def test_get_device_group_history_should_succeed(client, localhost):
+    url = reverse('devicehistory-view')
+    response = client.get(
+        f"{url}?from_date=2023-01-01&to_date=2025-01-01&eventtype=all&netboxgroup={NetboxGroup.objects.first()}&submit_module=View+device+group+history"
+    )
+
+    assert response.status_code == 200
+
+
+def test_get_module_history_should_succeed(db, client, localhost):
+    device = Device(serial="1234test")
+    device.save()
+    module = Module(device=device, netbox=localhost, name='Module 1', model='')
+    module.save()
+
+    url = reverse('devicehistory-view')
+    response = client.get(
+        f"{url}?from_date=2023-01-01&to_date=2025-01-01&eventtype=all&module={module.id}&submit_module=View+romoduleom+history"
+    )
+
+    assert response.status_code == 200


### PR DESCRIPTION
After discovering and fixing a bug in the device history search in #3258 I realized there were no tests for the device history search. So this PR adds some. 