### PR TITLE
Add model for JWT refresh token

### DIFF
--- a/changelog.d/3268.added.md
+++ b/changelog.d/3268.added.md
@@ -1,0 +1,1 @@
+Add database model for JWT refresh tokens

--- a/python/nav/models/sql/changes/sc.05.14.0001.sql
+++ b/python/nav/models/sql/changes/sc.05.14.0001.sql
@@ -1,0 +1,10 @@
+CREATE TABLE manage.jwtrefreshtoken (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR NOT NULL UNIQUE,
+    description VARCHAR,
+    expires TIMESTAMP NOT NULL,
+    activates TIMESTAMP NOT NULL,
+    last_used TIMESTAMP,
+    revoked BOOLEAN NOT NULL DEFAULT FALSE,
+    hash VARCHAR NOT NULL
+);

--- a/tests/unittests/models/jwtrefreshtoken_test.py
+++ b/tests/unittests/models/jwtrefreshtoken_test.py
@@ -1,0 +1,64 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from nav.models.api import JWTRefreshToken
+
+
+class TestIsActive:
+    def test_when_token_activates_in_the_future_it_should_return_false(self):
+        now = datetime.now()
+        token = JWTRefreshToken(
+            name="testtoken",
+            hash="dummyhash",
+            expires=now + timedelta(hours=1),
+            activates=now + timedelta(hours=1),
+        )
+        assert not token.is_active()
+
+    def test_when_token_expired_in_the_past_it_should_return_false(self):
+        now = datetime.now()
+        token = JWTRefreshToken(
+            name="testtoken",
+            hash="dummyhash",
+            expires=now - timedelta(hours=1),
+            activates=now - timedelta(hours=1),
+        )
+        assert not token.is_active()
+
+    def test_when_token_activated_in_the_past_and_expires_in_the_future_it_should_return_true(
+        self,
+    ):
+        now = datetime.now()
+        token = JWTRefreshToken(
+            name="testtoken",
+            hash="dummyhash",
+            expires=now + timedelta(hours=1),
+            activates=now - timedelta(hours=1),
+        )
+        assert token.is_active()
+
+    def test_when_token_activates_now_and_expires_in_the_future_it_should_return_true(
+        self,
+    ):
+        now = datetime.now()
+        token = JWTRefreshToken(
+            name="testtoken",
+            hash="dummyhash",
+            expires=now + timedelta(hours=1),
+            activates=now,
+        )
+        # Make sure the value we use for `activates` here matches
+        # the `now` value in jwtgen.is_active
+        with patch('nav.web.jwtgen.get_now', return_value=now):
+            assert token.is_active()
+
+
+def test_string_representation_should_match_name():
+    now = datetime.now()
+    token = JWTRefreshToken(
+        name="testtoken",
+        hash="dummyhash",
+        expires=now + timedelta(hours=1),
+        activates=now - timedelta(hours=1),
+    )
+    assert str(token) == token.name


### PR DESCRIPTION
Adds a model representing a JWT refresh token. Contains a hash of the real token. Refresh tokens can then effectively be authenticated by comparing the hash to incoming token to hashes in the database.

The model contains relevant information about the token that can be displayed in the frontend.

The function `is_active` in `jwtgen.py` exists so the logic for whether a token is active or not can be shared between the frontend and the API. The frontend will use `JWTRefreshToken.is_active` (which uses`jwtgen.is_active` internally), while the API will use `jwtgen.is_active` directly.

