### PR TITLE
Fix room map widget search not doing anything

### DIFF
--- a/changelog.d/3207.fixed.md
+++ b/changelog.d/3207.fixed.md
@@ -1,0 +1,1 @@
+Fixed search function in room map widget

--- a/python/nav/web/navlets/room_map.py
+++ b/python/nav/web/navlets/room_map.py
@@ -18,7 +18,7 @@
 from django.urls import reverse
 
 from nav.web.navlets import Navlet
-from nav.web.info.room.views import SearchForm
+from nav.web.info.room.views import RoomSearchForm
 
 
 class RoomMapNavlet(Navlet):
@@ -32,7 +32,7 @@ class RoomMapNavlet(Navlet):
         context['can_edit_rooms'] = request.account.has_perm(
             'web_access', reverse('seeddb-room-edit')
         )
-        context['searchform'] = SearchForm()
+        context['searchform'] = RoomSearchForm()
         return self.render_to_response(context)
 
     def get_template_basename(self):


### PR DESCRIPTION
Fixes #3207

Seemed like the form sent a request to home (/) directly, when it probably should have been sent to /search/ instead. This at least makes it so if you search for a room and it finds a match it opens the page for the room,
and if there is no match then it still shows the search page but with the message that nothing was found.

If this is how the map widget is supposed to function is uncertain to me, I don't actually know how it originally worked before it broke (if it ever worked)