### PR TITLE
Add frontend for JWT refresh tokens

### DIFF
--- a/changelog.d/3273.added.md
+++ b/changelog.d/3273.added.md
@@ -1,0 +1,1 @@
+Add frontend for managing JWT refresh tokens

--- a/doc/howto/using_the_api.rst
+++ b/doc/howto/using_the_api.rst
@@ -68,8 +68,8 @@ Locally issued JSON Web Tokens
 ------------------------------
 Local JSON Web Tokens (JWTs) must be :ref:`configured <local-jwt-configuration>` before they can be used.
 
-NAV will soon support generating JWT tokens for local use, as opposed to tokens generated externally.
-You will be able to generate refresh tokens via the frontend which can be used to obtain access tokens
+NAV supports generating JWT tokens for local use, as opposed to tokens generated externally.
+You can generate refresh tokens via the frontend which can be used to obtain access tokens
 that can be used as described :ref:`above <jwt-token>`.
 
 In order to create access tokens you must use the refresh token endpoint, which is available at ``/api/jwt/refresh/``.

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -80,12 +80,23 @@ class JWTRefreshToken(models.Model):
     generate an access token.
     """
 
+    permission_choices = (('read', 'Read'), ('write', 'Write'))
+    permission_help_text = (
+        "Read means that this token can be used for reading only. Write means that "
+        "this token can be used to create new, update and delete objects as well as "
+        "reading."
+    )
+
     name = VarcharField(unique=True)
     description = models.TextField(null=True, blank=True)
     expires = models.DateTimeField()
     activates = models.DateTimeField()
     last_used = models.DateTimeField(null=True, blank=True)
     revoked = models.BooleanField(default=False)
+    endpoints = HStoreField(null=True, blank=True, default=dict)
+    permission = VarcharField(
+        choices=permission_choices, help_text=permission_help_text, default='read'
+    )
     hash = VarcharField()
 
     def __str__(self):

--- a/python/nav/models/api.py
+++ b/python/nav/models/api.py
@@ -91,6 +91,7 @@ class JWTRefreshToken(models.Model):
     description = models.TextField(null=True, blank=True)
     expires = models.DateTimeField()
     activates = models.DateTimeField()
+    created = models.DateTimeField(auto_now_add=True)
     last_used = models.DateTimeField(null=True, blank=True)
     revoked = models.BooleanField(default=False)
     endpoints = HStoreField(null=True, blank=True, default=dict)

--- a/python/nav/models/sql/changes/sc.05.14.0003.sql
+++ b/python/nav/models/sql/changes/sc.05.14.0003.sql
@@ -1,0 +1,7 @@
+ALTER TABLE manage.jwtrefreshtoken ADD permission VARCHAR DEFAULT 'read';
+ALTER TABLE manage.jwtrefreshtoken
+      ADD CONSTRAINT check_permissions
+      CHECK (permission in ('read', 'write'));
+UPDATE manage.jwtrefreshtoken SET permission = 'read' WHERE permission IS NULL;
+
+ALTER TABLE manage.jwtrefreshtoken ADD COLUMN endpoints hstore;

--- a/python/nav/models/sql/changes/sc.05.14.0004.sql
+++ b/python/nav/models/sql/changes/sc.05.14.0004.sql
@@ -1,0 +1,1 @@
+ALTER TABLE manage.jwtrefreshtoken ADD COLUMN created TIMESTAMP DEFAULT now();

--- a/python/nav/web/templates/useradmin/base.html
+++ b/python/nav/web/templates/useradmin/base.html
@@ -21,7 +21,6 @@
    .action-list .button {
        margin-bottom: 0;
    }
-
   </style>
 {% endblock %}
 

--- a/python/nav/web/templates/useradmin/jwt_created.html
+++ b/python/nav/web/templates/useradmin/jwt_created.html
@@ -1,0 +1,35 @@
+{% extends "useradmin/base.html" %}
+
+{% block base_header_additional_head %}
+  {% include "useradmin/token_card_style.html" %}
+{% endblock %}
+
+
+{% block content %}
+
+  Back to
+  <a href="{% url 'useradmin-jwt_list' %}">token list</a>
+
+  <div id="form-panel" class="token-card panel white">
+
+    <h3>
+        {{ object.name }}
+    </h3>
+
+    <code id="token" style="display:block; white-space:pre-wrap">{{ token }}</code>
+
+    <button onclick="myFunction()">Copy to clipboard</button>
+
+    <script>
+        function myFunction() {
+        var copyText = document.getElementById("token");
+        navigator.clipboard.writeText(copyText.innerHTML);
+        }
+    </script>
+
+
+    <div class="float-clear"></div>
+
+  </div>
+
+{% endblock %}

--- a/python/nav/web/templates/useradmin/jwt_detail.html
+++ b/python/nav/web/templates/useradmin/jwt_detail.html
@@ -1,0 +1,96 @@
+{% extends "useradmin/base.html" %}
+{% load info %}
+
+{#  Display information about a single Json Web Token #}
+
+{% block base_header_additional_head %}
+  {% include "useradmin/token_card_style.html" %}
+{% endblock %}
+
+{% block content %}
+
+  <a href="{% url 'useradmin-jwt_list' %}">Back to token list</a>
+
+  <div class="row">
+    <div class="column small-12">
+
+      <div class="token-card panel white">
+        <a href="{% url 'useradmin-jwt_edit' object.pk %}" class="right">Edit token</a>
+
+        <h3>Token details</h3>
+
+        <h5>Name</h5>
+        <p>
+          <code>{{ object.name }}</code>
+        </p>
+
+        {% if object.description %}
+          <h5>Description</h5>
+          <div class="panel">
+            <p>
+              {{ object.description }}
+            </p>
+          </div>
+        {% endif %}
+
+        <h5>Status:
+          {% if object.revoked %}
+            <span class="label alert" title="Token Revoked">
+              Revoked
+            </span>
+          {% elif not object.is_active%}
+          <span class="label warning" title="Token Inactive">
+            Inactive
+          </span>
+          {% else %}
+          <span class="label success" title="Token Active">
+            Active
+          </span>
+          {% endif %}
+        </h5>
+
+        {% if object.revoked %}
+        <div class="alert-box warning with-icon">
+          This token has been revoked
+        </div>
+        {% else %}
+        <div class="alert-box {% if not object.is_active %}warning with-icon{% endif %}">
+          Active from {{ object.activates }} to {{ object.expires }}
+        </div>
+        {% endif %}
+
+        <h5>Permission:
+          {{ object.permission }}
+          <i class="fa fa-info-circle"
+             title="{{ object.permission_help_text }}"
+             style="cursor: pointer"
+          ></i>
+        </h5>
+
+        <h5>Endpoints:</h5>
+        <p>
+        {% if object.endpoints %}
+          {% for key, value in object.endpoints|sortdict  %}
+            <span class="label" title="{{ value }}">
+              {{ key }}
+            </span>
+          {% endfor %}
+        {% else %}
+            No endpoints set
+        {% endif %}
+        </p>
+
+
+        <ul class="no-bullet">
+          <li>
+            <small>Last successfully used: {{ object.last_used|default:'Never' }}</small>
+          </li>
+        </ul>
+
+      </div> {# end panel #}
+
+
+    </div> {# end column #}
+  </div> {# end row #}
+
+{% endblock %}

--- a/python/nav/web/templates/useradmin/jwt_detail.html
+++ b/python/nav/web/templates/useradmin/jwt_detail.html
@@ -83,6 +83,9 @@
 
         <ul class="no-bullet">
           <li>
+              <small>Created: {{ object.created|default:'N/A' }}</small>
+          </li>
+          <li>
             <small>Last successfully used: {{ object.last_used|default:'Never' }}</small>
           </li>
         </ul>

--- a/python/nav/web/templates/useradmin/jwt_edit.html
+++ b/python/nav/web/templates/useradmin/jwt_edit.html
@@ -1,10 +1,9 @@
 {% extends "useradmin/base.html" %}
 
-
 {% block base_header_additional_head %}
   <link rel="stylesheet" href="{{ STATIC_URL }}css/nav/multi-select.css">
   <style>
-    #edit-token-form input[type=submit] { float:left; margin-right: 1.25rem }
+    #edit-jwt-form input[type=submit] { float:left; margin-right: 1.25rem }
     label[for='id_endpoints'] { display: none; }
   </style>
   <script>
@@ -34,9 +33,9 @@
 {% block content %}
 
   Back to
-  <a href="{% url 'useradmin-token_list' %}">token list</a>
+  <a href="{% url 'useradmin-jwt_list' %}">token list</a>
   {% if object %}
-    | <a href="{% url 'useradmin-token_detail' object.pk %}">token details</a>
+    | <a href="{% url 'useradmin-jwt_detail' object.pk %}">token details</a>
   {% endif %}
 
   <div id="form-panel" class="panel white">
@@ -55,9 +54,13 @@
 
     {% if object %}
       {# Display button for revoking a token #}
-      <form action="{% url 'useradmin-token_expire' object.pk %}" method="post">
-        {% csrf_token %}
-        <input type="submit" value="Expire token" class="button small">
+      <form action="{% url 'useradmin-jwt_revoke' object.pk %}" method="post">
+        <input type="submit" value="Revoke token" class="button small">
+      </form>
+
+      {# Display button for recreating a token #}
+      <form action="{% url 'useradmin-jwt_recreate' object.pk %}" method="post">
+        <input type="submit" value="Recreate token" class="button small">
       </form>
 
       {# Display form for deleting a token #}
@@ -69,9 +72,8 @@
 
       <div id="confirm-token-delete" class="f-dropdown content">
         <form id="delete-token-form"
-              action="{% url 'useradmin-token_delete' object.pk %}"
-              method="post">
-          {% csrf_token %}
+              action="{% url 'useradmin-jwt_delete' object.pk %}"
+              method="post">{% csrf_token %}
           <input type="submit" value="Yes, delete" class="button small alert expand">
         </form>
         <span class="button secondary small close-button expand">No, don't delete</span>

--- a/python/nav/web/templates/useradmin/jwt_list.html
+++ b/python/nav/web/templates/useradmin/jwt_list.html
@@ -3,22 +3,18 @@
 
 {% block base_header_additional_head %}
   <style>
-    #token-list-table .label { cursor: help; margin-bottom: 1px; }
+    #jwt-list-table .label { cursor: help; margin-bottom: 1px; }
   </style>
   <script>
-    require(['libs/jquery.tablesorter.min', 'src/tablesorter_custom_sorters'], function() {
+    require(['libs/jquery.tablesorter.min'], function() {
       $(function() {
-        var $table = $('#token-list-table');
+        var $table = $('#jwt-list-table');
         if ($table.length && $table.find('tbody tr').length > 0) {
           $table.tablesorter({
             sortList: [[2, 0]],
             headers: {
-              2: {sorter: "custom-iso-datetime"},
-              3: {sorter: "custom-iso-datetime"},
-              4: {sorter: "custom-iso-datetime"},
               5: {sorter: false},
               6: {sorter: false},
-              7: {sorter: false}
             }
           });
         }
@@ -33,27 +29,32 @@
     {% include 'useradmin/tabs.html' %}
 
     <div class="tabcontent">
-      <a href="{% url 'useradmin-token_create' %}" class="button small">
+
+      {% if not is_configured %}
+        {% include 'useradmin/jwt_not_enabled_content.html' %}
+      {% else %}
+
+      <a href="{% url 'useradmin-jwt_create' %}" class="button small">
         Create new token
       </a>
 
       {# Show table with tokens if there are any #}
       {% if object_list %}
 
-        <table id="token-list-table" class="listtable hover tablesorter">
+        <table id="jwt-list-table" class="listtable hover tablesorter">
           <caption>
             List of issued API tokens
           </caption>
 
           <thead>
             <tr>
-              <th>Token</th>
+              <th>Name</th>
               <th>Permission</th>
+              <th>Activates</th>
               <th>Expires</th>
-              <th class="show-for-large-up">Created</th>
               <th class="show-for-large-up">Last used</th>
               <th class="show-for-medium-up">Endpoints</th>
-              <th class="show-for-medium-up">Comment</th>
+              <th>Status</th>
               <th>&nbsp;</th>
             </tr>
           </thead>
@@ -61,33 +62,30 @@
           <tbody>
             {% for token in object_list %}
               <tr>
+                {# Name #}
                 <td>
-                  <a href="{% url 'useradmin-token_detail' token.pk %}"
-                     title="See details for this token">
-                    {{ token.token|truncatechars:10 }}
-                  </a>
+                  <a href="{% url 'useradmin-jwt_detail' token.pk %}" title="Details">{{ token.name }}</a>
                 </td>
+
+                {# Permission #}
                 <td>
                   {{ token.permission }}
                 </td>
-                <td data-sort-value="{{ token.expires|date:'c' }}">
-                  {% if token.is_expired %}
-                    <span class="label warning"
-                          title="Token expired {{ token.expires|date:'DATE_FORMAT' }}">
-                      Expired
-                    </span>
-                  {% else %}
-                    {{ token.expires|date:'DATE_FORMAT' }}
-                  {% endif %}
+
+                {# Activates #}
+                <td>
+                  {{ token.activates }}
                 </td>
 
-                {# Created #}
-                <td class="show-for-large-up" data-sort-value="{{ token.created|date:'c'|default:'last' }}">{{ token.created|default:'' }}</td>
+                {# Expires #}
+                <td>
+                 {{ token.expires}}
+                </td>
 
                 {# Last used #}
                 <td class="show-for-large-up" data-sort-value="{{ token.last_used|date:'c'|default:'last' }}">{{ token.last_used|default:'Never' }}</td>
 
-                {# Token endpoints #}
+                {# Endpoints #}
                 <td class="show-for-medium-up">
                 {% if token.endpoints %}
                   {% for key, value in token.endpoints|sortdict %}
@@ -98,12 +96,26 @@
                 {% endif %}
                 </td>
 
-                {# Token comment #}
-                <td class="show-for-medium-up">{{ token.comment|default:'' }}</td>
+                {# Status #}
+                <td>
+                    {% if token.revoked %}
+                      <span class="label alert" title="Token Revoked">
+                        Revoked
+                      </span>
+                    {% elif not token.is_active %}
+                      <span class="label warning" title="Token Inactive">
+                        Inactive
+                      </span>
+                    {% else %}
+                      <span class="label success" title="Token Active">
+                        Active
+                      </span>
+                    {% endif %}
+                </td>
 
                 {# Link to token edit #}
                 <td>
-                  <a href="{% url 'useradmin-token_edit' token.pk %}" title="Edit this token">Edit</a>
+                  <a href="{% url 'useradmin-jwt_edit' token.pk %}" title="Edit this token">Edit</a>
                 </td>
               </tr>
             {% endfor %}
@@ -114,12 +126,13 @@
 
         {# If there are no tokens, show information about creating one #}
         <div class="alert-box info">No tokens are issued. Do you want to
-          <a href="{% url 'useradmin-token_create' %}">create one</a>?
+          <a href="{% url 'useradmin-jwt_create' %}">create one</a>?
         </div>
 
       {% endif %}
 
     </div>  {# .tabcontent #}
+    {% endif %}
   </div>  {# .tabs #}
 
 {% endblock %}

--- a/python/nav/web/templates/useradmin/jwt_list.html
+++ b/python/nav/web/templates/useradmin/jwt_list.html
@@ -52,6 +52,7 @@
               <th>Permission</th>
               <th>Activates</th>
               <th>Expires</th>
+              <th class="show-for-large-up">Created</th>
               <th class="show-for-large-up">Last used</th>
               <th class="show-for-medium-up">Endpoints</th>
               <th>Status</th>
@@ -81,6 +82,9 @@
                 <td>
                  {{ token.expires}}
                 </td>
+
+                {# Created #}
+                <td class="show-for-large-up" data-sort-value="{{ token.created|date:'c'|default:'last' }}">{{ token.created|default:'' }}</td>
 
                 {# Last used #}
                 <td class="show-for-large-up" data-sort-value="{{ token.last_used|date:'c'|default:'last' }}">{{ token.last_used|default:'Never' }}</td>

--- a/python/nav/web/templates/useradmin/jwt_not_enabled.html
+++ b/python/nav/web/templates/useradmin/jwt_not_enabled.html
@@ -1,0 +1,8 @@
+{% extends "useradmin/base.html" %}
+
+{% block content %}
+<div id="form-panel" class="panel white">
+  {% include 'useradmin/jwt_not_enabled_content.html' %}
+    <div class="float-clear"></div>
+</div>
+{% endblock %}

--- a/python/nav/web/templates/useradmin/jwt_not_enabled_content.html
+++ b/python/nav/web/templates/useradmin/jwt_not_enabled_content.html
@@ -1,0 +1,5 @@
+<h4>
+    You must configure local tokens in
+    <a target="_blank" href="/doc/reference/jwt.html#configuring-local-jwt-token-generation">jwt.conf</a>
+    before using this feature.
+</h4>

--- a/python/nav/web/templates/useradmin/tabs.html
+++ b/python/nav/web/templates/useradmin/tabs.html
@@ -9,4 +9,7 @@
   <li{% if active.token_list %} class="tabactive"{% endif %}>
     <a href="{% url 'useradmin-token_list' %}">API Token List</a>
   </li>
+  <li{% if active.jwt_list %} class="tabactive"{% endif %}>
+    <a href="{% url 'useradmin-jwt_list' %}">JWT API Token List</a>
+  </li>
 </ul>

--- a/python/nav/web/templates/useradmin/token_card_style.html
+++ b/python/nav/web/templates/useradmin/token_card_style.html
@@ -1,0 +1,5 @@
+<style>
+  .token-card { max-width: 470px; overflow-wrap: break-word; }
+  .token-card .label { cursor: help; margin-bottom: 1px; }
+  .token-card code { display: inline-block; width: 100%; }
+</style>

--- a/python/nav/web/templates/useradmin/token_detail.html
+++ b/python/nav/web/templates/useradmin/token_detail.html
@@ -3,15 +3,9 @@
 
 {#  Display information about a single token #}
 
-
 {% block base_header_additional_head %}
-  <style>
-    .token-card { max-width: 470px; }
-    .token-card .label { cursor: help; margin-bottom: 1px; }
-    .token-card code { display: inline-block; width: 100%; }
-  </style>
+  {% include "useradmin/token_card_style.html" %}
 {% endblock %}
-
 
 {% block content %}
 

--- a/python/nav/web/useradmin/urls.py
+++ b/python/nav/web/useradmin/urls.py
@@ -99,4 +99,34 @@ urlpatterns = [
         views.token_expire,
         name='useradmin-token_expire',
     ),
+    # Manage JWT tokens
+    re_path(r'^jwt_tokens/$', views.JWTList.as_view(), name='useradmin-jwt_list'),
+    re_path(
+        r'^jwt_tokens/create/$', views.JWTCreate.as_view(), name='useradmin-jwt_create'
+    ),
+    re_path(
+        r'^jwt_tokens/edit/(?P<pk>\d+)/$',
+        views.JWTEdit.as_view(),
+        name='useradmin-jwt_edit',
+    ),
+    re_path(
+        r'^jwt_tokens/detail/(?P<pk>\d+)/$',
+        views.JWTDetail.as_view(),
+        name='useradmin-jwt_detail',
+    ),
+    re_path(
+        r'^jwt_tokens/delete/(?P<pk>\d+)/$',
+        views.JWTDelete.as_view(),
+        name='useradmin-jwt_delete',
+    ),
+    re_path(
+        r'^jwt_tokens/expire/(?P<pk>\d+)/$',
+        views.jwt_revoke,
+        name='useradmin-jwt_revoke',
+    ),
+    re_path(
+        r'^jwt_tokens/recreate/(?P<pk>\d+)/$',
+        views.jwt_recreate,
+        name='useradmin-jwt_recreate',
+    ),
 ]

--- a/python/nav/web/useradmin/views.py
+++ b/python/nav/web/useradmin/views.py
@@ -16,7 +16,7 @@
 """Controller functions for the useradmin interface"""
 
 import copy
-from datetime import datetime
+from datetime import datetime, timezone
 
 from django.contrib import messages
 from django.core.cache import cache
@@ -30,10 +30,13 @@ from django.views.decorators.debug import sensitive_post_parameters
 from nav.auditlog.models import LogEntry
 from nav.models.profiles import Account, AccountGroup, Privilege
 from nav.models.manage import Organization
-from nav.models.api import APIToken
+from nav.models.api import APIToken, JWTRefreshToken
 
 from nav.web.auth.sudo import sudo
 from nav.web.useradmin import forms
+from nav.web.jwtgen import generate_refresh_token, hash_token, decode_token
+from nav.config import ConfigurationError
+from nav.django.settings import LOCAL_JWT_IS_CONFIGURED
 
 
 DEFAULT_NAVPATH = {'navpath': [('Home', '/'), ('User Administration',)]}
@@ -667,3 +670,162 @@ def log_add_account_to_org(request, organization, account):
         target=organization,
         object=account,
     )
+
+
+class JWTList(NavPathMixin, generic.ListView):
+    """Class based view for a token listing"""
+
+    model = JWTRefreshToken
+    template_name = 'useradmin/jwt_list.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(JWTList, self).get_context_data(**kwargs)
+        context['is_configured'] = LOCAL_JWT_IS_CONFIGURED
+        context['active'] = {'jwt_list': True}
+        return context
+
+
+class JWTCreate(NavPathMixin, generic.View):
+    """Class based view for creating a new token"""
+
+    model = JWTRefreshToken
+    form_class = forms.JWTRefreshTokenCreateForm
+    template_name = 'useradmin/jwt_edit.html'
+
+    def post(self, request, *args, **kwargs):
+        form = self.form_class(request.POST)
+        if form.is_valid():
+            token = form.save(commit=False)
+            try:
+                encoded_token = generate_refresh_token_from_model(token)
+            except ConfigurationError:
+                return render(
+                    request,
+                    'useradmin/jwt_not_enabled.html',
+                )
+            claims = decode_token(encoded_token)
+            token.expires = datetime.fromtimestamp(claims['exp'], tz=timezone.utc)
+            token.activates = datetime.fromtimestamp(claims['nbf'], tz=timezone.utc)
+            token.hash = hash_token(encoded_token)
+            token.save()
+            return render(
+                request,
+                'useradmin/jwt_created.html',
+                {"object": token, "token": encoded_token},
+            )
+        return render(request, self.template_name, {"form": form})
+
+    def get(self, request):
+        form = self.form_class()
+        context = {
+            'form': form,
+        }
+        return render(request, self.template_name, context)
+
+
+class JWTEdit(NavPathMixin, generic.View):
+    """Class based view for creating a new token"""
+
+    model = JWTRefreshToken
+    form_class = forms.JWTRefreshTokenEditForm
+    template_name = 'useradmin/jwt_edit.html'
+
+    def post(self, request, *args, **kwargs):
+        token = get_object_or_404(JWTRefreshToken, pk=kwargs['pk'])
+        form = self.form_class(request.POST, instance=token)
+        if form.is_valid():
+            form.save()
+            return redirect('useradmin-jwt_detail', pk=token.pk)
+        return render(request, self.template_name, {"form": form, "object": token})
+
+    def get(self, request, *args, **kwargs):
+        token = JWTRefreshToken.objects.get(pk=kwargs['pk'])
+        form = self.form_class(instance=token)
+        return render(request, self.template_name, {"form": form, "object": token})
+
+
+class JWTDetail(NavPathMixin, generic.DetailView):
+    """Display details for a token"""
+
+    model = JWTRefreshToken
+    template_name = 'useradmin/jwt_detail.html'
+
+
+class JWTDelete(generic.DeleteView):
+    """Delete a token"""
+
+    model = JWTRefreshToken
+
+    def get_success_url(self):
+        return reverse_lazy('useradmin-jwt_list')
+
+    def delete(self, request, *args, **kwargs):
+        old_object = copy.deepcopy(self.get_object())
+        response = super(JWTDelete, self).delete(self, request, *args, **kwargs)
+        messages.success(request, 'Token deleted')
+        LogEntry.add_delete_entry(request.account, old_object)
+        return response
+
+
+@require_POST
+def jwt_revoke(request, pk):
+    """Revoke a jwt token
+    :param pk: Primary key
+    :type request: django.http.request.HttpRequest
+    """
+    token = get_object_or_404(JWTRefreshToken, pk=pk)
+    token.revoked = True
+    token.save()
+
+    LogEntry.add_log_entry(
+        request.account,
+        'edit-jwttoken-revoked',
+        '{actor} revoked {object}',
+        object=token,
+    )
+    messages.success(request, 'Token has been manually revoked')
+    return redirect('useradmin-jwt_detail', pk=token.pk)
+
+
+@require_POST
+def jwt_recreate(request, pk):
+    """Recreate a jwt token. This will invalidate the old token
+    related to this object.
+    :param pk: Primary key
+    :type request: django.http.request.HttpRequest
+    """
+    token = get_object_or_404(JWTRefreshToken, pk=pk)
+    try:
+        encoded_token = generate_refresh_token_from_model(token)
+    except ConfigurationError:
+        return render(
+            request,
+            'useradmin/jwt_not_enabled.html',
+        )
+    claims = decode_token(encoded_token)
+    token.expires = datetime.fromtimestamp(claims['exp'], tz=timezone.utc)
+    token.activates = datetime.fromtimestamp(claims['nbf'], tz=timezone.utc)
+    token.hash = hash_token(encoded_token)
+    token.save()
+
+    LogEntry.add_log_entry(
+        request.account,
+        'edit-jwttoken-expiry',
+        '{actor} recreated {object}',
+        object=token,
+    )
+    messages.success(request, 'Token has been manually recreated')
+    return render(
+        request, 'useradmin/jwt_created.html', {"object": token, "token": encoded_token}
+    )
+
+
+def generate_refresh_token_from_model(token: JWTRefreshToken):
+    endpoint_list = [endpoint for endpoint in token.endpoints.values()]
+    encoded_token = generate_refresh_token(
+        {
+            "write": True if token.permission == 'write' else False,
+            "endpoints": endpoint_list,
+        }
+    )
+    return encoded_token

--- a/tests/integration/web/jwt_test.py
+++ b/tests/integration/web/jwt_test.py
@@ -1,0 +1,91 @@
+from mock import patch
+import pytest
+from typing import Generator
+from datetime import datetime, timedelta
+from django.urls import reverse
+
+from nav.models.api import JWTRefreshToken
+
+
+def test_posting_valid_data_to_create_endpoint_should_create_token(db, client):
+    """Tests that a token can be created"""
+    url = reverse("useradmin-jwt_create")
+    response = client.post(
+        url,
+        data={
+            'name': 'mytesttoken',
+            'permission': 'read',
+        },
+        follow=True,
+    )
+
+    assert response.status_code == 200
+    assert JWTRefreshToken.objects.filter(name='mytesttoken').exists()
+
+
+def test_posting_existing_token_id_to_delete_endpoint_should_delete_token(
+    db, client, token
+):
+    """Tests that a token can be deleted"""
+    url = reverse("useradmin-jwt_delete", args=[token.id])
+    response = client.post(url, follow=True)
+
+    assert response.status_code == 200
+    assert not JWTRefreshToken.objects.filter(name='mytesttoken').exists()
+
+
+def test_posting_existing_token_id_to_revoke_endpoint_should_revoke_token(
+    db, client, token
+):
+    """Tests that a token can be revoked"""
+    url = reverse("useradmin-jwt_revoke", args=[token.id])
+    response = client.post(url, follow=True)
+
+    assert response.status_code == 200
+    token.refresh_from_db()
+    assert token.revoked is True
+
+
+@pytest.fixture()
+def token(db) -> Generator[JWTRefreshToken, None, None]:
+    """Fixture to create a JWTRefreshToken instance for testing"""
+    token = JWTRefreshToken.objects.create(
+        name='mytesttoken',
+        permission='read',
+        expires=datetime.now() + timedelta(days=1),
+        activates=datetime.now() - timedelta(hours=1),
+    )
+    yield token
+    if token.id:
+        token.delete()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def jwt_private_key_mock(rsa_private_key) -> Generator[str, None, None]:
+    """Mocks the JWT_PRIVATE_KEY setting"""
+    with patch("nav.web.jwtgen.JWT_PRIVATE_KEY", rsa_private_key):
+        yield rsa_private_key
+
+
+@pytest.fixture(scope="module", autouse=True)
+def jwt_name_mock() -> Generator[str, None, None]:
+    """Mocks the JWT_NAME setting"""
+    with patch("nav.web.jwtgen.JWT_NAME", "localnav"):
+        with patch("nav.web.api.v1.views.JWT_NAME", "localnav"):
+            yield "localnav"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def jwt_access_token_lifetime_mock() -> Generator[timedelta, None, None]:
+    """Mocks the JWT_ACCESS_TOKEN_LIFETIME setting"""
+    lifetime = timedelta(hours=1)
+    with patch("nav.web.jwtgen.JWT_ACCESS_TOKEN_LIFETIME", lifetime):
+        yield lifetime
+
+
+@pytest.fixture(scope="module", autouse=True)
+def jwt_refresh_token_lifetime_mock() -> Generator[timedelta, None, None]:
+    """Mocks the JWT_REFRESH_TOKEN_LIFETIME setting"""
+    lifetime = timedelta(days=1)
+    with patch("nav.web.jwtgen.JWT_REFRESH_TOKEN_LIFETIME", lifetime):
+        yield lifetime


### PR DESCRIPTION
Adds a frontend for managing JWT refresh tokens. You can see which tokens exist, expire existing ones and generate new ones.

Created new issue for audit log #3405, this PR is big enough

The code duplication warning is legit, but its duplicate from the old token code which will be deleted when JWTs are fully implemented and ready to take over for the old token system.

Also adds permission related fields to the JWTRefreshToken model, since these will be used when creating a token. We store the relevant permissions there so they can be displayed as token metadata. They should never be changed (hence why you cant update them in the Edit form) because the values in the actual token are the ones that matter, and those will not be updated when the database is updated. If you want new permissions, you must make a new token.
