### PR TITLE
Remove unused `ColumnsForm`

### DIFF
--- a/changelog.d/3243.removed.1.md
+++ b/changelog.d/3243.removed.1.md
@@ -1,0 +1,1 @@
+Remove unused `ColumnsForm`

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -93,7 +93,6 @@ class Account(models.Model):
     # They should start with PREFERENCE_KEY
     PREFERENCE_KEY_LANGUAGE = 'language'  # AlertProfiles
     PREFERENCE_KEY_STATUS = 'status-preferences'
-    PREFERENCE_KEY_WIDGET_COLUMNS = 'widget_columns'
     PREFERENCE_KEY_REPORT_PAGE_SIZE = 'report_page_size'
     PREFERENCE_KEY_WIDGET_DISPLAY_DENSITY = 'widget_display_density'
     PREFERENCE_KEY_IPDEVINFO_PORT_LAYOUT = 'ipdevinfo_port_layout'

--- a/python/nav/models/sql/changes/sc.05.14.0002.sql
+++ b/python/nav/models/sql/changes/sc.05.14.0002.sql
@@ -1,0 +1,4 @@
+-- Delete widget_columns key from account preferences
+UPDATE account
+SET preferences = delete(preferences, 'widget_columns')
+WHERE preferences ? 'widget_columns';

--- a/python/nav/web/templates/webfront/preferences.html
+++ b/python/nav/web/templates/webfront/preferences.html
@@ -16,57 +16,49 @@
         <div class="alert-box {{ m.type }}">{{ m.message }}</div>
     {% endfor %}
 
-    <div class="row">
-        <div class="column medium-6 large-5">
+    <div class="medium-6 large-5">
 
-            <table class="vertitable full-width">
-                <caption>User information</caption>
-                <tr>
-                    <th>Login</th>
-                    <td>{{ account.login }}</td>
-                </tr>
-                <tr>
-                    <th>Name</th>
-                    <td>{{ account.name }}</td>
-                </tr>
-                <tr>
-                    <th>Groups</th>
-                    <td>
-                        {% if account.groups.all %}
-                            <ul class="inside">
-                                {% for g in account.groups.all %}
-                                    <li>{{ g }}</li>
-                                {% endfor %}
-                            </ul>
-                        {% else %}
-                            None
-                        {% endif %}
-                    </td>
-                </tr>
-                <tr>
-                    <th>Organizations</th>
-                    <td>
-                        {% if account.organizations.all %}
-                            <ul class="inside">
-                                {% for o in account.organizations.all %}
-                                    <li>{{ o }}</li>
-                                {% endfor %}
-                            </ul>
-                        {% else %}
-                            None
-                        {% endif %}
-                    </td>
-                </tr>
-            </table>
-        </div>
-
-        <div class="column medium-6 large-7">
-            {% include 'custom_crispy_templates/flat_form.html' with form=columns_form %}
-        </div>
-
+        <table class="vertitable full-width">
+            <caption>User information</caption>
+            <tr>
+                <th>Login</th>
+                <td>{{ account.login }}</td>
+            </tr>
+            <tr>
+                <th>Name</th>
+                <td>{{ account.name }}</td>
+            </tr>
+            <tr>
+                <th>Groups</th>
+                <td>
+                    {% if account.groups.all %}
+                        <ul class="inside">
+                            {% for g in account.groups.all %}
+                                <li>{{ g }}</li>
+                            {% endfor %}
+                        </ul>
+                    {% else %}
+                        None
+                    {% endif %}
+                </td>
+            </tr>
+            <tr>
+                <th>Organizations</th>
+                <td>
+                    {% if account.organizations.all %}
+                        <ul class="inside">
+                            {% for o in account.organizations.all %}
+                                <li>{{ o }}</li>
+                            {% endfor %}
+                        </ul>
+                    {% else %}
+                        None
+                    {% endif %}
+                </td>
+            </tr>
+        </table>
     </div>
-    <div class="row">
-        <div class="column medium-6 large-5">
+    <div class="medium-6 large-5">
 
     {% if account.ext_sync %}
         <p class='alert-box secondary'>
@@ -98,6 +90,5 @@
 
             </form>
         </div>
-    </div>
 
 {% endblock %}

--- a/python/nav/web/webfront/__init__.py
+++ b/python/nav/web/webfront/__init__.py
@@ -16,17 +16,6 @@ WELCOME_REGISTERED_PATH = find_config_file(
 )
 NAV_LINKS_PATH = find_config_file(os.path.join("webfront", "nav-links.conf"))
 
-DEFAULT_WIDGET_COLUMNS = 2
-
-
-def get_widget_columns(account):
-    """Get the preference for widget columns"""
-    return int(
-        account.preferences.get(
-            account.PREFERENCE_KEY_WIDGET_COLUMNS, DEFAULT_WIDGET_COLUMNS
-        )
-    )
-
 
 def find_dashboard(account, dashboard_id=None):
     """Find a dashboard for this account

--- a/python/nav/web/webfront/forms.py
+++ b/python/nav/web/webfront/forms.py
@@ -127,26 +127,3 @@ class ChangePasswordForm(forms.Form):
             del cleaned_data['new_password2']
         if 'old_password' in cleaned_data:
             del cleaned_data['old_password']
-
-
-class ColumnsForm(forms.Form):
-    """Form for choosing number of columns on webfront"""
-
-    _choices = [('2', '2 columns'), ('3', '3 columns'), ('4', '4 columns')]
-    num_columns = forms.ChoiceField(choices=_choices, label='Number of columns')
-
-    def __init__(self, *args, **kwargs):
-        super(ColumnsForm, self).__init__(*args, **kwargs)
-
-        self.attrs = set_flat_form_attributes(
-            form_action='webfront-preferences-setwidgetcolumns',
-            form_fields=[
-                FlatFieldset(
-                    legend='Number of columns for widgets',
-                    fields=[
-                        self['num_columns'],
-                        SubmitField(value='Save', css_classes='small'),
-                    ],
-                )
-            ],
-        )

--- a/python/nav/web/webfront/urls.py
+++ b/python/nav/web/webfront/urls.py
@@ -88,11 +88,6 @@ urlpatterns = [
         name='webfront-preferences-changepassword',
     ),
     re_path(
-        r'^preferences/setcolumns$',
-        views.set_widget_columns,
-        name='webfront-preferences-setwidgetcolumns',
-    ),
-    re_path(
         r'^preferences/set_account_preference$',
         views.set_account_preference,
         name='set-account-preference',

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -48,12 +48,10 @@ from nav.web.webfront.forms import (
     LoginForm,
     NavbarLinkFormSet,
     ChangePasswordForm,
-    ColumnsForm,
 )
 from nav.web.navlets import list_navlets, can_modify_navlet
 from nav.web.message import new_message, Messages
 from nav.web.webfront import (
-    get_widget_columns,
     find_dashboard,
     WELCOME_ANONYMOUS_PATH,
     WELCOME_REGISTERED_PATH,
@@ -303,9 +301,6 @@ def _create_preference_context(request):
         'navpath': [('Home', '/'), ('Preferences', None)],
         'title': 'Personal NAV preferences',
         'password_form': password_form,
-        'columns_form': ColumnsForm(
-            initial={'num_columns': get_widget_columns(account)}
-        ),
         'account': account,
         'tool': {
             'name': 'My account',
@@ -371,19 +366,6 @@ def save_links(request):
 
             return render(request, 'webfront/preferences.html', context)
 
-    return HttpResponseRedirect(reverse('webfront-preferences'))
-
-
-def set_widget_columns(request):
-    """Set the number of columns on the webfront"""
-    if request.method == 'POST':
-        form = ColumnsForm(request.POST)
-        if form.is_valid():
-            account = request.account
-            num_columns = form.cleaned_data.get('num_columns')
-            account.preferences[account.PREFERENCE_KEY_WIDGET_COLUMNS] = num_columns
-            account.save()
-            return HttpResponseRedirect(reverse('webfront-index'))
     return HttpResponseRedirect(reverse('webfront-preferences'))
 
 


### PR DESCRIPTION
Every dashboard has its own setting on how many columns it has

Closes #3243. 

I did some digging and this has not been in use since 2016 (c7cebd9210d02fbfbcdba92b033ae22300566fb4)