### PR TITLE
Add option for showing vendor name in Machinetracker searches

### DIFF
--- a/changelog.d/3292.added.md
+++ b/changelog.d/3292.added.md
@@ -1,0 +1,1 @@
+Add option for showing vendor name in MAC search

--- a/python/nav/web/machinetracker/forms.py
+++ b/python/nav/web/machinetracker/forms.py
@@ -33,6 +33,9 @@ class MachineTrackerForm(forms.Form):
         widget=forms.TextInput(attrs={'size': 3}),
         help_text="Days back in time to search",
     )
+    vendor = forms.BooleanField(
+        required=False, initial=False, help_text="Show vendor name (if any)"
+    )
 
     def clean_days(self):
         """Clean the days fields"""
@@ -104,6 +107,9 @@ class SwitchTrackerForm(forms.Form):
     module = forms.CharField(required=False, widget=forms.TextInput(attrs={'size': 3}))
     port = forms.CharField(required=False, widget=forms.TextInput(attrs={'size': 16}))
     days = forms.IntegerField(initial=7, widget=forms.TextInput(attrs={'size': 3}))
+    vendor = forms.BooleanField(
+        required=False, initial=False, help_text="Show vendor name (if any)"
+    )
 
 
 class NetbiosTrackerForm(MachineTrackerForm):

--- a/python/nav/web/templates/machinetracker/interface_tracker.html
+++ b/python/nav/web/templates/machinetracker/interface_tracker.html
@@ -12,6 +12,9 @@
             <th>Interface</th>
             <th>Alias</th>
             <th>Mac</th>
+            {% if form_data.vendor %}
+            <th>Vendor</th>
+            {% endif %}
         </tr>
     </thead>
 
@@ -31,6 +34,16 @@
                 <a href="{% query 'machinetracker-mac' mac=ifc.ifphysaddress days=form_data.days dns=dns %}" title="Search again for this MAC address">
                 {{ ifc.ifphysaddress }}</a>
             </td>
+
+            {% if form_data.vendor %}
+            <td>
+                {% if ifc.vendor %}
+                    {{ ifc.vendor }}
+                {% else %}
+                    N/A
+                {% endif %}
+            </td>
+            {% endif %}
 
         </tr>
     {% endfor %}

--- a/python/nav/web/templates/machinetracker/ip_search.html
+++ b/python/nav/web/templates/machinetracker/ip_search.html
@@ -76,7 +76,7 @@
             <legend>Columns</legend>
             <div class="row machinetracker-filter">
 
-              <div class="small-4 column">
+              <div class="small-3 column">
                 <label for="{{ form.netbios.auto_id }}"
                        title="{{ form.netbios.help_text }}">
                   {{ form.netbios }}
@@ -84,18 +84,26 @@
                 </label>
               </div>
 
-              <div class="small-4 column">
+              <div class="small-3 column">
                 <label for="{{ form.dns.auto_id }}" title="{{ form.dns.help_text }}">
                   {{ form.dns }}
                   {{ form.dns.label }}
                 </label>
               </div>
 
-              <div class="small-4 column">
+              <div class="small-3 column">
                 <label for="{{ form.source.auto_id }}"
                        title="{{ form.source.help_text }}">
                   {{ form.source }}
                   {{ form.source.label }}
+                </label>
+              </div>
+
+              <div class="small-3 column">
+                <label for="{{ form.vendor.auto_id }}"
+                       title="{{ form.vendor.help_text }}">
+                  {{ form.vendor }}
+                  {{ form.vendor.label }}
                 </label>
               </div>
 

--- a/python/nav/web/templates/machinetracker/ip_tracker.html
+++ b/python/nav/web/templates/machinetracker/ip_tracker.html
@@ -27,6 +27,9 @@
             {% if form_data.source %}
             <th>Source</th>
             {% endif %}
+            {% if form_data.vendor%}
+            <th>Vendor</th>
+            {% endif %}
         </tr>
     </thead>
 
@@ -44,7 +47,7 @@
 
             <td>
                 {% with form_data.dns|yesno:"True," as dns %}
-                <span style="display:none;">{{ row.ip_int_value }}</span> <a href="{% query 'machinetracker-ip' ip_range=row.ip days=form_data.days dns=dns %}" title="Search for this IP address">
+                <span style="display:none;">{{ row.ip_int_value }}</span> <a href="{% query 'machinetracker-ip' ip_range=row.ip days=form_data.days dns=dns vendor=form_data.vendor %}" title="Search for this IP address">
                     {{ row.ip }}</a>
             </td>
             <td>
@@ -53,7 +56,7 @@
             </td>
             <td>
                 {% if row.mac %}
-                <a href="{% query 'machinetracker-mac' mac=row.mac days=form_data.days dns=dns %}" title="Search for this MAC address">
+                <a href="{% query 'machinetracker-mac' mac=row.mac days=form_data.days dns=dns vendor=form_data.vendor %}" title="Search for this MAC address">
                 {{ row.mac }}</a>
                 {% endif %}
                 {% endwith %}
@@ -69,6 +72,15 @@
             </td>
             {% if form_data.source %}
             <td>{{row.sysname}}</td>
+            {% endif %}
+            {% if form_data.vendor %}
+            <td>
+                {% if row.vendor %}
+                    {{ row.vendor }}
+                {% else %}
+                    N/A
+                {% endif %}
+            </td>
             {% endif %}
         </tr>
         {% endfor %}

--- a/python/nav/web/templates/machinetracker/mac_search.html
+++ b/python/nav/web/templates/machinetracker/mac_search.html
@@ -62,17 +62,24 @@
             <legend>Columns</legend>
 
             <div class="row machinetracker-filter">
-              <div class="small-6 column">
+              <div class="small-4 column">
                 <label for="{{ form.dns.auto_id }}" title="{{ form.dns.help_text }}">
                   {{ form.dns.label }}
                   {{ form.dns }}
                 </label>
               </div>
 
-              <div class="small-6 column">
+              <div class="small-4 column">
                 <label for="{{ form.netbios.auto_id }}" title="{{ form.netbios.help_text }}">
                   {{ form.netbios.label }}
                   {{ form.netbios }}
+                </label>
+              </div>
+
+              <div class="small-4 column">
+                <label for="{{ form.vendor.auto_id }}" title="{{ form.vendor.help_text }}">
+                  {{ form.vendor.label }}
+                  {{ form.vendor }}
                 </label>
               </div>
             </div>
@@ -98,12 +105,12 @@
 
     {% if mac_tracker or not uplink_tracker or not interface_tracker %}
       <div class="results">
-        {% include "machinetracker/mac_tracker.html" %}
+        {% include "machinetracker/mac_tracker.html" with colspan=mac_tracker_colspan %}
       </div>
     {% endif %}
 
     <div class="results">
-      {% include "machinetracker/ip_tracker.html" %}
+      {% include "machinetracker/ip_tracker.html" with colspan=ip_tracker_colspan %}
     </div>
   {% elif mac_tracker != None %}
     <div class="alert-box">No results for "{{ form_data.mac }}"</div>

--- a/python/nav/web/templates/machinetracker/mac_tracker.html
+++ b/python/nav/web/templates/machinetracker/mac_tracker.html
@@ -23,6 +23,9 @@
             <th>Start time</th>
             <th>End time</th>
             <th>Mac</th>
+            {% if form_data.vendor %}
+            <th>Vendor</th>
+            {% endif %}
         </tr>
     </thead>
 
@@ -32,7 +35,7 @@
         {% if row.fishy %}<tr class="fishy-item">{% else %}<tr>{% endif %}
             <td>
                 {% if row.netbox.sysname %}
-                <a href="{% query 'machinetracker-swp' switch=row.netbox.sysname days=form_data.days %}" title="Search for other machines on this switch">
+                <a href="{% query 'machinetracker-swp' switch=row.netbox.sysname days=form_data.days vendor=form_data.vendor %}" title="Search for other machines on this switch">
                 {{ row.netbox.sysname }}</a>
                 {% else %}
                 {{ row.sysname }}
@@ -49,7 +52,7 @@
             </td>
             <td>
                 {% with form_data.dns|yesno:"True," as dns %}
-                <a href="{% query 'machinetracker-swp' switch=row.sysname module=row.module|default_if_none:'' port=row.port days=form_data.days %}" title="Search for other machines on this port">
+                <a href="{% query 'machinetracker-swp' switch=row.sysname module=row.module|default_if_none:'' port=row.port days=form_data.days vendor=form_data.vendor %}" title="Search for other machines on this port">
                 {{ row.port }}</a>
                 {% endwith %}
             </td>
@@ -71,11 +74,20 @@
             <td>
                 {% with form_data.dns|yesno:"True," as dns %}
                 {% if forloop.first %}
-                <a href="{% query 'machinetracker-mac' mac=row.mac days=form_data.days dns=dns %}" title="Search for this MAC address">
+                <a href="{% query 'machinetracker-mac' mac=row.mac days=form_data.days dns=dns vendor=form_data.vendor %}" title="Search for this MAC address">
                 {{ row.mac }}</a>
                 {% endif %}
                 {% endwith %}
             </td>
+            {% if form_data.vendor %}
+            <td>
+                {% if row.vendor %}
+                    {{ row.vendor }}
+                {% else %}
+                    N/A
+                {% endif %}
+            </td>
+            {% endif %}
         </tr>
         {% endfor %}
     {% endfor %}
@@ -83,7 +95,7 @@
 
     <tfoot>
         <tr>
-            <th colspan="8">{{ mac_tracker_count }}
+            <th colspan={{ colspan }}>{{ mac_tracker_count }}
             hit{{ mac_tracker_count|pluralize }}</th>
         </tr>
     </tfoot>

--- a/python/nav/web/templates/machinetracker/netbios_search.html
+++ b/python/nav/web/templates/machinetracker/netbios_search.html
@@ -20,7 +20,7 @@
 
       </div>
 
-      <div class="medium-2 column machinetracker-filter">
+      <div class="medium-1 column machinetracker-filter">
         <div>
           <label for="{{ form.dns.auto_id }}"
                  title="{{ form.dns.help_text }}">{{ form.dns.label }}
@@ -29,7 +29,17 @@
         </div>
       </div>
 
-      <div class="medium-2 column machinetracker-filter">
+      <div class="medium-1 column machinetracker-filter">
+        <div>
+          <label for="{{ form.vendor.auto_id }}" title="{{ form.vendor.help_text }}">
+            {{ form.vendor.label }}
+            {{ form.vendor }}
+          </label>
+        </div>
+      </div>
+
+
+      <div class="medium-1 column machinetracker-filter">
         <div class="machinetracker-filter-days">
           <label for="{{ form.days.auto_id }}"
                  title="{{ form.days.help_text }}">{{ form.days.label }}

--- a/python/nav/web/templates/machinetracker/netbios_tracker.html
+++ b/python/nav/web/templates/machinetracker/netbios_tracker.html
@@ -15,6 +15,9 @@
       <th>Username</th>
       <th>Start time</th>
       <th>End time</th>
+      {% if form_data.vendor %}
+      <th>Vendor</th>
+      {% endif %}
     </tr>
   </thead>
 
@@ -60,7 +63,15 @@
               {{ row.end_time|date:"DATETIME_FORMAT" }}
             {% endif %}
           </td>
-
+          {% if form_data.vendor %}
+          <td>
+              {% if row.vendor %}
+                {{ row.vendor }}
+              {% else %}
+                N/A
+              {% endif %}
+          </td>
+          {% endif %}
         </tr>
       {% endfor %}
     {% endfor %}

--- a/python/nav/web/templates/machinetracker/switch_search.html
+++ b/python/nav/web/templates/machinetracker/switch_search.html
@@ -50,6 +50,11 @@
                   <small class="error">{{ form.port.errors }}</small>
                 {% endif %}
               </td>
+
+              <th><label for="{{ form.vendor.auto_id }}" title="{{ form.vendor.help_text }}">{{ form.vendor.label }}</label></th>
+              <td>
+                {{ form.vendor }}
+              </td>
               <td colspan="2">
                 <input type="submit" value="Search" class="button small right"/>
               </td>
@@ -68,7 +73,7 @@
 
   {% if mac_tracker %}
     <div class="results">
-      {% include "machinetracker/mac_tracker.html" %}
+      {% include "machinetracker/mac_tracker.html" with colspan=mac_tracker_colspan %}
     </div>
   {% elif mac_tracker != None %}
     <div class="alert-box">No results for "{{ form_data.switch }}"</div>

--- a/python/nav/web/templates/machinetracker/uplink_tracker.html
+++ b/python/nav/web/templates/machinetracker/uplink_tracker.html
@@ -12,6 +12,10 @@
             <th>Uplink from</th>
             <th>Uplink to</th>
             <th>Mac</th>
+            {% if form_data.vendor %}
+            <th>Vendor</th>
+            {% endif %}
+
         </tr>
     </thead>
 
@@ -43,6 +47,16 @@
                 <a href="{% query 'machinetracker-mac' mac=row.mac days=form_data.days dns=dns %}" title="Search again for this MAC address">
                 {{ row.mac }}</a>
             </td>
+
+            {% if form_data.vendor %}
+            <td>
+                {% if row.vendor %}
+                    {{ row.vendor }}
+                {% else %}
+                    N/A
+                {% endif %}
+            </td>
+            {% endif %}
 
         </tr>
     {% endfor %}


### PR DESCRIPTION
Fixes #3292 

Adds option for showing vendor name on all Machinetracker searches. Uses mac address to look up vendor name with the OUI table. This obviously requires the table to be populated, which will currently not happen automatically.
It can be populated by running the `navoui` command. I assume you can just run it normally when NAV is running locally, but with docker atleast `docker exec -ti nav-nav-1 navoui` should work

Sonarcloud is complaining about html stuff that im not too familiar with, hopefully @podliashanyk can take a look

During testing ive gotten results with the mac address 00:00:00:00:00:00. Im not sure what this is supposed to represent, a real mac address or if its a placeholder/indication of no mac address, but there is a vendor that has the 00:00:00 OUI registered, XEROX something. So results with 00:00:00:00:00:00 will also get the vendor name XEROX in the vendor column

Links for testing: these are the search forms that now support the vendor option:

- http://localhost/machinetracker/ip/
- http://localhost/machinetracker/mac/
- http://localhost/machinetracker/swp/
- http://localhost/machinetracker/netbios/

With a database dump from sikt-vk.c.uninett.no (with all CAM/ARP records. there are probably examples that work with only active records, but i found it way easier to find examples with all records included):

- http://localhost/machinetracker/ip/?ip_range=2001%3A700%3A5720%3A20%3A%3A16&period_filter=active&days=7&vendor=on
- http://localhost/machinetracker/mac/?mac=b8%3Af0%3A15&days=14&vendor=on (note that this one is pretty long, and has 3 tables as a result (Uplink search results, Interface search results, IP search results)
- http://localhost/machinetracker/mac/?mac=F0EE7A&days=365&vendor=on (another MAC search, this one has a MAC Search results table)
- http://localhost/machinetracker/swp/?switch=sikt-bgo-7101-sw1.c.uninett.no&module=&days=7&port=&vendor=on
- http://localhost/machinetracker/netbios/?search=1&vendor=on&days=14 (this gives the XEROX results)