### PR TITLE
Add dot-files that git must keep to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,22 @@
+.*
+!.codecov.yml
+!.dockerignore
+!.git-blame-ignore-revs
+!.github/
+!.gitkeep
+!.mega-linter.yml
+!.pre-commit-config.yaml
+!.readthedocs.yaml
+!.sonarcloud.properties
+
 *.orig
 *.rej
 *.pyc
 *.swp
 *~
-.*
-!.gitkeep
-!.github/
-!.mega-linter.yml
 *.bak
 *.iml # JetBrains (PyCharm/IDEA) project files
 *.rrd
-.idea/*
 *.egg-info
 wheelhouse/*
 \#*


### PR DESCRIPTION
Files found via:

```
$ git ls-tree -r master --name-only | egrep "^\."
.codecov.yml
.dockerignore
.git-blame-ignore-revs
.github/ISSUE_TEMPLATE/bug_report.md
.github/ISSUE_TEMPLATE/feature_request.md
.github/dependabot.yml
.github/workflows/build-and-test.yml
.github/workflows/dockercompose.yml
.github/workflows/linter.yml
.github/workflows/publish-test-results.yml
.github/workflows/towncrier.yml
.gitignore
.mega-linter.yml
.pre-commit-config.yaml
.readthedocs.yaml
.sonarcloud.properties
```

Interestingly, it also says that `.dockerignore` is untracked!?