### PR TITLE
Send timestamp in correct format in netboxview

### DIFF
--- a/changelog.d/3329.fixed.md
+++ b/changelog.d/3329.fixed.md
@@ -1,0 +1,1 @@
+Fix filtering of 'Last seen' and sorting by 'Last active' in netbox interfaces view in room info

--- a/python/nav/web/templates/info/room/netboxview.html
+++ b/python/nav/web/templates/info/room/netboxview.html
@@ -159,7 +159,7 @@
                 {{ interface.to_netbox }}
               </a>
 
-              <span class="hidden" title="{{ maxtime }}"></span>
+              <span class="hidden" title="{{ maxtime|date:"Y-m-d H:i" }}"></span>
             </td>
           {% else %}
             {# If not connected to other equipment, use information from the cam table to indicate last used #}
@@ -173,7 +173,7 @@
 
               {% if not interface.trunk %}
                 {{ interface.last_cam|days_since }}
-                <span class="hidden" title="{{ interface.last_cam|default:'Never' }}"></span>
+                <span class="hidden" title="{{ interface.last_cam|date:"Y-m-d H:i"|default:'Never' }}"></span>
               {% endif %}
             </td>
           {% endif %}


### PR DESCRIPTION
Closes #3329.

Relevant link for testing: /search/room/<room_id>/#!netboxinterfaces

The frontend expects timestamps in the format yyyy-mm-dd hh:ii for the filtering/sorting to work.

How the `last seen` cell looked before:
In the case of `Never`:
```
Never<span class="hidden" title="Never"></span>
```

In the case of `Now` (the maxtime is given):
```
Now<span class="hidden" title="Dec. 31, 9999, 11:59 p.m."></span>
```

In the case of a specific date:
```
768 days<span class="hidden" title="Feb. 9, 2023, 11:01 p.m."></span>
```

How the frontend expects it to be:
```
51 days<span class="ui-helper-hidden" title="2012-06-11 18:19:30.491431"></span>
```

See also the [frontend tests](https://github.com/Uninett/nav/blob/c3a9bedd7918b46382d632f2f4ee3b945d8ca040/python/nav/web/static/js/test/info/global_dt_filters-test.js)

Since the filtering is happening in the frontend I don't know how I should test this automatically. But I manually tested it. 