### PR TITLE
Fix broken functional tests on GitHub actions

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -53,7 +53,7 @@ def selenium(selenium, base_url, admin_username, admin_password):
     username.send_keys(admin_username)
     password.send_keys(admin_password)
     selenium.find_element(By.NAME, "submit").click()
-    wait.until(EC.url_changes("/"))
+    wait.until(EC.url_to_be(f"{base_url}/"))
 
     # Yield logged-in session to the test
     yield selenium


### PR DESCRIPTION
The functional tests run fine locally, but have lately started failing when run on GitHub Actions.  Screenshots from the test reports seem to indicate that the web browser is still stuck on the NAV front page even after the test has issued a navigation request for a different URL, so it may just be a timing problem.

The main selenium test fixture is supposed to return a selenium web driver where the current browser session is already logged in as an admin, but it seems perhaps the final wait for the login to succeed has been formulated wrong.  The `url_changes` waiter only looks for partial URLs, so explicitly waiting the for the full base url seems to work better.