### PR TITLE
Stop installing Chrome and chromedriver explicitly into github workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -73,10 +73,6 @@ jobs:
           set -xe
           sudo apt-get install -y libldap2-dev libsasl2-dev libtidy5deb1 libsnmp40
 
-      - uses: browser-actions/setup-chrome@latest
-      - run: chrome --version
-      - uses: nanasess/setup-chromedriver@v2
-
       - name: "Set up PostgreSQL"
         uses: harmon758/postgresql-action@v1
         with:

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ setenv =
     django42: DJANGO_VER=42
 passenv =
     C_INCLUDE_PATH
+    CHROMEWEBDRIVER
     GITHUB_ACTIONS
     GITHUB_RUN_ID
     USER
@@ -87,7 +88,7 @@ commands =
 
          functional: sed -i 's/^nav.*=.*INFO/root=DEBUG/' {envdir}/etc/logging.conf
          functional: django-admin collectstatic --noinput
-         functional: pytest -o junit_suite_name="{envname} functional tests" --junitxml=reports/{envname}/functional-results.xml --verbose --driver Chrome --driver-path=/usr/local/bin/chromedriver --sensitive-url "nothing to see here" --html reports/{envname}/functional-report.html {posargs:tests/functional}
+         functional: pytest -o junit_suite_name="{envname} functional tests" --junitxml=reports/{envname}/functional-results.xml --verbose --driver Chrome --driver-path={env:CHROMEWEBDRIVER:/usr/local/bin}/chromedriver --sensitive-url "nothing to see here" --html reports/{envname}/functional-report.html {posargs:tests/functional}
 
 
 [testenv:javascript]


### PR DESCRIPTION
It appears the GitHub ubuntu-latest (24.04) runner is already pre-installed with Chrome, Chromium and chromedriver, so these explicit installation steps are unnecessary.  The chromedriver is installed in an unexpected location, though, so how we find it needed to change as well.
