### PR TITLE
Define project dependencies in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,87 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
 dynamic = ["version"]
+dependencies = [
+    "asciitree==0.3.3",
+    "psycopg2==2.9.9",
+    "IPy==1.01",
+    "pyaml",
+    "twisted>=23.8.0,<24.0",
+    "networkx==2.6.3",
+    "Pillow>3.3.2",
+    "qrcode>7.4",
+    "pyrad==2.1",
+    "sphinx==7.4.7",
+    "sphinxcontrib-programoutput==0.17",
+    "sphinxcontrib-django",
+    "Markdown==3.3.6",
 
+    "feedparser==6.0.8",
+    "dnspython<3.0.0,>=2.1.0",
+
+    "Django>=4.2,<4.3",
+    "django-filter>=2",
+    "djangorestframework>=3.12",
+    "pytz",
+
+    "iso8601",
+
+    "pynetsnmp-2>=0.1.10",
+
+    "napalm==3.4.1",
+
+    "drf-oidc-auth @ git+https://github.com/Uninett/drf-oidc-auth@v4.0",
+
+    "requests",
+
+    "pyjwt>=2.6.0",
+
+    # The following modules are really sub-requirements of Twisted, not of
+    # NAV directly.  They may be optional from Twisted's point of view,
+    # but they are required for parts of the Twisted library that NAV uses:
+    #
+    # PyOpenSSL is required for TLS verification during PaloAlto API GET operations
+    "PyOpenSSL==23.3.0",
+    # service-identity is required to make TLS communication libraries shut up about potential MITM attacks
+    "service-identity==21.1.0",
+]
+
+[project.optional-dependencies]
+ldap = ["python-ldap==3.4.4"]  # optional for LDAP authentication, requires libldap (OpenLDAP) to build
+docs = ["sphinx_rtd_theme>=2.0.0"]
+
+[dependency-groups]
+dev = [
+    "black",
+    "isort",
+    "ruff",
+    "towncrier",
+    "pre-commit",
+    "tox",
+]
+test = [
+    "astroid==2.2.4",
+    "gunicorn==23.0.0",
+    "lxml==4.9.1",
+    "mock==2.0.0",
+    "pylint==2.3.1",
+    "pylint-django==2.0.6",
+    "pytest==8.3.3",
+    "pytest-metadata==3.1.1",
+    "pytest-cov==6.0.0",
+    "pytest-selenium==4.1.0",
+    "pytest-timeout==2.3.1",
+    "pytest-twisted==1.14.3",
+    "pytest-xvfb==3.0.0",
+    "pytidylib==0.3.2",
+    "selenium<4.11.0",
+    "snmpsim>=1.0,!=1.1.6",
+    "toml",
+    "whisper>=0.9.9",
+    "whitenoise==4.1.4",
+    # Our version of selenium breaks down if it is allowed to pull in the newest version of urllib3
+    "urllib3<2.0",
+]
 
 [project.urls]
 Homepage = "https://nav.uninett.no/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,6 @@ test = [
     "gunicorn==23.0.0",
     "lxml==4.9.1",
     "mock==2.0.0",
-    "pylint==2.3.1",
-    "pylint-django==2.0.6",
     "pytest==8.3.3",
     "pytest-metadata==3.1.1",
     "pytest-cov==6.0.0",

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,2 +1,1 @@
 python-ldap==3.4.4 # optional for LDAP authentication, requires libldap (OpenLDAP) to build
-towncrier


### PR DESCRIPTION
We've fully switched to using `pyproject.toml` for the project definition, but the dependencies were not declared outside of the existing set of requirements files.

The requirements files are fine for defining various environments for testing, but the full dependency list should be declared in the project metadata.

This more or less copies all the existing requirements into the appropriate sections of `pyproject.toml`.  Minimal runtime dependencies, optional runtime dependencies, and also dependency groups for non-runtime requirements, like development or testing of the codebase.