### PR TITLE
Comply with PEP 639 license spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=80.3.1", "wheel", "setuptools_scm[toml]>=8.3.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,11 @@ description = "Network Administration Visualized - A comprehensive, free Network
 authors = [{name="Sikt - Norwegian agency for shared services in education and research", email="nav-support@uninett.no"}]
 readme = "README.rst"
 requires-python = ">=3.9"
-license = {text = "GPLv3"}
+license = "GPL-3.0-only"
 keywords = ["nms", "snmp"]
 classifiers = [
     "Development Status :: 6 - Mature",
     "Topic :: System :: Networking :: Monitoring",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
 dynamic = ["version"]
 dependencies = [


### PR DESCRIPTION
[PEP-639](https://peps.python.org/pep-0639/) explicitly defines the `license` field of the project to be an SPDX license expression, also obviating the need for a license classifier.

This cleans up `pyproject.toml` to comply with this.