### PR TITLE
Set default Django version for testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ setenv =
     DJANGO_SETTINGS_MODULE = nav.django.settings
     COVERAGE_FILE = {toxinidir}/reports/coverage/.coverage
     PYTHONFAULTHANDLER=1
+    DJANGO_VER=42
     django42: DJANGO_VER=42
 passenv =
     C_INCLUDE_PATH


### PR DESCRIPTION
This defaults tox environments to using Django 4.2 if no django term was part of the environment name. The file declared several environments that did not work because the Django version did not have a default fallback value.