### PR TITLE
Update docs for IP filtering in ArpViewSet

### DIFF
--- a/changelog.d/3215.fixed.md
+++ b/changelog.d/3215.fixed.md
@@ -1,0 +1,1 @@
+Fix ARP endpoint missing documentation for IP filtering

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -711,7 +711,9 @@ class ArpViewSet(MachineTrackerViewSet):
       timestamp*
     - `endtime`: *must be set with starttime: lists all active records in the
       period between starttime and endtime*
-    - `ip`
+    - `ip`: *Allows filtering by both individual IP addresses and subnet ranges.
+      Single IP example: "ip=2001:db8:a0b:12f0::1"
+      Subnet example: "ip=10.0.42.0/24"*
     - `mac`: *supports prefix filtering - for instance "mac=aa:aa:aa" will
        return all records where the mac address starts with aa:aa:aa*
     - `netbox`


### PR DESCRIPTION
Fixes #3215 

Is the example of how subnets work necessary?

Should more info be added? Like does it support ipv4 and ipv6? which formats of ip addresses does it support?
from looking at IPy it seems to support a wide range of formats. What is relevant for the user of the API?

Draft mode because I am myself not quite sure what values the filter is supposed to accept