### PR TITLE
Add default values to empty `DeviceHistory` form

### DIFF
--- a/changelog.d/3360.fixed.md
+++ b/changelog.d/3360.fixed.md
@@ -1,0 +1,1 @@
+Set default values for device history form for redirection from location search

--- a/python/nav/web/devicehistory/forms.py
+++ b/python/nav/web/devicehistory/forms.py
@@ -65,12 +65,18 @@ class DeviceHistoryViewFilter(forms.Form):
     group_by = forms.ChoiceField(choices=groupings, initial='netbox', required=False)
     group_by.widget.attrs.update({"class": "select2"})
 
+    @staticmethod
+    def get_initial():
+        return {
+            'eventtype': 'all',
+            'from_date': date.today() - timedelta(days=7),
+            'to_date': date.today() + timedelta(days=1),
+        }
+
     def __init__(self, *args, **kwargs):
         super(DeviceHistoryViewFilter, self).__init__(*args, **kwargs)
         self.fields['eventtype'].choices = get_event_and_alert_types()
-        self.fields['eventtype'].initial = 'all'
-        self.fields['from_date'].initial = date.today() - timedelta(days=7)
-        self.fields['to_date'].initial = date.today() + timedelta(days=1)
+        self.initial = self.get_initial()
 
         common_class = 'medium-3'
 

--- a/python/nav/web/devicehistory/utils/history.py
+++ b/python/nav/web/devicehistory/utils/history.py
@@ -208,7 +208,7 @@ def group_history_and_messages(history, messages, group_by=None):
 def describe_search_params(selection):
     data = {}
     for arg, model in (
-        ('room__location', Location),
+        ('loc', Location),
         ('room', Room),
         ('netbox', Netbox),
         ('groups', NetboxGroup),

--- a/python/nav/web/devicehistory/views.py
+++ b/python/nav/web/devicehistory/views.py
@@ -119,7 +119,7 @@ def devicehistory_view(request, **_):
     if len(set(valid_params) & set(request.GET.keys())) >= 1:
         form = DeviceHistoryViewFilter(request.GET)
     else:
-        form = DeviceHistoryViewFilter()
+        form = DeviceHistoryViewFilter(DeviceHistoryViewFilter.get_initial())
     if form.is_valid():
         # We need to handle locations as they are tree-based
         selection['room__location'] = add_descendants(selection['room__location'])


### PR DESCRIPTION
Closes #3360.

When redirecting to device history from location search the location parameter was not handled properly since the empty form was not valid, since it is not bound (contains no data).

Initial values are good for pre-populating HTML templates, but they are not used as default values: [(ref](https://docs.djangoproject.com/en/5.2/ref/forms/fields/#django.forms.Field.initial).

 So we have to set these defaults manually when instantiating the form when no other parameters are given.