### PR TITLE
Lock MegaLinter to v8.6.0

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -27,7 +27,7 @@ jobs:
         id: ml
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.io/flavors/
-        uses: oxsecurity/megalinter/flavors/python@v8
+        uses: oxsecurity/megalinter/flavors/python@v8.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Validate whole codebase on pushes and only changes on pull requests


### PR DESCRIPTION
For now to avoid https://github.com/oxsecurity/megalinter/issues/5358.