### PR TITLE
Fix ReadTheDocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,3 +16,5 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.9"
+  apt_packages:
+    - libsnmp40

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,6 @@ python:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.11"
   apt_packages:
     - libsnmp40

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,17 +4,12 @@ sphinx:
     configuration: doc/conf.py
     builder: html
 
-python:
-    install:
-      - requirements: doc/requirements.txt
-      - method: pip
-        path: .
-        extra_requirements:
-          - setuptools_scm
-
 build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
   apt_packages:
     - libsnmp40
+  jobs:
+    post_create_environment:
+      - pip install -e . -r doc/requirements.txt --constraint constraints.txt

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,1 @@
+snowballstemmer<3.0.0  # incompatible with Sphinx 7.4.7?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "psycopg2==2.9.9",
     "IPy==1.01",
     "pyaml",
-    "twisted>=23.8.0,<24.0",
+    "twisted>=24.7",
     "networkx==2.6.3",
     "Pillow>3.3.2",
     "qrcode>7.4",


### PR DESCRIPTION
A small dependency storm seems to have crept up on us today alone.

1. The docs would not build on ReadTheDocs because the Net-SNMP library is not installed in the build image. `pynetsnmp` is imported by several NAV modules that are imported for Sphinx autodocs, and these imports would fail if the C library was not present.
2. `snowballstemmer` 3.0.0 was released today, and apparently it breaks under Sphinx 7.4.7, which NAV is pinned to at the moment.  A constraint is needed to keep this package below 3.0.
3. There were incompatible Twisted requirements in the build process.  It seems #2955 and #3340 got their streams crossed, and #3340 did not include the changed Twisted version from #2955.

This PR fixes all three issues to get RTD builds working again.
