### PR TITLE
Add csrf token to forms in alert profiles

### DIFF
--- a/python/nav/web/templates/alertprofiles/account_detail.html
+++ b/python/nav/web/templates/alertprofiles/account_detail.html
@@ -50,6 +50,7 @@
       <div class="column medium-4">
         <h5>Alert language</h5>
         <form action="{% url 'alertprofiles-language-save' %}" method="post" class="inline-form custom">
+          {% csrf_token %}
           {{ language_form.language }}
           <input type="submit" value="Save changes" class="button tiny"/>
         </form>
@@ -65,4 +66,3 @@
   </div>
 
 {% endblock %}
-

--- a/python/nav/web/templates/alertprofiles/base_detail.html
+++ b/python/nav/web/templates/alertprofiles/base_detail.html
@@ -39,6 +39,7 @@
           {% endblock %}
         </h5>
         <form action="{% block url_remove_expression %}{% endblock %}" method="post">
+            {% csrf_token %}
             <table class="listtable">
                 <thead>
                     <tr>
@@ -67,6 +68,7 @@
 
     <div class="addexpressionform">
         <form action="{% block url_add_expression %}{% endblock %}" method="post">
+        {% csrf_token %}
         {% block addexpression %}
             <p>
                 <input type="hidden" name="id" value="{{ detail_id }}" />

--- a/python/nav/web/templates/alertprofiles/base_list.html
+++ b/python/nav/web/templates/alertprofiles/base_list.html
@@ -6,6 +6,7 @@
 {% endblock %}
 
 <form action="{{ form_action }}" method="post">
+  {% csrf_token %}
 
   <h4>{% block captioncontent %}{% endblock %}</h4>
 

--- a/python/nav/web/templates/alertprofiles/expression_form.html
+++ b/python/nav/web/templates/alertprofiles/expression_form.html
@@ -6,6 +6,7 @@
   </h4>
 
   <form action="{% url 'alertprofiles-filters-saveexpression' %}" method="post" class="custom">
+    {% csrf_token %}
     <table class="vertitable">
       <tbody>
         <tr>

--- a/python/nav/web/templates/alertprofiles/permissions.html
+++ b/python/nav/web/templates/alertprofiles/permissions.html
@@ -53,6 +53,7 @@
 
   {% if selected_group %}
     <form action="{% url 'alertprofiles-permissions-save' %}" method="post">
+      {% csrf_token %}
       <table class="listtable full-width">
         <caption>Set permissions for {{ selected_group.name }}</caption>
 

--- a/python/nav/web/templates/alertprofiles/profile.html
+++ b/python/nav/web/templates/alertprofiles/profile.html
@@ -7,6 +7,7 @@
 
 
   <form action="{% url 'alertprofiles-profile-remove' %}" method="post">
+    {% csrf_token %}
     <table class="listtable">
       <thead>
       <tr>

--- a/python/nav/web/templates/alertprofiles/profile_detail.html
+++ b/python/nav/web/templates/alertprofiles/profile_detail.html
@@ -10,7 +10,7 @@
 
 {% block headercontent %}
     {% if detail_id %}
-       Profile details 
+       Profile details
     {% else %}
         New profile
     {% endif %}
@@ -40,6 +40,7 @@
     <h4>Time periods</h4>
 
 <form action="{% url 'alertprofiles-profile-timeperiod-remove' %}" method="post">
+    {% csrf_token %}
     {% include "alertprofiles/timeperiods.html" %}
     <p>
         <input type="hidden" name="profile" value="{{ detail_id }}" />

--- a/python/nav/web/templates/alertprofiles/subscription_form.html
+++ b/python/nav/web/templates/alertprofiles/subscription_form.html
@@ -23,6 +23,7 @@
 {% if subscriptions %}
 
 <form action="{% url 'alertprofiles-profile-timeperiod-subscription-remove' %}" method="post">
+    {% csrf_token %}
     <table class="listtable full-width">
         <thead>
             <tr>
@@ -67,6 +68,7 @@
 
 <div class="addexpressionform">
     <form action="{% url 'alertprofiles-profile-timeperiod-subscription-add' %}" method="post">
+        {% csrf_token %}
         <h5>{{ editing|yesno:"Edit,Add new" }} subscription</h5>
         <div class="formcontainer">
 


### PR DESCRIPTION
Contributes to https://github.com/Uninett/campus-tasks/issues/45.

**Where to find the forms (ordered by commit):**

Language form: Go to http://localhost/alertprofiles/, click on "Groups and permissions", see language dropdown

Base list form: Applies to multiple sides, but e.g. see http://localhost/alertprofiles/address/ (right below "Add address" button)

Profile form: http://localhost/alertprofiles/profile/ (right below "Profiles" heading)

Add subscription form: http://localhost/alertprofiles/profile/time-period/\<id\>/subscriptions/, under "Add new expression"

Remove subscription form:  http://localhost/alertprofiles/profile/time-period/\<id\>/subscriptions/, when having added a subscription, under "For profile 'name'. Time period ..."

Delete time period from alert profile form: http://localhost/alertprofiles/profile/ and select or create a profile, see form under "Time Periods" heading

Remove expression from filter form: http://localhost/alertprofiles/filters/ and select or create a filter, see form under "Expression" heading

Add expression to filter form: http://localhost/alertprofiles/filters/ and select or create a filter, see form under  "Add another expression to this filter"

Save expression to filter form: Same as previous, only click "Build expression" and see under "Add expression"
Permission form: http://localhost/alertprofiles/permissions/, click on a group, see form around "Set permissions for group name"