### PR TITLE
Relax permissions for API interface view endpoint

### DIFF
--- a/changelog.d/3373.fixed.md
+++ b/changelog.d/3373.fixed.md
@@ -1,0 +1,1 @@
+Relax permissions for API interface view endpoint

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -515,6 +515,9 @@ class InterfaceViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):
     filter_backends = NAVAPIMixin.filter_backends + (IfClassFilter, NaturalIfnameFilter)
     filterset_class = InterfaceFilterClass
 
+    # Logged-in users must be able to access this API to use the ipdevinfo ports tool
+    permission_classes = (RelaxedPermission,)
+
     def get_serializer_class(self):
         request = self.request
         if request.query_params.get('last_used'):


### PR DESCRIPTION
c2b9002 has locked down API permissions for unprivileged users, but this lead to the port view in ipdevinfo to break for unprivileged users, since the API endpoint `api/interface/` is being called to fill that view by the [frontend](https://github.com/Uninett/nav/blob/6fdf19a32fb3509a8a88c7411cff14b85ca5619b/python/nav/web/static/js/src/porttable.js#L199)
This PR lets unprivileged users access that endpoint again.

No tests for now, since I realized that we need functional tests to make sure that the frontend API call does not break anything. But manually tested.