### PR TITLE
Relax permissions for API prefix usage endpoint

### DIFF
--- a/changelog.d/3374.fixed.md
+++ b/changelog.d/3374.fixed.md
@@ -1,0 +1,1 @@
+Relax permissions for API prefix usage view endpoint

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -921,6 +921,9 @@ class PrefixUsageList(NAVAPIMixin, ListAPIView):
     # RelatedOrderingFilter does not work with the custom pagination
     filter_backends = (filters.SearchFilter, DjangoFilterBackend)
 
+    # Logged-in users must be able to access this API to use the subnet matrix tool
+    permission_classes = (RelaxedPermission,)
+
     def get(self, request, *args, **kwargs):
         """Override get method to verify url parameters"""
         get_times(request)


### PR DESCRIPTION
Needed for subnet matrix tool to work for non-admin users. The [frontend](https://github.com/Uninett/nav/blob/6fdf19a32fb3509a8a88c7411cff14b85ca5619b/python/nav/web/static/js/src/subnetmatrix.js#L65) is using the `prefix/usage/` API endpoint.

This bug was introduced in c2b9002.

Url: http://localhost/report/matrix/