### PR TITLE
Relax permissions for API list room endpoint

### DIFF
--- a/changelog.d/3375.fixed.md
+++ b/changelog.d/3375.fixed.md
@@ -1,0 +1,1 @@
+Relax permissions for API list room endpoint

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -331,6 +331,7 @@ class RoomViewSet(LoggerMixin, NAVAPIMixin, viewsets.ModelViewSet):
     serializer_class = serializers.RoomSerializer
     filterset_fields = ('location', 'description')
     lookup_value_regex = '[^/]+'
+    permission_classes = (RelaxedReadPermission,)
 
 
 class LocationViewSet(LoggerMixin, NAVAPIMixin, viewsets.ModelViewSet):


### PR DESCRIPTION
Dependent on #3376.

Needed for room map widget. The [frontend](https://github.com/Uninett/nav/blob/6fdf19a32fb3509a8a88c7411cff14b85ca5619b/python/nav/web/static/js/src/plugins/room_mapper.js#L110) is using the `room/` API endpoint.

This bug was introduced in c2b9002