### PR TITLE
Add read-only for non-admin and read-write for admin permission class

### DIFF
--- a/python/nav/web/api/v1/auth.py
+++ b/python/nav/web/api/v1/auth.py
@@ -60,12 +60,18 @@ class NavBaseAuthentication(BaseAuthentication):
             return request.account, None
 
 
-class LoggedInPermission(BasePermission):
-    """Checks if the user is logged in"""
+class ReadOnlyNonAdminPermission(BasePermission):
+    """
+    Gives non-admin users read-only permission and admin users read-write permission
+    """
 
     def has_permission(self, request, _view):
-        """If user is logged in, it is authorized"""
-        return not request.account.is_default_account()
+        """If user is logged in and it is a safe method, it is authorized"""
+        if request.method in SAFE_METHODS and not request.account.is_default_account():
+            return True
+        if request.account.is_admin():
+            return True
+        return False
 
 
 class AdminPermission(BasePermission):
@@ -168,4 +174,4 @@ class JWTPermission(BasePermission):
 
 APITokensPermission = TokenPermission | JWTPermission
 DefaultPermission = AdminPermission | APITokensPermission
-RelaxedPermission = LoggedInPermission | APITokensPermission
+RelaxedReadPermission = ReadOnlyNonAdminPermission | APITokensPermission

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -57,7 +57,7 @@ from .auth import (
     APIAuthentication,
     DefaultPermission,
     NavBaseAuthentication,
-    RelaxedPermission,
+    RelaxedReadPermission,
 )
 from .helpers import prefix_collector
 from .filter_backends import (
@@ -516,7 +516,7 @@ class InterfaceViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):
     filterset_class = InterfaceFilterClass
 
     # Logged-in users must be able to access this API to use the ipdevinfo ports tool
-    permission_classes = (RelaxedPermission,)
+    permission_classes = (RelaxedReadPermission,)
 
     def get_serializer_class(self):
         request = self.request
@@ -922,7 +922,7 @@ class PrefixUsageList(NAVAPIMixin, ListAPIView):
     filter_backends = (filters.SearchFilter, DjangoFilterBackend)
 
     # Logged-in users must be able to access this API to use the subnet matrix tool
-    permission_classes = (RelaxedPermission,)
+    permission_classes = (RelaxedReadPermission,)
 
     def get(self, request, *args, **kwargs):
         """Override get method to verify url parameters"""
@@ -1035,7 +1035,7 @@ class AlertHistoryViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):
 
     filter_backends = (AlertHistoryFilterBackend,)
     # Logged-in users must be able to access this API to use the status tool
-    permission_classes = (RelaxedPermission,)
+    permission_classes = (RelaxedReadPermission,)
     model = event.AlertHistory
     serializer_class = alert_serializers.AlertHistorySerializer
     base_queryset = base = event.AlertHistory.objects.prefetch_related(


### PR DESCRIPTION
Inspired by Django Rest Framework's [IsAuthenticatedOrReadOnly](https://github.com/encode/django-rest-framework/blob/c0202a0aa5cbaf8573458b932878dfd5044c93ab/rest_framework/permissions.py#L163-L173) and our own [LoggedInPermission](https://github.com/Uninett/nav/blob/92442c288ad746add7262886c4e56bcbafc282a2/python/nav/web/api/v1/auth.py#L63-L68) I created a permission class that allows admin users to read/write and non-admin users to only read.

This was suggested by @lunkwill42 in https://github.com/Uninett/nav/pull/3375#pullrequestreview-2842642909. 