### PR TITLE
Replace all incorrect usage of kbd role

### DIFF
--- a/NOTES.rst
+++ b/NOTES.rst
@@ -2369,9 +2369,9 @@ installation. This is used by the Django framework for cryptographic signing
 in various situations. Here are three suggestions for generating a suitable
 string of random characters, depending on what tools you have available:
 
-    1. :kbd:`gpg -a --gen-random 1 51`
-    2. :kbd:`makepasswd --chars 51`
-    3. :kbd:`pwgen -s 51 1`
+    1. :code:`gpg -a --gen-random 1 51`
+    2. :code:`makepasswd --chars 51`
+    3. :code:`pwgen -s 51 1`
 
 Please see
 https://docs.djangoproject.com/en/1.4/ref/settings/#std:setting-SECRET_KEY if

--- a/doc/faq/faq.rst
+++ b/doc/faq/faq.rst
@@ -57,7 +57,7 @@ marked as down in its *ipdevinfo* page, without an actual alert having been
 posted yet.
 
 If things still seem to not work, ensure both :program:`pping` and
-:program:`eventengine` are running, using the :kbd:`nav status` command. Then
+:program:`eventengine` are running, using the :code:`nav status` command. Then
 check the logs of these programs to see whether they have detected the
 situation. :file:`pping.log` should indicate whether pping has failed to get a
 ping response from the device. :file:`eventengine.log` should indicate whether
@@ -66,7 +66,7 @@ the *event engine* has detected *pping*'s notice of this.
 A device is down, I see it on the status page, my profile should cover the event, but I am not alerted. Why?
 --------------------------------------------------------------------------------------------------------------
 
-First, verify that the alert engine (:kbd:`nav status alertengine`) is
+First, verify that the alert engine (:code:`nav status alertengine`) is
 running. Use :file:`alertengine.log` to verify that alert engine processed
 such an alert. Did it cover your user? If not, double check your active
 profile. You may want to make a new profile that covers every alarm, to see if

--- a/doc/hacking/using-docker.rst
+++ b/doc/hacking/using-docker.rst
@@ -60,12 +60,12 @@ Docker Compose build process needs to know your ``UID`` and ``GID``.
           bind-mounted volumes.  You still will need to set the ``UID`` and
           ``GID`` arguments for the build to work, though.
 
-The quickest way to go about this is the :kbd:`make .env` command.  This will
+The quickest way to go about this is the :code:`make .env` command.  This will
 attempt to generate a :file:`.env` file in your top-level source code
 directory, which will set the ``UID`` and ``GID`` variables from your running
 environment.  Docker Compose will implicitly read the environment variables in
 this file when it builds or runs the services defined in
-:file:`docker-compose.yml`.  If, for some reason, the :kbd:`make .env` command
+:file:`docker-compose.yml`.  If, for some reason, the :code:`make .env` command
 does not work for you, you can create the :file:`.env` file by hand (but supply
 real values if you're on Linux):
 
@@ -139,7 +139,7 @@ A complete rebuild of the NAV code can be initiated by::
 Rebuilding the containers
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Running :kbd:`docker compose up` will normally build the container images,
+Running :code:`docker compose up` will normally build the container images,
 before starting them, if they don't exist already.  However, if the image
 definitions have changed (e.g. when you are switching between development
 branches or changed the :file:`Dockerfile` definitions, or any of the files
@@ -207,7 +207,7 @@ The ``nav`` and ``web`` containers share a common configuration volume named
 ``nav_config``. This volume should persist even between rebuilds of the
 containers themselves. If you want NAV to install a completely new set of
 config files from scratch, you may need to manually trash this volume using the
-``-v`` option to the :kbd:`docker compose down` command.
+``-v`` option to the :code:`docker compose down` command.
 
 
 Overriding the compose services

--- a/doc/howto/api_parameters.rst
+++ b/doc/howto/api_parameters.rst
@@ -118,7 +118,7 @@ Provides access to NAVs prefix data
 
     .. NOTE:: The vlan__vlan is used to filter on vlan number as the vlan field
               references the primary key only.
-              e.g. :kbd:`prefix?vlan__vlan=<vlan-number>`
+              e.g. :code:`prefix?vlan__vlan=<vlan-number>`
 
 
 api/prefix/routed

--- a/doc/howto/commandline-utilities.rst
+++ b/doc/howto/commandline-utilities.rst
@@ -18,7 +18,7 @@ system, systemd or other process control systems.
 
 If NAV doesn't appear to be doing anything, the first order of business is
 checking the state of its background processes with the command
-:kbd:`nav status`
+:code:`nav status`
 
 
 Usage

--- a/doc/howto/debugging-topology.rst
+++ b/doc/howto/debugging-topology.rst
@@ -79,7 +79,7 @@ to ``cleese-sw``'s port *Gi2/1*. Do the following:
 2. Under the :guilabel:`Connection` table, in the row titled :guilabel:`To IP
    device` there should be a small, clickable icon to browse the *Neighbor
    candidates* report for port 26. Click on it:
-   
+
    .. image:: link-to-neighbor-candidates.png
 
    You might then see something like this:
@@ -114,7 +114,7 @@ neighbor candidates for each of the ports in your monitored network.
 
 Whereas protocols like CDP and LLDP, if supported and enabled, can usually
 provide a pretty precise indication of what a port's next-hop neighbor is, NAV
-can usually also detect topology without them. 
+can usually also detect topology without them.
 
 .. NOTE:: Also, proprietary protocols, such as CDP, can also be imprecise in
           heterogeneous networking environments, as CDP packets will be
@@ -141,5 +141,5 @@ for discerning which of the candidates are true next-hop neighbors.
 
 In a case where you have made changes to which devices are monitored by NAV,
 you can run the command manually, once `ipdevpoll` has finished it's `topo`
-job for any new devices. The command :kbd:`navtopology --l2` will run a
+job for any new devices. The command :code:`navtopology --l2` will run a
 physical topology analysis, and should be pretty quick.

--- a/doc/howto/generic-install-from-source.rst
+++ b/doc/howto/generic-install-from-source.rst
@@ -192,7 +192,7 @@ can install all of them by issuing the following command:
 
   Type 'yes' to continue, or 'no' to cancel:
 
-In this example, type :kbd:`yes`, hit :kbd:`Enter`, and ensure your web server's
+In this example, type :code:`yes`, hit :kbd:`Enter`, and ensure your web server's
 document root points to :file:`/usr/share/nav/www`, because that is where the
 :file:`static` directory is located. If that doesn't suit you, you will at
 least need an Alias to point the ``/static`` URL to the :file:`static`

--- a/doc/howto/manual-install-on-debian.rst
+++ b/doc/howto/manual-install-on-debian.rst
@@ -143,7 +143,7 @@ It'll respond with something like:
     Type 'yes' to continue, or 'no' to cancel:
 
 Take note of the path (:file:`/usr/share/nav/www`, without the ``static``
-subdir), as you'll need it in the next step and type :kbd:`yes` and hit
+subdir), as you'll need it in the next step and type :code:`yes` and hit
 :kbd:`Enter`.
 
 This will copy static files (css, javascript, images, fonts and similar) into

--- a/doc/howto/migrate-data.rst
+++ b/doc/howto/migrate-data.rst
@@ -141,7 +141,7 @@ This may require knowledge of NAV's data model before you proceed. If you know
 your way around SQL, you can even enact more advanced content filters using
 the `-f` or `--filter` option.
 
-.. tip:: See the output of :kbd:`navpgdump --help` for a complete overview of
+.. tip:: See the output of :code:`navpgdump --help` for a complete overview of
          the supported options.
 
 Restoring

--- a/doc/howto/migrate-rrd-to-graphite.rst
+++ b/doc/howto/migrate-rrd-to-graphite.rst
@@ -61,7 +61,7 @@ placed.
 
 When conversion is complete and the Whisper files are on the target server,
 ensure they are readable/writable by the user that runs the Carbon daemon
-(e.g. :kbd:`chmod -R graphite:graphite /opt/graphite/storage/whisper/nav`).
+(e.g. :code:`chmod -R graphite:graphite /opt/graphite/storage/whisper/nav`).
 
 Runtime considerations
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/intro/getting-started.rst
+++ b/doc/intro/getting-started.rst
@@ -36,9 +36,9 @@ before running NAV:
   in various situations. Here are three suggestions for generating a suitable
   string of random characters, depending on what tools you have available:
 
-    1. :kbd:`gpg -a --gen-random 1 51`
-    2. :kbd:`makepasswd --chars 51`
-    3. :kbd:`pwgen -s 51 1`
+    1. :code:`gpg -a --gen-random 1 51`
+    2. :code:`makepasswd --chars 51`
+    3. :code:`pwgen -s 51 1`
 
   Please see the
   `Django secret key documentation <https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-SECRET_KEY>`_
@@ -80,10 +80,10 @@ multiple processes.  While Apache serves the frontend, the backend
 processes can be controlled using the :program:`nav` command.
 
 The backend processes consist of some daemon processes, and some cron jobs.
-Running :kbd:`nav start` will start all the daemon processes in the
+Running :code:`nav start` will start all the daemon processes in the
 background, and install all the cron jobs in the ``navcron`` user's crontab.
 
-Depending on your OS of choice, you should configure it to run :kbd:`nav
+Depending on your OS of choice, you should configure it to run :code:`nav
 start` on boot.
 
 
@@ -273,7 +273,7 @@ the fields listed in square brackets are optional. Optional fields can be
 omitted or left blank. A line beginning with a ``#`` sign will be regarded as a
 comment and ignored. Thus, for adding some switch using the default SNMP
 management profile you added earlier, and a function description of
-:kbd:`Packet switching`, this line would do it::
+``Packet switching``, this line would do it::
 
   myroom:10.0.1.42:myorg:SW:Default SNMP v2c read-only profile::Packet switching
 

--- a/doc/reference/backend-processes.rst
+++ b/doc/reference/backend-processes.rst
@@ -12,7 +12,7 @@ The nav command
 The :program:`nav` program is used to start, stop and query the running state
 of NAV's backend processes.
 
-:kbd:`nav list` lists all back-end processes. :kbd:`nav status` reports their
+:code:`nav list` lists all back-end processes. :code:`nav status` reports their
 current running state. With reference to the list, jump directly to the
 relevant section in this document:
 

--- a/doc/reference/ldap.rst
+++ b/doc/reference/ldap.rst
@@ -222,16 +222,16 @@ Users that have been created locally in NAV will not be authenticated with the
 LDAP server when LDAP authentication is enabled at a later time.  The only way
 to do this is to tinker with the SQL database.
 
-Run :kbd:`psql nav nav`, use the password from :file:`db.conf`.  List the
+Run :code:`psql nav nav`, use the password from :file:`db.conf`.  List the
 existing accounts::
 
   nav=# select * from account;
-    id  |  login  |       name        | password | ext_sync 
+    id  |  login  |       name        | password | ext_sync
   ------+---------+-------------------+----------+----------
-      0 | default | Default User      |          | 
-      1 | admin   | NAV Administrator | password | 
-   1000 | foo     | Foo Bar           | password | 
-   1001 | arthur  | A. Dent           | password | 
+      0 | default | Default User      |          |
+      1 | admin   | NAV Administrator | password |
+   1000 | foo     | Foo Bar           | password |
+   1001 | arthur  | A. Dent           | password |
    1002 | zaphod  | Z. Beeblebrox     | password | ldap
   (5 rows)
 

--- a/tests/docker/README.rst
+++ b/tests/docker/README.rst
@@ -8,9 +8,9 @@ ready, you can use the included Makefile to build a Docker test environment
 image and to run NAV's full test suite inside it - excellent for use on a
 minimally provisioned CI server.
 
-To build the Docker image, issue the :kbd:`make` command. To run the full test
-suite on your checked out source code, inside a container, use :kbd:`make
-check`. You can also enter a CI environment interactively using :kbd:`make
+To build the Docker image, issue the :code:`make` command. To run the full test
+suite on your checked out source code, inside a container, use :code:`make
+check`. You can also enter a CI environment interactively using :code:`make
 shell`.
 
 Minimum requirements for a CI server


### PR DESCRIPTION
The Sphinx `kbd` role was being used incorrectly all over the docs. Its purpose is to semantically mark up *keystrokes* (Like e.g. `Control-C`).  Most usages in the docs were for shell command examples, not keystrokes.