### PR TITLE
Add CSRF tokens to forms in arnold

### DIFF
--- a/python/nav/web/templates/arnold/choose_detentions.html
+++ b/python/nav/web/templates/arnold/choose_detentions.html
@@ -3,7 +3,7 @@
 {% block tabcontent %}
 
     <form action="{% url 'arnold-lift-detentions' %}" method="POST">
-
+        {% csrf_token %}
         <table class="listtable">
             <caption>
                 Choose which ports to open

--- a/python/nav/web/templates/arnold/manualdetain-step2.html
+++ b/python/nav/web/templates/arnold/manualdetain-step2.html
@@ -19,6 +19,7 @@
       It is not feasible to add all the information to the labels otherwise.
       {% endcomment %}
       <form action="" method="POST" class="manualDetentionForm">
+        {% csrf_token %}
         <fieldset>
           <legend>Manual detention of {{ target }}</legend>
 


### PR DESCRIPTION
Contributes to https://github.com/Uninett/campus-tasks/issues/45.

Where to find the forms (ordered by commit):

Manual detention form: Go to http://localhost/arnold/manualdetention/, search for a valid IP/MAC address and see the form.

Lift detention form: After having detained a port, go to http://localhost/arnold/detainedports/ and click on "Enable" and see the form. 