### PR TITLE
Add csrf token to forms on main page

### DIFF
--- a/python/nav/web/templates/navlets/feedreader_edit.html
+++ b/python/nav/web/templates/navlets/feedreader_edit.html
@@ -2,6 +2,7 @@
 
 {% block navlet-content %}
   <form action="{% url 'get-user-navlet' navlet.navlet_id %}">
+    {% csrf_token %}
 
     <div class="row">
       <div class="medium-8 column">

--- a/python/nav/web/templates/navlets/machinetracker_view.html
+++ b/python/nav/web/templates/navlets/machinetracker_view.html
@@ -3,6 +3,7 @@
 {% block navlet-content %}
 
     <form action="{% url 'get-user-navlet' navlet.navlet_id %}" method="post">
+        {% csrf_token %}
         <div class="row collapse">
             <div class="large-9 column">
                 <input type="text" name="from_ip" placeholder="IP or MAC-address">

--- a/python/nav/web/templates/navlets/report_edit.html
+++ b/python/nav/web/templates/navlets/report_edit.html
@@ -3,7 +3,7 @@
 {% block navlet-content %}
 
   <form action="{% url 'get-user-navlet' navlet.navlet_id %}">
-
+    {% csrf_token %}
     <label>
       Choose report
       <select name="report_id">

--- a/python/nav/web/templates/navlets/vlangraph_edit.html
+++ b/python/nav/web/templates/navlets/vlangraph_edit.html
@@ -3,6 +3,7 @@
 {% block navlet-content %}
 
     <form action="{% url 'get-user-navlet' navlet.navlet_id %}" method="post" class="custom">
+        {% csrf_token %}
         <input type="hidden" name="id" value="{{ navlet.navlet_id }}">
         <select name="vlanid">
             <option value="-1">---Select vlan---</option>

--- a/python/nav/web/templates/webfront/index.html
+++ b/python/nav/web/templates/webfront/index.html
@@ -175,6 +175,7 @@
          data-dropdown-content
          class="f-dropdown content small right-action-content">
       <form id="form-add-dashboard" method="post" action="{% url 'add-dashboard' %}">
+        {% csrf_token %}
         <label>
           Add dashboard
           <input type="text" name="dashboard-name" placeholder="Dashboard name">

--- a/python/nav/web/templates/webfront/index.html
+++ b/python/nav/web/templates/webfront/index.html
@@ -130,6 +130,7 @@
             <div class="alert-box">This is the default dashboard</div>
             <form id="form-set-default-dashboard" method="post"
                   action="{% url 'set-default-dashboard' dashboard.pk %}">
+              {% csrf_token %}
               <input type="submit" value="Set as default dashboard"
                      class="small button secondary expand">
             </form>

--- a/python/nav/web/templates/webfront/index.html
+++ b/python/nav/web/templates/webfront/index.html
@@ -150,6 +150,7 @@
         <div class="column medium-4">
           {% if request.account.account_dashboards.count > 1 and not dashboard.is_default %}
             <form id="form-delete-dashboard" method="post" action="{% url 'delete-dashboard' dashboard.pk %}">
+              {% csrf_token %}
               <input type="submit" class="small button alert expand" value="Delete dashboard">
             </form>
             {% endif %}

--- a/python/nav/web/templates/webfront/index.html
+++ b/python/nav/web/templates/webfront/index.html
@@ -115,6 +115,7 @@
             method="post"
             data-dashboard="{{ dashboard.pk }}"
             action="{% url 'rename-dashboard' dashboard.pk %}" >
+        {% csrf_token %}
         <input type="submit" class="small button right" value="Rename dashboard">
         <label>
           <input type="text" name="dashboard-name" placeholder="Dashboard name" value="{{ dashboard.name }}">

--- a/python/nav/web/templates/webfront/index.html
+++ b/python/nav/web/templates/webfront/index.html
@@ -77,6 +77,7 @@
           <li>
             <div class="panel">
               <form class="add-user-navlet right" action="{% url 'add-user-navlet' dashboard.pk %}" method="post">
+                {% csrf_token %}
                 <input type="hidden" name="navlet" value="{{ navlet.get_class }}">
                 <input type="submit" class="button tiny" value="Add">
               </form>

--- a/python/nav/web/templates/webfront/index.html
+++ b/python/nav/web/templates/webfront/index.html
@@ -96,6 +96,7 @@
         <div data-alert class="alert-box warning hidden">
         </div>
         <form action="{% url 'import-dashboard' %}">
+            {% csrf_token %}
             <fieldset>
                 <legend>Select file to import</legend>
                 <input name="file" type="file" id="dashboard-import-file">


### PR DESCRIPTION
Contributes to https://github.com/Uninett/campus-tasks/issues/45.

**Where to find the forms (ordered by commit):**

Add widget form: Main page, click on "+" in sidebar and see form around every "Add" button

Import dashboard form: Main page, click on "+" in dashboard list and see form around "Import dashboard" link

Rename dashboard form: Main page, click on cog icon in sidebar and see form around input field and "Rename dashboard" button

Set default dashboard form: Main page, add/select a dashboard that is not default, click on cog icon in sidebar and see form around "Set as default dashboard" button

Delete dashboard form: Main page, add/select a dashboard that is not default, click on cog icon in sidebar and see form around "Delete dashboard" button

Add dashboard form: Main page, click on "+" in dashboard list and see form around input field and "Add dashboard" button

Widget report edit: Main page, click on "+" in sidebar, add "Report" widget, go to edit

Feed reader edit form: Main page, click on "+" in sidebar, add "FeedReader" widget, go to edit

Machine tracker form: Main page, click on "+" in sidebar, add "Machine Tracker" widget

Vlan graph form: Main page, click on "+" in sidebar, add "Vlan Graph" widget
