### PR TITLE
Add csrf token to forms in SeedDB

### DIFF
--- a/python/nav/web/templates/seeddb/bulk_import.html
+++ b/python/nav/web/templates/seeddb/bulk_import.html
@@ -7,6 +7,7 @@
   <h4>Bulk import</h4>
 
     <form enctype="multipart/form-data" action="" method="post">
+        {% csrf_token %}
         {% if form.non_field_errors %}
             <div class="alert-box alert">{{ form.non_field_errors }}</div>
         {% endif %}

--- a/python/nav/web/templates/seeddb/delete.html
+++ b/python/nav/web/templates/seeddb/delete.html
@@ -2,6 +2,7 @@
 
 {% block content %}
 <form action="" method="post">
+  {% csrf_token %}
 
   <p><a href="{{ back_url }}">Back to list</a></p>
 

--- a/python/nav/web/templates/seeddb/edit_patch.html
+++ b/python/nav/web/templates/seeddb/edit_patch.html
@@ -88,6 +88,7 @@
     <h4>Add patch</h4>
     Connect interface <em class="interfacename"></em> to
     <form>
+      {% csrf_token %}
       <input id="cable-search" name="cableid" type="text" placeholder="Search for cable">
       <input name="split" type="text" placeholder="Split" value="">
       <input class="interfaceid" name="interfaceid" type="hidden" value="">
@@ -103,6 +104,7 @@
     Remove patch from interface <em class="interfacename"></em>?
     <div>
       <form class="left">
+        {% csrf_token %}
         <input class="interfaceid" type="hidden" name="interfaceid" value="">
         <button id="remove-patch-button" class="button small warning">Yes</button>
       </form>

--- a/python/nav/web/templates/seeddb/list.html
+++ b/python/nav/web/templates/seeddb/list.html
@@ -15,6 +15,7 @@
   {% endif %}
 
   <form action="{{ request.path }}" method="post">
+    {% csrf_token %}
     {% if not hide_move or not hide_delete %}
       <div>
         {% if not hide_move %}

--- a/python/nav/web/templates/seeddb/move.html
+++ b/python/nav/web/templates/seeddb/move.html
@@ -6,6 +6,7 @@
 
 
 <form action="" method="post">
+{% csrf_token %}
 <table class="listtable">
     <caption>
         {{ title }}


### PR DESCRIPTION
Contributes to https://github.com/Uninett/campus-tasks/issues/45.

**Where to find the forms (ordered by commit):**

Add patch form: Unclear for now, somewhere in http://localhost/seeddb/patch/, need to add patch data first, but could not find any template for that

Remove patch form (same commit as first): Unclear for now, somewhere in http://localhost/seeddb/patch/

Bulk import form: http://localhost/seeddb/netbox/bulk/

Delete form: Go to http://localhost/seeddb/netbox/, select a IP device, click on "Delete" button

List form: Go to http://localhost/seeddb/netbox/, see form

Move form: Go to http://localhost/seeddb/netbox/, select some IP devices and click on "Move", see form