### PR TITLE
Add csrf token to forms in search

### DIFF
--- a/python/nav/web/templates/info/event/details.html
+++ b/python/nav/web/templates/info/event/details.html
@@ -248,6 +248,7 @@
   {# Acknowledge alert #}
   <div id="actions-acknowledge" class="action-container">
     <form action="{% url 'status2_acknowledge_alert' %}">
+      {% csrf_token %}
       <input type="hidden" name="id[]" value="{{ event.pk }}" />
 
       <label>
@@ -276,6 +277,7 @@
   {# Resolve/clear alert #}
   <div id="actions-resolve" class="action-container">
     <form action="{% url 'status2_clear_alert' %}">
+      {% csrf_token %}
       <input type="hidden" name="id[]" value="{{ event.pk }}" />
       <a data-dropdown="resolve-info" aria-controls="resolve-info" aria-expanded="false">About</a>
       <input type="submit" class="button small secondary right" value="Clear alert" />
@@ -301,6 +303,7 @@
   {# Put on maintenance #}
   <div id="actions-maintenance" class="action-container">
     <form action="{% url 'status2_put_on_maintenance' %}">
+      {% csrf_token %}
       <input type="hidden" name="id[]" value="{{ event.pk }}" />
       <label>
         Description
@@ -328,6 +331,7 @@
   {# Delete module or chassis #}
   <div id="actions-delete" class="action-container">
     <form action="{% url 'status2_delete_module_or_chassis' %}">
+      {% csrf_token %}
       <input type="hidden" name="id[]" value="{{ event.pk }}" />
       <input type="submit" class="button small secondary full-width" value="Delete module or chassis" />
     </form>

--- a/python/nav/web/templates/info/images/upload.html
+++ b/python/nav/web/templates/info/images/upload.html
@@ -1,4 +1,5 @@
 <form id="uploadform" method="POST" enctype="multipart/form-data">
+  {% csrf_token %}
   <input id="file" type="file" name="images" multiple class="inputfile" data-multiple-caption="{count} files selected">
   <label for="file" class="button small"><i class="fa fa-upload"></i><span>Select images to upload</span></label>
   <input type="submit" class="button small secondary" value="Upload selected images">

--- a/python/nav/web/templates/info/netboxgroup/group_edit.html
+++ b/python/nav/web/templates/info/netboxgroup/group_edit.html
@@ -10,6 +10,7 @@
       <div class="column medium-6">
 
         <form method="POST" action="">
+          {% csrf_token %}
 
           <div class="multiple-select-container">
 

--- a/python/nav/web/templates/info/prefix/details.html
+++ b/python/nav/web/templates/info/prefix/details.html
@@ -94,6 +94,7 @@
 
         {% if can_edit %}
           <form id="add-tag-form" class="hidden">
+            {% csrf_token %}
             {{ form.as_p }}
             <input type="submit" class="button tiny" value="Save tags"/>
             <a class="button tiny secondary close-tag-interface">Close</a>

--- a/python/nav/web/templates/info/room/fragment_add_sensor.html
+++ b/python/nav/web/templates/info/room/fragment_add_sensor.html
@@ -1,4 +1,5 @@
 <form method="post" action="{% url 'room-info-racks-save-sensor' room.pk %}">
+  {% csrf_token %}
   <label>
     Choose {{ sensortype }}
     <select class="sensordropdown" name="sensorid">

--- a/python/nav/web/templates/info/room/fragment_add_sensors_sum.html
+++ b/python/nav/web/templates/info/room/fragment_add_sensors_sum.html
@@ -1,4 +1,5 @@
 <form class="sumform" method="post" action="{% url 'room-info-racks-save-sensor' room.pk %}">
+  {% csrf_token %}
   <label>Title<input type="text" name="title" placeholder="Sum of sensors"></label>
   <label>
     {{ sensortype }}

--- a/python/nav/web/templates/info/room/fragment_add_sensorsdiff.html
+++ b/python/nav/web/templates/info/room/fragment_add_sensorsdiff.html
@@ -1,4 +1,5 @@
 <form method="post" action="{% url 'room-info-racks-save-sensor' room.pk %}">
+  {% csrf_token %}
   <label>
     Primary {{ sensortype }}
     <select class="sensordropdown" name="minuendid">

--- a/python/nav/web/templates/info/room/fragment_rack.html
+++ b/python/nav/web/templates/info/room/fragment_rack.html
@@ -21,6 +21,7 @@
   <form action="{% url 'room-info-racks-rename-rack' room.pk rack.pk %}"
         method="post"
         class="rename-rack-form block-when-edit">
+    {% csrf_token %}
     <label>
       Change rack name
       <small class="icon-container">
@@ -89,6 +90,7 @@
   <div class="block-when-edit">
     <h6>Set background color</h6>
     <form class="color-chooser">
+      {% csrf_token %}
       {% for color_class in color_classes %}
         <label>
           <span class="color-indicator {{ color_class }}"></span>

--- a/python/nav/web/templates/info/room/netboxview.html
+++ b/python/nav/web/templates/info/room/netboxview.html
@@ -92,6 +92,7 @@
       </label>
 
       <form id="csv-download-form" action="{% url 'room-csv' %}" method="POST">
+        {% csrf_token %}
         <input type="hidden" name="rows" value="">
         <input type="hidden" name="roomid" value="{{ room.id }}">
         <input type="submit" class="button small secondary" value="Download as CSV">

--- a/python/nav/web/templates/info/room/roominfo_racks.html
+++ b/python/nav/web/templates/info/room/roominfo_racks.html
@@ -23,6 +23,7 @@
 <div id="rackmodal" class="reveal-modal small" data-reveal role="dialog">
   <h3>Add new rack</h3>
   <form action="{% url 'room-info-racks-add-rack' room.pk %}" method="post">
+    {% csrf_token %}
     <input type="hidden" name="roomid" value="{{ room.pk }}">
     <label>
       Rack name


### PR DESCRIPTION
Contributes to https://github.com/Uninett/campus-tasks/issues/45.

**Where to find the forms (ordered by commit):**

Upload pictures form: http://localhost/search/room/900/upload/

Add sensor forms: http://localhost/search/room/900/#!racks, add a rack, then click on "Add sensor"

Rack forms: http://localhost/search/room/900/#!racks, add a rack, then see forms (Renaming and color chooser)

Download CSV form: http://localhost/search/room/900/#!netboxinterfaces, see form under "CSV"

Edit device group form: http://localhost/search/devicegroup/ACCESS/edit/

Event handling form: Go to http://localhost/search/event/1234, select one of the available actions

Add tags to prefix form: Go to http://localhost/search/prefix/225/, see form around "Add tags" button
