### PR TITLE
Use pypi package instead of github url for jwt-drf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 
     "napalm>=5.0.0,<5.1.0",
 
-    "drf-oidc-auth @ git+https://github.com/Uninett/drf-oidc-auth@v4.0",
+    "drf-jwt-multi-auth",
 
     "requests",
 


### PR DESCRIPTION
https://pypi.org/project/drf-jwt-multi-auth/

My account should prob be added to the uninett org so I can give the org account co-ownership