### PR TITLE
Fix adding sensor widget to main page

### DIFF
--- a/changelog.d/3394.fixed.md
+++ b/changelog.d/3394.fixed.md
@@ -1,0 +1,1 @@
+Fix adding sensor widget to main page

--- a/python/nav/web/navlets/__init__.py
+++ b/python/nav/web/navlets/__init__.py
@@ -418,12 +418,6 @@ def add_user_navlet_graph(request):
     return HttpResponse(status=400)
 
 
-ALERT_TYPES = {
-    Sensor.ALERT_TYPE_WARNING: 'warning',
-    Sensor.ALERT_TYPE_ALERT: 'alert',
-}
-
-
 def add_user_navlet_sensor(request):
     """Add a sensor widget with sensor id set"""
     if request.method == 'POST':
@@ -436,7 +430,7 @@ def add_user_navlet_sensor(request):
                 'on_message': sensor.on_message,
                 'off_message': sensor.off_message,
                 'on_state': sensor.on_state,
-                'alert_type': ALERT_TYPES[sensor.alert_type],
+                'alert_type': sensor.alert_type_class,
             }
         else:
             navlet = 'nav.web.navlets.sensor.SensorWidget'


### PR DESCRIPTION
Some sensors have no alert_type specified, which would make this fail. Luckily we already have specified the property `alert_type_class` which we can simply use here.

https://github.com/Uninett/nav/blob/master/python/nav/models/manage.py#L2609-L2613

Found this bug while working on https://github.com/Uninett/nav/pull/3387.