### PR TITLE
Use `flat_form` template for more forms

### DIFF
--- a/python/nav/web/ipdevinfo/forms.py
+++ b/python/nav/web/ipdevinfo/forms.py
@@ -95,6 +95,14 @@ class SensorRangesForm(forms.Form):
     minimum = forms.FloatField(label='Minimum', required=False)
     maximum = forms.FloatField(label='Maximum', required=False)
 
+    def __init__(self, *args, **kwargs):
+        super(SensorRangesForm, self).__init__(*args, **kwargs)
+
+        self.attrs = set_flat_form_attributes(
+            form_method="post",
+            submit_field=SubmitField(value="Update range", css_classes='small'),
+        )
+
 
 class BooleanSensorForm(forms.Form):
     """Form for configuring boolean sensor display"""

--- a/python/nav/web/ipdevinfo/forms.py
+++ b/python/nav/web/ipdevinfo/forms.py
@@ -120,3 +120,11 @@ class BooleanSensorForm(forms.Form):
     alert_type = forms.ChoiceField(
         label='What to display in "on" state', choices=Sensor.ALERT_TYPE_CHOICES
     )
+
+    def __init__(self, *args, **kwargs):
+        super(BooleanSensorForm, self).__init__(*args, **kwargs)
+
+        self.attrs = set_flat_form_attributes(
+            form_method="post",
+            submit_field=SubmitField(value="Update settings", css_classes='small'),
+        )

--- a/python/nav/web/templates/ipdevinfo/sensor-details.html
+++ b/python/nav/web/templates/ipdevinfo/sensor-details.html
@@ -103,10 +103,7 @@
                   data-dashboard-url="{% url 'add-user-navlet-sensor' %}?sensor_id={{ sensor.pk }}">
             Add to dashboard
           </button>
-          <form method="post">
-            {% include 'custom_crispy_templates/_form_content.html' %}
-            <button type="submit" class="button small">Update settings</button>
-          </form>
+          {% include 'custom_crispy_templates/flat_form.html' %}
         {% else %}
           <h4>Gauge display ranges</h4>
           <div id="gauge-wrapper">

--- a/python/nav/web/templates/ipdevinfo/sensor-details.html
+++ b/python/nav/web/templates/ipdevinfo/sensor-details.html
@@ -126,11 +126,7 @@
               Add to dashboard
             </button>
           </div>
-          <form method="post">
-            {% csrf_token %}
-            {{ form }}
-            <button type="submit" class="button small">Update range</button>
-          </form>
+          {% include 'custom_crispy_templates/flat_form.html' %}
         {% endif %}
     </div>
   </div>

--- a/python/nav/web/templates/webfront/preferences.html
+++ b/python/nav/web/templates/webfront/preferences.html
@@ -66,9 +66,7 @@
             account is managed through an external system, known as "{{ account.ext_sync }}".
         </p>
     {% else %}
-        <form method="post" id="change-password-form" action="{% url 'webfront-preferences-changepassword' %}">
-          {% include 'custom_crispy_templates/_form_content.html' with form=password_form %}
-        </form>
+        {% include 'custom_crispy_templates/flat_form.html' with form=password_form %}
     {% endif %}
 
         </div>

--- a/python/nav/web/webfront/forms.py
+++ b/python/nav/web/webfront/forms.py
@@ -85,6 +85,8 @@ class ChangePasswordForm(forms.Form):
         super(ChangePasswordForm, self).__init__(*args, **kwargs)
 
         self.attrs = set_flat_form_attributes(
+            form_id="change-password-form",
+            form_action='webfront-preferences-changepassword',
             form_fields=[
                 FlatFieldset(
                     legend='Change password',


### PR DESCRIPTION
These three forms could be refactored to use the `flat_form` template to automatically have a csrf token and also to look more uniform. 

Another part of working on Uninett/campus-tasks#45

SensorRangeForm: http://localhost/ipdevinfo/sensor/2400 (removes ":" in field labels)
BooleanSensorForm: http://localhost/ipdevinfo/sensor/1485
ChangePasswordForm: http://localhost/preferences/