### PR TITLE
Add CSRF middleware to enable CSRF protection

### DIFF
--- a/changelog.d/3395.security.md
+++ b/changelog.d/3395.security.md
@@ -1,0 +1,1 @@
+Enable CSRF protection

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -44,7 +44,8 @@ try:
 except (IOError, OSError):
     _webfront_config = {}
 
-DEBUG = NAV_CONFIG.get('DJANGO_DEBUG', 'False').upper() in ('TRUE', 'YES', 'ON')
+DEBUG = NAV_CONFIG.get('DJANGO_DEBUG', 'False').upper() in (
+    'TRUE', 'YES', 'ON')
 
 # Copy Django's default logging config, but modify it to enable HTML e-mail
 # part for improved debugging:
@@ -97,14 +98,16 @@ STATICFILES_DIRS = [
     ('uploads', UPLOAD_DIR),
 ]
 # Mount the NAV docs if running under the Django development server
-_base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..'))
+_base_dir = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), '../../..'))
 _doc_dir = os.path.join(_base_dir, 'build/sphinx/html')
 if os.path.isdir(_doc_dir):
     STATICFILES_DIRS.append(('doc', _doc_dir))
 
 
 # Templates
-_global_template_dir = [os.path.join(_config_dir, 'templates')] if _config_dir else []
+_global_template_dir = [os.path.join(
+    _config_dir, 'templates')] if _config_dir else []
 
 TEMPLATES = [
     {
@@ -134,6 +137,7 @@ MIDDLEWARE = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
     'django_htmx.middleware.HtmxMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     # 'nav.web.auth.middleware.NAVRemoteUserMiddleware',
@@ -153,7 +157,8 @@ LOGIN_URL = '/index/login/'
 
 SESSION_SERIALIZER = 'nav.web.session_serializer.PickleSerializer'
 SESSION_ENGINE = 'django.contrib.sessions.backends.db'
-SESSION_COOKIE_AGE = int(_webfront_config.get('sessions', {}).get('timeout', 3600))
+SESSION_COOKIE_AGE = int(_webfront_config.get(
+    'sessions', {}).get('timeout', 3600))
 SESSION_COOKIE_NAME = 'nav_sessionid'
 SESSION_SAVE_EVERY_REQUEST = False
 
@@ -272,7 +277,7 @@ SEARCHPROVIDERS = [
     'nav.web.info.searchproviders.UnrecognizedNeighborSearchProvider',
 ]
 
-## Web security options supported by Django
+# Web security options supported by Django
 # * https://docs.djangoproject.com/en/3.2/ref/middleware/#module-django.middleware.security
 # * https://docs.djangoproject.com/en/3.2/topics/http/sessions/
 # * https://docs.djangoproject.com/en/3.2/ref/clickjacking/

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -44,8 +44,7 @@ try:
 except (IOError, OSError):
     _webfront_config = {}
 
-DEBUG = NAV_CONFIG.get('DJANGO_DEBUG', 'False').upper() in (
-    'TRUE', 'YES', 'ON')
+DEBUG = NAV_CONFIG.get('DJANGO_DEBUG', 'False').upper() in ('TRUE', 'YES', 'ON')
 
 # Copy Django's default logging config, but modify it to enable HTML e-mail
 # part for improved debugging:
@@ -98,16 +97,14 @@ STATICFILES_DIRS = [
     ('uploads', UPLOAD_DIR),
 ]
 # Mount the NAV docs if running under the Django development server
-_base_dir = os.path.abspath(os.path.join(
-    os.path.dirname(__file__), '../../..'))
+_base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..'))
 _doc_dir = os.path.join(_base_dir, 'build/sphinx/html')
 if os.path.isdir(_doc_dir):
     STATICFILES_DIRS.append(('doc', _doc_dir))
 
 
 # Templates
-_global_template_dir = [os.path.join(
-    _config_dir, 'templates')] if _config_dir else []
+_global_template_dir = [os.path.join(_config_dir, 'templates')] if _config_dir else []
 
 TEMPLATES = [
     {
@@ -157,8 +154,7 @@ LOGIN_URL = '/index/login/'
 
 SESSION_SERIALIZER = 'nav.web.session_serializer.PickleSerializer'
 SESSION_ENGINE = 'django.contrib.sessions.backends.db'
-SESSION_COOKIE_AGE = int(_webfront_config.get(
-    'sessions', {}).get('timeout', 3600))
+SESSION_COOKIE_AGE = int(_webfront_config.get('sessions', {}).get('timeout', 3600))
 SESSION_COOKIE_NAME = 'nav_sessionid'
 SESSION_SAVE_EVERY_REQUEST = False
 

--- a/python/nav/web/__init__.py
+++ b/python/nav/web/__init__.py
@@ -22,6 +22,7 @@ import sys
 import os.path
 
 from django.http import HttpResponse
+from django.views.decorators.csrf import csrf_exempt
 
 import nav.logs
 from nav.config import NAVConfigParser
@@ -58,6 +59,7 @@ file_format = png
 webfrontConfig = WebfrontConfigParser()
 
 
+@csrf_exempt
 def refresh_session(request):
     """Forces a refresh of the session by setting the modified flag"""
     request.session.modified = True


### PR DESCRIPTION
Closes Uninett/campus-tasks/issues/45.

Reference: https://docs.djangoproject.com/en/4.2/howto/csrf/
Reference for exempting views from needing a CSRF token: https://docs.djangoproject.com/en/4.2/howto/csrf/#disabling-csrf-protection-for-just-a-few-views

Dependent on #3366, #3367, #3384, #3387, #3388, #3389, #3390, #3391, #3394, #3395, #3465.

Blocked by #3472 and #3563.