### PR TITLE
DHCP pool statistics from Kea DHCP API

### DIFF
--- a/changelog.d/2931.added.md
+++ b/changelog.d/2931.added.md
@@ -1,0 +1,1 @@
+Add support for fetching DHCP pool statistics from Kea DHCP API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ start_arnold = "nav.bin.start_arnold:main"
 t1000 = "nav.bin.t1000:main"
 thresholdmon = "nav.bin.thresholdmon:main"
 navoui = "nav.bin.update_ouis:main"
+navdhcpstats = "nav.bin.dhcpstats:main"
 
 [tool.setuptools]
 include-package-data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "drf-oidc-auth @ git+https://github.com/Uninett/drf-oidc-auth@v4.0",
 
     "requests",
+    "urllib3",
 
     "pyjwt>=2.6.0",
 

--- a/python/nav/bin/dhcpstats.py
+++ b/python/nav/bin/dhcpstats.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2025 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.  You should have received a copy of the GNU General Public License
+# along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Collects statistics from DHCP servers and sends them to the Carbon backend.
+"""
+
+import argparse
+import logging
+from functools import partial
+
+from nav.config import getconfig
+from nav.dhcpstats import kea_dhcp
+from nav.dhcpstats.errors import CommunicationError
+from nav.errors import ConfigurationError
+from nav.logs import init_generic_logging
+from nav.metrics import carbon
+
+_logger = logging.getLogger("nav.dhcpstats")
+LOGFILE = "dhcpstats.log"
+CONFIGFILE = "dhcpstats.conf"
+
+ENDPOINT_CLIENTS = {
+    "kea-dhcp4": partial(kea_dhcp.Client, dhcp_version=4),
+}
+
+
+def main():
+    """Start collecting statistics."""
+    init_generic_logging(logfile=LOGFILE)
+    parse_args()
+    config = getconfig(CONFIGFILE)
+    collect_stats(config)
+
+
+def parse_args():
+    """
+    Builds an ArgumentParser and returns parsed program arguments.
+    (For now, this is called solely to support the --help option.)
+    """
+    parser = argparse.ArgumentParser(
+        description="Collects statistics from DHCP servers and sends them to the Carbon "
+        "backend",
+        epilog="Statistics are collected from each DHCP API endpoint configured in "
+        "'CONFDIR/dhcpstats.conf', and then sent to the Carbon backend configured in "
+        "'CONFDIR/graphite.conf'.",
+    )
+    return parser.parse_args()
+
+
+def collect_stats(config):
+    """
+    Collects current stats from each configured endpoint.
+
+    :param config: dhcpstats.conf INI-parsed into a dict specifying
+    endpoints to collect metrics from.
+    """
+
+    _logger.info("--> Starting stats collection <--")
+
+    all_stats = []
+
+    for client in get_endpoint_clients(config):
+        _logger.info(
+            "Collecting stats using %s...",
+            client,
+        )
+
+        try:
+            fetched_stats = client.fetch_stats()
+        except ConfigurationError as err:
+            _logger.warning(
+                "%s is badly configured: %s, skipping endpoint...",
+                client,
+                err,
+            )
+        except CommunicationError as err:
+            _logger.warning(
+                "Error while collecting stats using %s: %s, skipping endpoint...",
+                client,
+                err,
+            )
+        else:
+            all_stats.extend(fetched_stats)
+            _logger.info(
+                "Successfully collected stats using %s",
+                client,
+            )
+
+    carbon.send_metrics(all_stats)
+
+    _logger.info("--> Stats collection done <--")
+
+
+def get_endpoint_clients(config):
+    """
+    Yields one client per correctly configured endpoint in config. A section
+    of the config correctly configures an endpoint if:
+
+    * Its name starts with 'endpoint_'.
+    * It has the mandatory option 'type'.
+    * The value of the 'type' option is mapped to a client initializer
+      by ENDPOINT_CLIENTS, and the client doesn't raise a
+      ConfigurationError when it is initialized with the rest of the
+      options of the section as keyword arguments.
+
+    :param config: dhcpstats.conf INI-parsed into a dict specifying
+    endpoints to collect metrics from.
+    """
+    for section, options in config.items():
+        if not section.startswith("endpoint_"):
+            continue
+        endpoint_name = section.removeprefix("endpoint_")
+        endpoint_type = options.get("type")
+        kwargs = {opt: val for opt, val in options.items() if opt != "type"}
+        try:
+            cls = ENDPOINT_CLIENTS[endpoint_type]
+        except KeyError:
+            _logger.warning(
+                "Invalid endpoint type '%s' defined in config section [%s], skipping "
+                "endpoint...",
+                endpoint_type,
+                section,
+            )
+            continue
+
+        try:
+            client = cls(endpoint_name, **kwargs)
+        except (ConfigurationError, TypeError) as err:
+            _logger.warning(
+                "Endpoint type '%s' defined in config section [%s] is badly configured: "
+                "%s, skipping endpoint...",
+                endpoint_type,
+                section,
+                err,
+            )
+        else:
+            yield client
+
+
+if __name__ == "__main__":
+    main()

--- a/python/nav/dhcpstats/errors.py
+++ b/python/nav/dhcpstats/errors.py
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2025 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.  You should have received a copy of the GNU General Public License
+# along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Exceptions and errors related to dhcpstats."""
+
+from nav.errors import GeneralException
+
+class CommunicationError(GeneralException):
+    """Communication error"""

--- a/python/nav/dhcpstats/kea_dhcp.py
+++ b/python/nav/dhcpstats/kea_dhcp.py
@@ -1,0 +1,582 @@
+#
+# Copyright (C) 2025 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.  You should have received a copy of the GNU General Public License
+# along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Fetch DHCP stats from Kea DHCP servers, using the Kea API
+"""
+
+from dataclasses import dataclass
+from enum import IntEnum
+from itertools import chain
+import json
+import logging
+import time
+from typing import Optional, Iterator
+
+from IPy import IP
+from requests import RequestException, JSONDecodeError, Session
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
+
+from nav.dhcpstats.errors import CommunicationError
+from nav.errors import ConfigurationError
+from nav.metrics.templates import metric_path_for_dhcp_pool
+
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass(order=True, frozen=True)
+class Pool:
+    """A Kea DHCP configured address pool"""
+
+    subnet_id: int
+    pool_id: int
+
+    name: str
+    range_start: IP
+    range_end: IP
+
+
+GraphiteMetric = tuple[str, tuple[float, int]]
+
+
+class Client:
+    """
+    Fetches DHCP stats for each address pool managed by some Kea DHCP server by using
+    the Kea API. See 'Client.fetch_stats()'.
+
+    Note: This client assumes no hooks have been installed into the Kea DHCP
+          server. The 'lease-stats' hook is required for reliable stats when
+          multiple servers share the same lease database because the standard
+          commands issue the cache, not the DB. This client does not support the
+          hook. Anyhow, the hook doesn't support fetching statistics on a
+          per-pool basis, only per-subnet pasis, which is too coarse for us.
+          See https://kea.readthedocs.io/en/kea-2.6.3/arm/hooks.html#libdhcp-stat-cmds-so-statistics-commands-for-supplemental-lease-statistics.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        url: str,
+        dhcp_version: int = 4,
+        http_basic_username: str = "",
+        http_basic_password: str = "",
+        client_cert_path: str = "",
+        client_cert_key_path: str = "",
+        user_context_poolname_key: str = "name",
+        timeout: float = 5.0,
+    ):
+        self._name: str = name
+        self._url: str = url
+        self._dhcp_version: int = dhcp_version
+        self._http_basic_user: str = http_basic_username
+        self._http_basic_password: str = http_basic_password
+        self._client_cert_path: str = client_cert_path
+        self._client_key_path: str = client_cert_key_path
+        self._user_context_poolname_key: str = user_context_poolname_key
+        self._timeout: float = timeout
+
+        self._kea_config: Optional[dict] = None
+        self._session: Optional[Session] = None
+        self._start_time: float = time.time()
+
+        if dhcp_version == 4:
+            # self._api_namings is a map between how stats are named in NAV and how stats
+            # are named in Kea.
+            self._api_namings = (
+                ("total", "total-addresses"),
+                ("assigned", "assigned-addresses"),
+                ("declined", "declined-addresses"),
+            )
+        else:
+            raise ConfigurationError(f"DHCPv{dhcp_version} is not supported")
+
+    def __str__(self):
+        return (
+            f"API client for Kea DHCPv{self._dhcp_version} endpoint '{self._name}' at "
+            f"{self._url}"
+        )
+
+    def fetch_stats(self) -> list[GraphiteMetric]:
+        """
+        Fetches and returns a list containing the most recent stats of interest
+        for each DHCP address pool. The stats of interest are:
+
+        * The total amount of addresses in that pool.
+          (Named "total" addresses in NAV.)
+
+        * The amount of currently assigned (aka. leased) addresses in that pool.
+          (Named "assigned" addresses in NAV.)
+
+        * The amount of declined addresses in that pool. That is, addresses in
+          that pool that is erroneously used by unkown entities and therefore
+          not available for assignment. The set of declined addresses is a
+          subset of the set of assigned addresses.
+          (Named "declined" addresses in NAV.)
+
+        If the Kea API responds with an empty response to one or more of the
+        stats of interest for a pool, these stats will be missing in the
+        returned list, but a list is still succesfully returned. Other errors
+        during this call will cause a subclass of
+        nav.dhcpstats.errors.CommunicationError or nav.errors.ConfigurationError
+        to be raised.
+        """
+
+        self._session = self._create_session()
+        self._start_time = time.time()
+
+        kea_config = self._fetch_kea_config()
+        raw_stats = self._fetch_raw_stats()
+
+        subnets = self._subnets_of_kea_config(kea_config)
+        pools = list(
+            chain.from_iterable(self._pools_of_subnet(subnet) for subnet in subnets)
+        )
+        stats = list(
+            chain.from_iterable(self._stats_of_pool(raw_stats, pool) for pool in pools)
+        )
+
+        self._log_consistency_with_upstream_pools(pools)
+        self._log_runtime(
+            start_time=self._start_time,
+            end_time=time.time(),
+            n_stats=len(stats),
+            n_pools=len(pools),
+        )
+
+        self._session.close()
+        self._session = None
+        return stats
+
+    def _fetch_raw_stats(self) -> dict:
+        """
+        Returns all statistics recorded by the Kea DHCP server.
+        (API command: 'statistic-get-all')
+        """
+        response = self._send_query("statistic-get-all")
+        return response.get("arguments", {})
+
+    def _fetch_kea_config(self) -> dict:
+        """
+        Returns the current configuration of the Kea DHCP server.
+        (API command: 'config-get'.)
+        """
+        if (
+            self._kea_config is None
+            or (kea_config_hash := self._kea_config.get("hash", None)) is None
+            or kea_config_hash != self._fetch_kea_config_hash()
+        ):
+            response = self._send_query("config-get")
+            self._kea_config = response.get("arguments", {}).get(
+                f"Dhcp{self._dhcp_version}", None
+            )
+            if not isinstance(self._kea_config, dict):
+                raise KeaUnexpected("Unrecognizable response to a 'config-get' request")
+        return self._kea_config
+
+    def _fetch_kea_config_hash(self) -> Optional[str]:
+        """
+        Returns the hash of the current configation of the Kea DHCP server.
+        (API command: 'config-hash-get'.)
+        """
+        try:
+            return (
+                self._send_query("config-hash-get")
+                .get("arguments", {})
+                .get("hash", None)
+            )
+        except KeaUnsupported as err:
+            _logger.debug(str(err))
+            return None
+
+    def _send_query(self, command: str, **kwargs) -> dict:
+        """
+        Returns the response from the Kea API to the given command instructed
+        towards the underlying Kea DHCP server. Keyword arguments to this
+        function will be passed along as arguments to the command.
+
+        Communication errors (HTTP errors, JSON errors, access control errors,
+        unrecognized json response formats) causes a CommunicationError to be
+        raised. If possible, it is reraised from a more descriptive error such
+        as an HTTPError.
+
+        Valid Kea API responses that indicate a failure on the server-end causes
+        a descriptive Kea-specific subclass of CommunicationError to be raised.
+
+        A ConfigurationError is raised if this client is configured in such a
+        way that it can't be consistent with its own configuration while still
+        properly communicating with the Kea API (for example when the use of
+        client certificates, which require TLS, are enabled but HTTPS is
+        disabled).
+        """
+        session = self._session or self._create_session()
+
+        _logger.debug("Sending command '%s' to Kea API at %s", command, self._url)
+
+        post_data = json.dumps(
+            {
+                "command": command,
+                "arguments": kwargs,
+                "service": [f"dhcp{self._dhcp_version}"],
+            }
+        )
+
+        try:
+            responses = session.post(
+                self._url,
+                data=post_data,
+                timeout=self._timeout,
+                headers={"Content-Type": "application/json"},
+            )
+            _logger.debug(
+                "HTTP response status to command '%s' from %s was 'HTTP %s: %s'",
+                command,
+                self._url,
+                responses.status_code,
+                responses.reason,
+            )
+            responses.raise_for_status()
+            responses = responses.json()
+        except JSONDecodeError as err:
+            raise KeaUnexpected(
+                f"{self._url} does not look like a Kea API endpoint; "
+                f"response to command {command} was not valid JSON",
+            ) from err
+        except RequestException as err:
+            raise CommunicationError from err
+
+        # Any valid response from Kea is a JSON list with one entry corresponding to the
+        # response from either the dhcp4 or dhcp6 service we queried
+        if not (
+            isinstance(responses, list)
+            and len(responses) == 1
+            and isinstance((response := responses[0]), dict)
+            and "result" in response
+            and isinstance((status := response["result"]), int)
+        ):
+            if (
+                isinstance(responses, dict)
+                and "result" in responses
+                and "text" in responses
+                and isinstance((status := responses["result"]), int)
+                and isinstance((message := responses["text"]), str)
+            ):
+                # If the response is a JSON object it's a specific error message
+                # See https://kea.readthedocs.io/en/kea-2.6.0/arm/ctrl-channel.html#control-agent-command-response-format
+                raise KeaUnexpected(f"{status}: {message}")
+            else:
+                # Otherwise, something odd is happening
+                raise KeaUnexpected(
+                    f"{self._url} does not look like a Kea API; "
+                    "response JSON structured in an unknown way",
+                )
+
+        _logger.debug(
+            "API response status to command '%s' from %s was 'Kea %s: %s'",
+            command,
+            self._url,
+            status,
+            response.get("text", _KeaStatus.describe(status)),
+        )
+
+        _raise_for_kea_status(status)
+
+        return response
+
+    def _create_session(self) -> Session:
+        """
+        Creates and returns an HTTP session with authentication based on
+        credentials passed during object initialization.
+        """
+        _logger.debug(
+            "Creating new HTTP/HTTPS session for use with Kea API at %s", self._url
+        )
+
+        session = Session()
+
+        retries = Retry(
+            total=3,
+            backoff_factor=0.1,
+            status_forcelist=[500, 502, 503, 504],
+            allowed_methods={"POST"},
+        )
+
+        session.mount("https://", HTTPAdapter(max_retries=retries))
+        session.mount("http://", HTTPAdapter(max_retries=retries))
+
+        https = self._url.startswith("https://")
+
+        if https:
+            _logger.debug("Using HTTPS")
+        else:
+            _logger.debug("Using HTTP")
+            _logger.warning(
+                "Using HTTP to request potentially sensitive data such as API passwords"
+            )
+
+        if self._http_basic_user and self._http_basic_password:
+            _logger.debug("Using HTTP Basic Authentication")
+            if not https:
+                _logger.warning("Using HTTP Basic Authentication without HTTPS")
+            session.auth = (self._http_basic_user, self._http_basic_password)
+        else:
+            _logger.debug("Not using HTTP Basic Authentication")
+
+        if self._client_cert_path:
+            _logger.debug("Using client certificate authentication")
+            if not https:
+                raise ConfigurationError(
+                    "Authentication using client certificates is only available for urls "
+                    "with HTTPS scheme"
+                )
+            _logger.debug("Certificate path: '%s'", self._client_cert_path)
+            if self._client_key_path:
+                _logger.debug("Certificate key path: '%s'", self._client_key_path)
+                session.cert = (self._client_cert_path, self._client_key_path)
+            else:
+                session.cert = self._client_cert_path
+        else:
+            _logger.debug("Not using client certificate authentication")
+
+        return session
+
+    def _subnets_of_kea_config(self, config: dict) -> Iterator[dict]:
+        """
+        Returns one subnet-dict per subnet configured under "subnet" or under "shared-networks"
+        of a Kea DHCP configuration.
+        """
+        subnetkey = f"subnet{self._dhcp_version}"
+
+        standalone_subnets = config.get(subnetkey, [])
+        shared_network_subnets = chain.from_iterable(
+            shared_network_config.get(subnetkey, [])
+            for shared_network_config in config.get("shared-networks", [])
+        )
+
+        yield from chain(standalone_subnets, shared_network_subnets)
+
+    def _pools_of_subnet(self, subnet: dict) -> Iterator[Pool]:
+        """
+        Returns one Pool instance per pool configured under "pools" of a subnet
+        of a Kea DHCP configuration.
+        """
+        try:
+            subnet_id = int(subnet["id"])
+        except (KeyError, TypeError, ValueError):
+            _logger.info(
+                "Misconfigured subnet from %s, skipping subnet...",
+                self._url,
+            )
+            return
+
+        for pool in subnet.get("pools", []):
+            try:
+                pool_id = int(pool["pool-id"])
+                pool_start, pool_end = self._bounds_of_pool_range(pool["pool"])
+                pool_name = self._name_of_pool(
+                    pool,
+                    fallback=f"pool-{pool_start.strNormal()}-{pool_end.strNormal()}",
+                )
+            except (AttributeError, KeyError, TypeError, ValueError):
+                _logger.info(
+                    'Could not parse pool in subnet %d from %s, skipping pool...  (make '
+                    'sure every pool has "pool-id" and "pool" configured in the Kea DHCP '
+                    'configuration)',
+                    subnet_id,
+                    self._url,
+                )
+                continue
+
+            yield Pool(
+                subnet_id=subnet_id,
+                pool_id=pool_id,
+                name=pool_name,
+                range_start=pool_start,
+                range_end=pool_end,
+            )
+
+    def _stats_of_pool(self, raw_stats: dict, pool: Pool) -> Iterator[GraphiteMetric]:
+        """
+        Return as graphite metric tuples the most recent stats of interest in
+        raw_stats, for the given pool.
+
+        raw_stats is a dictionary representing the result of the Kea API command
+        'statistic-get-all'.
+        """
+
+        for nav_stat_name, api_stat_name in self._api_namings:
+            statistic = f"subnet[{pool.subnet_id}].pool[{pool.pool_id}].{api_stat_name}"
+            samples = raw_stats.get(statistic, [])
+            if len(samples) == 0:
+                _logger.info(
+                    "No stats found when querying for '%s' in pool having range "
+                    "'%s-%s' and name '%s'",
+                    api_stat_name,
+                    pool.range_start,
+                    pool.range_end,
+                    pool.name,
+                )
+            else:
+                # The reference API client assumes samples[0] is the most recent sample
+                # See https://gitlab.isc.org/isc-projects/stork/-/blob/4193375c01e3ec0b3d862166e2329d76e686d16d/backend/server/apps/kea/rps.go#L223-227
+                value, _timestring = samples[0]
+                path = metric_path_for_dhcp_pool(
+                    self._dhcp_version,
+                    self._name,
+                    pool.name,
+                    pool.range_start,
+                    pool.range_end,
+                    nav_stat_name,
+                )
+                yield (path, (self._start_time, value))
+
+    def _bounds_of_pool_range(self, pool_range: str) -> tuple[IP, IP]:
+        """
+        Returns a pair where the first element is the first IP and the second
+        element is the last IP of a string used in the Kea DHCP configuration
+        file for representing a range of IP addresses. Example:
+
+        > self._bounds_of_pool_range("10.0.0.0 - 10.0.0.10")
+        > IP(10.0.0.0), IP(10.0.0.10)
+
+        > self._bounds_of_pool_range("10.0.0.0/24")
+        > IP(10.0.0.0), IP(10.0.0.255)
+        """
+        if "-" in pool_range:
+            # x.x.x.x - x.x.x.x
+            range_start, _, range_end = pool_range.partition("-")
+            range_start = IP(range_start.strip())
+            range_end = IP(range_end.strip())
+        else:
+            # x.x.x.x/m
+            ip = IP(pool_range.strip())
+            range_start = IP(ip[0])
+            range_end = IP(ip[-1])
+        return range_start, range_end
+
+    def _name_of_pool(self, pool: dict, fallback: str) -> str:
+        """
+        Looks for a pool name in a pool of a Kea DHCP configuration.
+        Returns pool name if found, else returns a fallback name.
+        """
+        pool_name_key = self._user_context_poolname_key
+        pool_name = pool.get("user-context", {}).get(pool_name_key, None)
+        if not isinstance(pool_name, str):
+            _logger.debug(
+                '%s did not find a pool name when looking up "%s" in "user-context" '
+                'for a pool, defaulting to name "%s"... ',
+                self,
+                pool_name_key,
+                fallback,
+            )
+            return fallback
+        return pool_name
+
+    def _log_consistency_with_upstream_pools(self, local_pools: list):
+        """
+        The part of the Kea API that deal with pools identify each pool by
+        ID. This function logs a warning if the mapping between pool ID and pool
+        object differs between the pools stored in the client (local_pools) and
+        the pools known to the Kea API right now.
+        """
+        upstream_config = self._fetch_kea_config()
+        upstream_subnets = self._subnets_of_kea_config(upstream_config)
+        upstream_pools = list(
+            chain.from_iterable(
+                self._pools_of_subnet(subnet) for subnet in upstream_subnets
+            )
+        )
+
+        if sorted(local_pools) != sorted(upstream_pools):
+            _logger.warning(
+                "The DHCP server's address pool configuration was modified while stats "
+                "were being fetched. This may cause stats collected during this run to "
+                "be associated with wrong address pool."
+            )
+
+    def _log_runtime(
+        self, start_time: float, end_time: float, n_stats: int, n_pools: int
+    ):
+        """
+        Logs a debug message about the time spent during a 'self.fetch_stats()'
+        run and the amount of pools and stats seen.
+        """
+        _logger.debug(
+            "Fetched %d stats(s) from %d pool(s) in %.2f seconds from %s",
+            n_stats,
+            n_pools,
+            end_time - start_time,
+            self._url,
+        )
+
+
+class KeaUnexpected(CommunicationError):
+    """An unexpected error occurred when communicating with Kea"""
+
+
+class KeaError(CommunicationError):
+    """Kea API failed during command processing"""
+
+
+class KeaUnsupported(CommunicationError):
+    """Command not supported by Kea API"""
+
+
+class KeaEmpty(CommunicationError):
+    """Requested resource not found by Kea API"""
+
+
+class KeaConflict(CommunicationError):
+    """
+    Kea API failed to apply requested changes due to conflicts with
+    its internal state
+    """
+
+
+class _KeaStatus(IntEnum):
+    """Status of a response sent from a Kea API"""
+
+    SUCCESS = 0
+    ERROR = 1
+    UNSUPPORTED = 2
+    EMPTY = 3
+    CONFLICT = 4
+
+    @classmethod
+    def describe(cls, status: int) -> str:
+        try:
+            return cls(status).name
+        except ValueError:
+            return "(status has no description)"
+
+
+def _raise_for_kea_status(status: int):
+    """
+    Raises a suitable Kea-specific subclass of CommunicationError if status is
+    not _KeaStatus.SUCCESS.
+    """
+    if status == _KeaStatus.SUCCESS:
+        return
+    elif status == _KeaStatus.UNSUPPORTED:
+        raise KeaUnsupported
+    elif status == _KeaStatus.EMPTY:
+        raise KeaEmpty
+    elif status == _KeaStatus.ERROR:
+        raise KeaError
+    elif status == _KeaStatus.CONFLICT:
+        raise KeaConflict
+    else:
+        raise KeaUnexpected("Unkown response status")

--- a/python/nav/etc/cron.d/navdhcpstats
+++ b/python/nav/etc/cron.d/navdhcpstats
@@ -1,0 +1,2 @@
+## info: Regularly fetch DHCP stats from endpoints in dhcpstats.conf to the Carbon backend
+*/5 * * * * navdhcpstats

--- a/python/nav/etc/dhcpstats.conf
+++ b/python/nav/etc/dhcpstats.conf
@@ -1,0 +1,112 @@
+# This file contains the configuration for collection of stats from DHCP servers.
+# For NAV to collect stats from a DHCP server, an endpoint that serves such
+# statistics (e.g. the DHCP server itself or an external API endpoint) must be
+# set up and then configured as an endpoint in this config file.
+#
+# Any section whose name starts with the endpoint_
+# prefix defines a new endpoint configuration:
+#
+# [endpoint_foo] <--- This section configures an endpoint with identifier 'foo'
+# type=dnsmasq <--- This option tells us it's a dnsmasq endpoint
+# url=https://url.to.dnsmasq.server/ <--- This option tells us where the endpoint is located
+#
+# [foo] <--- This section does *not* configure an endpoint
+# type=dnsmasq
+# url=https://url.to.dnsmasq.api.endpoint/
+#
+# Note that section names are used when storing data for endpoints into the
+# Carbon timeseries backend, and as such it *should* only contain english
+# letters, digits, underscores, and hyphens. Any other character is replaced by
+# an underscore, which at best causes some confusion and at worst causes
+# unrelated endpoints to be treated as the same endpoint in the timeseries
+# database.
+
+
+# The remainder of this commentary documents how to configure the
+# various types of endpoints that is supported:
+
+
+# Configuring collection of stats from 'kea-dhcp4' endpoints
+# ==========================================================
+#
+# Mandatory options
+# -----------------
+# * The 'type' option, specifying what type of endpoint is being configured. Its
+#   value must be set to 'kea-dhcp4'.
+#
+# * The 'url' option, specifying where the endpoint is located. The url's scheme
+#   must be 'http' or 'https'. Sensitive data (such as passwords) that might be
+#   stored in the Kea DHCPv4 server's configuration is transmitted during
+#   correspondence, so using 'https' is highly recommended. As a sidenote, such
+#   possibly sensitive data is also temporarily stored in the memory of a NAV
+#   process.
+#
+# Optional options
+# ----------------
+# * The 'timeout' optional option, specifying how long in seconds the client
+#   should wait for an HTTP response from the endpoint before timing
+#   out. Defaults to 5.0.
+#
+# * The 'http_basic_username' and 'http_basic_password' optional options. When
+#   both of these options are set, HTTP Basic Authentication will be used in
+#   communication with the endpoint.
+#
+# * The 'client_cert_path' optional option, specifying the path to a client-side
+#   certificate.  When this option is set, the certificate will be used to
+#   authenticate to the endpoint in TLS connections. If the
+#   'client_cert_key_path' option (described below) is not set, it is assumed
+#   that the certificate also contains the client private key necessary to
+#   authenticate the client.
+#
+# * The 'client_cert_key_path' optional option, specifying the path to the
+#   client private key to be used alongside the client certificate to
+#   authenticate the client.
+#
+# * The 'user_context_poolname_key' optional option, specifying how NAV finds
+#   the name of a Kea DHCPv4 address pool. On the server-side each Kea DHCPv4
+#   address pool is configured as a JSON object with a mandatory 'pool' key and
+#   an optional 'user-context' key holding an arbitrary JSON object. The
+#   'user_context_poolname_key' option specifies which key in this
+#   'user-context' object NAV will look up to find the name of a Kea DHCPv4
+#   address pool. By default, NAV will look for the 'name' key. Example:
+#
+#     If 'user_context_poolname_key' has been set to 'custom-poolname' for a Kea
+#     DHCPv4 server with the following configuration:
+#
+#     {
+#       "Dhcp4": {
+#         "subnet4": [
+#           {
+#             "subnet":  "172.31.255.0/24",
+#             "pools": [
+#               {
+#                 "pool": "172.31.255.0/25",
+#                  "user-context": {
+#                    "custom-poolname": "oslo-staff"
+#                  }
+#               }
+#             ],
+#             "id": 1,
+#             "interface": "eth0"
+#           }
+#         ]
+#       }
+#     }
+#
+#     Then NAV will associate with the address pool '172.31.255.0/25' the name
+#     'oslo-staff'. Note that the name of a Kea DHCPv4 address pool *should*
+#     only contain english letters, digits, underscores, and hyphens as it
+#     will be stored into the Carbon timeseries backend.
+#
+#
+# Example 'kea-dhcp4' configuration
+# ---------------------
+# [endpoint_example_1]
+# type=kea-dhcp4
+# url=https://example.org:8080/
+# timeout=5.0
+# http_basic_username=nav
+# http_basic_password=cfcc3475c4de4f0484a4a475ec0a6edd
+# client_cert_path=/etc/client.cert
+# client_cert_key_path=/etc/client.key
+# user_context_poolname_key=name

--- a/python/nav/etc/graphite/storage-schemas.conf
+++ b/python/nav/etc/graphite/storage-schemas.conf
@@ -38,6 +38,12 @@ retentions = 20s:6h, 60s:1d, 300s:7d, 30m:12d, 2h:50d, 1d:600d
 pattern = ^nav\.prefixes\.
 retentions = 30m:30d, 2h:90d, 6h:600d
 
+# NAV dhcp metric retention archive
+[nav-dhcp]
+pattern = ^nav\.dhcp\.
+retentions = 300s:7d, 30m:12d, 2h:50d, 1d:600d
+
+
 # NAV generic metric retention archive
 [nav-generic]
 pattern = ^nav\.

--- a/python/nav/metrics/templates.py
+++ b/python/nav/metrics/templates.py
@@ -20,6 +20,7 @@ Graphite.
 """
 
 from nav.metrics.names import escape_metric_name
+import IPy
 
 # pylint: disable=C0111
 
@@ -184,4 +185,20 @@ def metric_path_for_multicast_usage(group, sysname):
     return tmpl.format(
         group=metric_prefix_for_multicast_group(group),
         sysname=escape_metric_name(sysname),
+    )
+
+
+def metric_path_for_dhcp_pool(
+    ip_version, server_name, pool_name, range_start, range_end, metric_name
+):
+    tmpl = "nav.dhcp.{ip_version}.pool.{server_name}.{pool_name}.{range_start}.{range_end}.{metric_name}"
+    range_start = IPy.IP(range_start).strNormal()
+    range_end = IPy.IP(range_end).strNormal()
+    return tmpl.format(
+        ip_version=escape_metric_name(str(ip_version)),
+        server_name=escape_metric_name(server_name),
+        pool_name=escape_metric_name(pool_name),
+        range_start=escape_metric_name(range_start),
+        range_end=escape_metric_name(range_end),
+        metric_name=escape_metric_name(metric_name),
     )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -44,5 +44,6 @@ PyOpenSSL==23.3.0
 service-identity==21.1.0
 
 requests
+urllib3
 
 pyjwt>=2.6.0

--- a/tests/unittests/dhcpstats/kea_dhcp_test.py
+++ b/tests/unittests/dhcpstats/kea_dhcp_test.py
@@ -1,0 +1,943 @@
+from collections import deque, namedtuple
+from copy import deepcopy
+from datetime import datetime, timedelta
+from itertools import chain
+import json
+import logging
+import pytest
+from requests.exceptions import JSONDecodeError
+from typing import Callable
+
+import requests
+
+from nav.dhcpstats.errors import CommunicationError
+from nav.dhcpstats.kea_dhcp import Client, KeaUnexpected
+from nav.dhcpstats.kea_dhcp import _KeaStatus
+from nav.errors import ConfigurationError
+
+
+ENDPOINT_NAME = "dhcp-server-foo"
+
+
+class TestExpectedAPIResponses:
+    """
+    Checks that the client acts as expected when the Kea API responds in an
+    expected way
+    """
+
+    def test_fetch_stats_should_return_correct_stats(self, valid_dhcp4, api_mock):
+        """
+        This test checks that fetch_stats() returns the correct and most up to
+        date stats from the API for each <pool> and <stat type>.
+        """
+
+        config, statistics, expected_stats = valid_dhcp4
+        api_mock.autofill("dhcp4", config=config, statistics=statistics)
+        client = Client(ENDPOINT_NAME, "http://example.org/")
+
+        actual_stats = client.fetch_stats()
+
+        def normalize(stats):
+            """
+            Set stat timestamps to zero, because we do not care to compare the
+            time a stat was fetched into NAV in this test.
+            """
+            return sorted((path, (0, value)) for (path, (_time, value)) in stats)
+
+        assert normalize(actual_stats) == normalize(expected_stats)
+
+    def test_fetch_stats_should_only_have_recent_timestamps(
+        self, valid_dhcp4, api_mock
+    ):
+        """
+        This test checks that fetch_stats() returns stats that have recent
+        enough timestamps (instead of the potentially very old timestamps
+        representing the last time the stat was changed that the API assigns
+        each stat).
+
+        When fetched stats have recent timestamps, they will form an evenly
+        spaced timeseries in graphite.
+        """
+
+        config, statistics, expected_stats = valid_dhcp4
+        api_mock.autofill("dhcp4", config=config, statistics=statistics)
+        client = Client(ENDPOINT_NAME, "http://example.org/")
+
+        actual_stats = client.fetch_stats()
+        assert len(actual_stats) > 0
+        for _path, (time, _value) in actual_stats:
+            assert time >= (datetime.now() - timedelta(minutes=5)).timestamp()
+
+    def test_fetch_stats_should_handle_empty_config_api_response(
+        self, valid_dhcp4, api_mock
+    ):
+        """
+        The client should handle the case where the Kea DHCP server responds
+        with an empty JSON object as the dhcp4 configuration returned by a
+        'config-get' request.  We assume in this case that the Kea DHCP server
+        we query just doesn't have any pools configured.  The correct thing to
+        do in this case is to just return an empty list of stats since there are
+        no pools to fetch from.
+        """
+        config, statistics, expected_stats = valid_dhcp4
+        api_mock.autofill("dhcp4", config=None, statistics=statistics)
+        api_mock.add(
+            "config-get",
+            lambda kea_arguments, kea_service: make_api_response({"Dhcp4": {}}),
+        )
+        client = Client(ENDPOINT_NAME, "http://example.org/")
+        assert list(client.fetch_stats()) == []
+
+    def test_fetch_stats_should_handle_empty_statistic_in_statistics_api_response(
+        self, valid_dhcp4, api_mock
+    ):
+        """
+        If the Kea DHCP server returns no values for a specific statistic,
+        disregard that stat when creating a list of stats. In the extreme case
+        that all statistics from the API are empty, 'fetch_stats()' should
+        return an empty list.
+        """
+        config, statistics, expected_stats = valid_dhcp4
+        statistics = {key: [] for key, value in statistics.items()}
+        api_mock.autofill("dhcp4", config=config, statistics=statistics)
+        client = Client(ENDPOINT_NAME, "http://example.org/")
+        assert list(client.fetch_stats()) == []
+
+    def test_fetch_stats_should_handle_empty_statistics_api_response(
+        self, valid_dhcp4, api_mock
+    ):
+        """
+        If the Kea DHCP server returns an empty JSON object when querying for
+        all of its recorded statistics with the API call 'statistic-get-all',
+        then it has recorded no statistics and 'fetch_stats()' should return an
+        empty list.
+        """
+
+        config, statistics, expected_stats = valid_dhcp4
+        api_mock.autofill("dhcp4", config=config, statistics=None)
+        api_mock.add(
+            "statistic-get-all",
+            lambda kea_arguments, kea_service: make_api_response({}),
+        )
+        client = Client(ENDPOINT_NAME, "http://example.org/")
+        assert list(client.fetch_stats()) == []
+
+    @pytest.mark.parametrize("http_status", chain(range(400, 430), range(500, 530)))
+    def test_fetch_stats_should_raise_an_exception_on_http_error_response(
+        self, valid_dhcp4, api_mock, http_status
+    ):
+        """
+        If the server responds with an HTTP error, the client should raise an
+        error.
+        """
+
+        config, statistics, expected_stats = valid_dhcp4
+        api_mock.autofill(
+            "dhcp4",
+            config=config,
+            statistics=statistics,
+            attrs={"status_code": http_status},
+        )
+
+        client = Client(ENDPOINT_NAME, "http://example.org/")
+
+        with pytest.raises(CommunicationError):
+            client.fetch_stats()
+
+    @pytest.mark.parametrize(
+        "kea_status", [status for status in _KeaStatus if status != _KeaStatus.SUCCESS]
+    )
+    def test_fetch_stats_should_raise_an_exception_on_error_status_in_config_api_response(
+        self, valid_dhcp4, api_mock, kea_status
+    ):
+        """
+        If the server reports an API-specific error regarding serving its
+        configuration, the client should raise an error.
+        """
+        config, statistics, expected_stats = valid_dhcp4
+        api_mock.autofill("dhcp4", config=None, statistics=statistics)
+        api_mock.add(
+            "config-get",
+            lambda kea_arguments, kea_service: make_api_response(
+                config, status=kea_status
+            ),
+        )
+        client = Client(ENDPOINT_NAME, "http://example.org/")
+        with pytest.raises(CommunicationError):
+            client.fetch_stats()
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            status
+            for status in _KeaStatus
+            if status not in (_KeaStatus.SUCCESS, _KeaStatus.EMPTY)
+        ],
+    )
+    def test_fetch_stats_should_raise_an_exception_on_error_status_in_statistic_api_response(
+        self, valid_dhcp4, api_mock, status
+    ):
+        """
+        If the server reports an API-specific error regarding serving
+        statistics, the client should raise an error.
+        """
+        config, statistics, expected_stats = valid_dhcp4
+        api_mock.autofill("dhcp4", config=config, statistics=None)
+        api_mock.add(
+            "statistic-get-all",
+            lambda kea_arguments, kea_service: make_api_response(
+                statistics, status=status
+            ),
+        )
+        client = Client(ENDPOINT_NAME, "http://example.org/")
+        with pytest.raises(CommunicationError):
+            client.fetch_stats()
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            status
+            for status in _KeaStatus
+            if status not in (_KeaStatus.SUCCESS, _KeaStatus.UNSUPPORTED)
+        ],
+    )
+    def test_fetch_stats_should_raise_an_exception_on_error_status_in_config_hash_api_response(
+        self, valid_dhcp4, api_mock, status
+    ):
+        """
+        If the server reports an API-specific error regarding serving its
+        configuration's hash, other than that functionality being unsupported,
+        the client should raise an error.
+        """
+        foohash = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
+        config, statistics, expected_stats = valid_dhcp4
+        client = Client(ENDPOINT_NAME, "http://example.org/")
+        config["Dhcp4"]["hash"] = foohash
+        api_mock.autofill("dhcp4", config=config, statistics=statistics)
+        api_mock.add(
+            "config-hash-get", make_api_response({"hash": foohash}, status=status)
+        )
+        with pytest.raises(CommunicationError):
+            client.fetch_stats()
+
+    def test_fetch_stats_should_check_and_warn_if_server_config_changed_during_call(
+        self, valid_dhcp4, api_mock, caplog
+    ):
+        """
+        Due to how the Kea API works, we must fetch the Kea DHCP configuration,
+        and then fetch the Kea DHCP statistics, and only after that can we
+        create some mapping from values in the configuration to values in the
+        statistics.
+
+        A warning should be logged when the Kea DHCP configuration changes after
+        we've fetched the configuration but before we've fully fetched and
+        processed the statistics to signify that we might have relied upon a
+        stale configuration while fetching/processing and thus may have created
+        a bad mapping from configuration to statistics.
+        """
+        config, statistics, expected_stats = valid_dhcp4
+        client = Client(ENDPOINT_NAME, "http://example.org/")
+        api_mock.autofill("dhcp4", config=None, statistics=statistics)
+        api_mock.add("config-get", make_api_response(config))
+        updated_config = deepcopy(config)
+        updated_config["Dhcp4"]["subnet4"][0]["pools"][0]["pool"] = "42.0.1.1-42.0.1.5"
+        api_mock.add(
+            "config-get",
+            lambda kea_arguments, kea_service: make_api_response(updated_config),
+        )
+
+        with caplog.at_level(logging.WARNING):
+            client.fetch_stats()
+
+        assert (
+            "configuration was modified while stats were being fetched" in caplog.text
+        )
+
+
+@pytest.mark.parametrize("invalid_response", ["{}", "foo", "\x00", "[]", "1"])
+class TestUnexpectedAPIResponses:
+    """
+    Checks that the client fails loudly if the Kea API responds in an unexpected
+    way.
+    """
+
+    def test_fetch_stats_should_raise_an_exception_on_unrecognizable_config_api_response(
+        self, valid_dhcp4, api_mock, invalid_response
+    ):
+        config, statistics, expected_stats = valid_dhcp4
+        client = Client(ENDPOINT_NAME, "http://example.org/")
+
+        api_mock.autofill("dhcp4", config=None, statistics=statistics)
+        api_mock.add("config-get", invalid_response)
+        with pytest.raises(KeaUnexpected):
+            client.fetch_stats()
+
+    def test_fetch_stats_should_raise_an_exception_on_unrecognizable_statistic_api_response(
+        self, valid_dhcp4, api_mock, invalid_response
+    ):
+        config, statistics, expected_stats = valid_dhcp4
+        client = Client(ENDPOINT_NAME, "http://example.org/")
+
+        api_mock.autofill("dhcp4", config=config, statistics=None)
+        api_mock.add("statistic-get-all", invalid_response)
+        with pytest.raises(KeaUnexpected):
+            client.fetch_stats()
+
+    def test_fetch_stats_should_raise_an_exception_on_unrecognizable_config_hash_api_response(
+        self, valid_dhcp4, api_mock, invalid_response
+    ):
+        config, statistics, expected_stats = valid_dhcp4
+        client = Client(ENDPOINT_NAME, "http://example.org/")
+        config["Dhcp4"]["hash"] = "foo"
+        api_mock.autofill("dhcp4", config=config, statistics=statistics)
+        api_mock.add("config-hash-get", invalid_response)
+        with pytest.raises(KeaUnexpected):
+            client.fetch_stats()
+
+
+class TestConfigCaching:
+    """
+    Checks that the '_fetch_kea_config()' method doesn't request the DHCP
+    configuration from the Kea DHCP server more often than necessary.
+    """
+
+    def test_fetch_kea_config_should_not_refetch_config_if_its_hash_is_unchanged(
+        self, api_mock
+    ):
+        api_mock.add(
+            "config-get",
+            lambda kea_arguments, kea_service: make_api_response(
+                {"Dhcp4": {"hash": "1"}}
+            ),
+        )
+        api_mock.add(
+            "config-hash-get",
+            lambda kea_arguments, kea_service: make_api_response({"hash": "1"}),
+        )
+
+        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client._fetch_kea_config()
+        client._fetch_kea_config()
+
+        assert len(api_mock.requests["config-get"]) == 1
+
+    def test_fetch_kea_config_should_refetch_config_if_its_hash_is_changed(
+        self, api_mock
+    ):
+        api_mock.add(
+            "config-get",
+            lambda kea_arguments, kea_service: make_api_response(
+                {"Dhcp4": {}, "hash": "1"}
+            ),
+        )
+        api_mock.add(
+            "config-hash-get",
+            lambda kea_arguments, kea_service: make_api_response({"hash": "2"}),
+        )
+
+        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client._fetch_kea_config()
+        client._fetch_kea_config()
+
+        assert len(api_mock.requests["config-get"]) == 2
+
+    def test_fetch_kea_config_should_refetch_config_if_its_hash_is_missing(
+        self, api_mock
+    ):
+        api_mock.add(
+            "config-get",
+            lambda kea_arguments, kea_service: make_api_response({"Dhcp4": {}}),
+        )
+        api_mock.add(
+            "config-hash-get",
+            lambda kea_arguments, kea_service: make_api_response({"hash": "1"}),
+        )
+
+        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client._fetch_kea_config()
+        client._fetch_kea_config()
+
+        assert len(api_mock.requests["config-get"]) == 2
+
+    def test_fetch_kea_config_should_refetch_config_if_config_hash_is_unsupported(
+        self, api_mock
+    ):
+        api_mock.add(
+            "config-get",
+            lambda kea_arguments, kea_service: make_api_response(
+                {"Dhcp4": {}, "hash": "1"}
+            ),
+        )
+
+        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client._fetch_kea_config()
+        client._fetch_kea_config()
+
+        assert len(api_mock.requests["config-get"]) == 2
+
+
+class TestHTTPSession:
+    """
+    Checks that the client creates and uses HTTP sessions the way we want it to.
+    """
+
+    def test_fetch_stats_should_warn_if_using_http(self, valid_dhcp4, api_mock, caplog):
+        """
+        A warning should be logged when the scheme is HTTP since config responses
+        from the Kea API may contain sensitive data such as passwords in plaintext.
+        """
+        config, statistics, expected_stats = valid_dhcp4
+        client = Client(ENDPOINT_NAME, "http://example.org/")
+        api_mock.autofill("dhcp4", config=config, statistics=statistics)
+
+        with caplog.at_level(logging.WARNING):
+            client.fetch_stats()
+
+        assert (
+            "Using HTTP to request potentially sensitive data such as API passwords"
+            in caplog.text
+        )
+
+    def test_fetch_stats_should_warn_if_using_http_basic_auth_with_http(
+        self, valid_dhcp4, api_mock, caplog
+    ):
+        """
+        An extra warning when the scheme is HTTP should be logged when HTTP Basic
+        Authentication is being used since this entails passwords being sent in
+        plaintext from client to server.
+        """
+        config, statistics, expected_stats = valid_dhcp4
+        client = Client(
+            ENDPOINT_NAME,
+            "http://example.org/",
+            http_basic_username="nav",
+            http_basic_password="nav",
+        )
+        api_mock.autofill("dhcp4", config=config, statistics=statistics)
+
+        with caplog.at_level(logging.WARNING):
+            client.fetch_stats()
+
+        assert "Using HTTP Basic Authentication without HTTPS" in caplog.text
+
+    def test_fetch_stats_should_error_if_using_client_certificate_with_http(
+        self, valid_dhcp4, api_mock
+    ):
+        """
+        Client authentication is part of the TLS spec so it doesn't make sense to
+        continue if it is configured and the specified scheme is HTTP as we would
+        have to either ignore the wish to use HTTP or the wish to use TLS
+        certificates or both.
+        """
+        config, statistics, expected_stats = valid_dhcp4
+        client = Client(
+            ENDPOINT_NAME, "http://example.org/", client_cert_path="/bar/baz.pem"
+        )
+        api_mock.autofill("dhcp4", config=config, statistics=statistics)
+
+        with pytest.raises(ConfigurationError):
+            client.fetch_stats()
+
+    def test_fetch_stats_should_use_http_basic_auth_when_this_is_configured(
+        self, valid_dhcp4, api_mock, monkeypatch
+    ):
+        """
+        Checks that the requests.Session object used during a call to
+        Client.fetch_stats() has HTTP Basic Authentication parameters configured
+        throughout the call if HTTP Basic Authentication was configured during
+        client init.
+        """
+        config, statistics, expected_stats = valid_dhcp4
+        client = Client(
+            ENDPOINT_NAME,
+            "http://example.org/",
+            http_basic_username="bar",
+            http_basic_password="baz",
+        )
+        api_mock.autofill("dhcp4", config=config, statistics=statistics)
+
+        post = requests.Session.post
+        check_was_called = False
+
+        def check_auth(self, *args, **kwargs):
+            nonlocal check_was_called
+            check_was_called = True
+            assert self.auth == ("bar", "baz")
+            return post(self, *args, **kwargs)
+
+        monkeypatch.setattr(requests.Session, 'post', check_auth)
+        client.fetch_stats()
+
+        assert check_was_called
+
+    def test_fetch_stats_should_use_client_certificates_when_this_is_configured(
+        self, valid_dhcp4, api_mock, monkeypatch
+    ):
+        """
+        Checks that the requests.Session object used during a call to
+        Client.fetch_stats() has certificate parameters configured throughout the
+        call if client TLS certificates was configured during client init.
+        """
+        config, statistics, expected_stats = valid_dhcp4
+        client = Client(
+            ENDPOINT_NAME,
+            "https://example.org/",
+            client_cert_path="/bar/baz.pem",
+        )
+        api_mock.autofill("dhcp4", config=config, statistics=statistics)
+
+        post = requests.Session.post
+        check_was_called = False
+
+        def check_cert(self, *args, **kwargs):
+            nonlocal check_was_called
+            check_was_called = True
+            assert self.cert == "/bar/baz.pem"
+            return post(self, *args, **kwargs)
+
+        monkeypatch.setattr(requests.Session, 'post', check_cert)
+        client.fetch_stats()
+
+        assert check_was_called
+
+
+TestData = namedtuple("TestData", ["config", "statistics", "expected_stats"])
+
+
+@pytest.fixture
+def valid_dhcp4():
+    config = {
+        "Dhcp4": {
+            "control-socket": {
+                "socket-name": "/run/kea/control_socket_4",
+                "socket-type": "unix",
+            },
+            "hooks-libraries": [],
+            "lease-database": {
+                "name": "/var/lib/kea/kea-leases4.csv",
+                "type": "memfile",
+            },
+            "shared-networks": [
+                {
+                    "name": "shared-network-1",
+                    "subnet4": [
+                        {
+                            "id": 3,
+                            "pools": [
+                                {
+                                    "option-data": [],
+                                    "pool": "42.0.3.1-42.0.3.10",
+                                    "pool-id": 1,
+                                    "user-context": {
+                                        "name": "oslo-student",
+                                    },
+                                },
+                            ],
+                            "subnet": "42.0.3.0/24",
+                        },
+                        {
+                            "id": 4,
+                            "option-data": [],
+                            "pools": [
+                                {
+                                    "option-data": [],
+                                    "pool": "42.0.4.1-42.0.4.5",
+                                    "pool-id": 1,
+                                    # Pool with 'user-context'
+                                    "user-context": {
+                                        "name": "oslo-staff",
+                                    },
+                                },
+                            ],
+                            "subnet": "42.0.4.1/24",
+                        },
+                    ],
+                    "valid-lifetime": 4000,
+                },
+                {
+                    "name": "shared-network-2",
+                    "subnet4": [
+                        {
+                            "id": 5,
+                            "option-data": [],
+                            "pools": [
+                                {
+                                    "option-data": [],
+                                    "pool": "42.0.5.1-42.0.5.5",
+                                    "pool-id": 1,
+                                    # Pool without 'user-context'
+                                },
+                            ],
+                            "subnet": "42.0.5.0/24",
+                        },
+                    ],
+                    "valid-lifetime": 4000,
+                },
+            ],
+            "subnet4": [
+                {
+                    "id": 1,
+                    "option-data": [],
+                    "pools": [
+                        {
+                            "option-data": [],
+                            "pool": "42.0.1.1-42.0.1.10",
+                            "pool-id": 1,
+                            "user-context": {
+                                "name": "bergen-staff",
+                            },
+                        },
+                    ],
+                    "subnet": "42.0.1.0/24",
+                },
+                {
+                    "id": 2,
+                    "option-data": [],
+                    "pools": [
+                        {
+                            "option-data": [],
+                            # First range format: x.x.x.x/m
+                            "pool": "42.0.2.1-42.0.2.10",
+                            "pool-id": 1,
+                            "user-context": {
+                                "name": "bergen-student",
+                            },
+                        },
+                        {
+                            "option-data": [],
+                            # Second range format: x.x.x.x - x.x.x.x
+                            "pool": "42.0.2.32/28",
+                            "pool-id": 3,
+                            "user-context": {
+                                "name": "bergen-student",
+                            },
+                        },
+                        {
+                            "option-data": [],
+                            "pool": "42.0.2.128/25",
+                            "pool-id": 2,
+                            "user-context": {
+                                "name": "bergen-student",
+                            },
+                        },
+                    ],
+                    "subnet": "42.0.2.0/24",
+                },
+            ],
+            "valid-lifetime": 4000,
+        },
+    }
+
+    statistics = {
+        "subnet[1].pool[1].assigned-addresses": [
+            [2, "2025-05-30 05:49:49.467993"],
+            [0, "2025-05-29 05:49:49.467993"],
+            [0, "2025-05-28 05:49:49.467993"],
+        ],
+        "subnet[1].pool[1].declined-addresses": [
+            [1, "2025-05-30 05:49:49.467995"],
+            [0, "2025-05-29 05:49:49.467995"],
+            [0, "2025-05-28 05:49:49.467995"],
+        ],
+        "subnet[1].pool[1].total-addresses": [
+            [10, "2025-05-30 05:49:49.467930"],
+            [8, "2025-05-29 05:49:49.467930"],
+        ],
+        "subnet[2].pool[1].assigned-addresses": [
+            [0, "2025-05-30 05:49:49.468017"],
+            [1, "2025-05-29 05:49:49.468017"],
+        ],
+        "subnet[2].pool[1].declined-addresses": [[1, "2025-05-30 05:49:49.468019"]],
+        "subnet[2].pool[1].total-addresses": [[10, "2025-05-30 05:49:49.467941"]],
+        "subnet[2].pool[2].assigned-addresses": [[1, "2025-05-30 05:49:49.468033"]],
+        "subnet[2].pool[2].declined-addresses": [[0, "2025-05-30 05:49:49.468035"]],
+        "subnet[2].pool[2].total-addresses": [[128, "2025-05-30 05:49:49.467949"]],
+        "subnet[2].pool[3].assigned-addresses": [
+            [0, "2025-05-30 05:49:49.468025"],
+            [2, "2025-05-29 05:49:49.468025"],
+        ],
+        "subnet[2].pool[3].declined-addresses": [
+            [0, "2025-05-30 05:49:49.468027"],
+            [3, "2025-05-29 05:49:49.468027"],
+        ],
+        "subnet[2].pool[3].total-addresses": [
+            [16, "2025-05-30 05:49:49.467945"],
+            [16, "2025-05-29 05:49:49.467945"],
+            [16, "2025-05-28 05:49:49.467945"],
+        ],
+        "subnet[3].pool[1].assigned-addresses": [[0, "2025-05-30 05:49:49.468051"]],
+        "subnet[3].pool[1].declined-addresses": [[0, "2025-05-30 05:49:49.468053"]],
+        "subnet[3].pool[1].total-addresses": [[10, "2025-05-30 05:49:49.467959"]],
+        "subnet[4].pool[1].assigned-addresses": [[0, "2025-05-30 05:49:49.468067"]],
+        "subnet[4].pool[1].declined-addresses": [[0, "2025-05-30 05:49:49.468070"]],
+        "subnet[4].pool[1].total-addresses": [[5, "2025-05-30 05:49:49.467968"]],
+        "subnet[5].pool[1].assigned-addresses": [[0, "2025-05-30 05:49:49.468085"]],
+        "subnet[5].pool[1].declined-addresses": [[0, "2025-05-30 05:49:49.468087"]],
+        "subnet[5].pool[1].total-addresses": [[5, "2025-05-30 05:49:49.467976"]],
+        # Some irrelevant values that won't be used by the client:
+        "subnet[1].cumulative-assigned-addresses": [[0, "2022-02-11 17:54:17.487528"]],
+        "subnet[1].declined-addresses": [[0, "2022-02-11 17:54:17.487585"]],
+        "subnet[1].reclaimed-declined-addresses": [[0, "2022-02-11 17:54:17.487595"]],
+        "subnet[1].reclaimed-leases": [[0, "2022-02-11 17:54:17.487604"]],
+        "subnet[1].total-addresses": [[10, "2022-02-11 17:54:17.487512"]],
+    }
+
+    # Each list in the 'statistics' response from the api (see above dict) is a
+    # timeseries for a specific stat type for a specific pool.  The first
+    # stat in each list is assumed to be the most recent, and this is the
+    # stat we expect to get for each stat type and pool after processing
+    # the api response.
+    expected_stats = [
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-staff.42_0_1_1.42_0_1_10.assigned",
+            ("2025-05-30 05:49:49.467993", 2),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-staff.42_0_1_1.42_0_1_10.declined",
+            ("2025-05-30 05:49:49.467993", 1),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-staff.42_0_1_1.42_0_1_10.total",
+            ("2025-05-30 05:49:49.467993", 10),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-student.42_0_2_1.42_0_2_10.assigned",
+            ("2025-05-30 05:49:49.467993", 0),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-student.42_0_2_1.42_0_2_10.declined",
+            ("2025-05-30 05:49:49.467993", 1),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-student.42_0_2_1.42_0_2_10.total",
+            ("2025-05-30 05:49:49.467993", 10),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-student.42_0_2_128.42_0_2_255.assigned",
+            ("2025-05-30 05:49:49.467993", 1),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-student.42_0_2_128.42_0_2_255.declined",
+            ("2025-05-30 05:49:49.467993", 0),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-student.42_0_2_128.42_0_2_255.total",
+            ("2025-05-30 05:49:49.467993", 128),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-student.42_0_2_32.42_0_2_47.assigned",
+            ("2025-05-30 05:49:49.467993", 0),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-student.42_0_2_32.42_0_2_47.declined",
+            ("2025-05-30 05:49:49.467993", 0),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-student.42_0_2_32.42_0_2_47.total",
+            ("2025-05-30 05:49:49.467993", 16),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.oslo-student.42_0_3_1.42_0_3_10.assigned",
+            ("2025-05-30 05:49:49.467993", 0),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.oslo-student.42_0_3_1.42_0_3_10.declined",
+            ("2025-05-30 05:49:49.467993", 0),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.oslo-student.42_0_3_1.42_0_3_10.total",
+            ("2025-05-30 05:49:49.467993", 10),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.oslo-staff.42_0_4_1.42_0_4_5.assigned",
+            ("2025-05-30 05:49:49.467993", 0),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.oslo-staff.42_0_4_1.42_0_4_5.declined",
+            ("2025-05-30 05:49:49.467993", 0),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.oslo-staff.42_0_4_1.42_0_4_5.total",
+            ("2025-05-30 05:49:49.467993", 5),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.pool-42_0_5_1-42_0_5_5.42_0_5_1.42_0_5_5.assigned",
+            ("2025-05-30 05:49:49.467993", 0),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.pool-42_0_5_1-42_0_5_5.42_0_5_1.42_0_5_5.declined",
+            ("2025-05-30 05:49:49.467993", 0),
+        ),
+        (
+            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.pool-42_0_5_1-42_0_5_5.42_0_5_1.42_0_5_5.total",
+            ("2025-05-30 05:49:49.467993", 5),
+        ),
+    ]
+
+    return TestData(config=config, statistics=statistics, expected_stats=expected_stats)
+
+
+def make_api_response(val: dict, status: _KeaStatus = _KeaStatus.SUCCESS):
+    """
+    Make a Kea API conformant response body whose response value (called
+    response 'arguments' in the specification) is given by the dictionary `val`.
+    """
+    return f'''
+[
+    {{
+        "result": {status},
+        "arguments": {json.dumps(val)}
+    }}
+]
+    '''
+
+
+@pytest.fixture
+def api_mock(monkeypatch):
+    """
+    Any test that include this fixture, will automatically mock
+    requests.Session.post() and requests.post(). The fixture returns a
+    namespace with three functions:
+
+    api_mock.add(command, text_or_func, attrs=None) --- appends the given
+    text_or_func, which is either a string or a function f(dict, list) ->
+    string, to the given command string's associated fifo queue to use in
+    generating responses for Kea API requests for command. On any calls to
+    requests.post() or requests.Session().post() in the code under test, the Kea
+    API command is extracted from the request body and the text of the next
+    element in that command's fifo becomes the text-value of the mocked
+    requests.post() requests.Response return value. Text strings are popped from
+    the fifo after use, while functions are not. If the fifo was empty, an API
+    conformant "command not supported" response is returned instead. The attrs
+    keyword (see again the function signature at the top of this paragraph) can
+    optionally be set to a dictionary of attributes to set on the
+    requests.Response response. Setting attrs={"status": 404} will cause the
+    response to be an HTTP 404 error.
+
+    api_mock.clear() --- Empty the fifo queues of all commands. This
+    removes all previously configured command responses.
+
+    api_mock.autofill(service, config, statistics) --- fill the queue for
+    the "config-get" and "statistic-get-all" commands to mimic the response
+    texts actually sent by the Kea API for a Kea DHCP server named `service`
+    ("dhcp4" for ipv4 DHCP "dhcp6" for ipv6 DHCP) with config `config` and
+    statistics `statistics`.
+
+    The returned namespace contains a dictionary in addition to the three above
+    functions:
+
+    api_mock.responses --- dictionary mapping Kea API command names
+    to a list of ordered pairs (<request-arguments>, <request-service>),
+    one pair per request for that API command recorded so far.
+    """
+    command_requests: dict[str, list[tuple[dict, list]]] = {}
+    command_responses: dict[
+        str, deque[tuple[str | Callable[[dict, list], str], dict]]
+    ] = {}
+    unknown_command_response = """[
+  {{
+    "result": 2,
+    "text": "'{0}' command not supported."
+  }}
+]"""
+
+    def post_function_mock(url, *args, data="{}", **kwargs):
+        """This function will replace requests.post()"""
+        if isinstance(data, dict):
+            data = json.dumps(data)
+        elif isinstance(data, bytes):
+            data = data.decode("utf8")
+        if not isinstance(data, str):
+            pytest.fail(
+                f"data argument to the mocked requests.post() is of unknown type {type(data)}"
+            )
+
+        try:
+            data = json.loads(data)
+            command = data["command"]
+        except (JSONDecodeError, KeyError):
+            pytest.fail(
+                "All post requests that NAV sends to the Kea API"
+                "should be a JSON with a 'command' key. Instead, NAV sent "
+                f"\n\n{data!r}\n\n to the test's Kea API mock"
+            )
+
+        kea_arguments = data.get("arguments", {})
+        kea_service = data.get("service", [])
+
+        command_requests.setdefault(command, [])
+        command_requests[command].append((kea_arguments, kea_service))
+
+        response_text = unknown_command_response.format(command)
+        attrs = {}
+        fifo = command_responses.get(command, deque())
+        if fifo:
+            text_or_func, attrs = fifo[0]
+            if callable(text_or_func):
+                response_text = text_or_func(kea_arguments, kea_service)
+            else:
+                response_text = str(text_or_func)
+                fifo.popleft()
+
+        response = requests.Response()
+        response._content = response_text.encode("utf8")
+        response.encoding = "utf8"
+        response.status_code = 200
+        response.reason = "OK"
+        response.headers = kwargs.get("headers", {})
+        response.cookies = kwargs.get("cookies", {})
+        response.url = url
+        response.close = lambda: None
+
+        for attr, value in attrs.items():
+            setattr(response, attr, value)
+
+        return response
+
+    def post_method_mock(self, url, *args, **kwargs):
+        """This function will replace requests.Session.post()"""
+        return post_function_mock(url, *args, **kwargs)
+
+    def add_command_response(command_name, text_or_func, attrs=None):
+        attrs = attrs or {}
+        command_responses.setdefault(command_name, deque())
+        command_responses[command_name].append((text_or_func, attrs))
+
+    def clear_command_responses():
+        command_responses.clear()
+
+    def autofill_command_responses(
+        expected_service, config=None, statistics=None, attrs=None
+    ):
+        attrs = attrs or {}
+
+        if config is not None:
+
+            def config_response(arguments, service):
+                assert service == [expected_service], (
+                    f"API Client for service '{expected_service}' should not send requests to service '{service}'"
+                )
+                return make_api_response(config)
+
+            add_command_response("config-get", config_response, attrs)
+
+        if statistics is not None:
+
+            def statistic_response(arguments, service):
+                assert service == [expected_service], (
+                    f"API Client for service '{expected_service}' should not send requests to service '{service}'"
+                )
+                return make_api_response(statistics)
+
+            add_command_response("statistic-get-all", statistic_response, attrs)
+
+    class ResponseQueue:
+        add = add_command_response
+        clear = clear_command_responses
+        autofill = autofill_command_responses
+        requests = command_requests
+
+    monkeypatch.setattr(requests, 'post', post_function_mock)
+    monkeypatch.setattr(requests.Session, 'post', post_method_mock)
+
+    return ResponseQueue


### PR DESCRIPTION
## Scope and purpose

Fixes #2931 and #2369. Deprecates #2937.

### This pull request
* Adds a package `nav.dhcpstats` where a Kea DHCP API client is defined in `nav.dhcpstats.kea_dhcp`.

* Adds a cronjob script called `navdhcpstats` that runs every 5 minutes. It fetches DHCP stats using Kea DHCP API clients and stores the stats in graphite. 

* Adds a `dhcpstats.conf` file that configures which DHCP servers `navdhcpstats` should fetch from and how.

* Stores stats as graphite metrics in `nav.dhcp.4.pools.<server-name>.<pool-name>.<range-start>.<range-end>.{assigned,total,declined}`. 
  * Including `<range-start>` and `<range-end>` is necessary to map graphite metrics to NAV's internal `Vlan` and `Prefix` models. It also makes it easy to show the user how DHCP IP-ranges have changed over time.
   * By including `<pool-name>`, stats can be displayed/grouped on a per-pool basis such that any changes in `<range-start>` or `<range-end>` won't change how stats are displayed/grouped. Having a flexible scheme for how the names of pools are obtained (usually from a DHCP server's configuration), administrators should be able to choose for themselves what a `<pool-name>` represents, e.g. the name of a VLAN, the name of a subnet, the name of a set of IP-ranges, or the name of a single IP-range, and thus how stats are displayed/grouped.
  * By including `<server-name>`, there won't be any conflicts due to two independent DHCP servers being configured the same. That is, there won't be any conflicts when NATed pools are named the same on two independent DHCP servers. Since `<server-name>` is specified in `dhcpstats.conf` we can ensure server names are unique whenever `navdhcpstats` is being used to store stats in graphite (the implementation in this PR does sort-of inherently ensure this, given that administrators follow advice given in `dhcpstats.conf` and abstain from using characters not supported by graphite/carbon).

* Adds an explicit dependency to `urllib3`.

## Contributor Checklist
* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [X] Added/amended tests for new/changed code
* [ ] ~Added/changed documentation~ (documentation will be added in separate pull requests)
* [X] Linted/formatted the code with black and ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-black)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation ~and is 50 characters or less long~. See https://cbea.ms/git-commit/
* [X] This pull request is based on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done.~
* [ ] ~If this results in changes in the UI: Added screenshots of the before and after.~
* [X] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
