### PR TITLE
Upgrade django-rest-framework to >= 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 
     "Django>=4.2,<4.3",
     "django-filter>=2",
-    "djangorestframework>=3.12",
+    "djangorestframework>=3.14",
     "pytz",
 
     "iso8601",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ feedparser==6.0.8
 dnspython<3.0.0,>=2.1.0
 
 django-filter>=2
-djangorestframework>=3.12
+djangorestframework>=3.14
 
 # REST framework
 iso8601


### PR DESCRIPTION
Older drf used the undocumented function `django.http.multipartparser.parse_header` which was replaced with `django.utils.http.parse_header_parameters` in Django 4.2.