### PR TITLE
Add noqa for line-to-long for test names

### DIFF
--- a/tests/unittests/api/jwtpermission_test.py
+++ b/tests/unittests/api/jwtpermission_test.py
@@ -12,14 +12,14 @@ class TestIsPathInEndpoints:
         endpoints = ['/api/1/netbox/']
         assert not JWTPermission.is_path_in_endpoints(path, endpoints)
 
-    def test_when_endpoint_matches_path_except_endpoint_lacks_trailing_slash_then_it_should_return_true(
+    def test_when_endpoint_matches_path_except_endpoint_lacks_trailing_slash_then_it_should_return_true(  # noqa: E501
         self,
     ):
         path = '/api/1/room/'
         endpoints = ['/api/1/room']
         assert JWTPermission.is_path_in_endpoints(path, endpoints)
 
-    def test_when_endpoint_matches_path_except_path_lacks_version_then_it_should_return_true(
+    def test_when_endpoint_matches_path_except_path_lacks_version_then_it_should_return_true(  # noqa: E501
         self,
     ):
         path = '/api/room/'
@@ -39,7 +39,7 @@ class TestIsPathInEndpoints:
 
         assert JWTPermission.is_path_in_endpoints(path, endpoints)
 
-    def test_when_path_is_not_in_list_with_multiple_endpoints_then_it_should_return_false(
+    def test_when_path_is_not_in_list_with_multiple_endpoints_then_it_should_return_false(  # noqa: E501
         self,
     ):
         path = '/api/1/alert/'


### PR DESCRIPTION
## Scope and purpose

Fixes lint errors introduced in #3401 


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [ ] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry) (not relevant)
* [ ] Added/amended tests for new/changed code (not relevant)
* [ ] Added/changed documentation (not relevant)
* [x] Linted/formatted the code with black and ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-black)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] This pull request is based on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done (not relevant)
* [ ] If this results in changes in the UI: Added screenshots of the before and after (not relevant)
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file (not relevant)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
