### PR TITLE
Replace foundation tooltips with custom implementation

### DIFF
--- a/changelog.d/3449.added.md
+++ b/changelog.d/3449.added.md
@@ -1,0 +1,1 @@
+Add custom nav tooltip as replacement for foundation js

--- a/python/nav/web/sass/nav.scss
+++ b/python/nav/web/sass/nav.scss
@@ -21,6 +21,7 @@
 @import "nav/footer";
 @import "nav/rickshaw";
 @import "nav/qr_code";
+@import "nav/tooltip";
 @import "nav/popover";
 
 // Custom css for libraries

--- a/python/nav/web/sass/nav/_tooltip.scss
+++ b/python/nav/web/sass/nav/_tooltip.scss
@@ -43,6 +43,14 @@
     transform: translateY(0);
     transition: opacity 0.2s ease, transform 0.2s ease;
 
+    & > * {
+      font-size: 0.875rem;
+    }
+
+    & > *:last-child {
+      margin-bottom: 0;
+    }
+
     &:before {
       content: '';
       left: 5px;

--- a/python/nav/web/sass/nav/_tooltip.scss
+++ b/python/nav/web/sass/nav/_tooltip.scss
@@ -1,0 +1,80 @@
+
+
+.nav-tooltip {
+  display: inline-flex;
+  align-items: center;
+  position: relative;
+  width: fit-content;
+  &:hover [role="tooltip"] {
+    visibility: visible;
+    opacity: 1;
+    transform: translateY(8px);
+  }
+
+  [aria-describedby] {
+    border-bottom: dotted 1px #cccccc;
+    cursor: help;
+    font-weight: bold;
+    color: #333333;
+
+    &:hover, &:focus {
+      border-bottom: dotted 1px rgb(0.9, 55.35, 84.15);
+      color: #027bbb;
+    }
+  }
+
+  [role="tooltip"] {
+    visibility: hidden;
+    opacity: 0;
+    position: absolute;
+    z-index: 1006;
+    font-weight: 400;
+    font-size: 0.875rem;
+    line-height: 1.3;
+    padding: 20px;
+    top: 100%;
+    left: calc(50% - 10px);
+    width: max-content;
+    max-width: 300px;
+    color: #ffffff;
+    background: #333;
+
+    // Animate
+    transform: translateY(0);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+
+    &:before {
+      content: '';
+      left: 5px;
+      position: absolute;
+      width: 0;
+      height: 0;
+      border: solid 5px;
+      border-color: transparent transparent #333 transparent;
+      top: -10px;
+      pointer-events: none;
+    }
+    &.tiny {
+      max-width: 200px;
+    }
+    &.small {
+      max-width: 300px;
+    }
+    &.medium {
+      max-width: 500px;
+    }
+    &.large {
+      max-width: 800px;
+    }
+  }
+  &[data-align='end'] {
+    [role="tooltip"] {
+      right: calc(50% - 10px);
+      left: auto;
+    }
+    [role="tooltip"]:before {
+      left: auto;
+      right: 5px;
+    }
+  }
+}

--- a/python/nav/web/static/js/src/info_room.js
+++ b/python/nav/web/static/js/src/info_room.js
@@ -68,7 +68,6 @@ require(
             add_filters();
             add_csv_download();
             $(document).foundation('reveal');  // Apply reveal after ajax request
-            $(document).foundation('tooltip');  // Apply tooltip after ajax request
         }
 
         /* Add navigation to jQuery ui tabs */

--- a/python/nav/web/static/js/src/main.js
+++ b/python/nav/web/static/js/src/main.js
@@ -8,8 +8,9 @@ require([
     'libs/select2.min',
     'plugins/megadrop',
     'plugins/popover',
+    'plugins/tooltip',
     'libs/underscore'
-], function (accordionMaker, popover) {
+], function (accordionMaker) {
     /** Enable slash to navigate to search, whereas escape removes focus from search */
     function addSearchFocusHandlers() {
         var $searchInput = $('#query');

--- a/python/nav/web/static/js/src/plugins/tooltip.js
+++ b/python/nav/web/static/js/src/plugins/tooltip.js
@@ -1,0 +1,30 @@
+require([], function () {
+
+    function init() {
+        document.querySelectorAll('.nav-tooltip [role="tooltip"]').forEach(tooltip => {
+        setTimeout(() => {
+            const vw = window.innerWidth;
+
+            // Reverse alignment if element is out of viewport
+            let rect = tooltip.getBoundingClientRect();
+            if (rect.right > vw) {
+                tooltip.parentElement.setAttribute('data-align', 'end');
+            } else if (rect.left < 0) {
+                tooltip.parentElement.setAttribute('data-align', 'start');
+            }
+
+            // Reduce max width if element is out of viewport
+            rect = tooltip.getBoundingClientRect();
+            if (rect.right > vw) {
+                tooltip.style.maxWidth = (vw - rect.left - 16) + 'px';
+            } else if (rect.left < 0) {
+                tooltip.style.maxWidth = (rect.right - 16) + 'px';
+            } else {
+                tooltip.style.maxWidth = '';
+            }
+        }, 100);
+        });
+    }
+
+    init();
+});

--- a/python/nav/web/static/js/src/portadmin.js
+++ b/python/nav/web/static/js/src/portadmin.js
@@ -85,11 +85,12 @@ require(['libs/spin.min', 'libs/jquery-ui.min'], function (Spinner) {
                 .append(this.createProgress());
         },
         restartingInterfaces: function() {
-            var restartReason = "<p>A computer connected to a port does not detect that the vlan changes. When that happens the computer will have the IP-address from the old vlan and it will lose connectivity. But if the link goes down and up (a 'restart') the computer will send a request for a new address.</p> 'Restarting' interfaces is only done when changing vlans.";
-            var why = $('<span data-tooltip class="has-tip" title="' + restartReason + '">(why?)</span>');
-            var listItem = this.addFeedback('Restarting interfaces ').append(why, this.createProgress());
-            $(document).foundation('tooltip', 'reflow');
-            return listItem;
+            const restartReason = "A computer connected to a port does not detect that the vlan changes. When that happens the computer will have the IP-address from the old vlan and it will lose connectivity. But if the link goes down and up (a 'restart') the computer will send a request for a new address. 'Restarting' interfaces is only done when changing vlans.";
+            const why = $('<span class="nav-tooltip">' +
+                '<span aria-describedby="restart-tooltip">(why?)</span>' +
+                '<span id="restart-tooltip" role="tooltip">' + restartReason + '</span>' +
+                '</span>');
+            return this.addFeedback('Restarting interfaces ').append(why, this.createProgress());
         },
         committingConfig: function() {
             return this.addFeedback('Committing configuration changes')

--- a/python/nav/web/templates/alertprofiles/filter_form.html
+++ b/python/nav/web/templates/alertprofiles/filter_form.html
@@ -50,9 +50,13 @@
   {% if owner %}
     <h5>
       Add another expression to this filter
-      <i data-tooltip class="fa fa-info-circle" 
-         title="Expressions are ANDed together.<br /> This means that an alert must match
-                all the above expressions to match this filter."></i>
+        <span class="nav-tooltip">
+            <i class="fa fa-info-circle" aria-describedby="expressions-tooltip"></i>
+            <span id="expressions-tooltip" class="small" role="tooltip">
+                Expressions are ANDed together.<br /> This means that an alert must match
+                all the above expressions to match this filter.
+            </span>
+        </span>
     </h5>
 
     <div class="row">

--- a/python/nav/web/templates/alertprofiles/matchfield_form.html
+++ b/python/nav/web/templates/alertprofiles/matchfield_form.html
@@ -19,14 +19,18 @@
     <div class="medium-4 column">
       <label for="id_operator">
         Available operators
-        <i class="fa fa-info-circle" data-tooltip title="
-          The operators that will be available to use on this match field.
-          &nbsp;&nbsp;
-          Note:
-          Only 'equals' and 'in' makes sense when 'Show list' is checked, there
-          is however nothing that will prevent you from selecting them all for
-          use on a list, but alert engine won't understand it.
-        "></i>
+          <span class="nav-tooltip">
+              <i class="fa fa-info-circle" aria-describedby="available-operators"></i>
+              <span id="available-operators" class="small" role="tooltip">
+                  The operators that will be available to use on this match field.
+                  &nbsp;&nbsp;
+                  Note:
+                  Only 'equals' and 'in' makes sense when 'Show list' is checked, there
+                  is however nothing that will prevent you from selecting them all for
+                  use on a list, but alert engine won't understand it.
+              </span>
+          </span>
+
       </label>
 
       <select name="operator" id="id_operator" multiple="multiple">

--- a/python/nav/web/templates/alertprofiles/timeperiods.html
+++ b/python/nav/web/templates/alertprofiles/timeperiods.html
@@ -6,11 +6,14 @@
 <table class="listtable full-width">
     <caption>
         {{ type.title }}
-      <i class="fa fa-info-circle right" data-tooltip title="
-        If, when hovering over one period in one of the tables, two rows
-        in different tables are highlighted, those two periods are
-        actually the one and same period. It's just an <em>all days</em> period.
-      "></i>
+        <span class="nav-tooltip" data-align="end" style="float: right;">
+            <i class="fa fa-info-circle right" aria-describedby="subscription-tooltip-{{ type.title }}"></i>
+            <span id="subscription-tooltip-{{ type.title }}" class="small" role="tooltip">
+                If, when hovering over one period in one of the tables, two rows
+                in different tables are highlighted, those two periods are
+                actually the one and same period. It's just an <em>all days</em> period.
+            </span>
+        </span>
     </caption>
 
     <thead>

--- a/python/nav/web/templates/custom_crispy_templates/field_helptext_as_icon.html
+++ b/python/nav/web/templates/custom_crispy_templates/field_helptext_as_icon.html
@@ -12,9 +12,12 @@
             <label for="{{ field.id_for_label }}" {% if field.field.required %}class="requiredField"{% endif %}>
               {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
               {% if field.help_text %}
-                  &nbsp;<i id="hint_{{ field.auto_id }}" class="fa fa-info-circle" data-tooltip title="
-                  {{ field.help_text }}
-                  "></i>
+                  <span class="nav-tooltip">
+                      &nbsp;<i aria-describedby="hint_{{ field.auto_id }}" class="fa fa-info-circle" ></i>
+                      <span id="hint_{{ field.auto_id }}" role="tooltip">
+                          {{ field.help_text }}
+                      </span>
+                  </span>
               {% endif %}
             </label>
         {% endif %}

--- a/python/nav/web/templates/foundation-5/field.html
+++ b/python/nav/web/templates/foundation-5/field.html
@@ -20,10 +20,12 @@
             <span class="asteriskField">*</span>
           {% endif %}
           {% if field.help_text %}
-            &nbsp;<i id="hint_{{ field.auto_id }}" class="fa fa-info-circle right"
-                     data-tooltip title="
-                  {{ field.help_text }}
-                  "></i>
+            <span class="nav-tooltip">
+                &nbsp;<i aria-describedby="hint_{{ field.auto_id }}" class="fa fa-info-circle right"></i>
+                <span id="hint_{{ field.auto_id }}" class="medium" role="tooltip">
+                    {{ field.help_text }}
+                </span>
+            </span>
           {% endif %}
         </label>
 

--- a/python/nav/web/templates/info/room/netboxview.html
+++ b/python/nav/web/templates/info/room/netboxview.html
@@ -85,10 +85,12 @@
     <div class="small-3 columns">
       <label>
         CSV
-        <i class="fa fa-question-circle has-tip"
-           data-tooltip
-           title="To open this in Microsoft Excel, you need to change the file to a .txt file, start Excel and import the file.">
-        </i>
+          <span class="nav-tooltip" data-align="end">
+              <i class="fa fa-question-circle has-tip" aria-describedby="csv-tooltip"></i>
+              <span id="csv-tooltip" role="tooltip">
+                  To open this in Microsoft Excel, you need to change the file to a .txt file, start Excel and import the file.
+              </span>
+          </span>
       </label>
 
       <form id="csv-download-form" action="{% url 'room-csv' %}" method="POST">

--- a/python/nav/web/templates/ipdevinfo/frag-disclaimer.html
+++ b/python/nav/web/templates/ipdevinfo/frag-disclaimer.html
@@ -1,13 +1,14 @@
 <div class="right">
-  <span data-tooltip class="tip-left"
-        title="&lt;p&gt;NAV gathers information by periodically running
-               jobs. None of the information you see here is gathered
-               real time.&lt;/p&gt;
-
-               &lt;p&gt;The &lt;em&gt;Jobs&lt;/em&gt; table in Ip Device Info has
-               information about when the different jobs have run on a
-               device. To see a description of what information the
-               job collects, hover the mouse above the job name.&lt;/p&gt;">
-    <i class="fa fa-info-circle"></i>
+  <span class="nav-tooltip" data-align="end">
+    <i class="fa fa-info-circle" aria-describedby="tooltip-disclaimer"></i>
+      <span id="tooltip-disclaimer" class="medium" role="tooltip">
+        <p>NAV gathers information by periodically running
+        jobs. None of the information you see here is gathered
+        real time.</p>
+        <p style="margin-bottom: 0;"><em>Jobs</em> table in Ip Device Info has
+        information about when the different jobs have run on a
+        device. To see a description of what information the
+          job collects, hover the mouse above the job name.</p>
+      </span>
   </span>
 </div>

--- a/python/nav/web/templates/ipdevinfo/frag-ipdevinfo.html
+++ b/python/nav/web/templates/ipdevinfo/frag-ipdevinfo.html
@@ -103,10 +103,13 @@
                           (serial: {{ chass.device.serial|default:"N/A" }},
                           {% if chass.model_name %}
                             model:
-                            <span data-tooltip
-                                  class="has-tip"
-                                  title="{{ chass.descr }}">
-                              {{ chass.model_name }}
+                            <span class="nav-tooltip">
+                                <span aria-describedby="model-description-tooltip">
+                                  {{ chass.model_name }}
+                                </span>
+                                <span id="model-description-tooltip" role="tooltip">
+                                    {{ chass.descr }}
+                                </span>
                             </span>,
                           {% endif %}
                           software: {{ chass.get_software_revision|default:"N/A" }})
@@ -352,15 +355,15 @@
                             {{ task.end_time }}
                           {% endif %})
                           {% if not netbox.is_on_maintenance %}
-                            <i class="fa fa-exclamation-triangle has-tip" style="color:#8a6d3b;" data-tooltip
-                               title="
-                                      &lt;ul style=&quot;list-style-type:none;&quot;&gt;
-                                      &lt;li&gt;Task not yet active&lt;/li&gt;
-                                      &lt;li&gt;(Maintenance tasks are activated by default in 5 minute intervals)&lt;/li&gt;
-                                      &lt;/ul&gt;
-                                      "
-                            >
-                            </i>
+                            <div class="nav-tooltip">
+                                <i class="fa fa-exclamation-triangle" aria-describedby="task-not-yet-active" style="color:#8a6d3b;"></i>
+                                <div id="task-not-yet-active" role="tooltip">
+                                    <ul style="list-style-type:none">
+                                        <li>Task not yet active</li>
+                                        <li>(Maintenance tasks are activated by default in 5 minute intervals)</li>
+                                    </ul>
+                                </div>
+                            </div>
                           {% endif %}
                         </div>
                       </li>

--- a/python/nav/web/templates/l2trace/l2trace.html
+++ b/python/nav/web/templates/l2trace/l2trace.html
@@ -18,8 +18,8 @@
       <div class="column medium-6">
           <div class="nav-tooltip" data-align="end">
             <i class="fa fa-info-circle" aria-describedby="hostname-tooltip"></i>
-            <div id="hostname-tooltip" role="tooltip" >
-                <ul style="list-style-type:none;">
+            <div id="hostname-tooltip" role="tooltip">
+                <ul>
                     <li>Enter a hostname or IP address and trace up to its router.</li>
                     <li>Optionally enter a destination hostname or IP address and trace between the two.</li>
                     <li>Press the trace button to start.</li>

--- a/python/nav/web/templates/l2trace/l2trace.html
+++ b/python/nav/web/templates/l2trace/l2trace.html
@@ -16,13 +16,15 @@
       </div>
 
       <div class="column medium-6">
-        <i class="fa fa-info-circle has-tip" data-tooltip title="
-          &lt;ul style=&quot;list-style-type:none;&quot;&gt;
-            &lt;li&gt;Enter a hostname or IP address and trace up to its router.&lt;/li&gt;
-            &lt;li&gt;Optionally enter a destination hostname or IP address and trace between the two.&lt;/li&gt;
-            &lt;li&gt;Press the trace button to start.&lt;/li&gt;
-          &lt;/ul&gt;
-        "></i>
+          <div class="nav-tooltip" data-align="end">
+            <i class="fa fa-info-circle" aria-describedby="hostname-tooltip"></i>
+            <div id="hostname-tooltip" role="tooltip" >
+                <ul style="list-style-type:none;">
+                    <li>Enter a hostname or IP address and trace up to its router.</li>
+                    <li>Optionally enter a destination hostname or IP address and trace between the two.</li>
+                    <li>Press the trace button to start.</li>
+                </ul>
+            </div>
       </div>
 
     </div>

--- a/python/nav/web/templates/machinetracker/mac_tracker.html
+++ b/python/nav/web/templates/machinetracker/mac_tracker.html
@@ -1,15 +1,16 @@
 <table id="tracker-table" class="listtable tablesorter">
     <caption>
         MAC Search results
-        <i id="hint_id_mac_result_exposition" class="fa fa-info-circle" data-tooltip title="
-
-    Please note that the MAC search results are &lt;em&gt;historic&lt;/em&gt;
+        <span class="nav-tooltip">
+            <i aria-describedby="hind_id_mac_result_exposition" class="fa fa-info-circle"></i>
+            <span id="hint_id_mac_result_exposition" class="medium" role="tooltip">
+                Please note that the MAC search results are <em>historic</em>
     data, while the information found at the interface details link is the
-    &lt;em&gt;current&lt;/em&gt; data on the interface. They may have no other
+                <em>current</em> data on the interface. They may have no other
     connection than being related to the same interface at different points in
     time.
-
-        "></i>
+            </span>
+        </span>
         <span class="subtitle right">
             {{ mac_tracker_count }} hit{{ mac_tracker_count|pluralize }}
         </span>

--- a/python/nav/web/templates/webfront/index.html
+++ b/python/nav/web/templates/webfront/index.html
@@ -140,11 +140,12 @@
         <div class="column medium-4">
           <a href="{% url 'export-dashboard' dashboard.pk %}" class="small button expand">Export dashboard
           </a><br/>
-          <small data-tooltip
-                 class="has-tip"
-                 title="Download this dashboards definition into a file that can later be imported by pressing the + next to the tab list">
-              what's this?
-          </small>
+          <div class="nav-tooltip">
+              <small aria-describedby="download-dashboard-tooltip">what's this?</small>
+              <span id="download-dashboard-tooltip" role="tooltip">
+                  Download this dashboards definition into a file that can later be imported by pressing the + next to the tab list
+              </span>
+          </div>
         </div>
 
         <div class="column medium-4">


### PR DESCRIPTION
## Scope and purpose

Part of #2972. 

Adds an implementation for a custom NAV Tooltip. This PR replaces usages of `[data-tooltip]` throughout the codebase, with the exception of one case in the Status tool that should be done in a follow-up task, namely #3463 .

The new tooltip supports alignment from the start or end of the trigger element, and automatic change of alignment if the tooltip extends beyond the viewport.

<!-- remove things that do not apply -->
### This pull request
* Adds nav tooltip styles and event listeners for updating alignment based on viewport
* Replaces usages of [data-tooltip] in various tools with the new implementation
* Replaces usage of [data-tooltip] in reusable form templates, like `foundation-5/field.html` or `custom_crispy_templates/field_helptext_as_icon.html`

## Screenshots

### Before
**/search/room/100/#!netboxinterfaces**
<img width="319" height="171" alt="image" src="https://github.com/user-attachments/assets/6e9ac0d0-3e3a-457a-9b29-ad77b93adb12" />

**/alertprofiles/profile/1026/**
<img width="459" height="182" alt="image" src="https://github.com/user-attachments/assets/5fdcfb80-a3f4-476c-a069-5595b5a79ee6" />

**/l2trace/**
<img width="518" height="267" alt="image" src="https://github.com/user-attachments/assets/78a852ae-a6a6-4cc7-826f-8096f273e37a" />

### After
**/search/room/100/#!netboxinterfaces**
<img width="313" height="155" alt="image" src="https://github.com/user-attachments/assets/dcb56249-d65d-44c6-90f2-60d555b45154" />

**/alertprofiles/profile/1026/**
<img width="406" height="182" alt="image" src="https://github.com/user-attachments/assets/51a9be3f-13dd-4287-86bd-d9b09b47aee7" />

**/l2trace/**
<img width="467" height="266" alt="image" src="https://github.com/user-attachments/assets/23aaa9b0-345b-4956-9282-8789c74e205c" />

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] This pull request is based on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
