### PR TITLE
Unrevoke token on recreate

### DIFF
--- a/changelog.d/3457.fixed.md
+++ b/changelog.d/3457.fixed.md
@@ -1,0 +1,1 @@
+Make it possible to un-revoke JWT refresh token by recreating the token

--- a/python/nav/web/useradmin/views.py
+++ b/python/nav/web/useradmin/views.py
@@ -806,6 +806,7 @@ def jwt_recreate(request, pk):
     token.expires = datetime.fromtimestamp(claims['exp'], tz=timezone.utc)
     token.activates = datetime.fromtimestamp(claims['nbf'], tz=timezone.utc)
     token.hash = hash_token(encoded_token)
+    token.revoked = False
     token.save()
 
     LogEntry.add_log_entry(

--- a/tests/integration/web/jwt_test.py
+++ b/tests/integration/web/jwt_test.py
@@ -46,6 +46,17 @@ def test_posting_existing_token_id_to_revoke_endpoint_should_revoke_token(
     assert token.revoked is True
 
 
+def test_recreating_token_should_unrevoke_it(db, client, token):
+    token.revoked = True
+    token.save()
+    url = reverse("useradmin-jwt_recreate", args=[token.id])
+    response = client.post(url, follow=True)
+
+    assert response.status_code == 200
+    token.refresh_from_db()
+    assert not token.revoked
+
+
 @pytest.fixture()
 def token(db) -> Generator[JWTRefreshToken, None, None]:
     """Fixture to create a JWTRefreshToken instance for testing"""


### PR DESCRIPTION
## Scope and purpose

Fixes #3457

Makes it so the "Recreate" function Also un-revokes the token if the token was previously revoked.

Recreate button can be found in the Edit form of a refresh token (http://localhost:8000/useradmin/jwt_tokens/edit/<pk>/)

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* ~~[ ] Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] This pull request is based on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* ~~[ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* ~~[ ] If this results in changes in the UI: Added screenshots of the before and after~~
* ~~[ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
