### PR TITLE
Replace import dashboard modal

### DIFF
--- a/changelog.d/+b607de92.changed.md
+++ b/changelog.d/+b607de92.changed.md
@@ -1,0 +1,1 @@
+Replace import dashboard modal with HTMX

--- a/python/nav/web/static/js/src/webfront.js
+++ b/python/nav/web/static/js/src/webfront.js
@@ -298,36 +298,6 @@ require([
         });
     }
 
-
-    /**
-     * Import dashboard sumbit function
-     */
-    function setupImportDashboard() {
-        $('#dashboard-import form').submit(function(event) {
-            event.preventDefault();
-            var formData = new FormData($(this)[0]);
-
-            $.ajax({
-                url: $(this).attr("action"),
-                type: 'POST',
-                data: formData,
-                processData: false,
-                contentType: false,
-                success: function (data) {
-                    window.location = data.location;
-                },
-                error: function(jqXHR, textStatus, errorThrown) {
-                    var error = "Error importing dashboard";
-                    if (jqXHR.responseJSON.error) {
-                        error = jqXHR.responseJSON.error;
-                    }
-                    $('#dashboard-import .alert-box').text(error).show();
-                }
-            });
-
-        });
-    }
-
     /**
      * Load runner - runs on page load
      */
@@ -367,7 +337,6 @@ require([
 
         addDashboardKeyNavigation();
         addDroppableDashboardTargets();
-        setupImportDashboard();
 
         /**
          * The following listeners are applied to buttons on the right hand side

--- a/python/nav/web/templates/webfront/_import_dashboard_form_modal.html
+++ b/python/nav/web/templates/webfront/_import_dashboard_form_modal.html
@@ -1,0 +1,13 @@
+<h4>Import dashboard</h4>
+
+<form
+    hx-post="{% url 'import-dashboard' %}"
+    hx-encoding="multipart/form-data"
+>
+    {% csrf_token %}
+    <fieldset>
+        <legend>Select file to import</legend>
+        <input name="file" type="file" id="dashboard-import-file">
+    </fieldset>
+    <button type="submit" class="button" aria-label="submit form">Import</button>
+</form>

--- a/python/nav/web/templates/webfront/index.html
+++ b/python/nav/web/templates/webfront/index.html
@@ -73,23 +73,6 @@
 
     </div>
 
-    {% comment %} Dashboard import form {% endcomment %}
-    <div id="dashboard-import" class="reveal-modal small" data-reveal>
-        <h4>Import dashboard</h4>
-
-        <div data-alert class="alert-box warning hidden">
-        </div>
-        <form action="{% url 'import-dashboard' %}">
-            {% csrf_token %}
-            <fieldset>
-                <legend>Select file to import</legend>
-                <input name="file" type="file" id="dashboard-import-file">
-            </fieldset>
-            <button type="submit" class="button" aria-label="submit form">Import</button>
-        </form>
-
-    </div>
-
     {# Content dropdown for dashboard settings #}
     <div id="dropdown-dashboard-settings"
          data-dropdown-content
@@ -167,7 +150,9 @@
         </label>
         <input type="submit" class="small button full-width" value="Add dashboard">
       </form>
-      <a data-reveal data-reveal-id="dashboard-import">Import dashboard</a>
+        <a hx-get="{% url 'import-dashboard-modal' %}"
+           hx-target="body"
+           hx-swap="beforeend">Import dashboard</a>
     </div>
 
     {# Buttons for selecting dashboards #}

--- a/python/nav/web/webfront/urls.py
+++ b/python/nav/web/webfront/urls.py
@@ -67,6 +67,11 @@ urlpatterns = [
     re_path(
         r'^index/dashboard/import$', views.import_dashboard, name='import-dashboard'
     ),
+    re_path(
+        r'îndex/dashboard/importmodal$',
+        views.import_dashboard_modal,
+        name='import-dashboard-modal',
+    ),
     re_path(r'^index/dashboard/', views.index, name='dashboard-index'),
     re_path(r'^about/', views.about, name='webfront-about'),
     re_path(

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -34,6 +34,7 @@ from django.views.decorators.http import require_POST
 from django.views.decorators.debug import sensitive_variables, sensitive_post_parameters
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
+from django_htmx.http import HttpResponseClientRedirect
 
 from nav.auditlog.models import LogEntry
 from nav.django.utils import get_account
@@ -42,7 +43,7 @@ from nav.web.auth import logout as auth_logout
 from nav.web import auth, webfrontConfig
 from nav.web.auth import ldap
 from nav.web.auth.utils import set_account
-from nav.web.modals import render_modal
+from nav.web.modals import render_modal, render_modal_alert
 from nav.web.utils import generate_qr_code_as_string
 from nav.web.utils import require_param
 from nav.web.webfront.utils import quick_read, tool_list
@@ -130,7 +131,6 @@ def import_dashboard(request):
     """Receive an uploaded dashboard file and store in database"""
     if not can_modify_navlet(request.account, request):
         return HttpResponseForbidden()
-    response = {}
     if 'file' in request.FILES:
         try:
             # Ensure file is interpreted as utf-8 regardless of locale
@@ -162,23 +162,29 @@ def import_dashboard(request):
             for widget in widgets:
                 dashboard.widgets.create(account=request.account, **widget)
             dashboard.save()
-            response['location'] = reverse('dashboard-index-id', args=(dashboard.id,))
+            dashboard_url = reverse('dashboard-index-id', args=(dashboard.id,))
+            return HttpResponseClientRedirect(dashboard_url)
         except ValueError:
             _logger.exception('Failed to parse dashboard file for import')
-            return JsonResponse(
-                {
-                    'error': "File is not a valid dashboard file",
-                },
-                status=400,
+            return render_modal_alert(
+                request,
+                "File is not a valid dashboard file",
+                modal_id="import-dashboard-form",
             )
     else:
-        return JsonResponse(
-            {
-                'error': "You need to provide a file",
-            },
-            status=400,
+        return render_modal_alert(
+            request, "You need to provide a file", modal_id="import-dashboard-form"
         )
-    return JsonResponse(response)
+
+
+def import_dashboard_modal(request):
+    """Render the import dashboard modal dialog"""
+    return render_modal(
+        request,
+        'webfront/_import_dashboard_form_modal.html',
+        modal_id="import-dashboard-form",
+        size="small",
+    )
 
 
 @sensitive_post_parameters('password')


### PR DESCRIPTION
## Scope and purpose

Part of #2972. Replaces Import Dashboard modal with an HTMX implementation.

<!-- remove things that do not apply -->
### This pull request
* Replaces foundation modal with HTMX
* Adds test coverage for the `import_dashboard` view
* Submit import dashboard form with htmx instead of ajax

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] This pull request is based on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
