### PR TITLE
Adjust close modal icon to avoid text overlap

### DIFF
--- a/changelog.d/+42a720f9.fixed.md
+++ b/changelog.d/+42a720f9.fixed.md
@@ -1,0 +1,1 @@
+Adjust size and position of close modal icon to avoid overlap with text

--- a/python/nav/web/sass/nav/_modal.scss
+++ b/python/nav/web/sass/nav/_modal.scss
@@ -33,7 +33,16 @@ $default-width: 30%;
         transform: translateY(-100vh);
         animation: slideInFromTop 0.3s ease-out forwards;
 
-        .close-reveal-modal { @include reveal-close; }
+        .close-reveal-modal {
+            font-size: 1.5rem;
+            line-height: 1;
+            position: absolute;
+            top: 0.5rem;
+            right: 0.6875rem;
+            color: #AAAAAA;
+            font-weight: bold;
+            cursor: pointer;
+        }
     }
 }
 


### PR DESCRIPTION
## Scope and purpose

Fixes an issue where the close icon overlaps the text in modals, as commented in #3497 and #3505.

### This pull request
* Reduces the font size of the icon to avoid overlap with modal text
* Changes close-modal-icon styles to use explicit css styles instead of extending foundation styles

## Screenshots
The change will have the following effect on the Classification Hint modal in #3505.
<img width="528" height="493" alt="image" src="https://github.com/user-attachments/assets/4c97f44c-b54a-420e-a958-1d2d9a8382c3" />


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] This pull request is based on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
