### PR TITLE
Replace radius detail modals with htmx

### DIFF
--- a/changelog.d/3514.changed.md
+++ b/changelog.d/3514.changed.md
@@ -1,0 +1,1 @@
+Replace radius detail modals with htmx

--- a/python/nav/web/radius/views.py
+++ b/python/nav/web/radius/views.py
@@ -146,10 +146,10 @@ def log_detail_page(request, accountid):
 def log_detail_modal(request, accountid):
     """Displays log details as a separate page"""
     template = 'radius/detail_modal.html'
-    return log_detail(request, accountid, template)
+    return log_detail(request, accountid, template, use_modal=True)
 
 
-def log_detail(request, accountid, template):
+def log_detail(request, accountid, template, use_modal=False):
     """Displays log details for accountid with the given template"""
     query = LogDetailQuery(accountid)
     query.execute()
@@ -158,13 +158,27 @@ def log_detail(request, accountid, template):
     field_desc = [LOG_FIELDDESCRIPTIONS[field] for field in LOG_DETAILFIELDS]
     fields = zip(field_desc, result)
 
-    navpath = get_navpath(('Log Detail',))
     context = {
-        'reverse': reverse('radius-log_detail', args=(accountid,)),
-        'title': create_title(navpath),
-        'navpath': navpath,
         'fields': fields,
+        'result': query.result,
+        'reverse': reverse('radius-log_detail', args=(accountid,)),
     }
+
+    if use_modal:
+        return render_modal(
+            request,
+            template,
+            context=context,
+            modal_id="log-detail",
+        )
+
+    navpath = get_navpath(('Log Detail',))
+    context.update(
+        {
+            'title': create_title(navpath),
+            'navpath': navpath,
+        }
+    )
 
     return render(request, template, context)
 
@@ -219,10 +233,10 @@ def account_detail_page(request, accountid):
 def account_detail_modal(request, accountid):
     """Displays account details suitable for a modal"""
     template = 'radius/detail_modal.html'
-    return account_detail(request, accountid, template)
+    return account_detail(request, accountid, template, use_modal=True)
 
 
-def account_detail(request, accountid, template):
+def account_detail(request, accountid, template, use_modal=False):
     """Finds account details for a specific accountid"""
     query = AcctDetailQuery(accountid)
     query.execute()
@@ -231,14 +245,27 @@ def account_detail(request, accountid, template):
     field_desc = [ACCT_DBFIELDSDESCRIPTIONS[field] for field in ACCT_DETAILSFIELDS]
     fields = zip(field_desc, result)
 
-    navpath = get_navpath(('Account Detail',))
     context = {
-        'reverse': reverse('radius-account_detail', args=(accountid,)),
-        'title': create_title(navpath),
-        'navpath': navpath,
         'fields': fields,
         'result': query.result,
+        'reverse': reverse('radius-account_detail', args=(accountid,)),
     }
+
+    if use_modal:
+        return render_modal(
+            request,
+            template,
+            context=context,
+            modal_id="account-detail",
+        )
+
+    navpath = get_navpath(('Account Detail',))
+    context.update(
+        {
+            'title': create_title(navpath),
+            'navpath': navpath,
+        }
+    )
 
     return render(request, template, context)
 

--- a/python/nav/web/radius/views.py
+++ b/python/nav/web/radius/views.py
@@ -153,10 +153,12 @@ def log_detail(request, accountid, template, use_modal=False):
     """Displays log details for accountid with the given template"""
     query = LogDetailQuery(accountid)
     query.execute()
-    result = query.result[0]
 
-    field_desc = [LOG_FIELDDESCRIPTIONS[field] for field in LOG_DETAILFIELDS]
-    fields = zip(field_desc, result)
+    fields = []
+    if query.result:
+        result = query.result[0]
+        field_desc = [LOG_FIELDDESCRIPTIONS[field] for field in LOG_DETAILFIELDS]
+        fields = zip(field_desc, result)
 
     context = {
         'fields': fields,
@@ -240,10 +242,12 @@ def account_detail(request, accountid, template, use_modal=False):
     """Finds account details for a specific accountid"""
     query = AcctDetailQuery(accountid)
     query.execute()
-    result = query.result[0]
 
-    field_desc = [ACCT_DBFIELDSDESCRIPTIONS[field] for field in ACCT_DETAILSFIELDS]
-    fields = zip(field_desc, result)
+    fields = []
+    if query.result:
+        result = query.result[0]
+        field_desc = [ACCT_DBFIELDSDESCRIPTIONS[field] for field in ACCT_DETAILSFIELDS]
+        fields = zip(field_desc, result)
 
     context = {
         'fields': fields,

--- a/python/nav/web/static/js/src/radius.js
+++ b/python/nav/web/static/js/src/radius.js
@@ -1,4 +1,4 @@
-require(['src/dt_plugins/ip_address_sort', 'src/dt_plugins/ip_address_typedetect'], function () {
+require(['libs/datatables.min', 'src/dt_plugins/ip_address_sort', 'src/dt_plugins/ip_address_typedetect'], function () {
 
     function initTimeField() {
         var time_field = $('#id_time_1');

--- a/python/nav/web/static/js/src/radius.js
+++ b/python/nav/web/static/js/src/radius.js
@@ -64,12 +64,6 @@ require(['src/dt_plugins/ip_address_sort', 'src/dt_plugins/ip_address_typedetect
         addFilterInputListener(resulttable, datatable);
     }
 
-    function addDetailsClickListener(resulttable) {
-        resulttable.on('click', '[data-bubble-reveal]', function () {
-            $('#details_modal').foundation('reveal', 'open', $(this).attr('data-bubble-reveal'));
-        });
-    }
-
     $(document).ready(function () {
 
         initTimeField();
@@ -77,7 +71,6 @@ require(['src/dt_plugins/ip_address_sort', 'src/dt_plugins/ip_address_typedetect
         var resulttable = $('#resulttable');
         if (resulttable.length) {
             initResulttable(resulttable);
-            addDetailsClickListener(resulttable);
         }
     });
 });

--- a/python/nav/web/templates/radius/account_log.html
+++ b/python/nav/web/templates/radius/account_log.html
@@ -29,8 +29,6 @@
 
     {% if result %}
 
-    <div id="details_modal" class="reveal-modal" data-reveal></div>
-
     <table id="resulttable" class="listtable full-width">
         <thead data-nosort='[5, 6]'>
           <tr>
@@ -58,8 +56,10 @@
               <td>{{ row.acctstoptime }}</td>
               <td>{{ row.acctsessiontime|time_from_seconds }}</td>
               <td>
-                <a href="javascript:void(0);"
-                   data-bubble-reveal="{% url 'radius-account_detail-modal' row.radacctid %}"
+                <a
+                   hx-get="{% url 'radius-account_detail-modal' row.radacctid %}"
+                   hx-target="body"
+                   hx-swap="beforeend"
                    title="View all available information on this session">
                   Details
                    </a>

--- a/python/nav/web/templates/radius/detail_modal.html
+++ b/python/nav/web/templates/radius/detail_modal.html
@@ -1,3 +1,5 @@
 {% include 'radius/details_table.html' %}
 
+{% if result %}
 <a href="{{ reverse }}">Link to details</a>
+{% endif %}

--- a/python/nav/web/templates/radius/details_table.html
+++ b/python/nav/web/templates/radius/details_table.html
@@ -1,3 +1,4 @@
+{% if fields %}
 <table class="vertitable">
   <caption>Details</caption>
   {% for desc, field in fields %}
@@ -11,3 +12,8 @@
     </tr>
   {% endfor %}
 </table>
+{% else %}
+<div class="alert-box alert">
+    No details available.
+</div>
+{% endif %}

--- a/python/nav/web/templates/radius/error_log.html
+++ b/python/nav/web/templates/radius/error_log.html
@@ -25,8 +25,6 @@
 
   {% if form.is_bound %}
     {% if result %}
-      <div id="detailsmodal" class="reveal-modal" data-reveal></div>
-
       <table id="resulttable" class="listtable full-width">
         <thead data-nosort='[-1]'>
           <tr>
@@ -46,10 +44,9 @@
                 {% endif %}
               {% endfor %}
                <td>
-                  <a href="{% url 'radius-log_detail-modal' row.id %}"
-                     data-reveal-id="detailsmodal"
-                     data-reveal-ajax="true"
-                     data-reveal
+                  <a hx-get="{% url 'radius-log_detail-modal' row.id %}"
+                     hx-target="body"
+                     hx-swap="beforeend"
                      title="View all available information on this session">
                     Details
                      </a>

--- a/tests/integration/web/radius_test.py
+++ b/tests/integration/web/radius_test.py
@@ -237,9 +237,9 @@ class TestRadiusAccountDetailViews:
         mock_query_class.return_value = mock_query
 
         url = reverse('radius-account_detail', args=[999])
+        response = client.get(url)
 
-        with pytest.raises(IndexError):
-            client.get(url)
+        assert "No details available" in smart_str(response.content)
 
     @patch('nav.web.radius.views.AcctDetailQuery')
     def test_with_custom_username(
@@ -292,9 +292,9 @@ class TestRadiusLogDetailViews:
         mock_query_class.return_value = mock_query
 
         url = reverse('radius-log_detail', args=[999])
+        response = client.get(url)
 
-        with pytest.raises(IndexError):
-            client.get(url)
+        assert "No details available" in smart_str(response.content)
 
     @patch('nav.web.radius.views.LogDetailQuery')
     def test_log_detail_with_custom_message(

--- a/tests/integration/web/radius_test.py
+++ b/tests/integration/web/radius_test.py
@@ -1,7 +1,10 @@
+from datetime import datetime
 from urllib.parse import urlencode
 
+import pytest
 from django.urls import reverse
 from django.utils.encoding import smart_str
+from mock import MagicMock, patch
 
 
 class TestAccountLogSearch:
@@ -195,3 +198,177 @@ class TestRadiusSearchHintModalViews:
 
         assert response.status_code == 200
         assert 'id="account-chart-hints"' in smart_str(response.content)
+
+
+class TestRadiusAccountDetailViews:
+    @patch('nav.web.radius.views.AcctDetailQuery')
+    def test_should_render_account_detail_page(
+        self, mock_query_class, db, client, mock_account_detail_query
+    ):
+        mock_query_class.return_value = mock_account_detail_query()
+
+        url = reverse('radius-account_detail', args=[1])
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert 'Account Detail' in smart_str(response.content)
+        assert 'navpath' in response.context
+
+    @patch('nav.web.radius.views.AcctDetailQuery')
+    def test_should_render_account_detail_modal(
+        self, mock_query_class, db, client, mock_account_detail_query
+    ):
+        mock_query_class.return_value = mock_account_detail_query()
+
+        url = reverse('radius-account_detail-modal', args=[1])
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert 'id="account-detail"' in smart_str(response.content)
+        assert (
+            'navpath' not in response.context or response.context.get('navpath') is None
+        )
+
+    @patch('nav.web.radius.views.AcctDetailQuery')
+    def test_account_detail_handles_empty_result(self, mock_query_class, db, client):
+        # Override for empty result test
+        mock_query = MagicMock()
+        mock_query.result = []
+        mock_query_class.return_value = mock_query
+
+        url = reverse('radius-account_detail', args=[999])
+
+        with pytest.raises(IndexError):
+            client.get(url)
+
+    @patch('nav.web.radius.views.AcctDetailQuery')
+    def test_with_custom_username(
+        self, mock_query_class, db, client, mock_account_detail_query
+    ):
+        # Example of customizing the mock data
+        mock_query_class.return_value = mock_account_detail_query(
+            {'username': 'custom_user'}
+        )
+
+        url = reverse('radius-account_detail', args=[1])
+        response = client.get(url)
+
+        assert response.status_code == 200
+
+
+class TestRadiusLogDetailViews:
+    @patch('nav.web.radius.views.LogDetailQuery')
+    def test_should_render_log_detail_page(
+        self, mock_query_class, db, client, mock_log_detail_query
+    ):
+        mock_query_class.return_value = mock_log_detail_query()
+
+        url = reverse('radius-log_detail', args=[1])
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert 'Log Detail' in smart_str(response.content)
+        assert 'navpath' in response.context
+
+    @patch('nav.web.radius.views.LogDetailQuery')
+    def test_should_render_log_detail_modal(
+        self, mock_query_class, db, client, mock_log_detail_query
+    ):
+        mock_query_class.return_value = mock_log_detail_query()
+
+        url = reverse('radius-log_detail-modal', args=[1])
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert 'id="log-detail"' in smart_str(response.content)
+        assert (
+            'navpath' not in response.context or response.context.get('navpath') is None
+        )
+
+    @patch('nav.web.radius.views.LogDetailQuery')
+    def test_log_detail_handles_empty_result(self, mock_query_class, db, client):
+        mock_query = MagicMock()
+        mock_query.result = []
+        mock_query_class.return_value = mock_query
+
+        url = reverse('radius-log_detail', args=[999])
+
+        with pytest.raises(IndexError):
+            client.get(url)
+
+    @patch('nav.web.radius.views.LogDetailQuery')
+    def test_log_detail_with_custom_message(
+        self, mock_query_class, db, client, mock_log_detail_query
+    ):
+        mock_query_class.return_value = mock_log_detail_query(
+            {'message': 'Custom [error] message', 'type': 'Auth-Reject'}
+        )
+
+        url = reverse('radius-log_detail', args=[1])
+        response = client.get(url)
+
+        assert response.status_code == 200
+
+
+@pytest.fixture
+def mock_account_detail_query():
+    """Factory fixture for creating mocked AcctDetailQuery"""
+
+    def _create_mock(custom_attributes=None):
+        mock_result = MagicMock()
+
+        default_attributes = {
+            'acctuniqueid': '1309f5d67b0a752d',
+            'username': 'test_user',
+            'nasipaddress': '192.168.1.1 (test-nas.example.com)',
+            'framedipaddress': '10.0.0.1 (10.0.0.1)',
+            'acctstarttime': datetime(2023, 1, 1, 12, 0, 0),
+            'acctstoptime': '2023-01-01 12:30:00',
+            'acctsessiontime': '30m',
+            'acctterminatecause': 'User-Request',
+            'acctinputoctets': '130.445 KB',
+            'acctoutputoctets': '357.501 KB',
+        }
+
+        if custom_attributes:
+            default_attributes.update(custom_attributes)
+
+        for attr, value in default_attributes.items():
+            setattr(mock_result, attr, value)
+
+        mock_query = MagicMock()
+        mock_query.result = [mock_result]
+
+        return mock_query
+
+    return _create_mock
+
+
+@pytest.fixture
+def mock_log_detail_query():
+    """Factory fixture for creating mocked LogDetailQuery"""
+
+    def _create_mock(custom_attributes=None):
+        mock_result = MagicMock()
+
+        default_attributes = {
+            'id': 12345,
+            'username': 'test_user',
+            'time': datetime(2023, 1, 1, 12, 0, 0),
+            'type': 'Auth-Accept',
+            'message': 'Login OK [user/test_realm]',
+            'realm': 'test_realm',
+        }
+
+        if custom_attributes:
+            default_attributes.update(custom_attributes)
+
+        for attr, value in default_attributes.items():
+            setattr(mock_result, attr, value)
+
+        mock_query = MagicMock()
+        mock_query.result = [mock_result]
+
+        return mock_query
+
+    return _create_mock


### PR DESCRIPTION
## Scope and purpose

Part of #2972. 

This PR replaces the foundation modals for the Account Log and Error Log tables. 

I was not able to find any data for Error Logs, but there is some data for Account Log if you select the following parameters:
* Username: mvold
* Time options: Day(s), 5000 days

However, I added tests for the Error Log view that should verify that the modals and refactor are working as expected.

<!-- remove things that do not apply -->
### This pull request
* Replaces Account Detail modal with HTMX
* Replaces Log Detail modal with HTMX
* Add test coverage to Account and Log detail views
* Fixes bug where account and log detail views crash when query returns no results

### Screenshots

EDIT: Account not found bug



**Before**:
<img width="1581" height="709" alt="image" src="https://github.com/user-attachments/assets/960b0e1d-356f-4aa1-ac38-a02a15ca8942" />

Account detail view crashes on index error: [/radius/acctdetail/99999999](http://localhost:8000/radius/acctdetail/99999999)
<img width="609" height="182" alt="image" src="https://github.com/user-attachments/assets/1b18154a-d11d-48ba-bfd6-1b34317673ec" />

**After**: The modal only takes up the necessary width (of the table)
<img width="567" height="700" alt="image" src="https://github.com/user-attachments/assets/bc999bff-684e-4184-b890-e8abffbb3521" />

Handle account detail error: [/radius/acctdetail/99999999](http://localhost:8000/radius/acctdetail/99999999)
<img width="844" height="225" alt="image" src="https://github.com/user-attachments/assets/b395404f-7b0d-4baf-bf24-a0dfa7cbc0e6" />


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] This pull request is based on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
