### PR TITLE
Remove no racks alert after adding a new rack

### DIFF
--- a/changelog.d/3506.fixed.md
+++ b/changelog.d/3506.fixed.md
@@ -1,0 +1,1 @@
+Remove no racks alert after adding a new rack to a room

--- a/python/nav/web/info/room/views.py
+++ b/python/nav/web/info/room/views.py
@@ -302,7 +302,7 @@ def add_rack(request, roomid):
     room = get_object_or_404(Room, pk=roomid)
     rackname = request.POST.get('rackname')
     rack = create_rack(room, rackname)
-    return resolve_modal(
+    response = resolve_modal(
         request,
         'info/room/fragment_rack.html',
         {
@@ -313,6 +313,7 @@ def add_rack(request, roomid):
         },
         modal_id='add-rack-modal',
     )
+    return trigger_client_event(response, 'room.rack.added', {'rackId': rack.id})
 
 
 def add_rack_modal(request, roomid):

--- a/python/nav/web/static/js/src/info_room_rack.js
+++ b/python/nav/web/static/js/src/info_room_rack.js
@@ -81,6 +81,10 @@ require([
             });
         });
 
+        document.body.addEventListener('room.rack.added', function () {
+            $('[data-id="no-racks-alert"]').remove()
+        })
+
         /* Form submission is handled by htmx, we just need to add a listener for
            when the sensor is added to update it with data */
         document.body.addEventListener('room.rack.sensorAdded', function(event) {

--- a/python/nav/web/templates/info/room/roominfo_racks.html
+++ b/python/nav/web/templates/info/room/roominfo_racks.html
@@ -16,7 +16,7 @@
 <h3>Environment sensors in racks in {{ room.pk }}</h3>
 
 {% if not racks %}
-  <p class="alert-box">There are no racks in this room.</p>
+  <p class="alert-box" data-id="no-racks-alert">There are no racks in this room.</p>
 {% endif %}
 
 <div id="racks-container" class="racks-container">

--- a/tests/integration/web/info/room_test.py
+++ b/tests/integration/web/info/room_test.py
@@ -70,6 +70,17 @@ class TestAddRoomRackViews:
         assert response.status_code == 200
         assert 'name="rack-color"' in smart_str(response.content)
 
+    def test_when_rack_is_added_then_return_rack_added_event(self, client):
+        url = reverse('room-info-racks-add-rack', args=['myroom'])
+        response = client.post(
+            url,
+            {
+                'rackname': 'Test Rack',
+            },
+        )
+        assert response.status_code == 200
+        assert 'room.rack.added' in response.headers['HX-Trigger']
+
 
 class TestAddSensorModalView:
     def test_should_render_add_sensor_modal(self, client, test_rack):


### PR DESCRIPTION
## Scope and purpose

Fixes #3506. Removes "No racks" message after a rack is added to a room.

<!-- remove things that do not apply -->
### This pull request
* Add new client side event (`room.rack.added`) to handle removal of no racks message


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] This pull request is based on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
