### PR TITLE
Show invalid IP errors in network explorer search

### DIFF
--- a/changelog.d/3534.fixed.md
+++ b/changelog.d/3534.fixed.md
@@ -1,0 +1,1 @@
+Show errors on invalid IP in network explorer search

--- a/python/nav/web/networkexplorer/forms.py
+++ b/python/nav/web/networkexplorer/forms.py
@@ -1,5 +1,7 @@
 from django import forms
 
+from nav.util import is_valid_ip
+
 
 # TODO: Borrowed from newer radius. Need to be removed
 # TODO: and imported from elsewhere
@@ -81,3 +83,12 @@ class NetworkSearchForm(forms.Form):
     hide_ports = forms.BooleanField(
         label='Hide ports with no description', required=False
     )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if cleaned_data.get("query"):
+            query, query_type = cleaned_data["query"]
+            if query_type == "ip" and cleaned_data["exact_results"]:
+                if not is_valid_ip(query):
+                    self._errors['address'] = self.error_class(["Invalid IP address"])
+        return cleaned_data

--- a/python/nav/web/networkexplorer/views.py
+++ b/python/nav/web/networkexplorer/views.py
@@ -94,17 +94,19 @@ class ExpandSWPortView(JSONResponseMixin, ExpandSWPortContextMixin, BaseDetailVi
 
 class SearchView(JSONResponseMixin, View):
     def form_invalid(self, form):
-        return {'error': form.errors}
+        return {'errors': form.errors}
 
     def form_valid(self, form):
         return search(form.cleaned_data)
 
     def get(self, request, *_args, **_kwargs):
         form = NetworkSearchForm(request.GET)
+        status = 200
 
         if form.is_valid():
             context = self.form_valid(form)
         else:
             context = self.form_invalid(form)
+            status = 400
 
-        return self.render_json_response(context)
+        return self.render_json_response(context, status=status)


### PR DESCRIPTION
## Scope and purpose

When reviewing #3529 I noticed that the bug that @Simrayz found goes actually even deeper than the frontend just showing when a search failed. 

Because every time an invalid IP was given and exact search chosen that triggered an internal server error:

```
[Thu Sep 11 12:30:53 2025] [ERROR] [pid=56276 django.request] Internal Server Error: /networkexplorer/search/
Traceback (most recent call last):
  File "/home/vscode/.venv/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.venv/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.venv/lib/python3.11/site-packages/django/views/generic/base.py", line 105, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.venv/lib/python3.11/site-packages/django/views/generic/base.py", line 144, in dispatch
    return handler(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/nav/python/nav/web/networkexplorer/views.py", line 106, in get
    context = self.form_valid(form)
              ^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/nav/python/nav/web/networkexplorer/views.py", line 100, in form_valid
    return search(form.cleaned_data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/nav/python/nav/web/networkexplorer/search.py", line 52, in search
    ) = search_function(query, exact_results)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/nav/python/nav/web/networkexplorer/search.py", line 258, in ip_search
    gwportprefixes = GwPortPrefix.objects.filter(gw_ip=ip)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.venv/lib/python3.11/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.venv/lib/python3.11/site-packages/django/db/models/query.py", line 1436, in filter
    return self._filter_or_exclude(False, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.venv/lib/python3.11/site-packages/django/db/models/query.py", line 1454, in _filter_or_exclude
    clone._filter_or_exclude_inplace(negate, args, kwargs)
  File "/home/vscode/.venv/lib/python3.11/site-packages/django/db/models/query.py", line 1461, in _filter_or_exclude_inplace
    self._query.add_q(Q(*args, **kwargs))
  File "/home/vscode/.venv/lib/python3.11/site-packages/django/db/models/sql/query.py", line 1546, in add_q
    clause, _ = self._add_q(q_object, self.used_aliases)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.venv/lib/python3.11/site-packages/django/db/models/sql/query.py", line 1577, in _add_q
    child_clause, needed_inner = self.build_filter(
                                 ^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.venv/lib/python3.11/site-packages/django/db/models/sql/query.py", line 1492, in build_filter
    condition = self.build_lookup(lookups, col, value)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.venv/lib/python3.11/site-packages/django/db/models/sql/query.py", line 1319, in build_lookup
    lookup = lookup_class(lhs, rhs)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.venv/lib/python3.11/site-packages/django/db/models/lookups.py", line 27, in __init__
    self.rhs = self.get_prep_lookup()
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.venv/lib/python3.11/site-packages/django/db/models/lookups.py", line 341, in get_prep_lookup
    return super().get_prep_lookup()
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.venv/lib/python3.11/site-packages/django/db/models/lookups.py", line 85, in get_prep_lookup
    return self.lhs.output_field.get_prep_value(self.rhs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py", line 2423, in get_prep_value
    return self.to_python(value)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/nav/python/nav/models/fields.py", line 110, in to_python
    raise exceptions.ValidationError("Value must be a valid CIDR address")
django.core.exceptions.ValidationError: ['Value must be a valid CIDR address']
[11/Sep/2025 12:30:53] "GET /networkexplorer/search/?query_0=invalid&query_1=ip&exact_results=on HTTP/1.1" 500 163796
```

To reproduce: 
Go to `/networkexplorer/`, enter `invalid` into the search field and select `IP` in the dropdown, select "Search exact (no substring)", the click "Search". See internal server error. 

The only thing this PR is lacking is a way for the frontend to show the errors that are being send in as context. Maybe @Simrayz can help me there? 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [X] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] This pull request is based on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
