### PR TITLE
Add modal closing behaviour controls

### DIFF
--- a/changelog.d/3537.added.md
+++ b/changelog.d/3537.added.md
@@ -1,0 +1,1 @@
+Add modal closing behaviour controls for close button visibility and outside click handling

--- a/python/nav/web/modals.py
+++ b/python/nav/web/modals.py
@@ -31,6 +31,8 @@ def render_modal(
     context: Optional[dict] = None,
     modal_id: Optional[str] = DEFAULT_MODAL_ID,
     size: Optional[str] = DEFAULT_MODAL_SIZE,
+    show_close_button: bool = True,
+    close_on_outside_click: bool = True,
 ):
     """Render a modal dialog with the given template and context"""
 
@@ -40,6 +42,8 @@ def render_modal(
         'modal_id': modal_id,
         'content_template': template_name,
         'modal_size': size,
+        'show_close_button': show_close_button,
+        'close_on_outside_click': close_on_outside_click,
         **context,
     }
     return render(request, 'modals/_nav_modal.html', modal_context)

--- a/python/nav/web/templates/modals/_nav_modal.html
+++ b/python/nav/web/templates/modals/_nav_modal.html
@@ -3,9 +3,11 @@
         class="nav-modal "
         tabindex="-1"
 >
-    <div class="modal-underlay" hx-on:click="htmx.remove(this.closest('#{{ modal_id }}'))"></div>
+    <div class="modal-underlay"{% if close_on_outside_click %} hx-on:click="htmx.remove(this.closest('#{{ modal_id }}'))"{% endif %}></div>
     <div class="modal-content{% if modal_size %} {{ modal_size }}{% endif %}">
+        {% if show_close_button %}
         <a class="close-reveal-modal" aria-label="Close" hx-on:click="htmx.remove(this.closest('#{{ modal_id }}'))">&#215;</a>
+        {% endif %}
         {% include content_template %}
         <div id="{{ modal_id }}-alert"></div>
     </div>

--- a/python/nav/web/templates/styleguide.html
+++ b/python/nav/web/templates/styleguide.html
@@ -606,6 +606,8 @@
         <ul>
             <li><strong>Size:</strong> <code>tiny</code>, <code>small</code>, <code>medium</code>, <code>large</code>, or <code>fit-content</code> (default)</li>
             <li><strong>Modal ID:</strong> Custom ID for targeting specific modals (default: <code>'modal'</code>)</li>
+            <li><strong>Show close button:</strong> <code>show_close_button=True</code> (default) or <code>False</code> to hide the × button</li>
+            <li><strong>Close on outside click:</strong> <code>close_on_outside_click=True</code> (default) or <code>False</code> to disable underlay closing</li>
         </ul>
     </div>
        <div class="large-6 column">

--- a/tests/unittests/web/modals_test.py
+++ b/tests/unittests/web/modals_test.py
@@ -27,6 +27,8 @@ class TestModalUtilities:
             'modal_id': DEFAULT_MODAL_ID,
             'content_template': 'test_template.html',
             'modal_size': DEFAULT_MODAL_SIZE,
+            'show_close_button': True,
+            'close_on_outside_click': True,
         }
 
         mock_render.assert_called_once_with(
@@ -47,6 +49,8 @@ class TestModalUtilities:
             'modal_id': modal_id,
             'content_template': template_name,
             'modal_size': DEFAULT_MODAL_SIZE,
+            'show_close_button': True,
+            'close_on_outside_click': True,
             'netboxid': '123',
         }
 
@@ -67,6 +71,8 @@ class TestModalUtilities:
             'modal_id': DEFAULT_MODAL_ID,
             'content_template': template_name,
             'modal_size': modal_size,
+            'show_close_button': True,
+            'close_on_outside_click': True,
         }
 
         mock_render.assert_called_once_with(
@@ -118,4 +124,69 @@ class TestModalUtilities:
         expected_context = {'message': message, 'modal_id': modal_id}
         mock_render.assert_called_once_with(
             self.request, 'modals/_nav_modal_alert.html', expected_context
+        )
+
+    @patch('nav.web.modals.render')
+    def test_should_render_modal_with_close_button_disabled(self, mock_render):
+        """Test render_modal with close button disabled"""
+        mock_render.return_value = HttpResponse('modal content')
+        template_name = 'test_template.html'
+
+        render_modal(self.request, template_name, show_close_button=False)
+
+        expected_context = {
+            'modal_id': DEFAULT_MODAL_ID,
+            'content_template': template_name,
+            'modal_size': DEFAULT_MODAL_SIZE,
+            'show_close_button': False,
+            'close_on_outside_click': True,
+        }
+
+        mock_render.assert_called_once_with(
+            self.request, 'modals/_nav_modal.html', expected_context
+        )
+
+    @patch('nav.web.modals.render')
+    def test_should_render_modal_with_outside_click_disabled(self, mock_render):
+        """Test render_modal with outside click closing disabled"""
+        mock_render.return_value = HttpResponse('modal content')
+        template_name = 'test_template.html'
+
+        render_modal(self.request, template_name, close_on_outside_click=False)
+
+        expected_context = {
+            'modal_id': DEFAULT_MODAL_ID,
+            'content_template': template_name,
+            'modal_size': DEFAULT_MODAL_SIZE,
+            'show_close_button': True,
+            'close_on_outside_click': False,
+        }
+
+        mock_render.assert_called_once_with(
+            self.request, 'modals/_nav_modal.html', expected_context
+        )
+
+    @patch('nav.web.modals.render')
+    def test_should_render_modal_with_both_close_options_disabled(self, mock_render):
+        """Test render_modal with both close options disabled for manual control"""
+        mock_render.return_value = HttpResponse('modal content')
+        template_name = 'test_template.html'
+
+        render_modal(
+            self.request,
+            template_name,
+            show_close_button=False,
+            close_on_outside_click=False,
+        )
+
+        expected_context = {
+            'modal_id': DEFAULT_MODAL_ID,
+            'content_template': template_name,
+            'modal_size': DEFAULT_MODAL_SIZE,
+            'show_close_button': False,
+            'close_on_outside_click': False,
+        }
+
+        mock_render.assert_called_once_with(
+            self.request, 'modals/_nav_modal.html', expected_context
         )


### PR DESCRIPTION
## Scope and purpose

Resolves #3537.

This PR adds closing behaviour controls to the `render_modal` utility. This is necessary to support "persistent modal" patterns, specifically the feedback modal in the Portadmin tool.

I have added two new options when rendering modals:
* `close_on_outside_click` (default: True): Whether to close the modal when clicking the background (modal overlay).
* `show_close_button` (default: True): Whether to show the `x` button in the top right corner.

<!-- remove things that do not apply -->
### This pull request
* Support close behaviour options in `render_modal`
* Updates tests to include new close options
* Updates styleguide to include new close options

### How to test

I tested the new options by modifying the Image Upload Help modal. However, this PR does not commit any changes to existing modals as it is purely a "utility update". 

<img width="696" height="292" alt="image" src="https://github.com/user-attachments/assets/9bc74c58-a41f-4ef8-a8fb-f31430d2d43c" />

To manually test the changes yourself, find a random modal and set the two new options to `False`.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] This pull request is based on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
