### PR TITLE
Strip null-bytes from bytestrings being made safe for PostgreSQL

### DIFF
--- a/changelog.d/2479.added.md
+++ b/changelog.d/2479.added.md
@@ -1,1 +1,1 @@
-Changelog content
+Added .strip(b'\x00') before decoding at safestring function when the function argument is of type "byte".

--- a/python/nav/Snmp/__init__.py
+++ b/python/nav/Snmp/__init__.py
@@ -57,10 +57,6 @@ def safestring(string, encodings_to_try=('utf-8', 'latin-1')):
     database (which only accepts UTF-8), we make various attempts at decoding
     strings to unicode objects before the database becomes involved.
 
-    11092025: Added .strip(b'\x00') for the bytes check since the decode
-    function does not read this as NULL and adds to the string. The string
-    in it's turn will make postgres trigger an exception when in queries as
-    postgres cannot handle the \x00 character.
     """
     if string is None:
         return


### PR DESCRIPTION
## Scope and purpose

Fixes #2479. 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [ ] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] This pull request is based on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
