### PR TITLE
Add support for positioning popover on multiple sides

### DIFF
--- a/changelog.d/3550.added.md
+++ b/changelog.d/3550.added.md
@@ -1,0 +1,1 @@
+Add support for positioning popover on multiple sides

--- a/python/nav/web/sass/nav/_popover.scss
+++ b/python/nav/web/sass/nav/_popover.scss
@@ -1,78 +1,225 @@
+// Base popover styles
 .popover {
   position: relative;
   width: fit-content;
+}
 
-  // Alignment classes on the popover wrapper
+// Content positioning by side
+.popover:not([data-side]),
+.popover[data-side="bottom"] {
+  .popover-content {
+    left: 0;
+  }
+
   &[data-align="end"] .popover-content {
     right: 0;
     left: unset;
   }
+}
 
-  &[data-align="center"] .popover-content {
-    left: 50%;
-    transform: translate(-50%, 10px);
+.popover[data-side="top"] {
+  .popover-content {
+    bottom: 100%;
+    left: 0;
   }
 
-  // Arrow positioning based on popover alignment
-  &.with-arrow {
-    .popover-content {
-      &:before {
-        position: absolute;
-        content: '';
-        width: 0;
-        height: 0;
-        border: inset 6px;
-        border-color: rgba(0, 0, 0, 0) rgba(0, 0, 0, 0) #fff rgba(0, 0, 0, 0);
-        border-bottom-style: solid;
-        top: -12px;
-        left: 10px;
-        z-index: 2;
-      }
-
-      &:after {
-        content: '';
-        display: block;
-        width: 0;
-        height: 0;
-        border: inset 7px;
-        border-color: rgba(0, 0, 0, 0) rgba(0, 0, 0, 0) #ccc rgba(0, 0, 0, 0);
-        border-bottom-style: solid;
-        position: absolute;
-        top: -14px;
-        left: 9px;
-        z-index: 1;
-      }
-    }
-
-    &[data-align="end"] .popover-content {
-      &:before {
-        right: 10px;
-        left: unset;
-      }
-      &:after {
-        right: 9px;
-        left: unset;
-      }
-    }
-
-    &[data-align="center"] .popover-content {
-      &:before {
-        left: calc(50% - 6px);
-      }
-      &:after {
-        left: calc(50% - 7px);
-      }
-    }
+  &[data-align="end"] .popover-content {
+    bottom: 100%;
+    right: 0;
+    left: unset;
   }
 }
 
+.popover[data-side="left"] {
+  .popover-content {
+    top: 0;
+    right: 100%;
+  }
+
+  &[data-align="end"] .popover-content {
+    bottom: 0;
+    top: unset;
+  }
+}
+
+.popover[data-side="right"] {
+  .popover-content {
+    top: 0;
+    left: 100%;
+  }
+
+  &[data-align="end"] .popover-content {
+    bottom: 0;
+    top: unset;
+  }
+}
+
+// Open state animations
+.popover.open .popover-content {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(0, 10px);
+}
+
+.popover.open[data-side="left"] .popover-content {
+  transform: translate(-10px, 0);
+}
+
+.popover.open[data-side="right"] .popover-content {
+  transform: translate(10px, 0);
+}
+
+.popover.open[data-side="top"] .popover-content {
+  transform: translate(0, -10px);
+}
+
+// Arrow base styles
+.popover.with-arrow .popover-content {
+  &:before,
+  &:after {
+    position: absolute;
+    content: '';
+    width: 0;
+    height: 0;
+  }
+
+  &:before {
+    border: 6px inset transparent;
+    border-bottom: 6px solid #fff;
+    z-index: 2;
+  }
+
+  &:after {
+    border: 7px inset transparent;
+    border-bottom: 7px solid #ccc;
+    z-index: 1;
+  }
+}
+
+// Arrow positioning for bottom/default
+.popover.with-arrow:not([data-side]) .popover-content,
+.popover.with-arrow[data-side="bottom"] .popover-content {
+  &:before {
+    top: -12px;
+    left: 10px;
+  }
+
+  &:after {
+    top: -14px;
+    left: 9px;
+  }
+}
+
+.popover.with-arrow[data-side="bottom"][data-align="end"] .popover-content {
+  &:before {
+    top: -12px;
+    right: 10px;
+    left: unset;
+  }
+
+  &:after {
+    top: -14px;
+    right: 9px;
+    left: unset;
+  }
+}
+
+// Arrow positioning for left side
+.popover.with-arrow[data-side="left"] .popover-content {
+  &:before,
+  &:after {
+    transform: rotate(90deg);
+  }
+
+  &:before {
+    right: -12px;
+    top: 10px;
+  }
+
+  &:after {
+    right: -14px;
+    top: 9px;
+  }
+}
+
+.popover.with-arrow[data-side="left"][data-align="end"] .popover-content {
+  &:before {
+    bottom: 10px;
+    top: unset;
+  }
+
+  &:after {
+    bottom: 9px;
+    top: unset;
+  }
+}
+
+// Arrow positioning for right side
+.popover.with-arrow[data-side="right"] .popover-content {
+  &:before,
+  &:after {
+    transform: rotate(-90deg);
+  }
+
+  &:before {
+    left: -12px;
+    top: 10px;
+  }
+
+  &:after {
+    left: -14px;
+    top: 9px;
+  }
+}
+
+.popover.with-arrow[data-side="right"][data-align="end"] .popover-content {
+  &:before {
+    bottom: 10px;
+    top: unset;
+  }
+
+  &:after {
+    bottom: 9px;
+    top: unset;
+  }
+}
+
+// Arrow positioning for top side
+.popover.with-arrow[data-side="top"] .popover-content {
+  &:before,
+  &:after {
+    transform: rotate(180deg);
+  }
+
+  &:before {
+    bottom: -12px;
+    left: 10px;
+  }
+
+  &:after {
+    bottom: -14px;
+    left: 9px;
+  }
+}
+
+.popover.with-arrow[data-side="top"][data-align="end"] .popover-content {
+  &:before {
+    right: 10px;
+    left: unset;
+  }
+
+  &:after {
+    right: 9px;
+    left: unset;
+  }
+}
+
+// Popover content base styles
 .popover-content {
   opacity: 0;
   visibility: hidden;
-  transform: translate(0, 5px);
   transition: opacity 0.3s ease, transform 0.3s ease, visibility 0.3s ease;
   position: absolute;
-  left: 0;
   background-color: #fff;
   border: 1px solid #ccc;
   padding: 1.25rem;
@@ -83,19 +230,16 @@
   &.tiny {
     max-width: 200px;
   }
+
   &.small {
     max-width: 300px;
   }
+
   &.medium {
     max-width: 500px;
   }
+
   &.large {
     max-width: 800px;
   }
-}
-
-.popover.open .popover-content {
-  opacity: 1;
-  transform: translate(0, 10px);
-  visibility: visible;
 }

--- a/python/nav/web/templates/styleguide.html
+++ b/python/nav/web/templates/styleguide.html
@@ -466,14 +466,15 @@
         <p>Interactive popover component for confirmation dialogs and contextual actions. Provides accessible, non-intrusive user interactions without navigating away from the current page.</p>
         <h4>Options</h4>
         <ul>
-          <li><strong>Alignment:</strong> <code>data-align="start"</code> (default), <code>data-align="center"</code>, or <code>data-align="end"</code></li>
+          <li><strong>Alignment:</strong> <code>data-align</code> Options: <code>start</code> (default), <code>end</code></li>
+          <li><strong>Side:</strong> <code>data-side</code> Options: <code>bottom</code> (default), <code>left</code>, <code>right</code>, <code>top</code></li>
           <li><strong>Size:</strong> <code>tiny</code>, <code>small</code>, <code>medium</code>, or <code>large</code> classes on popover-content</li>
           <li><strong>Arrow:</strong> Add <code>with-arrow</code> class to display a pointing arrow</li>
           <li><strong>Close button:</strong> Add <code>close-popover</code> attribute to any element to make it close the popover when clicked</li>
         </ul>
         <div style="margin-bottom: 1rem;">
             <h4>Example popover</h4>
-            <div id="demo-popover" class="popover with-arrow" data-align="start">
+            <div id="demo-popover" class="popover with-arrow" data-side="right" data-align="start">
               <button
                   class="secondary" style="margin-bottom: 0;"
                   data-popover-target="#demo-popover"
@@ -494,7 +495,7 @@
       <div class="columns large-6">
           <div class="panel white">
             <pre class="prettyprint">
-&lt;div id="demo-popover" class="popover with-arrow" data-align="start"&gt;
+&lt;div id="demo-popover" class="popover with-arrow" data-side="right" data-align="start"&gt;
     &lt;button
         class="secondary"
         data-popover-target="#demo-popover"


### PR DESCRIPTION
## Scope and purpose

Follow up to #3458, and necessary to position popovers in #3531.

* This PR adds support for positioning the popover on multiple sides: left, top, right and bottom. The side is configured with the `data-side` attribute, as described in the styleguide. 
* The styleguide has been updated with the new `data-side` attribute, and the example was updated to use a `data-side="right" data-align="start"` configuration.
* `data-align="center"` was removed, as it is not likely to be used, and to simplify the code for multiple sides.
* `_popover.scss` was refactored to be more readable and reduce unnecessary nesting. It should be easier to follow the logic now.

I'm a bit uncertain if putting the `data-*` attributes on the `.popover` container was the best idea (the styles become a bit convoluted). We might want to consider moving `data-side`, `data-align` and `with-arrow` to the `.popover-content` container instead. Alternatively, combine the attributes into `data-position="bottom-start"` etc. However, this requires refactoring a lot of files, and would cause conflicts with #3531.

### Screenshots

| | Start | End |
| --- | --- | --- |
| Bottom | <img width="309" height="271" alt="image" src="https://github.com/user-attachments/assets/123ebd4b-3cbd-4ce4-9e22-d4e40007bed0" /> | <img width="311" height="270" alt="image" src="https://github.com/user-attachments/assets/26bff194-eb7e-4c40-bd7c-42ad2bbe288f" /> |
| Left | <img width="483" height="215" alt="image" src="https://github.com/user-attachments/assets/83425931-234f-4a9f-a679-18d26494793b" /> | <img width="477" height="213" alt="image" src="https://github.com/user-attachments/assets/faae7e67-f98a-46fa-9c19-f4b414045525" /> |
| Top |  <img width="311" height="269" alt="image" src="https://github.com/user-attachments/assets/53d77b1c-dee4-43ef-895e-a297b6519098" /> | <img width="311" height="274" alt="image" src="https://github.com/user-attachments/assets/3a209600-cb69-4a4b-885e-55b9f335ddf8" /> |
| Right | <img width="487" height="218" alt="image" src="https://github.com/user-attachments/assets/1c6602f4-a05e-41fc-b548-2c4adb0b215a" /> | <img width="485" height="220" alt="image" src="https://github.com/user-attachments/assets/701a6a35-9293-4a2a-a856-4faa982ea266" /> |

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] This pull request is based on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
