### PR TITLE
Add shareable dashboard functionality

### DIFF
--- a/changelog.d/2344.added.md
+++ b/changelog.d/2344.added.md
@@ -1,0 +1,1 @@
+Add shareable dashboard functionality

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -1648,6 +1648,11 @@ class AccountDashboard(models.Model):
         related_name="account_dashboards",
     )
     is_shared = models.BooleanField(default=False)
+    subscriptions = models.ManyToManyField(
+        Account,
+        through='AccountDashboardSubscription',
+        related_name="account_dashboard_subscriptions",
+    )
 
     def __str__(self):
         return self.name

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -1647,6 +1647,7 @@ class AccountDashboard(models.Model):
         on_delete=models.CASCADE,
         related_name="account_dashboards",
     )
+    is_shared = models.BooleanField(default=False)
 
     def __str__(self):
         return self.name
@@ -1669,6 +1670,25 @@ class AccountDashboard(models.Model):
     class Meta(object):
         db_table = 'account_dashboard'
         ordering = ('name',)
+
+
+class AccountDashboardSubscription(models.Model):
+    """Subscriptions for dashboards shared between users"""
+
+    account = models.ForeignKey(
+        Account,
+        on_delete=models.CASCADE,
+        related_name="dashboard_subscriptions",
+    )
+    dashboard = models.ForeignKey(
+        AccountDashboard,
+        on_delete=models.CASCADE,
+        related_name="subscribers",
+    )
+
+    class Meta(object):
+        db_table = 'account_dashboard_subscription'
+        unique_together = (('account', 'dashboard'),)
 
 
 class AccountNavlet(models.Model):

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -1667,6 +1667,17 @@ class AccountDashboard(models.Model):
             data['widgets'].append(widget.to_json_dict())
         return data
 
+    def can_access(self, account):
+        return self.account_id == account.id or self.is_shared
+
+    def can_edit(self, account):
+        if account.is_anonymous:
+            return False
+        return self.account_id == account.id
+
+    def is_subscribed(self, account):
+        return self.subscribers.filter(account=account).exists()
+
     class Meta(object):
         db_table = 'account_dashboard'
         ordering = ('name',)

--- a/python/nav/models/sql/changes/sc.05.15.0001.sql
+++ b/python/nav/models/sql/changes/sc.05.15.0001.sql
@@ -1,0 +1,9 @@
+ALTER TABLE account_dashboard
+ADD COLUMN is_shared BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE TABLE profiles.account_dashboard_subscription (
+    id SERIAL PRIMARY KEY,
+    account_id INT REFERENCES account(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    dashboard_id INT REFERENCES account_dashboard(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT unique_account_dashboard_subscription UNIQUE(account_id, dashboard_id)
+)

--- a/python/nav/web/navlets/__init__.py
+++ b/python/nav/web/navlets/__init__.py
@@ -86,6 +86,7 @@ class Navlet(TemplateView):
     is_title_editable = False
     can_be_added = True
     is_deprecated = False
+    can_edit = False  # Set to true if user can edit this instance
 
     # Set to true if we are to reload only an image. This is useful for
     # loading charts that may take some time to display, thus making the
@@ -243,24 +244,41 @@ def dispatcher(request, navlet_id):
     The as_view method takes any attribute and adds it to the instance
     as long as it is defined on the Navlet class
     """
-    account = request.account
+    current_account = request.account
+
     try:
-        account_navlet = AccountNavlet.objects.get(account=account, pk=navlet_id)
+        account_navlet = AccountNavlet.objects.get(pk=navlet_id)
     except AccountNavlet.DoesNotExist as error:
         _logger.error(
-            '%s tried to fetch widget with id %s: %s', account, navlet_id, error
+            '%s tried to fetch widget with id %s: %s', current_account, navlet_id, error
         )
         return HttpResponse(status=404)
-    else:
-        cls = get_navlet_from_name(account_navlet.navlet)
-        if not cls:
-            cls = get_navlet_from_name(ERROR_WIDGET)
-        view = cls.as_view(
-            preferences=account_navlet.preferences,
-            navlet_id=navlet_id,
-            account_navlet=account_navlet,
+
+    dashboard = account_navlet.dashboard
+    owner = account_navlet.account
+    can_access = dashboard.can_access(current_account)
+
+    if not can_access:
+        _logger.error(
+            '%s tried to fetch private widget with id %s owned by %s',
+            current_account,
+            navlet_id,
+            owner,
         )
-        return view(request)
+        return HttpResponse(status=403)
+
+    cls = get_navlet_from_name(account_navlet.navlet)
+    if not cls:
+        cls = get_navlet_from_name(ERROR_WIDGET)
+
+    can_edit = dashboard.can_edit(current_account)
+    view = cls.as_view(
+        preferences=account_navlet.preferences,
+        navlet_id=navlet_id,
+        account_navlet=account_navlet,
+        can_edit=can_edit,
+    )
+    return view(request)
 
 
 def add_user_navlet(request, dashboard_id=None):

--- a/python/nav/web/sass/nav/_tooltip.scss
+++ b/python/nav/web/sass/nav/_tooltip.scss
@@ -11,15 +11,19 @@
     transform: translateY(8px);
   }
 
-  [aria-describedby] {
-    border-bottom: dotted 1px #cccccc;
+  [aria-described-by] {
     cursor: help;
-    font-weight: bold;
-    color: #333333;
+  }
+  &:not(.unstyled) {
+    [aria-describedby] {
+      border-bottom: dotted 1px #cccccc;
+      font-weight: bold;
+      color: #333333;
 
-    &:hover, &:focus {
-      border-bottom: dotted 1px rgb(0.9, 55.35, 84.15);
-      color: #027bbb;
+      &:hover, &:focus {
+        border-bottom: dotted 1px rgb(0.9, 55.35, 84.15);
+        color: #027bbb;
+      }
     }
   }
 

--- a/python/nav/web/sass/nav/custom.scss
+++ b/python/nav/web/sass/nav/custom.scss
@@ -87,6 +87,13 @@
           border-bottom: none;
         }
     }
+    .export-action {
+      width: 100%;
+      a.widget-action {
+        width: 100%;
+        border-bottom: none;
+      }
+    }
 }
 
 #dropdown-dashboard-settings.popover {

--- a/python/nav/web/sass/nav/custom.scss
+++ b/python/nav/web/sass/nav/custom.scss
@@ -66,13 +66,13 @@
 
 #widgets-actions {
     box-shadow: 0px 3px 5px grey;
-    color: white;
     position: absolute;
     right: 0;
     top: 0;
     width: 40px;
     z-index: 1000;
     .widget-action {
+        color: white;
         background-color: $topbar-bg-color;
         height: 40px;
         display: flex;
@@ -83,16 +83,34 @@
             background-color: $primary-color;
             cursor: pointer;
         }
+        &:last-child {
+          border-bottom: none;
+        }
     }
-    .dashboard-settings {
-      width: 100%;
-      .widget-action {
-        border-bottom: none;
-      }
-      .popover-content {
-        width: 800px;
-      }
+}
+
+#dropdown-dashboard-settings.popover {
+  width: 100%;
+  .widget-action {
+    border-bottom: none;
+  }
+  .popover-content {
+    width: 800px;
+  }
+  .row {
+    margin-bottom: 1em;
+    &:last-child {
+      margin-bottom: 0;
     }
+  }
+  #toggle-dashboard-shared-form {
+    * {
+      margin-bottom: 0.5rem;
+    }
+    *:last-child {
+      margin-bottom: 0;
+    }
+  }
 }
 
 

--- a/python/nav/web/sass/nav/custom.scss
+++ b/python/nav/web/sass/nav/custom.scss
@@ -154,6 +154,42 @@
   }
 }
 
+#dashboard-search-form {
+  .description {
+    color: lighten(#333, 20%);
+  }
+}
+
+#dashboard-search-results {
+  ul {
+    margin: 0;
+  }
+  .search-result-item {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 0.5rem;
+    padding: 0.5rem;
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    * {
+      margin-bottom: 0;
+    }
+  }
+
+  .search-result-name {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    .dashboard-owner {
+      font-size: 0.8em;
+      color: lighten(#333, 20%);
+    }
+  }
+}
+
 /* Padding for all pages */
 
 .top-bar, #megadrop {

--- a/python/nav/web/sass/nav/custom.scss
+++ b/python/nav/web/sass/nav/custom.scss
@@ -113,6 +113,33 @@
   }
 }
 
+.dashboard-nav-wrapper {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+}
+
+.dashboard-meta-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.badge {
+    padding: 0.2rem 0.25rem;
+    font-size: 0.75rem;
+    background: #e0e0e0;
+    border: 1px solid #ccc;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+
+    &.white {
+      background: #fff;
+      border-color: #bbb;
+    }
+}
 
 #dashboard-settings-feedback {
   * {

--- a/python/nav/web/sass/nav/custom.scss
+++ b/python/nav/web/sass/nav/custom.scss
@@ -114,6 +114,12 @@
 }
 
 
+#dashboard-settings-feedback {
+  * {
+    margin-bottom: 0;
+  }
+}
+
 /* Padding for all pages */
 
 .top-bar, #megadrop {

--- a/python/nav/web/static/js/src/webfront.js
+++ b/python/nav/web/static/js/src/webfront.js
@@ -139,18 +139,17 @@ require([
 
 
     function createFeedbackElements() {
-        var $dashboardSettingsPanel = $('#dropdown-dashboard-settings');
-        var $alertBox = $('<div class="alert-box">');
-        // Error element for naming the dashboard
+        var $dashboardSettingsPanel = $('#dashboard-settings-feedback');
         var errorElement = $('<small class="error">Name the dashboard</small>');
 
         function removeAlertbox() {
-            $alertBox.detach();
+            $dashboardSettingsPanel.empty();
         }
 
         function addFeedback(text, klass) {
             klass = klass ? klass : 'success';
-            $alertBox.attr('class', 'alert-box').addClass(klass).text(text).appendTo($dashboardSettingsPanel);
+            $dashboardSettingsPanel.empty();
+            $('<div class="alert-box">').addClass(klass).text(text).appendTo($dashboardSettingsPanel);
         }
 
         $dashboardSettingsPanel.on('closed', removeAlertbox);

--- a/python/nav/web/templates/navlets/base.html
+++ b/python/nav/web/templates/navlets/base.html
@@ -1,6 +1,6 @@
 <div class="row navlet-header">
   <div class="small-12 column">
-    {% if not current_user_data.account.is_default_account or current_user_data.sudoer %}
+    {% if navlet.can_edit or current_user_data.sudoer %}
       <ul class="navlet-action-group button-group">
         <li>
           <span class="navlet-drag-button right">
@@ -43,13 +43,13 @@
     <div class="title-container">
       <span class="subheader" title="{{ navlet.description }}"
         {% if navlet.is_title_editable %}
-          {% if not current_user_data.account.is_default_account or current_user_data.sudoer %}
+          {% if navlet.can_edit or current_user_data.sudoer %}
               data-set-title="{% url 'set-navlet-preferences' %}"
           {% endif %}
         {% endif %}>
         <span class="navlet-title">{{ navlet.title }}</span>
           {% if navlet.is_title_editable %}
-            {% if not current_user_data.account.is_default_account or current_user_data.sudoer %}
+            {% if navlet.can_edit or current_user_data.sudoer %}
               <i class="fa fa-edit"></i>
             {% endif %}
           {% endif %}

--- a/python/nav/web/templates/webfront/_dashboard_nav.html
+++ b/python/nav/web/templates/webfront/_dashboard_nav.html
@@ -40,9 +40,22 @@
                 <input type="submit" class="small button full-width" value="Add dashboard">
             </form>
 
-            <a hx-get="{% url 'import-dashboard-modal' %}"
-               hx-target="body"
-               hx-swap="beforeend">Import dashboard</a>
+            <div style="display: flex; flex-direction: column; gap: 0.5em;">
+                <a
+                    hx-get="{% url 'import-dashboard-modal' %}"
+                    hx-target="body"
+                    hx-swap="beforeend"
+                >
+                    <i class="fa fa-upload"></i> Import dashboard
+                </a>
+                <a
+                    hx-get="{% url 'dashboard-search-modal' %}"
+                    hx-target="body"
+                    hx-swap="beforeend"
+                >
+                    <i class="fa fa-search"></i> Find shared dashboard
+                </a>
+            </div>
         </div>
       </li>
     </ul>

--- a/python/nav/web/templates/webfront/_dashboard_nav.html
+++ b/python/nav/web/templates/webfront/_dashboard_nav.html
@@ -71,15 +71,7 @@
                 </button>
             {% endif %}
         {% endif %}
-        <div id="is-shared-badge" class="nav-tooltip unstyled{% if not dashboard.is_shared %} hidden{% endif %}">
-            <div class="badge" aria-describedby="shared-tooltip">
-                <i class="fa fa-share-alt"></i>
-                <span>Shared</span>
-            </div>
-            <div id="shared-tooltip" role="tooltip">
-                This dashboard is shared with other users.
-            </div>
-        </div>
+        {% include "webfront/_dashboard_nav_shared_indicator.html" with dashboard=dashboard %}
         <div class="nav-tooltip unstyled">
             <div class="badge" aria-describedby="owner-tooltip">
                 <i class="fa fa-user"></i>

--- a/python/nav/web/templates/webfront/_dashboard_nav.html
+++ b/python/nav/web/templates/webfront/_dashboard_nav.html
@@ -1,0 +1,73 @@
+{# Buttons for selecting dashboards #}
+<div style="display: flex; align-items: start; justify-content: space-between">
+    <ul id="dashboard-nav" class="pagination">
+      <li class="unavailable"><a href="">Dashboards:</a></li>
+      {% for d in dashboards %}
+        <li {% if d.pk == current_dashboard.pk %}class="current"{% endif %}>
+          {% if d.pk != current_dashboard.pk %}
+            <div class="alert-box hidden" data-dashboardname="{{ d.name }}"></div>
+          {% endif %}
+          <a href="{{ d.get_absolute_url }}"
+             title="Go to dashboard «{{ d.name }}»"
+             data-dashboard="{{ d.pk }}"
+             data-url="{% url 'moveto-dashboard' d.pk %}"
+          >
+            <span>
+                {{ d.name }}
+            </span>
+            <i class="fa fa-star {% if not d.is_default or d.shared_by_other %}hidden{% endif %}"
+               title="This is the default dashboard &mdash; it will be loaded when you log in. To change default, change to another dashboard and set it as default in the dashboard settings."></i>
+            <i class="fa fa-share-alt {% if not d.shared_by_other %}hidden{% endif %}"
+               title="This dashboard is shared by another account."></i>
+          </a>
+        </li>
+      {% endfor %}
+      <li id="dropdown-dashboard-add" class="popover with-arrow">
+        <a
+                title="Add new dashboard"
+                data-popover-target="#dropdown-dashboard-add"
+                aria-haspopup="true"
+        >
+            <i class="fa fa-plus"></i>
+        </a>
+        <div class="popover-content small">
+            <form id="form-add-dashboard" method="post" action="{% url 'add-dashboard' %}">
+                {% csrf_token %}
+                <label>
+                    Add dashboard
+                    <input type="text" name="dashboard-name" placeholder="Dashboard name">
+                </label>
+                <input type="submit" class="small button full-width" value="Add dashboard">
+            </form>
+
+            <a hx-get="{% url 'import-dashboard-modal' %}"
+               hx-target="body"
+               hx-swap="beforeend">Import dashboard</a>
+        </div>
+      </li>
+    </ul>
+    {% if dashboard.shared_by_other %}
+        <div id="owner-tooltip" class="popover with-arrow" data-side="bottom" data-align="end">
+            <button class="secondary tiny" style="margin-bottom: 0" aria-haspopup="true" data-popover-target="#owner-tooltip">
+                <i class="fa fa-user"></i>
+                <span>{{ dashboard.account.name }}</span>
+            </button>
+           <div class="popover-content">
+               <p>This dashboard is owned by <br /> <strong>{{ dashboard.account.name }}</strong></p>
+               {% if is_subscribed %}
+                   <p>You are <em>subscribed</em> to this dashboard.</p>
+               {% else %}
+                   <p>You are <em>not subscribed</em> to this dashboard</p>
+               {% endif %}
+               <button class="small secondary" style="margin-bottom: 0" hx-post="{% url 'dashboard-toggle-subscribe' current_dashboard.pk %}">
+                   Click here to
+                   {% if is_subscribed %}
+                       unsubscribe
+                   {% else %}
+                       subscribe
+                   {% endif %}
+               </button>
+           </div>
+        </div>
+    {% endif %}
+</div>

--- a/python/nav/web/templates/webfront/_dashboard_nav.html
+++ b/python/nav/web/templates/webfront/_dashboard_nav.html
@@ -1,5 +1,5 @@
 {# Buttons for selecting dashboards #}
-<div style="display: flex; align-items: start; justify-content: space-between">
+<div class="dashboard-nav-wrapper">
     <ul id="dashboard-nav" class="pagination">
       <li class="unavailable"><a href="">Dashboards:</a></li>
       {% for d in dashboards %}
@@ -46,28 +46,35 @@
         </div>
       </li>
     </ul>
-    {% if dashboard.shared_by_other %}
-        <div id="owner-tooltip" class="popover with-arrow" data-side="bottom" data-align="end">
-            <button class="secondary tiny" style="margin-bottom: 0" aria-haspopup="true" data-popover-target="#owner-tooltip">
+    <div class="dashboard-meta-wrapper">
+        {% if dashboard.shared_by_other %}
+            {% if is_subscribed %}
+                <button class="tiny secondary" style="margin-bottom: 0;" hx-post="{% url 'dashboard-toggle-subscribe' current_dashboard.pk %}">
+                    <i class="fa fa-bell-slash" style="margin-right: 0.25rem;"></i><span>Unsubscribe</span>
+                </button>
+            {% else %}
+                <button class="tiny info" style="margin-bottom: 0;" hx-post="{% url 'dashboard-toggle-subscribe' current_dashboard.pk %}">
+                    <i class="fa fa-bell" style="margin-right: 0.25rem;"></i><span>Subscribe</span>
+                </button>
+            {% endif %}
+        {% endif %}
+        <div id="is-shared-badge" class="nav-tooltip unstyled{% if not dashboard.is_shared %} hidden{% endif %}">
+            <div class="badge" aria-describedby="shared-tooltip">
+                <i class="fa fa-share-alt"></i>
+                <span>Shared</span>
+            </div>
+            <div id="shared-tooltip" role="tooltip">
+                This dashboard is shared with other users.
+            </div>
+        </div>
+        <div class="nav-tooltip unstyled">
+            <div class="badge" aria-describedby="owner-tooltip">
                 <i class="fa fa-user"></i>
                 <span>{{ dashboard.account.name }}</span>
-            </button>
-           <div class="popover-content">
-               <p>This dashboard is owned by <br /> <strong>{{ dashboard.account.name }}</strong></p>
-               {% if is_subscribed %}
-                   <p>You are <em>subscribed</em> to this dashboard.</p>
-               {% else %}
-                   <p>You are <em>not subscribed</em> to this dashboard</p>
-               {% endif %}
-               <button class="small secondary" style="margin-bottom: 0" hx-post="{% url 'dashboard-toggle-subscribe' current_dashboard.pk %}">
-                   Click here to
-                   {% if is_subscribed %}
-                       unsubscribe
-                   {% else %}
-                       subscribe
-                   {% endif %}
-               </button>
-           </div>
+            </div>
+            <div id="owner-tooltip" role="tooltip">
+                This dashboard belongs to <br /><strong>{{ dashboard.account.name }}</strong>.
+            </div>
         </div>
-    {% endif %}
+    </div>
 </div>

--- a/python/nav/web/templates/webfront/_dashboard_nav_shared_indicator.html
+++ b/python/nav/web/templates/webfront/_dashboard_nav_shared_indicator.html
@@ -1,0 +1,15 @@
+<div
+        id="is-shared-badge"
+        class="nav-tooltip unstyled{% if not dashboard.is_shared %} hidden{% endif %}"
+        {% if swap %}
+        hx-swap-oob="true"
+        {% endif %}
+>
+    <div class="badge" aria-describedby="shared-tooltip">
+        <i class="fa fa-share-alt"></i>
+        <span>Shared</span>
+    </div>
+    <div id="shared-tooltip" role="tooltip">
+        This dashboard is shared with other users.
+    </div>
+</div>

--- a/python/nav/web/templates/webfront/_dashboard_search_form.html
+++ b/python/nav/web/templates/webfront/_dashboard_search_form.html
@@ -1,0 +1,26 @@
+<h4>Dashboard Search</h4>
+<p class="description">
+    Find dashboards shared by other users. Search by dashboard name or account name.
+</p>
+<form
+    hx-post="{% url 'dashboard-search' %}"
+    hx-trigger="input changed delay:500ms, search"
+    hx-target="#dashboard-search-results"
+    autocomplete="off"
+>
+    {% csrf_token %}
+        <div class="form-group">
+            <label for="dashboard-search">
+                Search Dashboards
+            </label>
+            <input
+                id="dashboard-search"
+                class="form-control"
+                type="search"
+                name="search"
+                placeholder="Begin typing to search..."
+                autofocus
+            />
+        </div>
+    <div id="dashboard-search-results"></div>
+</form>

--- a/python/nav/web/templates/webfront/_dashboard_search_results.html
+++ b/python/nav/web/templates/webfront/_dashboard_search_results.html
@@ -1,0 +1,28 @@
+{% if dashboards %}
+    <ul>
+        {% for dashboard in dashboards %}
+            <li class="panel search-result-item">
+                <div class="search-result-name">
+                    <p class="dashboard-name">{{ dashboard.name }}</p>
+                    <p class="dashboard-owner">
+                        <i class="fa fa-user" aria-label="Owner"></i>
+                        {{ dashboard.account.name }}
+                    </p>
+                </div>
+                {% if dashboard.is_subscribed %}
+                    <span class="badge white small">
+                        <i class="fa fa-bell" aria-hidden="true"></i>
+                        Subscribed
+                    </span>
+                {% endif %}
+                <a href="{% url 'dashboard-index-id' dashboard.pk %}" class="button secondary tiny">
+                    View
+                </a>
+            </li>
+        {% endfor %}
+    </ul>
+{% elif search %}
+    <div class="alert-box">
+        No dashboards found matching your search.
+    </div>
+{% endif %}

--- a/python/nav/web/templates/webfront/_dashboard_settings_form.html
+++ b/python/nav/web/templates/webfront/_dashboard_settings_form.html
@@ -55,13 +55,22 @@
             </div>
 
         </div>
-
-        <h5>Columns</h5>
-        <ul class="button-group" data-url="{% url 'save-dashboard-columns' dashboard.pk %}">
-            <li><a href="#" class="button tiny secondary column-chooser" data-columns="1">One</a></li>
-            <li><a href="#" class="button tiny secondary column-chooser" data-columns="2">Two</a></li>
-            <li><a href="#" class="button tiny secondary column-chooser" data-columns="3">Three</a></li>
-            <li><a href="#" class="button tiny secondary column-chooser" data-columns="4">Four</a></li>
-        </ul>
+        <div class="row">
+            <div class="column medium-4">
+                <h5>Columns</h5>
+                <ul class="button-group" data-url="{% url 'save-dashboard-columns' dashboard.pk %}">
+                    <li><a href="#" class="button tiny secondary column-chooser" data-columns="1">One</a></li>
+                    <li><a href="#" class="button tiny secondary column-chooser" data-columns="2">Two</a></li>
+                    <li><a href="#" class="button tiny secondary column-chooser" data-columns="3">Three</a></li>
+                    <li><a href="#" class="button tiny secondary column-chooser" data-columns="4">Four</a></li>
+                </ul>
+            </div>
+            <div class="column medium-8">
+                {# Toggle dashboard shared #}
+                <h5>Sharing</h5>
+                {% include 'webfront/_dashboard_settings_shared_form.html' with dashboard=dashboard %}
+            </div>
+            <div class="column medium-4"></div>
+        </div>
     </div>
 </div>

--- a/python/nav/web/templates/webfront/_dashboard_settings_form.html
+++ b/python/nav/web/templates/webfront/_dashboard_settings_form.html
@@ -72,5 +72,7 @@
             </div>
             <div class="column medium-4"></div>
         </div>
+        <div id="dashboard-settings-feedback">
+        </div>
     </div>
 </div>

--- a/python/nav/web/templates/webfront/_dashboard_settings_shared_form.html
+++ b/python/nav/web/templates/webfront/_dashboard_settings_shared_form.html
@@ -26,6 +26,10 @@
     <input type="submit" class="button small" value="Save sharing settings">
 </form>
 
+{% if changed %}
+{% include "webfront/_dashboard_nav_shared_indicator.html" with dashboard=dashboard swap=True %}
+{% endif %}
+
 {% if message %}
 <div id="dashboard-settings-feedback" hx-swap-oob="innerHtml">
     <div class="alert-box success">

--- a/python/nav/web/templates/webfront/_dashboard_settings_shared_form.html
+++ b/python/nav/web/templates/webfront/_dashboard_settings_shared_form.html
@@ -1,0 +1,27 @@
+<form
+        id="toggle-dashboard-shared-form"
+        hx-post="{% url 'dashboard-toggle-shared' dashboard.pk %}"
+        hx-swap="outerHTML"
+>
+    <div class="alert-box">Sharing this dashboard will allow other NAV users to view, search for, and subscribe to it. Only share dashboards you want to be accessible to others.</div>
+    {% csrf_token %}
+    <div>
+        <input type="hidden" name="is_shared" value="off" />
+        <input
+            id="checkbox-dashboard-shared"
+            name="is_shared"
+            type="checkbox"
+            {% if dashboard.is_shared %}checked{% endif %}
+            {% if dashboard.is_shared %}
+            onchange="document.getElementById('unshare-warning').classList.toggle('hidden');"
+            {% endif %}
+        >
+        <label for="checkbox-dashboard-shared">
+            Share dashboard
+        </label>
+    </div>
+    <div id="unshare-warning" class="alert-box warning hidden">
+        Unsharing this dashboard will remove access for users who currently are subscribed to it.
+    </div>
+    <input type="submit" class="button small" value="Save sharing settings">
+</form>

--- a/python/nav/web/templates/webfront/_dashboard_settings_shared_form.html
+++ b/python/nav/web/templates/webfront/_dashboard_settings_shared_form.html
@@ -25,3 +25,11 @@
     </div>
     <input type="submit" class="button small" value="Save sharing settings">
 </form>
+
+{% if message %}
+<div id="dashboard-settings-feedback" hx-swap-oob="innerHtml">
+    <div class="alert-box success">
+        {{ message }}
+    </div>
+</div>
+{% endif %}

--- a/python/nav/web/templates/webfront/index.html
+++ b/python/nav/web/templates/webfront/index.html
@@ -78,9 +78,16 @@
           <a href="{{ d.get_absolute_url }}"
              title="Go to dashboard «{{ d.name }}»"
              data-dashboard="{{ d.pk }}"
-             data-url="{% url 'moveto-dashboard' d.pk %}">
-            <span>{{ d.name }}</span>
-            <i class="fa fa-star {% if not d.is_default %}hidden{% endif %}"
+             data-url="{% url 'moveto-dashboard' d.pk %}"
+          >
+            <span>
+              {% if d.shared_by_other %}
+                {{ d.name }} ({{ d.account.login }})
+              {% else %}
+                {{ d.name }}
+              {% endif %}
+            </span>
+            <i class="fa fa-star {% if not d.is_default or d.shared_by_other %}hidden{% endif %}"
                title="This is the default dashboard &mdash; it will be loaded when you log in. To change default, change to another dashboard and set it as default in the dashboard settings."></i>
           </a>
         </li>

--- a/python/nav/web/templates/webfront/index.html
+++ b/python/nav/web/templates/webfront/index.html
@@ -67,6 +67,19 @@
 
       {% if can_edit %}
           {% include 'webfront/_dashboard_settings_form.html' %}
+      {% else %}
+        <div class="nav-tooltip export-action">
+            <a
+                class="widget-action"
+                href="{% url 'export-dashboard' dashboard.pk %}"
+                aria-describedby="#export-action-tooltip"
+            >
+              <i class="fa fa-download" title="Export dashboard"></i>
+            </a>
+            <div id="export-action-tooltip" role="tooltip">
+                 Download this dashboard's definition into a file that can later be imported by pressing the + next to the tab list
+            </div>
+        </div>
       {% endif %}
 
     </div>

--- a/python/nav/web/templates/webfront/index.html
+++ b/python/nav/web/templates/webfront/index.html
@@ -35,16 +35,17 @@
   {% if not current_user_data.account.is_default_account or current_user_data.sudoer %}
 
     <div id="widgets-actions" class="hide-for-small" >
-      <div
-          title="Add widget"
-          class="widget-action"
-          hx-get="{% url 'add-navlet-modal' dashboard.id %}"
-          hx-target="body"
-          hx-swap="beforeend"
-      >
-        <i class="fa fa-plus"></i>
-      </div>
-
+      {% if can_edit %}
+          <div
+              title="Add widget"
+              class="widget-action"
+              hx-get="{% url 'add-navlet-modal' dashboard.id %}"
+              hx-target="body"
+              hx-swap="beforeend"
+          >
+            <i class="fa fa-plus"></i>
+          </div>
+      {% endif %}
       <div id="widgets-show-fullscreen" class="widget-action" title="Show dashboard in fullscreen">
         <i class="fa fa-arrows-alt"></i>
       </div>
@@ -64,58 +65,14 @@
         <i class="fa fa-compress"></i>
       </div>
 
-      {% include 'webfront/_dashboard_settings_form.html' %}
+      {% if can_edit %}
+          {% include 'webfront/_dashboard_settings_form.html' %}
+      {% endif %}
+
     </div>
 
     {# Buttons for selecting dashboards #}
-    <ul id="dashboard-nav" class="pagination">
-      <li class="unavailable"><a href="">Dashboards:</a></li>
-      {% for d in dashboards %}
-        <li {% if d.pk == dashboard.pk %}class="current"{% endif %}>
-          {% if d.pk != dashboard.pk %}
-            <div class="alert-box hidden" data-dashboardname="{{ d.name }}"></div>
-          {% endif %}
-          <a href="{{ d.get_absolute_url }}"
-             title="Go to dashboard «{{ d.name }}»"
-             data-dashboard="{{ d.pk }}"
-             data-url="{% url 'moveto-dashboard' d.pk %}"
-          >
-            <span>
-              {% if d.shared_by_other %}
-                {{ d.name }} ({{ d.account.login }})
-              {% else %}
-                {{ d.name }}
-              {% endif %}
-            </span>
-            <i class="fa fa-star {% if not d.is_default or d.shared_by_other %}hidden{% endif %}"
-               title="This is the default dashboard &mdash; it will be loaded when you log in. To change default, change to another dashboard and set it as default in the dashboard settings."></i>
-          </a>
-        </li>
-      {% endfor %}
-        <li id="dropdown-dashboard-add" class="popover with-arrow">
-            <a
-                    title="Add new dashboard"
-                    data-popover-target="#dropdown-dashboard-add"
-                    aria-haspopup="true"
-            >
-                <i class="fa fa-plus"></i>
-            </a>
-            <div class="popover-content small">
-                <form id="form-add-dashboard" method="post" action="{% url 'add-dashboard' %}">
-                    {% csrf_token %}
-                    <label>
-                        Add dashboard
-                        <input type="text" name="dashboard-name" placeholder="Dashboard name">
-                    </label>
-                    <input type="submit" class="small button full-width" value="Add dashboard">
-                </form>
-
-                <a hx-get="{% url 'import-dashboard-modal' %}"
-                   hx-target="body"
-                   hx-swap="beforeend">Import dashboard</a>
-            </div>
-      </li>
-    </ul>
+    {%  include 'webfront/_dashboard_nav.html' with current_dashboard=dashboard dashboards=dashboards %}
 
   {% endif %}
 
@@ -132,6 +89,5 @@
        data-base-template-url="{% url 'navlet-base-template' %}"
        data-widget-columns="{{ dashboard.num_columns }}"
        ></div>
-
 
 {% endblock %}

--- a/python/nav/web/webfront/__init__.py
+++ b/python/nav/web/webfront/__init__.py
@@ -26,6 +26,7 @@ def find_dashboard(account, dashboard_id=None):
     kwargs = {'pk': dashboard_id} if dashboard_id else {'is_default': True}
     try:
         dashboard = AccountDashboard.objects.get(account=account, **kwargs)
+
     except AccountDashboard.DoesNotExist:
         if dashboard_id:
             raise Http404

--- a/python/nav/web/webfront/__init__.py
+++ b/python/nav/web/webfront/__init__.py
@@ -2,7 +2,7 @@
 
 import os
 
-from django.db.models import Count
+from django.db.models import Count, Q
 from django.http import Http404
 
 from nav.config import find_config_file
@@ -25,7 +25,10 @@ def find_dashboard(account, dashboard_id=None):
     """
     kwargs = {'pk': dashboard_id} if dashboard_id else {'is_default': True}
     try:
-        dashboard = AccountDashboard.objects.get(account=account, **kwargs)
+        dashboard = AccountDashboard.objects.get(
+            (Q(account=account) | Q(is_shared=True)), **kwargs
+        )
+        dashboard.shared_by_other = dashboard.is_shared and dashboard.account != account
 
     except AccountDashboard.DoesNotExist:
         if dashboard_id:
@@ -43,3 +46,22 @@ def find_dashboard(account, dashboard_id=None):
         dashboard = AccountDashboard.objects.filter(account=account, **kwargs)[0]
 
     return dashboard
+
+
+def get_dashboards_for_account(account) -> list[AccountDashboard]:
+    """
+    Returns a queryset of dashboards for the given account,
+    including those the account subscribes to.
+    """
+    dashboards = (
+        AccountDashboard.objects.filter(
+            Q(account=account) | Q(subscribers__account=account)
+        )
+        .select_related('account')
+        .distinct()
+    )
+    for dash in dashboards:
+        dash.can_edit = dash.can_edit(account)
+        dash.shared_by_other = dash.is_shared and dash.account_id != account.id
+
+    return list(dashboards)

--- a/python/nav/web/webfront/urls.py
+++ b/python/nav/web/webfront/urls.py
@@ -33,6 +33,11 @@ urlpatterns = [
     path('index/logout/', views.logout, name='webfront-logout'),
     # Dashboard
     path('index/dashboard/<int:did>/', views.index, name='dashboard-index-id'),
+    path(
+        'index/dashboard/toggle-shared/<int:did>/',
+        views.toggle_dashboard_shared,
+        name='dashboard-toggle-shared',
+    ),
     path('index/dashboard/add/', views.add_dashboard, name='add-dashboard'),
     path(
         'index/dashboard/set_default/<int:did>/',

--- a/python/nav/web/webfront/urls.py
+++ b/python/nav/web/webfront/urls.py
@@ -76,7 +76,7 @@ urlpatterns = [
     ),
     path('index/dashboard/import', views.import_dashboard, name='import-dashboard'),
     path(
-        'îndex/dashboard/importmodal',
+        'index/dashboard/importmodal',
         views.import_dashboard_modal,
         name='import-dashboard-modal',
     ),

--- a/python/nav/web/webfront/urls.py
+++ b/python/nav/web/webfront/urls.py
@@ -43,6 +43,12 @@ urlpatterns = [
         views.toggle_subscribe,
         name='dashboard-toggle-subscribe',
     ),
+    path(
+        'index/dashboard/search/modal/',
+        views.dashboard_search_modal,
+        name='dashboard-search-modal',
+    ),
+    path('index/dashboard/search/', views.dashboard_search, name='dashboard-search'),
     path('index/dashboard/add/', views.add_dashboard, name='add-dashboard'),
     path(
         'index/dashboard/set_default/<int:did>/',

--- a/python/nav/web/webfront/urls.py
+++ b/python/nav/web/webfront/urls.py
@@ -38,6 +38,11 @@ urlpatterns = [
         views.toggle_dashboard_shared,
         name='dashboard-toggle-shared',
     ),
+    path(
+        'index/dashboard/toggle-subscribe/<int:did>/',
+        views.toggle_subscribe,
+        name='dashboard-toggle-subscribe',
+    ),
     path('index/dashboard/add/', views.add_dashboard, name='add-dashboard'),
     path(
         'index/dashboard/set_default/<int:did>/',

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -158,7 +158,7 @@ def toggle_subscribe(request, did):
 
 def export_dashboard(request, did):
     """Export dashboard as JSON."""
-    dashboard = get_object_or_404(AccountDashboard, pk=did, account=request.account)
+    dashboard = find_dashboard(request.account, did)
 
     response = JsonResponse(dashboard.to_json_dict())
     response['Content-Disposition'] = 'attachment; filename={name}.json'.format(

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -34,7 +34,7 @@ from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.views.decorators.debug import sensitive_variables, sensitive_post_parameters
 from django.views.decorators.http import require_POST
-from django_htmx.http import HttpResponseClientRedirect
+from django_htmx.http import HttpResponseClientRedirect, HttpResponseClientRefresh
 
 from nav.auditlog.models import LogEntry
 from nav.django.utils import get_account
@@ -55,6 +55,7 @@ from nav.web.utils import generate_qr_code_as_string
 from nav.web.utils import require_param
 from nav.web.webfront import (
     find_dashboard,
+    get_dashboards_for_account,
     WELCOME_ANONYMOUS_PATH,
     WELCOME_REGISTERED_PATH,
 )
@@ -77,7 +78,11 @@ def index(request, did=None):
         welcome = quick_read(WELCOME_REGISTERED_PATH)
 
     dashboard = find_dashboard(request.account, did)
-    dashboards = AccountDashboard.objects.filter(account=request.account)
+    dashboards = get_dashboards_for_account(request.account)
+
+    dashboard_ids = [d.id for d in dashboards]
+    if dashboard.id not in dashboard_ids:
+        dashboards.append(dashboard)
 
     context = {
         'navpath': [('Home', '/')],
@@ -85,6 +90,8 @@ def index(request, did=None):
         'welcome': welcome,
         'dashboard': dashboard,
         'dashboards': dashboards,
+        'can_edit': dashboard.can_edit(request.account),
+        'is_subscribed': dashboard.is_subscribed(request.account),
         'title': 'NAV - {}'.format(dashboard.name),
     }
 
@@ -131,6 +138,22 @@ def _render_share_form_response(
             'message': message,
         },
     )
+
+
+@require_POST
+def toggle_subscribe(request, did):
+    """Toggle subscription status for this dashboard"""
+    dashboard = get_object_or_404(AccountDashboard, pk=did, is_shared=True)
+    if dashboard.is_subscribed(request.account):
+        AccountDashboardSubscription.objects.filter(
+            account=request.account, dashboard=dashboard
+        ).delete()
+    else:
+        AccountDashboardSubscription(
+            account=request.account, dashboard=dashboard
+        ).save()
+
+    return HttpResponseClientRefresh()
 
 
 def export_dashboard(request, did):

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -138,6 +138,7 @@ def _render_share_form_response(
         {
             'dashboard': dashboard,
             'message': message,
+            'changed': True,
         },
     )
 

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -113,16 +113,22 @@ def toggle_dashboard_shared(request, did):
     return _render_share_form_response(
         request,
         dashboard,
+        message="Dashboard sharing is now {}.".format(
+            "enabled" if is_shared else "disabled"
+        ),
     )
 
 
-def _render_share_form_response(request, dashboard: AccountDashboard):
+def _render_share_form_response(
+    request, dashboard: AccountDashboard, message: str = None
+):
     """Render the share dashboard form response."""
     return render(
         request,
         'webfront/_dashboard_settings_shared_form.html',
         {
             'dashboard': dashboard,
+            'message': message,
         },
     )
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -341,7 +341,7 @@ def admin_account(db):
 def non_admin_account(db):
     from nav.models.profiles import Account
 
-    account = Account(login="other_user")
+    account = Account(login="other_user", name="Other User")
     account.set_password("password")
     account.save()
     yield account

--- a/tests/integration/web/webfront_test.py
+++ b/tests/integration/web/webfront_test.py
@@ -2,6 +2,7 @@ import json
 from io import BytesIO
 
 import pytest
+from django.http import Http404
 from django.test import Client
 from django.urls import reverse
 from django.utils.encoding import smart_str
@@ -11,7 +12,9 @@ from nav.models.profiles import (
     Account,
     AccountDashboard,
     AccountDashboardSubscription,
+    AccountNavlet,
 )
+from nav.web.webfront import find_dashboard, get_dashboards_for_account
 from nav.web.webfront.utils import tool_list
 
 
@@ -200,6 +203,212 @@ def test_should_render_about_logging_modal(client):
 
     assert response.status_code == 200
     assert 'id="about-audit-logging"' in smart_str(response.content)
+
+
+class TestDashboardIndexView:
+    def test_given_no_dashboard_id_then_return_default_dashboard(
+        self, db, client, admin_account
+    ):
+        """Tests that the default dashboard is shown when no ID is given"""
+        default_dashboard = AccountDashboard.objects.get(
+            is_default=True, account=admin_account
+        )
+        url = reverse('dashboard-index')
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response.context['dashboard'].id == default_dashboard.id
+
+    def test_given_valid_dashboard_id_then_return_that_dashboard(
+        self, db, client, admin_account
+    ):
+        """Tests that the specified dashboard is shown when a valid ID is given"""
+        dashboard = create_dashboard(admin_account)
+        url = reverse('dashboard-index-id', args=(dashboard.id,))
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response.context['dashboard'].id == dashboard.id
+
+    def test_given_dashboard_id_that_does_not_exist_then_return_404(
+        self, db, client, admin_account
+    ):
+        """Tests that 404 is returned when a non-existing ID is given"""
+        url = reverse('dashboard-index-id', args=(9999,))
+        response = client.get(url)
+
+        assert response.status_code == 404
+
+    def test_given_dashboard_id_for_other_account_when_shared_then_return_dashboard(
+        self, db, client, admin_account, non_admin_account
+    ):
+        """Tests that a shared dashboard of another account can be accessed"""
+        other_dashboard = create_dashboard(non_admin_account, is_shared=True)
+        url = reverse('dashboard-index-id', args=(other_dashboard.id,))
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response.context['dashboard'].id == other_dashboard.id
+
+    def test_given_dashboard_id_for_other_account_when_not_shared_then_return_404(
+        self, db, client, admin_account, non_admin_account
+    ):
+        """
+        Tests that 404 is returned when trying to access another account's dashboard
+        """
+        other_dashboard = create_dashboard(non_admin_account, is_shared=False)
+        url = reverse('dashboard-index-id', args=(other_dashboard.id,))
+        response = client.get(url)
+
+        assert response.status_code == 404
+
+    def test_given_subscribed_dashboard_id_then_return_dashboard(
+        self, db, client, admin_account, non_admin_account
+    ):
+        """Tests that a subscribed dashboard of another account can be accessed"""
+        other_dashboard = create_dashboard(non_admin_account, is_shared=True)
+        AccountDashboardSubscription.objects.create(
+            account=admin_account,
+            dashboard=other_dashboard,
+        )
+        url = reverse('dashboard-index-id', args=(other_dashboard.id,))
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response.context['dashboard'].id == other_dashboard.id
+
+    def test_given_subscribed_dashboard_id_then_return_is_subscribed(
+        self, db, client, admin_account, non_admin_account
+    ):
+        """Tests that a subscribed dashboard of another account can be accessed"""
+        other_dashboard = create_dashboard(non_admin_account, is_shared=True)
+        AccountDashboardSubscription.objects.create(
+            account=admin_account,
+            dashboard=other_dashboard,
+        )
+        url = reverse('dashboard-index-id', args=(other_dashboard.id,))
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response.context['is_subscribed'] is True
+
+    def test_given_own_dashboard_id_then_return_can_edit_true(
+        self, db, client, admin_account
+    ):
+        """Tests that can_edit is True for own dashboards"""
+        own_dashboard = create_dashboard(admin_account, is_shared=False)
+        url = reverse('dashboard-index-id', args=(own_dashboard.id,))
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response.context['can_edit'] is True
+
+    def test_given_other_account_dashboard_id_then_return_can_edit_false(
+        self, db, client, admin_account, non_admin_account
+    ):
+        """Tests that can_edit is False for other account's dashboards"""
+        other_dashboard = create_dashboard(non_admin_account, is_shared=True)
+        url = reverse('dashboard-index-id', args=(other_dashboard.id,))
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response.context['can_edit'] is False
+
+    def test_given_subscribed_dashboard_then_include_dashboard_in_response_list(
+        self, db, client, admin_account, non_admin_account
+    ):
+        """
+        Tests that subscribed dashboards of other accounts are included in the list
+        """
+        subscribed_dashboard = create_dashboard(non_admin_account, is_shared=True)
+        AccountDashboardSubscription.objects.create(
+            account=admin_account,
+            dashboard=subscribed_dashboard,
+        )
+        url = reverse('dashboard-index')
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert subscribed_dashboard in response.context['dashboards']
+
+    def test_given_shared_dashboard_id_when_not_subscribed_then_include_dashboard_last(
+        self, db, client, admin_account, non_admin_account
+    ):
+        """
+        Tests that a shared dashboard of another account is included last in the list
+        when the current account is not subscribed
+        """
+        shared_dashboard = create_dashboard(non_admin_account, is_shared=True)
+        url = reverse('dashboard-index-id', args=(shared_dashboard.id,))
+        response = client.get(url)
+
+        assert response.status_code == 200
+        dashboards = response.context['dashboards']
+        assert dashboards[-1] == shared_dashboard
+
+
+class TestToggleDashboardSubscriptionView:
+    def test_when_not_subscribed_then_subscribe(
+        self, db, client, admin_account, non_admin_account
+    ):
+        """Tests that a dashboard can be subscribed to"""
+        other_dashboard = create_dashboard(non_admin_account, is_shared=True)
+        url = reverse('dashboard-toggle-subscribe', args=(other_dashboard.id,))
+        client.post(url, follow=True)
+
+        assert other_dashboard.is_subscribed(admin_account) is True
+
+    def test_when_subscribed_then_unsubscribe(
+        self, db, client, admin_account, non_admin_account
+    ):
+        """Tests that a dashboard can be unsubscribed from"""
+        other_dashboard = create_dashboard(non_admin_account, is_shared=True)
+        AccountDashboardSubscription.objects.create(
+            account=admin_account,
+            dashboard=other_dashboard,
+        )
+        url = reverse('dashboard-toggle-subscribe', args=(other_dashboard.id,))
+        client.post(url, follow=True)
+
+        assert other_dashboard.is_subscribed(admin_account) is False
+
+    def test_given_dashboard_that_does_not_exist_then_return_404(
+        self, db, client, admin_account
+    ):
+        """
+        Tests that 404 is returned when trying to subscribe to a non-existing dashboard
+        """
+        url = reverse('dashboard-toggle-subscribe', args=(9999,))
+        response = client.post(url)
+
+        assert response.status_code == 404
+
+    def test_given_existing_dashboard_when_not_shared_then_return_404(
+        self, db, client, admin_account, non_admin_account
+    ):
+        """
+        Tests that 404 is returned when trying to subscribe to a non-shared dashboard
+        """
+        other_dashboard = create_dashboard(non_admin_account, is_shared=False)
+        url = reverse('dashboard-toggle-subscribe', args=(other_dashboard.id,))
+        response = client.post(url)
+
+        assert response.status_code == 404
+
+    def test_given_existing_shared_dashboard_id_then_return_refresh_header(
+        self, db, client, admin_account, non_admin_account
+    ):
+        """
+        Tests that subscribing to a shared dashboard returns a response with
+        HX-Refresh header set to true
+        """
+        shared_dashboard = create_dashboard(non_admin_account, is_shared=True)
+        url = reverse('dashboard-toggle-subscribe', args=(shared_dashboard.id,))
+        response = client.post(url)
+
+        assert response.status_code == 200
+        assert 'HX-Refresh' in response.headers
+        assert response.headers['HX-Refresh'] == 'true'
 
 
 class TestToggleDashboardSharingView:
@@ -511,12 +720,219 @@ class TestImportDashboardViews:
         assert 'File is not a valid dashboard file' in smart_str(response.content)
 
 
+class TestFindDashboardUtil:
+    """
+    Tests for the find_dashboard utility function which determines which dashboard
+    to show based on the given account and optional dashboard ID
+    """
+
+    def test_given_no_dashboard_id_then_return_default_dashboard(
+        self, db, non_admin_account
+    ):
+        """Tests that the default dashboard is returned when no ID is given"""
+        default_dashboard = AccountDashboard.objects.get(
+            is_default=True, account=non_admin_account
+        )
+
+        dashboard = find_dashboard(non_admin_account)
+        assert dashboard == default_dashboard
+
+    def test_given_valid_dashboard_id_then_return_that_dashboard(
+        self, db, non_admin_account
+    ):
+        """Tests that the specified dashboard is returned when a valid ID is given"""
+        dashboard = create_dashboard(non_admin_account, name="Test dashboard")
+
+        found_dashboard = find_dashboard(non_admin_account, dashboard_id=dashboard.id)
+        assert found_dashboard == dashboard
+
+    def test_given_dashboard_id_that_does_not_exist_then_return_404(
+        self, db, non_admin_account
+    ):
+        """Tests that 404 is raised when a non-existing dashboard ID is given"""
+
+        with pytest.raises(Http404):
+            find_dashboard(non_admin_account, dashboard_id=9999)
+
+    def test_given_no_dashboard_id_when_no_default_and_no_dashboards_then_return_404(
+        self, db, non_admin_account
+    ):
+        """Tests that 404 is raised when no dashboards exist for the account"""
+        # Clean up any existing dashboards
+        AccountDashboard.objects.filter(account=non_admin_account).delete()
+        with pytest.raises(Http404):
+            find_dashboard(non_admin_account)
+
+    def test_given_no_dashboard_id_then_returns_dashboard_with_most_widgets(
+        self, db, non_admin_account
+    ):
+        """
+        Tests that when no ID is given and no default dashboard is set, the dashboard
+        with the most widgets is returned
+        """
+        # Clean up any existing dashboards
+        AccountDashboard.objects.filter(account=non_admin_account).delete()
+        # Create first dashboard with three widgets
+        first_dashboard = create_dashboard(non_admin_account, name="First")
+        for _ in range(3):
+            create_widget(first_dashboard)
+            create_widget(first_dashboard)
+        # Create second dashboard with no widgets
+        create_dashboard(non_admin_account, name="Second")
+
+        dashboard = find_dashboard(non_admin_account)
+        assert dashboard == first_dashboard
+
+    def test_given_dashboard_id_for_other_account_when_shared_then_return_dashboard(
+        self, db, non_admin_account, admin_account
+    ):
+        """Tests that a shared dashboard of another account can be accessed"""
+        other_dashboard = create_dashboard(admin_account, name="Other", is_shared=True)
+        found_dashboard = find_dashboard(
+            non_admin_account, dashboard_id=other_dashboard.id
+        )
+        assert found_dashboard == other_dashboard
+
+    def test_given_dashboard_id_for_other_account_when_not_shared_then_return_404(
+        self, db, client, non_admin_account, admin_account
+    ):
+        """
+        Test that 404 is raised when accessing a non-shared dashboard of another account
+        """
+        other_dashboard = create_dashboard(admin_account, name="Other", is_shared=False)
+
+        with pytest.raises(Http404):
+            find_dashboard(non_admin_account, dashboard_id=other_dashboard.id)
+
+    def test_given_own_dashboard_then_find_dashboard_sets_shared_by_other_to_false(
+        self, db, non_admin_account
+    ):
+        """Tests that find_dashboard sets shared_by_other to False for own dashboards"""
+        dashboard = create_dashboard(non_admin_account, name="Own", is_shared=True)
+        found_dashboard = find_dashboard(non_admin_account, dashboard_id=dashboard.id)
+        assert found_dashboard.shared_by_other is False
+
+    def test_given_dashboard_of_another_account_then_find_dashboard_sets_shared_by_other_to_true(  # noqa: E501
+        self, db, non_admin_account, admin_account
+    ):
+        """
+        Test that find_dashboard sets shared_by_other to True for other a dashboard
+        of another account
+        """
+        other_dashboard = create_dashboard(admin_account, name="Other", is_shared=True)
+        found_dashboard = find_dashboard(
+            non_admin_account, dashboard_id=other_dashboard.id
+        )
+        assert found_dashboard.shared_by_other is True
+
+
+class TestGetDashboardsForAccount:
+    """
+    Tests for the get_dashboards_for_account utility function which retrieves all
+    dashboards for a given account, including shared dashboards from other accounts
+    """
+
+    def test_given_account_then_return_all_own_dashboards(self, db, non_admin_account):
+        """Tests that all own dashboards are returned"""
+        default_dashboard = AccountDashboard.objects.get(
+            is_default=True, account=non_admin_account
+        )
+        other_dashboard = create_dashboard(
+            non_admin_account, name="Own 1", is_shared=False
+        )
+
+        dashboards = get_dashboards_for_account(non_admin_account)
+        assert default_dashboard in dashboards
+        assert other_dashboard in dashboards
+
+    def test_given_account_with_no_subscriptions_then_return_own_dashboards(
+        self, db, non_admin_account, admin_account
+    ):
+        """
+        Tests that only own dashboards are returned when there are no subscriptions
+        """
+        own_dashboard = create_dashboard(non_admin_account, name="Own", is_shared=False)
+        shared_dashboard = create_dashboard(
+            admin_account, name="Shared", is_shared=True
+        )
+
+        dashboards = get_dashboards_for_account(non_admin_account)
+        assert own_dashboard in dashboards
+        assert shared_dashboard not in dashboards
+
+    def test_given_account_with_subscriptions_then_return_shared_dashboards(
+        self, db, non_admin_account, admin_account
+    ):
+        """Tests that shared dashboards are returned when there are subscriptions"""
+        own_dashboard = create_dashboard(non_admin_account, name="Own", is_shared=False)
+        shared_dashboard = create_dashboard(
+            admin_account, name="Shared", is_shared=True
+        )
+        AccountDashboardSubscription.objects.create(
+            account=non_admin_account,
+            dashboard=shared_dashboard,
+        )
+
+        dashboards = get_dashboards_for_account(non_admin_account)
+
+        assert own_dashboard in dashboards
+        assert shared_dashboard in dashboards
+
+    def test_given_dashboard_subscription_then_shared_by_other_is_set_correctly(
+        self, db, non_admin_account, admin_account
+    ):
+        """
+        Tests that shared_by_other is set correctly for shared dashboards
+        """
+        shared_dashboard = create_dashboard(
+            admin_account, name="Shared", is_shared=True
+        )
+        AccountDashboardSubscription.objects.create(
+            account=non_admin_account,
+            dashboard=shared_dashboard,
+        )
+
+        dashboards = get_dashboards_for_account(non_admin_account)
+        assert all(
+            dashboard.shared_by_other is (dashboard.account != non_admin_account)
+            for dashboard in dashboards
+        )
+
+    def test_given_dashboard_subscription_then_can_edit_is_set_correctly(
+        self, db, non_admin_account, admin_account
+    ):
+        """
+        Tests that can_edit is set correctly for shared dashboards
+        """
+        shared_dashboard = create_dashboard(
+            admin_account, name="Shared", is_shared=True
+        )
+        AccountDashboardSubscription.objects.create(
+            account=non_admin_account,
+            dashboard=shared_dashboard,
+        )
+        dashboards = get_dashboards_for_account(non_admin_account)
+        assert all(
+            dashboard.can_edit is (dashboard.account == non_admin_account)
+            for dashboard in dashboards
+        )
+        assert len(dashboards) == 2  # Default + shared
+
+
 def create_dashboard(account, name="Test Dashboard", is_default=False, is_shared=False):
     return AccountDashboard.objects.create(
         name=name,
         is_default=is_default,
         account=account,
         is_shared=is_shared,
+    )
+
+
+def create_widget(dashboard, navlet='nav.web.navlets.welcome.WelcomeNavlet'):
+    return AccountNavlet.objects.create(
+        dashboard=dashboard,
+        account=dashboard.account,
+        navlet=navlet,
     )
 
 


### PR DESCRIPTION
## Scope and purpose

This PR will resolve #2344 when all dependent PRs are merged.
This PR resolves #3554 in itself.

Dependent PRs: #3553, #3557 (see dependency graph)

```mermaid
  graph LR;
      A(#3551: Base PR)
      B(#3553: Loading and subscription - merged)
      C(#3557: Dashboard search - merged)
      D(#3559: Export and import - merged)
      A-->B;
      B-->C;
      B-->D;
```

This PR adds support for sharing dashboards in NAV by modifying the `account_dashboard` table and adds a new `account_dashboard_subscription` table to hold account-dashboard joins.. A dashboard owner can set the dashboard as shared, which in turn will make it visible to other accounts in the follow-up PR.  

<!-- remove things that do not apply -->
### This pull request
* Adds an `is_shared` property to the AccountDashboard model
* Adds new AccountDashboardSubscription to support account subscriptions on a dashboard
* Adds two new methods to the AccountDashboard model
    * `can_edit(self, account)`: Used in views to determine if the request account has edit rights.
    * `is_subscribed(self, account)`: Used in views to determine if the request account is subscribed to the dashboard.
* Adds a "Shared" section to the dashboard settings form
    * A shared dashboard shows a warning if the owner unchecks the shared checkbox, as this will remove any existing subscriptions.
    
## Screenshots

**A new Sharing form has been added to dashboard settings**

This form shows a currently unshared dashboard.

<img width="812" height="386" alt="image" src="https://github.com/user-attachments/assets/62fe9a82-f907-484c-b4f0-0935c177adde" />

**Unsharing a dashboard**

| Shared dashboard form | Shared dashboard with "Share" unchecked |
| --- | --- |
| <img width="525" height="218" alt="image" src="https://github.com/user-attachments/assets/e7fc34cc-b9a5-435c-8436-4409100c8c41" /> | <img width="515" height="269" alt="image" src="https://github.com/user-attachments/assets/f402e9c7-4e03-4486-90c0-a698870f32db" /> |


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] This pull request is based on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
