### PR TITLE
Shared dashboards: Add dashboard search form

### DIFF
--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -1648,6 +1648,11 @@ class AccountDashboard(models.Model):
         related_name="account_dashboards",
     )
     is_shared = models.BooleanField(default=False)
+    subscriptions = models.ManyToManyField(
+        Account,
+        through='AccountDashboardSubscription',
+        related_name="account_dashboard_subscriptions",
+    )
 
     def __str__(self):
         return self.name

--- a/python/nav/web/sass/nav/custom.scss
+++ b/python/nav/web/sass/nav/custom.scss
@@ -154,6 +154,42 @@
   }
 }
 
+#dashboard-search-form {
+  .description {
+    color: lighten(#333, 20%);
+  }
+}
+
+#dashboard-search-results {
+  ul {
+    margin: 0;
+  }
+  .search-result-item {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 0.5rem;
+    padding: 0.5rem;
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    * {
+      margin-bottom: 0;
+    }
+  }
+
+  .search-result-name {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    .dashboard-owner {
+      font-size: 0.8em;
+      color: lighten(#333, 20%);
+    }
+  }
+}
+
 /* Padding for all pages */
 
 .top-bar, #megadrop {

--- a/python/nav/web/templates/webfront/_dashboard_nav.html
+++ b/python/nav/web/templates/webfront/_dashboard_nav.html
@@ -40,9 +40,22 @@
                 <input type="submit" class="small button full-width" value="Add dashboard">
             </form>
 
-            <a hx-get="{% url 'import-dashboard-modal' %}"
-               hx-target="body"
-               hx-swap="beforeend">Import dashboard</a>
+            <div style="display: flex; flex-direction: column; gap: 0.5em;">
+                <a
+                    hx-get="{% url 'import-dashboard-modal' %}"
+                    hx-target="body"
+                    hx-swap="beforeend"
+                >
+                    <i class="fa fa-upload"></i> Import dashboard
+                </a>
+                <a
+                    hx-get="{% url 'dashboard-search-modal' %}"
+                    hx-target="body"
+                    hx-swap="beforeend"
+                >
+                    <i class="fa fa-search"></i> Find shared dashboard
+                </a>
+            </div>
         </div>
       </li>
     </ul>

--- a/python/nav/web/templates/webfront/_dashboard_search_form.html
+++ b/python/nav/web/templates/webfront/_dashboard_search_form.html
@@ -1,0 +1,26 @@
+<h4>Dashboard Search</h4>
+<p class="description">
+    Find dashboards shared by other users. Search by dashboard name or account name.
+</p>
+<form
+    hx-post="{% url 'dashboard-search' %}"
+    hx-trigger="input changed delay:500ms, search"
+    hx-target="#dashboard-search-results"
+    autocomplete="off"
+>
+    {% csrf_token %}
+        <div class="form-group">
+            <label for="dashboard-search">
+                Search Dashboards
+            </label>
+            <input
+                id="dashboard-search"
+                class="form-control"
+                type="search"
+                name="search"
+                placeholder="Begin typing to search..."
+                autofocus
+            />
+        </div>
+    <div id="dashboard-search-results"></div>
+</form>

--- a/python/nav/web/templates/webfront/_dashboard_search_results.html
+++ b/python/nav/web/templates/webfront/_dashboard_search_results.html
@@ -1,0 +1,28 @@
+{% if dashboards %}
+    <ul>
+        {% for dashboard in dashboards %}
+            <li class="panel search-result-item">
+                <div class="search-result-name">
+                    <p class="dashboard-name">{{ dashboard.name }}</p>
+                    <p class="dashboard-owner">
+                        <i class="fa fa-user" aria-label="Owner"></i>
+                        {{ dashboard.account.name }}
+                    </p>
+                </div>
+                {% if dashboard.is_subscribed %}
+                    <span class="badge white small">
+                        <i class="fa fa-bell" aria-hidden="true"></i>
+                        Subscribed
+                    </span>
+                {% endif %}
+                <a href="{% url 'dashboard-index-id' dashboard.pk %}" class="button secondary tiny">
+                    View
+                </a>
+            </li>
+        {% endfor %}
+    </ul>
+{% elif search %}
+    <div class="alert-box">
+        No dashboards found matching your search.
+    </div>
+{% endif %}

--- a/python/nav/web/webfront/urls.py
+++ b/python/nav/web/webfront/urls.py
@@ -43,6 +43,12 @@ urlpatterns = [
         views.toggle_subscribe,
         name='dashboard-toggle-subscribe',
     ),
+    path(
+        'index/dashboard/search/modal/',
+        views.dashboard_search_modal,
+        name='dashboard-search-modal',
+    ),
+    path('index/dashboard/search/', views.dashboard_search, name='dashboard-search'),
     path('index/dashboard/add/', views.add_dashboard, name='add-dashboard'),
     path(
         'index/dashboard/set_default/<int:did>/',

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -341,7 +341,7 @@ def admin_account(db):
 def non_admin_account(db):
     from nav.models.profiles import Account
 
-    account = Account(login="other_user")
+    account = Account(login="other_user", name="Other User")
     account.set_password("password")
     account.save()
     yield account


### PR DESCRIPTION
## Scope and purpose

Resolves #3556, part of #2344.
Dependent on PR #3553.

No-news as #3551 contains the news fragment.

This PR adds search functionality to the dashboard navigation. A user can search for shared dashboards by dashboard name, account name or account login. Dashboards belonging to the current account are excluded, and the search results show whether the user is currently subscribed.

I added two methods of triggering the search modal: From within the "Add dashboard" popover, and with a separate search button. Having both might be overkill, but I either could be a good solution.

<!-- remove things that do not apply -->
### This pull request
* Adds a dashboard search modal and search results template
* Adds views for displaying a search modal and handling shared dashboard search
* Adds a `name` to the `non_admin_account` fixture, necessary for the tests to work.

## How to test

You'll need two different users, so if have admin and you can make a new test user that's the easiest.

1. Make a test user, sudo to it, and have that test user make a shared dashboard.
2. Desudo and search for the new dashboard.
3. If you find it and view it, you are not subscribed so it'll disappaer on page reload.
4. Subscribe to the dashboard.

## Screenshots

#### Dashboard search results

| Dashboards found | No dashboards found |
| --- | --- |
| <img width="989" height="771" alt="image" src="https://github.com/user-attachments/assets/0323f4ab-0bf5-4a0c-90ba-24012c8a5b7f" /> |<img width="486" height="320" alt="image" src="https://github.com/user-attachments/assets/12fc1494-af19-4dc5-9f21-879e50e1cf9a" /> |

#### Open dashboard search

| From add dashboard popover | With search button trigger |
| --- | --- |
| <img width="313" height="214" alt="image" src="https://github.com/user-attachments/assets/46725f48-cdf4-472f-9573-e0ed085f6157" /> | <img width="285" height="44" alt="image" src="https://github.com/user-attachments/assets/d061938b-1942-4c65-86d8-221e6ec98dc5" /> |


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [ ] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] This pull request is based on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
