### PR TITLE
Support shared dashboard as default

### DIFF
--- a/changelog.d/3572.changed.md
+++ b/changelog.d/3572.changed.md
@@ -1,0 +1,1 @@
+Add support for setting shared dashboards as account default

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -1707,6 +1707,25 @@ class AccountDashboard(models.Model):
         ordering = ('name',)
 
 
+class AccountDefaultDashboard(models.Model):
+    account = models.OneToOneField(
+        Account,
+        on_delete=models.CASCADE,
+        db_column='account_id',
+        primary_key=True,
+        related_name='default_dashboard_mapping',
+    )
+    dashboard = models.ForeignKey(
+        AccountDashboard,
+        on_delete=models.CASCADE,
+        db_column='dashboard_id',
+        related_name='default_for_accounts',
+    )
+
+    class Meta:
+        db_table = 'account_default_dashboard'
+
+
 class AccountDashboardSubscription(models.Model):
     """Subscriptions for dashboards shared between users"""
 

--- a/python/nav/models/sql/changes/sc.05.17.0002.sql
+++ b/python/nav/models/sql/changes/sc.05.17.0002.sql
@@ -1,0 +1,11 @@
+CREATE TABLE profiles.account_default_dashboard (
+    account_id INT PRIMARY KEY REFERENCES profiles.account(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    dashboard_id INT NOT NULL REFERENCES profiles.account_dashboard(id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+INSERT INTO profiles.account_default_dashboard (account_id, dashboard_id)
+SELECT d.account_id, d.id
+FROM profiles.account_dashboard AS d
+WHERE d.is_default = true
+ON CONFLICT (account_id) DO UPDATE
+SET dashboard_id = EXCLUDED.dashboard_id;

--- a/python/nav/models/sql/changes/sc.05.17.0003.sql
+++ b/python/nav/models/sql/changes/sc.05.17.0003.sql
@@ -1,0 +1,33 @@
+-- Create a new dashboard, copy all the widgets from the default user to
+-- the dashboard, and set the new dashboard as the default dashboard
+-- for the newly created account.
+CREATE OR REPLACE FUNCTION create_new_dashboard() RETURNS trigger AS $$
+  DECLARE
+    new_dashboard_id INTEGER;
+  BEGIN
+    -- Insert dashboard
+    INSERT INTO profiles.account_dashboard (account_id, is_default, num_columns)
+      VALUES (NEW.id, TRUE, 3)
+      RETURNING id INTO new_dashboard_id;
+
+    -- Copy navlets from default user
+    INSERT INTO profiles.account_navlet (account, navlet, displayorder, col, preferences, dashboard_id)
+      SELECT NEW.id, navlet, displayorder, col, preferences, new_dashboard_id
+        FROM profiles.account_navlet WHERE account=0;
+
+    -- Insert into account_default_dashboard
+    INSERT INTO profiles.account_default_dashboard (account_id, dashboard_id)
+      VALUES (NEW.id, new_dashboard_id);
+
+    RETURN NULL;
+  END
+$$ LANGUAGE plpgsql;
+
+-- Drop the trigger to allow re-creation with updated create_new_dashboard function
+DROP TRIGGER IF EXISTS add_default_dashboard_on_account_create ON profiles.account;
+
+-- Create the trigger
+CREATE TRIGGER add_default_dashboard_on_account_create
+  AFTER INSERT ON profiles.account
+  FOR EACH ROW
+  EXECUTE PROCEDURE create_new_dashboard();

--- a/python/nav/web/navlets/__init__.py
+++ b/python/nav/web/navlets/__init__.py
@@ -389,7 +389,7 @@ def add_navlet(account, navlet, preferences=None, dashboard=None):
     if preferences is None:
         preferences = {}
     if dashboard is None:
-        dashboard = AccountDashboard.objects.get(account=account, is_default=True)
+        dashboard = account.default_dashboard
 
     accountnavlet = AccountNavlet(account=account, navlet=navlet, dashboard=dashboard)
     accountnavlet.column, accountnavlet.order = find_new_placement()

--- a/python/nav/web/sass/nav/custom.scss
+++ b/python/nav/web/sass/nav/custom.scss
@@ -156,8 +156,11 @@
   .widget-action {
     border-bottom: none;
   }
-  .popover-content {
+  .settings-popover {
     width: 800px;
+  }
+  .shared-settings-popover {
+    width: 600px;
   }
   .row {
     margin-bottom: 1em;

--- a/python/nav/web/static/js/src/webfront.js
+++ b/python/nav/web/static/js/src/webfront.js
@@ -183,7 +183,7 @@ require([
 
     /** Functions for handling setting of default dashboard */
     function addDefaultDashboardListener(feedback) {
-        var defaultDashboardContainer = $('#default-dashboard-container'),
+        const defaultDashboardContainer = $('#default-dashboard-container'),
             setDefaultDashboardForm = $('#form-set-default-dashboard'),
             isDefaultDashboardAlert = defaultDashboardContainer.find('.alert-box'),
             deleteDashboardForm = $('#form-delete-dashboard');
@@ -194,21 +194,15 @@ require([
             isDefaultDashboardAlert.hide();
         }
 
-        setDefaultDashboardForm.submit(function (event) {
-            event.preventDefault();
-            feedback.removeAlertbox();
-            const request = $.post(
-                this.getAttribute('action'),
-                $(this).serialize()
-            );
-            request.done(function (responseText) {
-                feedback.addFeedback(responseText);
+        // Handle UI updates after HTMX request completes
+        document.body.addEventListener('htmx:afterRequest', function (event) {
+            if (event.detail.elt.id === 'form-set-default-dashboard') {
                 setDefaultDashboardForm.hide();
                 isDefaultDashboardAlert.show();
                 deleteDashboardForm.hide();
                 $dashboardNavigator.find('.fa-star').addClass('hidden');
                 $dashboardNavigator.find('.current .fa-star').removeClass('hidden');
-            });
+            }
         });
     }
 

--- a/python/nav/web/static/js/src/webfront.js
+++ b/python/nav/web/static/js/src/webfront.js
@@ -185,7 +185,7 @@ require([
     function addDefaultDashboardListener(feedback) {
         const defaultDashboardContainer = $('#default-dashboard-container'),
             setDefaultDashboardForm = $('#form-set-default-dashboard'),
-            isDefaultDashboardAlert = defaultDashboardContainer.find('.alert-box'),
+            isDefaultDashboardAlert = $('#is-default-dashboard-alert'),
             deleteDashboardForm = $('#form-delete-dashboard');
 
         if (defaultDashboardContainer.data('is-default-dashboard')) {
@@ -194,15 +194,13 @@ require([
             isDefaultDashboardAlert.hide();
         }
 
-        // Handle UI updates after HTMX request completes
-        document.body.addEventListener('htmx:afterRequest', function (event) {
-            if (event.detail.elt.id === 'form-set-default-dashboard') {
-                setDefaultDashboardForm.hide();
-                isDefaultDashboardAlert.show();
-                deleteDashboardForm.hide();
-                $dashboardNavigator.find('.fa-star').addClass('hidden');
-                $dashboardNavigator.find('.current .fa-star').removeClass('hidden');
-            }
+        // Handle UI updates when default dashboard changes
+        document.body.addEventListener('nav.dashboard.defaultChanged', function () {
+            setDefaultDashboardForm.hide();
+            isDefaultDashboardAlert.show();
+            deleteDashboardForm.hide();
+            $dashboardNavigator.find('.fa-star').addClass('hidden');
+            $dashboardNavigator.find('.current .fa-star').removeClass('hidden');
         });
     }
 

--- a/python/nav/web/templates/webfront/_dashboard_nav.html
+++ b/python/nav/web/templates/webfront/_dashboard_nav.html
@@ -15,7 +15,7 @@
             <span>
                 {{ d.name }}
             </span>
-            <i class="fa fa-star {% if not d.is_default or d.shared_by_other %}hidden{% endif %}"
+            <i class="fa fa-star {% if not d.is_default %}hidden{% endif %}"
                title="This is the default dashboard &mdash; it will be loaded when you log in. To change default, change to another dashboard and set it as default in the dashboard settings."></i>
             <i class="fa fa-share-alt {% if not d.shared_by_other %}hidden{% endif %}"
                title="This dashboard is shared by another account."></i>

--- a/python/nav/web/templates/webfront/_dashboard_nav.html
+++ b/python/nav/web/templates/webfront/_dashboard_nav.html
@@ -60,17 +60,7 @@
       </li>
     </ul>
     <div class="dashboard-meta-wrapper">
-        {% if dashboard.shared_by_other %}
-            {% if is_subscribed %}
-                <button class="tiny secondary" style="margin-bottom: 0;" hx-post="{% url 'dashboard-toggle-subscribe' current_dashboard.pk %}">
-                    <i class="fa fa-bell-slash" style="margin-right: 0.25rem;"></i><span>Unsubscribe</span>
-                </button>
-            {% else %}
-                <button class="tiny info" style="margin-bottom: 0;" hx-post="{% url 'dashboard-toggle-subscribe' current_dashboard.pk %}">
-                    <i class="fa fa-bell" style="margin-right: 0.25rem;"></i><span>Subscribe</span>
-                </button>
-            {% endif %}
-        {% endif %}
+        {% include "webfront/_dashboard_subscribe_button.html" with dashboard=current_dashboard %}
         {% include "webfront/_dashboard_nav_shared_indicator.html" with dashboard=dashboard %}
         <div class="nav-tooltip" data-align="end">
             <div class="badge unstyled-tooltip" aria-describedby="owner-tooltip">

--- a/python/nav/web/templates/webfront/_dashboard_set_default_response.html
+++ b/python/nav/web/templates/webfront/_dashboard_set_default_response.html
@@ -1,0 +1,4 @@
+<div class="alert-box {{ status }}">{{ message }}</div>
+{% if dashboard.shared_by_other %}
+{% include "webfront/_dashboard_subscribe_button.html" with dashboard=dashboard is_subscribed=is_subscribed oob=True %}
+{% endif %}

--- a/python/nav/web/templates/webfront/_dashboard_set_default_response.html
+++ b/python/nav/web/templates/webfront/_dashboard_set_default_response.html
@@ -2,3 +2,4 @@
 {% if dashboard.shared_by_other %}
 {% include "webfront/_dashboard_subscribe_button.html" with dashboard=dashboard is_subscribed=is_subscribed oob=True %}
 {% endif %}
+<div id="no-default-dashboard-warning" hx-swap-oob="delete"></div>

--- a/python/nav/web/templates/webfront/_dashboard_settings_form.html
+++ b/python/nav/web/templates/webfront/_dashboard_settings_form.html
@@ -7,7 +7,8 @@
     >
         <i class="fa fa-gear fa-lg"></i>
     </div>
-    <div class="popover-content large">
+    <div class="popover-content large {% if can_edit %}settings-popover{% else %}shared-settings-popover{% endif %}">
+        {% if can_edit %}
         <form id="form-rename-dashboard"
               method="post"
               data-dashboard="{{ dashboard.pk }}"
@@ -17,10 +18,13 @@
                    value="{{ dashboard.name }}">
             <input type="submit" class="small button" value="Rename dashboard">
         </form>
+        {% else %}
+        <p aria-label="Dashboard name">{{ dashboard.name }}</p>
+        {% endif %}
 
         <div class="row">
 
-            <div class="column medium-4">
+            <div class="column medium-6">
                 <div id="default-dashboard-container"
                      data-is-default-dashboard="{{ dashboard.is_default|yesno:'1,0' }}">
                     <div class="alert-box">This is the default dashboard</div>
@@ -32,8 +36,7 @@
                     </form>
                 </div>
             </div>
-
-            <div class="column medium-4">
+            <div class="column medium-6">
                 <a href="{% url 'export-dashboard' dashboard.pk %}" class="small button expand">Export dashboard
                 </a><br/>
                 <div class="nav-tooltip">
@@ -44,8 +47,9 @@
                 </div>
             </div>
 
+            {% if can_edit %}
             <div class="column medium-4">
-                {% if request.user.account_dashboards.count > 1 and not dashboard.is_default %}
+                {% if request.account.account_dashboards.count > 1 and not dashboard.is_default %}
                     <form
                         hx-post="{% url 'delete-dashboard' dashboard.pk %}"
                             hx-target="body"
@@ -63,8 +67,9 @@
                 {% endif %}
 
             </div>
-
+            {% endif %}
         </div>
+        {% if can_edit %}
         <div class="row">
             <div class="column medium-4">
                 <h5>Columns</h5>
@@ -77,6 +82,7 @@
             </div>
             <div class="column medium-4"></div>
         </div>
+        {% endif %}
         <div id="dashboard-settings-feedback">
         </div>
     </div>

--- a/python/nav/web/templates/webfront/_dashboard_settings_form.html
+++ b/python/nav/web/templates/webfront/_dashboard_settings_form.html
@@ -27,7 +27,7 @@
             <div class="column medium-6">
                 <div id="default-dashboard-container"
                      data-is-default-dashboard="{{ dashboard.is_default|yesno:'1,0' }}">
-                    <div class="alert-box">This is the default dashboard</div>
+                    <div id="is-default-dashboard-alert" class="alert-box">This is the default dashboard</div>
                     <form id="form-set-default-dashboard"
                           hx-post="{% url 'set-default-dashboard' dashboard.pk %}"
                           hx-target="#dashboard-settings-feedback">

--- a/python/nav/web/templates/webfront/_dashboard_settings_form.html
+++ b/python/nav/web/templates/webfront/_dashboard_settings_form.html
@@ -28,8 +28,9 @@
                 <div id="default-dashboard-container"
                      data-is-default-dashboard="{{ dashboard.is_default|yesno:'1,0' }}">
                     <div class="alert-box">This is the default dashboard</div>
-                    <form id="form-set-default-dashboard" method="post"
-                          action="{% url 'set-default-dashboard' dashboard.pk %}">
+                    <form id="form-set-default-dashboard"
+                          hx-post="{% url 'set-default-dashboard' dashboard.pk %}"
+                          hx-target="#dashboard-settings-feedback">
                         {% csrf_token %}
                         <input type="submit" value="Set as default dashboard"
                                class="small button secondary expand">

--- a/python/nav/web/templates/webfront/_dashboard_subscribe_button.html
+++ b/python/nav/web/templates/webfront/_dashboard_subscribe_button.html
@@ -1,0 +1,13 @@
+<div id="dashboard-subscribe-button" {% if oob %}hx-swap-oob="true"{% endif %}>
+{% if dashboard.shared_by_other %}
+    {% if is_subscribed %}
+        <button class="tiny secondary" style="margin-bottom: 0;" hx-post="{% url 'dashboard-toggle-subscribe' dashboard.pk %}">
+            <i class="fa fa-bell-slash" style="margin-right: 0.25rem;"></i><span>Unsubscribe</span>
+        </button>
+    {% else %}
+        <button class="tiny info" style="margin-bottom: 0;" hx-post="{% url 'dashboard-toggle-subscribe' dashboard.pk %}">
+            <i class="fa fa-bell" style="margin-right: 0.25rem;"></i><span>Subscribe</span>
+        </button>
+    {% endif %}
+{% endif %}
+</div>

--- a/python/nav/web/templates/webfront/index.html
+++ b/python/nav/web/templates/webfront/index.html
@@ -64,24 +64,7 @@
            title="Use compact layout for dashboard">
         <i class="fa fa-compress"></i>
       </div>
-
-      {% if can_edit %}
-          {% include 'webfront/_dashboard_settings_form.html' %}
-      {% else %}
-        <div class="nav-tooltip export-action">
-            <a
-                class="widget-action"
-                href="{% url 'export-dashboard' dashboard.pk %}"
-                aria-describedby="#export-action-tooltip"
-            >
-              <i class="fa fa-download" title="Export dashboard"></i>
-            </a>
-            <div id="export-action-tooltip" role="tooltip">
-                 Download this dashboard's definition into a file that can later be imported by pressing the + next to the tab list
-            </div>
-        </div>
-      {% endif %}
-
+      {% include 'webfront/_dashboard_settings_form.html' %}
     </div>
 
     {# Buttons for selecting dashboards #}

--- a/python/nav/web/templates/webfront/index.html
+++ b/python/nav/web/templates/webfront/index.html
@@ -70,6 +70,17 @@
     {# Buttons for selecting dashboards #}
     {%  include 'webfront/_dashboard_nav.html' with current_dashboard=dashboard dashboards=dashboards %}
 
+    {% if dashboard.needs_default_set %}
+    <div id="no-default-dashboard-warning" class="alert-box warning with-icon">
+        No default dashboard is set. The default dashboard is shown when you log in.
+        <button class="button tiny" style="margin-bottom: 0;"
+                hx-post="{% url 'set-default-dashboard' dashboard.pk %}"
+                hx-target="#dashboard-settings-feedback">
+            Set this dashboard as default
+        </button>
+    </div>
+    {% endif %}
+
   {% endif %}
 
 

--- a/python/nav/web/webfront/__init__.py
+++ b/python/nav/web/webfront/__init__.py
@@ -23,27 +23,43 @@ def find_dashboard(account, dashboard_id=None):
     Either find a specific one or the default one. If none of those exist we
     find the one with the most widgets.
     """
-    kwargs = {'pk': dashboard_id} if dashboard_id else {'is_default': True}
+    dashboard = (
+        _find_dashboard_by_id(account, dashboard_id)
+        if dashboard_id
+        else _find_default_dashboard(account)
+    )
+    dashboard.shared_by_other = dashboard.is_shared and dashboard.account != account
+    dashboard.is_default = dashboard.is_default_for_account(account)
+
+    return dashboard
+
+
+def _find_dashboard_by_id(account, dashboard_id):
+    """Find a specific dashboard by ID for this account"""
     try:
         dashboard = AccountDashboard.objects.get(
-            (Q(account=account) | Q(is_shared=True)), **kwargs
+            (Q(account=account) | Q(is_shared=True)), pk=dashboard_id
         )
-        dashboard.shared_by_other = dashboard.is_shared and dashboard.account != account
+        return dashboard
 
     except AccountDashboard.DoesNotExist:
-        if dashboard_id:
-            raise Http404
+        raise Http404
 
-        # Do we have a dashboard at all?
-        dashboards = AccountDashboard.objects.filter(account=account)
-        if dashboards.count() == 0:
-            raise Http404
 
-        # No default dashboard? Find the one with the most widgets
-        dashboard = dashboards.annotate(Count('widgets')).order_by('-widgets__count')[0]
-    except AccountDashboard.MultipleObjectsReturned:
-        # Grab the first one
-        dashboard = AccountDashboard.objects.filter(account=account, **kwargs)[0]
+def _find_default_dashboard(account):
+    """Find the default dashboard for this account"""
+    if account.has_default_dashboard:
+        return account.default_dashboard
+
+    # No default dashboard? Find the one with the most widgets
+    dashboards = AccountDashboard.objects.filter(account=account)
+    if dashboards.count() == 0:
+        raise Http404
+    dashboard = (
+        dashboards.annotate(widget_count=Count('widgets'))
+        .order_by('-widget_count')
+        .first()
+    )
 
     return dashboard
 
@@ -53,9 +69,13 @@ def get_dashboards_for_account(account) -> list[AccountDashboard]:
     Returns a queryset of dashboards for the given account,
     including those the account subscribes to.
     """
+    default_dashboard = account.default_dashboard
+    default_dashboard_id = default_dashboard.id if default_dashboard else None
     dashboards = (
         AccountDashboard.objects.filter(
-            Q(account=account) | Q(subscribers__account=account)
+            Q(account=account)
+            | Q(subscribers__account=account)
+            | Q(pk=default_dashboard_id)
         )
         .select_related('account')
         .distinct()
@@ -63,5 +83,6 @@ def get_dashboards_for_account(account) -> list[AccountDashboard]:
     for dash in dashboards:
         dash.can_edit = dash.can_edit(account)
         dash.shared_by_other = dash.is_shared and dash.account_id != account.id
+        dash.is_default = dash.id == default_dashboard_id
 
     return list(dashboards)

--- a/python/nav/web/webfront/__init__.py
+++ b/python/nav/web/webfront/__init__.py
@@ -30,6 +30,8 @@ def find_dashboard(account, dashboard_id=None):
     )
     dashboard.shared_by_other = dashboard.is_shared and dashboard.account != account
     dashboard.is_default = dashboard.is_default_for_account(account)
+    # Only show warning on root view, not when navigating to specific dashboards
+    dashboard.needs_default_set = not account.has_default_dashboard and not dashboard_id
 
     return dashboard
 

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -580,7 +580,7 @@ def set_default_dashboard(request, did):
     account.set_default_dashboard(dash.id)
 
     dash.shared_by_other = dash.is_shared and dash.account_id != account.id
-    return render(
+    response = render(
         request,
         'webfront/_dashboard_set_default_response.html',
         {
@@ -590,6 +590,7 @@ def set_default_dashboard(request, did):
             'status': 'success',
         },
     )
+    return trigger_client_event(response, name='nav.dashboard.defaultChanged')
 
 
 @require_POST

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -579,7 +579,17 @@ def set_default_dashboard(request, did):
     dash = find_dashboard(account, did)
     account.set_default_dashboard(dash.id)
 
-    return HttpResponse('Default dashboard set to «{}»'.format(dash.name))
+    dash.shared_by_other = dash.is_shared and dash.account_id != account.id
+    return render(
+        request,
+        'webfront/_dashboard_set_default_response.html',
+        {
+            'dashboard': dash,
+            'is_subscribed': dash.is_subscribed(account),
+            'message': f'Default dashboard set to «{dash.name}»',
+            'status': 'success',
+        },
+    )
 
 
 @require_POST

--- a/tests/integration/web/navlets_test.py
+++ b/tests/integration/web/navlets_test.py
@@ -205,9 +205,7 @@ def _get_dashboard_url(dashboard: AccountDashboard):
 
 @pytest.fixture
 def dashboard(db, admin_account):
-    dashboard = AccountDashboard(
-        account=admin_account, name='Test Dashboard', is_default=True
-    )
+    dashboard = AccountDashboard(account=admin_account, name='Test Dashboard')
     dashboard.save()
     yield dashboard
     dashboard.delete()
@@ -221,9 +219,7 @@ def other_account_dashboard(db):
         password='apasswordthatislongenough123',
     )
     account.save()
-    dashboard = AccountDashboard(
-        account=account, name='Other Dashboard', is_default=True
-    )
+    dashboard = AccountDashboard(account=account, name='Other Dashboard')
     dashboard.save()
     yield dashboard
     account.delete()

--- a/tests/integration/web/webfront_test.py
+++ b/tests/integration/web/webfront_test.py
@@ -29,56 +29,32 @@ def test_set_default_dashboard_should_succeed(db, client, admin_account):
     """Tests that a default dashboard can be set"""
     dashboard = AccountDashboard.objects.create(
         name="new_default",
-        is_default=False,
         account=admin_account,
     )
     url = reverse("set-default-dashboard", args=(dashboard.pk,))
     response = client.post(url, follow=True)
 
-    dashboard.refresh_from_db()
-
     assert response.status_code == 200
     assert f"Default dashboard set to «{dashboard.name}»" in smart_str(response.content)
-    assert dashboard.is_default
-    assert (
-        AccountDashboard.objects.filter(account=admin_account, is_default=True).count()
-        == 1
-    )
+    assert dashboard.is_default_for_account(admin_account)
 
 
-def test_set_default_dashboard_with_multiple_previous_defaults_should_succeed(
+def test_set_default_dashboard_with_previous_default_should_succeed(
     db, client, admin_account
 ):
-    """
-    Tests that a default dashboard can be set if multiple default dashboards
-    exist currently
-    """
-    # By default there already exists one default dashboard for the admin user
-    # which is why we only have to create a second default one
-    default_dashboard = AccountDashboard.objects.create(
-        name="default_dashboard",
-        is_default=True,
-        account=admin_account,
-    )
-    dashboard = AccountDashboard.objects.create(
+    """Tests that a default dashboard can be set when another default exists"""
+    default_dashboard = admin_account.default_dashboard
+    dashboard = create_dashboard(
         name="new_default",
-        is_default=False,
         account=admin_account,
     )
     url = reverse("set-default-dashboard", args=(dashboard.pk,))
     response = client.post(url, follow=True)
 
-    default_dashboard.refresh_from_db()
-    dashboard.refresh_from_db()
-
     assert response.status_code == 200
     assert f"Default dashboard set to «{dashboard.name}»" in smart_str(response.content)
-    assert dashboard.is_default
-    assert not default_dashboard.is_default
-    assert (
-        AccountDashboard.objects.filter(account=admin_account, is_default=True).count()
-        == 1
-    )
+    assert dashboard.is_default_for_account(admin_account)
+    assert not default_dashboard.is_default_for_account(admin_account)
 
 
 class TestDeleteDashboardView:
@@ -93,7 +69,6 @@ class TestDeleteDashboardView:
         dashboard = self._create_dashboard(
             admin_account,
             name="to_be_deleted",
-            is_default=False,
         )
         url = reverse("delete-dashboard", args=(dashboard.pk,))
         response = client.post(url)
@@ -110,7 +85,6 @@ class TestDeleteDashboardView:
         dashboard = self._create_dashboard(
             admin_account,
             name="to_be_deleted",
-            is_default=False,
         )
         url = reverse("delete-dashboard", args=(dashboard.pk,))
         response = client.post(url)
@@ -176,9 +150,7 @@ class TestDeleteDashboardView:
         """Tests that the default dashboard cannot be deleted"""
         # Ensure at least one non-default dashboard exists
         self._create_dashboard(admin_account, name="non_default_dashboard")
-        default_dashboard = AccountDashboard.objects.get(
-            is_default=True, account=admin_account
-        )
+        default_dashboard = admin_account.default_dashboard
         url = reverse("delete-dashboard", args=(default_dashboard.pk,))
         response = client.post(url)
 
@@ -187,12 +159,9 @@ class TestDeleteDashboardView:
         assert AccountDashboard.objects.filter(id=default_dashboard.id).exists()
 
     @staticmethod
-    def _create_dashboard(
-        account, name="to_be_deleted", is_default=False, is_shared=False
-    ):
+    def _create_dashboard(account, name="to_be_deleted", is_shared=False):
         return AccountDashboard.objects.create(
             name=name,
-            is_default=is_default,
             account=account,
             is_shared=is_shared,
         )
@@ -293,9 +262,7 @@ class TestDashboardIndexView:
         self, db, client, admin_account
     ):
         """Tests that the default dashboard is shown when no ID is given"""
-        default_dashboard = AccountDashboard.objects.get(
-            is_default=True, account=admin_account
-        )
+        default_dashboard = admin_account.default_dashboard
         url = reverse('dashboard-index')
         response = client.get(url)
 
@@ -883,9 +850,7 @@ class TestFindDashboardUtil:
         self, db, non_admin_account
     ):
         """Tests that the default dashboard is returned when no ID is given"""
-        default_dashboard = AccountDashboard.objects.get(
-            is_default=True, account=non_admin_account
-        )
+        default_dashboard = non_admin_account.default_dashboard
 
         dashboard = find_dashboard(non_admin_account)
         assert dashboard == default_dashboard
@@ -987,9 +952,7 @@ class TestGetDashboardsForAccount:
 
     def test_given_account_then_return_all_own_dashboards(self, db, non_admin_account):
         """Tests that all own dashboards are returned"""
-        default_dashboard = AccountDashboard.objects.get(
-            is_default=True, account=non_admin_account
-        )
+        default_dashboard = non_admin_account.default_dashboard
         other_dashboard = create_dashboard(
             non_admin_account, name="Own 1", is_shared=False
         )
@@ -1377,10 +1340,9 @@ class TestLoadDashboardView:
         assert column2_ids == [widget2.id]
 
 
-def create_dashboard(account, name="Test Dashboard", is_default=False, is_shared=False):
+def create_dashboard(account, name="Test Dashboard", is_shared=False):
     return AccountDashboard.objects.create(
         name=name,
-        is_default=is_default,
         account=account,
         is_shared=is_shared,
     )

--- a/tests/integration/web/webfront_test.py
+++ b/tests/integration/web/webfront_test.py
@@ -74,6 +74,23 @@ def test_when_setting_shared_dashboard_as_default_then_it_should_subscribe(
     assert shared_dashboard.is_subscribed(admin_account)
 
 
+def test_when_no_default_dashboard_set_then_it_should_set_needs_default_flag(
+    db, admin_account
+):
+    """Tests that find_dashboard sets needs_default_set when no default exists"""
+    # Clear any existing dashboards and defaults for a clean slate
+    AccountDashboard.objects.filter(account=admin_account).delete()
+    create_dashboard(account=admin_account)
+
+    # Verify no default is set
+    admin_account.refresh_from_db()
+    assert not admin_account.has_default_dashboard
+
+    # Find dashboard should set needs_default_set to True
+    dashboard = find_dashboard(admin_account)
+    assert dashboard.needs_default_set is True
+
+
 def test_when_setting_shared_default_then_it_should_toggle_subscribe_button(
     db, client, admin_account, non_admin_account
 ):

--- a/tests/integration/web/webfront_test.py
+++ b/tests/integration/web/webfront_test.py
@@ -57,6 +57,41 @@ def test_set_default_dashboard_with_previous_default_should_succeed(
     assert not default_dashboard.is_default_for_account(admin_account)
 
 
+def test_when_setting_shared_dashboard_as_default_then_it_should_subscribe(
+    db, client, admin_account, non_admin_account
+):
+    """Tests that setting a shared dashboard as default also subscribes to it"""
+    shared_dashboard = create_dashboard(
+        account=non_admin_account,
+        name="shared_dashboard",
+        is_shared=True,
+    )
+    url = reverse("set-default-dashboard", args=(shared_dashboard.pk,))
+    response = client.post(url, follow=True)
+
+    assert response.status_code == 200
+    assert shared_dashboard.is_default_for_account(admin_account)
+    assert shared_dashboard.is_subscribed(admin_account)
+
+
+def test_when_setting_shared_default_then_it_should_toggle_subscribe_button(
+    db, client, admin_account, non_admin_account
+):
+    """Tests that setting a shared dashboard as default updates the subscribe button"""
+    shared_dashboard = create_dashboard(
+        account=non_admin_account,
+        name="shared_dashboard",
+        is_shared=True,
+    )
+    url = reverse("set-default-dashboard", args=(shared_dashboard.pk,))
+    response = client.post(url)
+
+    assert response.status_code == 200
+    content = smart_str(response.content)
+    assert 'id="dashboard-subscribe-button"' in content
+    assert 'hx-swap-oob="true"' in content
+
+
 class TestDeleteDashboardView:
     """Tests for the delete_dashboard view which allows deleting dashboards"""
 


### PR DESCRIPTION
## Scope and purpose

Resolves #3572 ~, continuation of #2344.~

> EDIT 15.10.25:
> This PR has replaced #3585, and replaces the create_default_dashboard database trigger instead of using django signals.

This PR adds support for setting a shared dashboard as the user default. In order to achieve this, I had to adjust the schema by moving from an `is_default` field on the `AccountDashboard` model, to using a join model `AccountDefaultDashboard` to store an (account_id, dashboard_id) pair. I also had to adjust the existing logic for handling default dashboard creation for new accounts, which can be seen in ~#3585~ the first commit, where the default dashboard trigger is updated. 

In the current implementation, setting a shared dashboard as your default and subscribing to it are two separate actions. As such, you can set a dashboard as your default without subscribing first. However, it might be desirable to automatically subscribe to a shared dashboard when setting it as your default. This would ensure that the dashboard does not disappear from the dashboard nav after setting a different dashboard as the our default. However, it could be confusing to the user that setting a dashboard as your default also subscribes to it. I'll leave it up to the reviewers whether to implement this or not.

Follow-up task (#3586): Remove `is_default` field from database schema. This has to be done after this PR is merged, to avoid breaking other PRs or the master branch, as removing the field will cause an error on the dashboard pages. We might also want to keep the `is_default` value until we are sure that the new system works as intended.

<!-- remove things that do not apply -->
### This pull request
* Changes Account post_save signal to use new default dashboard logic
* Changes dashboard utilities to include default dashboards regardless of owner for the current account
* Changes dashboard actions to include a settings popover for shared dashboards, which enables setting the default dashboard and export.
* Removed separate export button, as this is now found in the shared dashboard settings.

### Screenshots

#### A shared dashboard settings menu has been added
<img width="662" height="198" alt="image" src="https://github.com/user-attachments/assets/d5233f4c-9dbe-4ee4-8bf0-a6b593d3ab44" />

#### A default shared dashboard is included in the dashboard nav, with both a default and shared icon
<img width="657" height="70" alt="image" src="https://github.com/user-attachments/assets/af8346cb-3fce-4bc6-ae8f-0a666ac9b051" />


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
