### PR TITLE
Add functionality to graph DHCP stats on each VLAN page and Prefix page in NAV 

### DIFF
--- a/changelog.d/2373.added.md
+++ b/changelog.d/2373.added.md
@@ -1,0 +1,1 @@
+Show DHCP stats graphs on VLAN and Prefix pages when recent enough DHCP stats are found

--- a/python/nav/dhcpstats/common.py
+++ b/python/nav/dhcpstats/common.py
@@ -18,18 +18,185 @@ Common classes and functions used by DHCP API clients and various other parts of
 NAV that wants to make use of DHCP stats.
 """
 
+import logging
+from collections import defaultdict
 from dataclasses import dataclass
-from typing import Iterable, Literal, Optional, Union
+from typing import Any, Iterable, Literal, Optional, Union
 
 import IPy
 
-from nav.metrics.names import safe_name
+from nav.metrics.graphs import (
+    aliased_series,
+    json_graph_url,
+    nonempty_series,
+    summed_series,
+)
+from nav.metrics.names import get_expanded_nodes, safe_name
 from nav.metrics.templates import metric_path_for_dhcp
 
+
+_logger = logging.getLogger(__name__)
 
 # Type expected by functions in NAV that send stats to a Graphite/Carbon backend. Values
 # of this type are interpreted as (path, (timestamp, value)).
 GraphiteMetric = tuple[str, tuple[float, int]]
+
+
+def fetch_graph_urls_for_prefixes(prefixes: list[IPy.IP]) -> list[str]:
+    """
+    Takes a list of IP prefixes, queries Graphite for DHCP stat paths, and
+    returns a list of Graphite graph URLs; one URL for each group of DHCP stat
+    paths in Graphite where at least one path in the group represents a range of
+    IP addresses that intersect with one or more of the given prefixes.
+
+    Each returned Graphite URL points to JSON graph data and can be supplied
+    directly to NAV's JavaScript RickshawGraph function.
+    """
+    if not prefixes:
+        return []
+
+    all_paths = fetch_paths_from_graphite()
+    grouped_paths = group_paths(all_paths)
+    filtered_grouped_paths = drop_groups_not_in_prefixes(grouped_paths, prefixes)
+
+    graph_urls: list[str] = []
+    for paths_of_same_group in sorted(filtered_grouped_paths):
+        paths_of_same_group = sorted(paths_of_same_group)
+        graph_lines = []
+        for path in paths_of_same_group:
+            assigned_addresses = nonempty_series(
+                aliased_series(
+                    path.to_graphite_path("assigned"),
+                    name=(
+                        f"Assigned addresses in {path.allocation_type} "
+                        f"{range_str(path.first_ip, path.last_ip)}"
+                    ),
+                    renderer="area",
+                ),
+            )
+            graph_lines.append(assigned_addresses)
+
+        # Just select an arbitrary path instance in the group
+        if len(paths_of_same_group) == 0:
+            _logger.error("group_paths() returned an empty group")
+            continue
+        path = paths_of_same_group[0]
+
+        unassigned_addresses = aliased_series(
+            summed_series(path.to_graphite_path("unassigned", wildcard_for_group=True)),
+            name="Total unassigned addresses",
+            renderer="area",
+            color="#d9d9d9",
+        )
+        graph_lines.append(unassigned_addresses)
+        total_addresses = aliased_series(
+            summed_series(path.to_graphite_path("total", wildcard_for_group=True)),
+            name="Total addresses",
+            color="#707070",
+        )
+        graph_lines.append(total_addresses)
+
+        type_human = path.allocation_type + ("" if path.is_standalone() else "s")
+        title = (
+            f"{path.group_name} {type_human} on DHCPv{path.ip_version} server "
+            f"'{path.server_name}'"
+        )
+        graph_urls.append(json_graph_url(*graph_lines, title=title))
+    return graph_urls
+
+
+def fetch_paths_from_graphite():
+    """
+    Fetches and returns all unique DHCP stat paths in Graphite when their
+    trailing metric_name path segment has been removed.
+    """
+    wildcard = metric_path_for_dhcp(
+        ip_version=safe_name("{4,6}"),
+        server_name=safe_name("*"),
+        allocation_type=safe_name("{range,pool,subnet}"),
+        group_name_source=safe_name("{custom_groups,special_groups}"),
+        group_name=safe_name("*"),
+        first_ip=safe_name("*"),
+        last_ip=safe_name("*"),
+        metric_name="assigned",
+    )
+    graphite_paths = get_expanded_nodes(wildcard)
+
+    native_paths: list[DhcpPath] = []
+    for graphite_path in graphite_paths:
+        try:
+            native_path = DhcpPath.from_graphite_path(graphite_path)
+        except ValueError as err:
+            _logger.warning(
+                "Could not decode the timeseries path '%s' fetched from Graphite: %s. "
+                "NAV will ignore this path, whereas Graphite will not; this incorrect "
+                "Graphite state is a likely cause of graphing-related bugs.",
+                graphite_path,
+                err,
+            )
+            pass
+        else:
+            native_paths.append(native_path)
+    return native_paths
+
+
+def group_paths(paths: list["DhcpPath"]):
+    """
+    Takes a list of DhcpPath instances and partitions it into multiple lists,
+    such that two DhcpPath instances belong to the same list if and only if they
+    have the same group data.
+    """
+    grouped_paths: dict[Any, list[DhcpPath]] = defaultdict(list)
+    for path in paths:
+        group_path = path.to_graphite_path("assigned", wildcard_for_group=True)
+        grouped_paths[group_path].append(path)
+    return list(grouped_paths.values())
+
+
+def drop_groups_not_in_prefixes(
+    grouped_paths: list[list["DhcpPath"]], prefixes: list[IPy.IP]
+):
+    """
+    Takes a list of grouped DhcpPath instances, and returns only the groups that
+    have at least one DhcpPath instance that intersect with one or more of the
+    given prefixes.
+    """
+    grouped_paths_to_keep: list[list[DhcpPath]] = []
+    for paths_of_same_group in grouped_paths:
+        if any(path.intersects(prefixes) for path in paths_of_same_group):
+            grouped_paths_to_keep.append(paths_of_same_group)
+    return grouped_paths_to_keep
+
+
+def range_str(first_ip: IPy.IP, last_ip: IPy.IP):
+    """
+    Returns a human-readable string that represents the range of IP addresses
+    between first_ip and last_ip (inclusive). If the addresses comprise a CIDR
+    block, CIDR notation is used. Otherwise, an ad-hoc notation is used.
+
+    >>> range_str(IPy.IP("192.0.0.32"), IPy.IP("192.0.0.63"))
+    "192.0.0.32/27"
+    >>> range_str(IPy.IP("192.0.0.31"), IPy.IP("192.0.0.63"))
+    "192.0.0.31-192.0.0.63"
+    >>> range_str(IPy.IP("192.0.0.32"), IPy.IP("192.0.0.64"))
+    "192.0.0.32-192.0.0.64"
+    """
+    fallback = f"{first_ip}-{last_ip}"
+    if first_ip.version() == last_ip.version() == 4:
+        totalbits = 32
+    elif first_ip.version() == last_ip.version() == 6:
+        totalbits = 128
+    else:
+        return fallback
+    hostbits = (last_ip.int() - first_ip.int()).bit_length()
+    try:
+        net = IPy.IP(f"{first_ip}/{totalbits - hostbits}")
+    except ValueError:
+        return fallback
+    if net[0] == first_ip and net[-1] == last_ip:
+        return str(net)
+    else:
+        return fallback
 
 
 @dataclass(frozen=True, order=True)

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -57,6 +57,7 @@ from nav.models.fields import DateTimeInfinityField, VarcharField, PointField
 from nav.models.fields import CIDRField
 import nav.models.event
 from nav.oids import get_enterprise_id
+import nav.dhcpstats.common
 
 
 _logger = logging.getLogger(__name__)
@@ -1469,6 +1470,16 @@ class Prefix(models.Model):
     def get_absolute_url(self):
         return reverse('prefix-details', args=[self.pk])
 
+    def get_dhcp_graph_urls(self):
+        """
+        Creates urls to graphs showing range/pool/subnet utilization, with one
+        url (and one graph) per set of ranges/pools/subnets in graphite with the
+        same ip_version, server_name and group where at least one
+        range/pool/subnet intersects this prefix.
+        """
+        prefix = IPy.IP(self.net_address)
+        return nav.dhcpstats.common.fetch_graph_urls_for_prefixes([prefix])
+
 
 class Vlan(models.Model):
     """From NAV Wiki: The vlan table defines the IP broadcast domain / vlan. A
@@ -1566,6 +1577,16 @@ class Vlan(models.Model):
                 ),
                 format='json',
             )
+
+    def get_dhcp_graph_urls(self):
+        """
+        Creates urls to graphs showing range/pool/subnet utilization, with one
+        url (and one graph) per set of ranges/pools/subnets in graphite with the
+        same ip_version, server_name and group where at least one
+        range/pool/subnet intersects this vlan.
+        """
+        prefixes = [IPy.IP(prefix.net_address) for prefix in self.prefixes.all()]
+        return nav.dhcpstats.common.fetch_graph_urls_for_prefixes(prefixes)
 
 
 class NetType(models.Model):

--- a/python/nav/web/info/prefix/views.py
+++ b/python/nav/web/info/prefix/views.py
@@ -26,6 +26,7 @@ from IPy import IP
 
 from nav.web import utils
 from nav.web.auth.utils import get_account
+from nav.metrics.errors import GraphiteUnreachableError
 from nav.models.manage import Prefix, Usage, PrefixUsage
 from ..forms import SearchForm
 
@@ -143,6 +144,16 @@ def prefix_details(request, prefix_id):
     context = get_context(prefix)
     context['form'] = PrefixUsageForm(instance=prefix)
     context['can_edit'] = authorize_user(request)
+
+    try:
+        dhcp_graph_urls = prefix.get_dhcp_graph_urls()
+        graphite_error = False
+    except GraphiteUnreachableError:
+        dhcp_graph_urls = []
+        graphite_error = True
+
+    context['dhcp_graph_urls'] = dhcp_graph_urls
+    context['graphite_error'] = graphite_error
 
     return render(request, 'info/prefix/details.html', context)
 

--- a/python/nav/web/info/vlan/views.py
+++ b/python/nav/web/info/vlan/views.py
@@ -28,6 +28,7 @@ from django.http import HttpResponse
 
 from nav.models.manage import Prefix, Vlan
 from nav.web.utils import create_title
+from nav.metrics.errors import GraphiteUnreachableError
 from nav.metrics.graphs import get_simple_graph_url
 from nav.metrics.names import join_series
 from nav.metrics.templates import metric_path_for_prefix
@@ -125,6 +126,13 @@ def vlan_details(request, vlanid):
 
     navpath = get_path([(str(vlan), '')])
 
+    try:
+        dhcp_graph_urls = vlan.get_dhcp_graph_urls()
+        graphite_error = False
+    except GraphiteUnreachableError:
+        dhcp_graph_urls = []
+        graphite_error = True
+
     return render(
         request,
         'info/vlan/vlandetails.html',
@@ -136,6 +144,8 @@ def vlan_details(request, vlanid):
             'has_v4': has_v4,
             'has_v6': has_v6,
             'title': create_title(navpath),
+            'dhcp_graph_urls': dhcp_graph_urls,
+            'graphite_error': graphite_error,
         },
     )
 

--- a/python/nav/web/static/js/src/plugins/rickshaw_graph.js
+++ b/python/nav/web/static/js/src/plugins/rickshaw_graph.js
@@ -69,6 +69,9 @@ define([
             serie.key = name;
             serie.name = RickshawUtils.filterFunctionCalls(name);
             serie.renderer = meta.renderer ? meta.renderer : 'line';
+            if (meta.color !== undefined) {
+                serie.color = meta.color;
+            }
 
             // If this is a nav-metric, typically very long, display only the last two "parts"
             if (serie.name.substr(0, 4) === 'nav.') {

--- a/python/nav/web/templates/info/prefix/details.html
+++ b/python/nav/web/templates/info/prefix/details.html
@@ -16,6 +16,9 @@
        $('.prefixgraph').each(function (index, element) {
            new GraphFetcher($(element), element.dataset.url);
        });
+       $('.dhcpgraph').each(function (index, element) {
+           new GraphFetcher($(element), element.dataset.url);
+       });
    });
   </script>
 
@@ -201,6 +204,21 @@
         <div class="rickshaw-container"></div>
       </div>
     </div>
+
+    {% if dhcp_graph_urls or graphite_error %}
+      {% if graphite_error %}
+        <span class="label alert">Graphite unreachable</span>
+      {% else %}
+        <div class="large-6 column">
+          {% for graph in dhcp_graph_urls %}
+            <div class="dhcpgraph graphitegraph" data-url="{{ graph }}">
+              <div class="rickshaw-container"></div>
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% endif %}
+
 
   </div>
 

--- a/python/nav/web/templates/info/vlan/vlandetails.html
+++ b/python/nav/web/templates/info/vlan/vlandetails.html
@@ -16,6 +16,9 @@
        $('.prefixgraph').each(function (index, element) {
            new GraphFetcher($(element), element.dataset.url);
        });
+       $('.dhcpgraph').each(function (index, element) {
+           new GraphFetcher($(element), element.dataset.url);
+       });
    });
   </script>
 {% endblock %}
@@ -154,4 +157,19 @@
     {% endfor %}
   </ul>
 
+  {% comment %} Graph containing DHCP statistics for total, assigned and declined addresses {% endcomment %}
+  {% if dhcp_graph_urls or graphite_error %}
+    <h2>DHCP graphs</h2>
+    {% if graphite_error %}
+      <span class="label alert">Graphite unreachable</span>
+    {% else %}
+      <ul class="small-block-grid-1 large-block-grid-2">
+        {% for graph in dhcp_graph_urls %}
+          <li class="dhcpgraph graphitegraph" data-url="{{ graph }}">
+            <div class="rickshaw-container"></div>
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  {% endif %}
 {% endblock %}

--- a/tests/unittests/dhcpstats/common_test.py
+++ b/tests/unittests/dhcpstats/common_test.py
@@ -1,9 +1,19 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from itertools import chain
+import logging
+import random
+import re
 
 import IPy
 import pytest
 
-from nav.dhcpstats.common import DhcpPath
+from nav.dhcpstats.common import (
+    DhcpPath,
+    drop_groups_not_in_prefixes,
+    fetch_paths_from_graphite,
+    group_paths,
+    range_str,
+)
 from nav.metrics.templates import metric_path_for_dhcp
 
 
@@ -269,3 +279,309 @@ class TestDhcpPath:
                 server_name, allocation_type, group_name, first_ip, last_ip
             )
             pytest.fail(f"Didn't fail when {reason!r}")
+
+
+def test_group_paths_should_group_special_standalone_groups_paths_individually():
+    path0 = DhcpPath(
+        ip_version=6,
+        server_name="server1",
+        allocation_type="range",
+        group_name="standalone",
+        group_name_source="special_groups",
+        first_ip=IPy.IP("::0:1"),
+        last_ip=IPy.IP("::0:ffff"),
+    )
+    path1 = replace(path0, first_ip=IPy.IP("::1:1"), last_ip=IPy.IP("::1:ffff"))
+    path2 = replace(path0, first_ip=IPy.IP("::2:1"), last_ip=IPy.IP("::2:ffff"))
+    assert sorted(group_paths([path0, path1, path2])) == sorted(
+        [[path0], [path1], [path2]]
+    )
+
+
+def test_group_paths_should_group_special_groups_paths_separately_from_custom_groups_paths():  # noqa: E501
+    path0 = DhcpPath(
+        ip_version=6,
+        server_name="server1",
+        allocation_type="range",
+        group_name="standalone",
+        group_name_source="special_groups",
+        first_ip=IPy.IP("::0:1"),
+        last_ip=IPy.IP("::0:ffff"),
+    )
+    path1 = replace(path0, first_ip=IPy.IP("::1:1"), last_ip=IPy.IP("::1:ffff"))
+    path2 = replace(
+        path0,
+        first_ip=IPy.IP("::2:1"),
+        last_ip=IPy.IP("::2:ffff"),
+        group_name_source="custom_groups",
+    )
+    path3 = replace(
+        path0,
+        first_ip=IPy.IP("::3:1"),
+        last_ip=IPy.IP("::3:ffff"),
+        group_name_source="custom_groups",
+    )
+    assert sorted(group_paths([path0, path1, path2, path3])) == sorted(
+        [[path0], [path1], [path2, path3]]
+    )
+
+
+def test_group_paths_should_group_custom_groups_paths_together_when_only_ip_addresses_differ():  # noqa: E501
+    path0 = DhcpPath(
+        ip_version=6,
+        server_name="server1",
+        allocation_type="range",
+        group_name="group1",
+        group_name_source="custom_groups",
+        first_ip=IPy.IP("::0:1"),
+        last_ip=IPy.IP("::0:ffff"),
+    )
+    path1 = replace(path0, first_ip=IPy.IP("::1:1"), last_ip=IPy.IP("::1:ffff"))
+    path2 = replace(
+        path0,
+        first_ip=IPy.IP("::2:1"),
+        last_ip=IPy.IP("::2:ffff"),
+        group_name="different",
+    )
+    path3 = replace(
+        path0,
+        first_ip=IPy.IP("::3:1"),
+        last_ip=IPy.IP("::3:ffff"),
+        allocation_type="pool",
+    )
+    path4 = replace(
+        path0,
+        first_ip=IPy.IP("::4:1"),
+        last_ip=IPy.IP("::4:ffff"),
+        server_name="different",
+    )
+    path5 = replace(
+        path0, first_ip=IPy.IP("0.0.5.1"), last_ip=IPy.IP("0.0.5.255"), ip_version=4
+    )
+    assert sorted(group_paths([path0, path1, path2, path3, path4, path5])) == sorted(
+        [[path0, path1], [path2], [path3], [path4], [path5]]
+    )
+
+
+def test_group_paths_should_group_custom_groups_paths_separately_when_other_than_ip_addresses_differ():  # noqa: E501
+    path0 = DhcpPath(
+        ip_version=6,
+        server_name="server1",
+        allocation_type="range",
+        group_name="group1",
+        group_name_source="custom_groups",
+        first_ip=IPy.IP("::1"),
+        last_ip=IPy.IP("::ff"),
+    )
+    path1 = replace(path0, group_name="different")
+    path2 = replace(path0, server_name="different")
+    path3 = replace(path0, allocation_type="subnet")
+    path4 = replace(
+        path0, first_ip=IPy.IP("0.0.0.1"), last_ip=IPy.IP("0.0.0.255"), ip_version=4
+    )
+    assert sorted(group_paths([path0, path1, path2, path3, path4])) == sorted(
+        [[path0], [path1], [path2], [path3], [path4]]
+    )
+
+
+@pytest.mark.parametrize(
+    "prefixes,test_input,expected_output",
+    [
+        (
+            [IPy.IP("0.0.0.0/0")],
+            [
+                "nav.dhcp.servers.server1.range.custom_groups.group1.4.1_1_252_0.1_1_252_12.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group1.4.1_1_252_64.1_1_252_127.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group2.4.1_1_253_1.1_1_253_8.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group2.4.1_1_254_0.1_1_254_15.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group2.4.1_1_100_0.1_1_101_0.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group3.4.1_1_100_0.1_1_101_0.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server2.range.custom_groups.group1.4.1_1_100_0.1_1_101_0.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server2.range.custom_groups.group2.4.1_1_254_0.1_1_254_15.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server2.range.custom_groups.group3.4.1_1_253_1.1_1_253_8.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server3.range.custom_groups.group1.4.1_1_250_1.1_1_255_1.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server4.range.custom_groups.group1.4.1_1_253_1.1_1_255_1.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server5.range.custom_groups.group1.4.1_1_250_1.1_1_253_1.foo",  # Inside  # noqa: E501
+            ],
+            [
+                "nav.dhcp.servers.server1.range.custom_groups.group1.4.1_1_252_0.1_1_252_12.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group1.4.1_1_252_64.1_1_252_127.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group2.4.1_1_253_1.1_1_253_8.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group2.4.1_1_254_0.1_1_254_15.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group2.4.1_1_100_0.1_1_101_0.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group3.4.1_1_100_0.1_1_101_0.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server2.range.custom_groups.group1.4.1_1_100_0.1_1_101_0.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server2.range.custom_groups.group2.4.1_1_254_0.1_1_254_15.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server2.range.custom_groups.group3.4.1_1_253_1.1_1_253_8.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server3.range.custom_groups.group1.4.1_1_250_1.1_1_255_1.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server4.range.custom_groups.group1.4.1_1_253_1.1_1_255_1.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server5.range.custom_groups.group1.4.1_1_250_1.1_1_253_1.foo",  # Inside  # noqa: E501
+            ],
+        ),
+        (
+            [IPy.IP("1.1.252.0/24"), IPy.IP("1.1.253.0/24")],
+            [
+                "nav.dhcp.servers.server1.range.custom_groups.group1.4.1_1_252_0.1_1_252_12.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group1.4.1_1_252_64.1_1_252_127.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group2.4.1_1_253_1.1_1_253_8.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group2.4.1_1_254_0.1_1_254_15.foo",  # Another path in the group is inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group2.4.1_1_100_0.1_1_101_0.foo",  # Another path in the group is inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group3.4.1_1_100_0.1_1_101_0.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server2.range.custom_groups.group1.4.1_1_100_0.1_1_101_0.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server2.range.custom_groups.group2.4.1_1_254_0.1_1_254_15.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server2.range.custom_groups.group3.4.1_1_253_1.1_1_253_8.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server3.range.custom_groups.group1.4.1_1_250_1.1_1_255_1.foo",  # Partially Inside  # noqa: E501
+                "nav.dhcp.servers.server4.range.custom_groups.group1.4.1_1_253_1.1_1_255_1.foo",  # Partially Inside  # noqa: E501
+                "nav.dhcp.servers.server5.range.custom_groups.group1.4.1_1_250_1.1_1_253_1.foo",  # Partially Inside  # noqa: E501
+            ],
+            [
+                "nav.dhcp.servers.server1.range.custom_groups.group1.4.1_1_252_0.1_1_252_12.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group1.4.1_1_252_64.1_1_252_127.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group2.4.1_1_253_1.1_1_253_8.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group2.4.1_1_254_0.1_1_254_15.foo",  # Another path in the group is inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group2.4.1_1_100_0.1_1_101_0.foo",  # Another path in the group inside  # noqa: E501
+                "nav.dhcp.servers.server2.range.custom_groups.group3.4.1_1_253_1.1_1_253_8.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server3.range.custom_groups.group1.4.1_1_250_1.1_1_255_1.foo",  # Partially Inside  # noqa: E501
+                "nav.dhcp.servers.server4.range.custom_groups.group1.4.1_1_253_1.1_1_255_1.foo",  # Partially Inside  # noqa: E501
+                "nav.dhcp.servers.server5.range.custom_groups.group1.4.1_1_250_1.1_1_253_1.foo",  # Partially Inside  # noqa: E501
+            ],
+        ),
+        (
+            [IPy.IP("1.1.252.0/24")],
+            [
+                "nav.dhcp.servers.server1.range.custom_groups.group1.4.1_1_252_0.1_1_252_12.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group1.4.1_1_252_64.1_1_252_127.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group2.4.1_1_253_1.1_1_253_8.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group2.4.1_1_254_0.1_1_254_15.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group2.4.1_1_100_0.1_1_101_0.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group3.4.1_1_100_0.1_1_101_0.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server2.range.custom_groups.group1.4.1_1_100_0.1_1_101_0.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server2.range.custom_groups.group2.4.1_1_254_0.1_1_254_15.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server2.range.custom_groups.group3.4.1_1_253_1.1_1_253_8.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server3.range.custom_groups.group1.4.1_1_250_1.1_1_255_1.foo",  # Partially Inside  # noqa: E501
+                "nav.dhcp.servers.server4.range.custom_groups.group1.4.1_1_253_1.1_1_255_1.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server5.range.custom_groups.group1.4.1_1_250_1.1_1_253_1.foo",  # Partially Inside  # noqa: E501
+            ],
+            [
+                "nav.dhcp.servers.server1.range.custom_groups.group1.4.1_1_252_0.1_1_252_12.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group1.4.1_1_252_64.1_1_252_127.foo",  # Inside  # noqa: E501
+                "nav.dhcp.servers.server3.range.custom_groups.group1.4.1_1_250_1.1_1_255_1.foo",  # Partially Inside  # noqa: E501
+                "nav.dhcp.servers.server5.range.custom_groups.group1.4.1_1_250_1.1_1_253_1.foo",  # Partially Inside  # noqa: E501
+            ],
+        ),
+        (
+            [],
+            [
+                "nav.dhcp.servers.server1.range.custom_groups.group1.4.1_1_252_0.1_1_252_12.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group1.4.1_1_252_64.1_1_252_127.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group2.4.1_1_253_1.1_1_253_8.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group2.4.1_1_254_0.1_1_254_15.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group2.4.1_1_100_0.1_1_101_0.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server1.range.custom_groups.group3.4.1_1_100_0.1_1_101_0.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server2.range.custom_groups.group1.4.1_1_100_0.1_1_101_0.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server2.range.custom_groups.group2.4.1_1_254_0.1_1_254_15.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server2.range.custom_groups.group3.4.1_1_253_1.1_1_253_8.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server3.range.custom_groups.group1.4.1_1_250_1.1_1_255_1.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server4.range.custom_groups.group1.4.1_1_253_1.1_1_255_1.foo",  # Outside  # noqa: E501
+                "nav.dhcp.servers.server5.range.custom_groups.group1.4.1_1_250_1.1_1_253_1.foo",  # Outside  # noqa: E501
+            ],
+            [],
+        ),
+    ],
+)
+def test_drop_groups_not_in_prefixes_should_work_as_expected(
+    prefixes, test_input, expected_output
+):
+    native_paths = [DhcpPath.from_graphite_path(path) for path in test_input]
+    grouped_paths = group_paths(native_paths)
+    remaining_grouped_paths = drop_groups_not_in_prefixes(grouped_paths, prefixes)
+    remaining_graphite_paths = [
+        path.to_graphite_path("foo")
+        for path in chain.from_iterable(remaining_grouped_paths)
+    ]
+    assert sorted(remaining_graphite_paths) == sorted(expected_output)
+
+
+@pytest.mark.parametrize(
+    "path,log_pattern",
+    [
+        (
+            "nav.dhcp.servers.kea-trd.range.custom_groups.staff.4.193_0_2_1.192_0_2_16",
+            r"first_ip.{0,10}193\.0\.2\.1.{0,10}greater than.{0,10}last_ip.{0,10}192\.0\.2\.16",  # noqa: E501
+        ),
+        (
+            "nav.dhcp.servers.kea-trd.Range.custom_groups.staff.4.192_0_2_1.192_0_2_16",
+            r"allocation_type.{0,10}Range.{0,10}is not in.{0,30}range",
+        ),
+        (
+            "nav.dhcp.servers.kea-trd.range.Custom_groups.staff.4.192_0_2_1.192_0_2_16",
+            r"group_source_name.{0,10}Custom_groups.{0,10}is not.{0,50}custom_groups",
+        ),
+        (
+            "nav.dhcp.servers.kea-trd.range.custom_groups.staff.6.192_0_2_1.192_0_2_16",
+            r"expected ip_version.{0,3}6",
+        ),
+        (
+            "nav.dhcp.servers.kea-trd.range.custom_groups.staff.6.0_0_0_0_c0_0_2_1.192_0_2_16",
+            r"expected ip_version.{0,3}6|first_ip.{0,10}c0:0:2:1.{0,10}not.{0,10}same version as last_ip.{0,10}192\.0\.2\.16",  # noqa: E501
+        ),
+        (
+            "nav.dhcp.servers.kea-trd.range.custom_groups.staff.6.192_0_2_1.0_0_0_0_c0_0_2_10",
+            r"expected ip_version.{0,3}6|first_ip.{0,10}192\.0\.2\.1.{0,10}not.{0,10}same version as last_ip.{0,10}c0:0:2:10",  # noqa: E501
+        ),
+        (
+            "dhcp.servers.kea-trd.range.custom_groups.staff.4.192_0_2_1.192_0_2_16",
+            r"expected.{0,20}dhcp\.servers\.kea-trd\.range\.custom_groups\.staff\.4\.192_0_2_1\.192_0_2_16.{0,20}to have.{0,20}10.{0,20}segments",  # noqa: E501
+        ),
+    ],
+)
+def test_fetch_paths_from_graphite_should_warn_when_paths_from_graphite_are_bad(
+    path, log_pattern, caplog, monkeypatch
+):
+    monkeypatch.setattr(
+        "nav.dhcpstats.common.get_expanded_nodes", lambda *args, **kwargs: [path]
+    )
+    with caplog.at_level(logging.WARNING):
+        fetch_paths_from_graphite()
+        assert re.search(log_pattern, caplog.text, flags=re.IGNORECASE)
+
+
+def test_range_str_should_use_cidr_notation_when_possible():
+    r = random.Random()
+    r.seed(1, version=2)
+    for totalbits, ipversion in ((32, 4), (128, 6)):
+        for i in range(128):
+            base = r.randint(0, 2**totalbits - 1)
+            hostbits = i % totalbits + 1
+            netbits = totalbits - hostbits
+            netmask = ((2**totalbits - 1) << hostbits) & (2**totalbits - 1)
+            net = IPy.IP(base & netmask, ipversion=ipversion).make_net(netbits)
+            assert range_str(net[0], net[-1]) == f"{net[0]}/{netbits}"
+
+
+def test_range_str_output_should_represent_inputs():
+    r = random.Random()
+    r.seed(2, version=2)
+    for totalbits, ipversion in ((32, 4), (128, 6)):
+        for _ in range(128):
+            ip1 = IPy.IP(r.randint(0, 2**totalbits - 1), ipversion=ipversion)
+            ip2 = IPy.IP(r.randint(0, 2**totalbits - 1), ipversion=ipversion)
+            ip1, ip2 = min(ip1, ip2), max(ip1, ip2)
+            output = range_str(ip1, ip2)
+            if "-" in output:
+                actual_ip1, _, actual_ip2 = output.partition("-")
+                actual_ip1 = IPy.IP(actual_ip1)
+                actual_ip2 = IPy.IP(actual_ip2)
+            else:
+                temp = IPy.IP(output)
+                actual_ip1, actual_ip2 = temp[0], temp[-1]
+            assert (actual_ip1, actual_ip2) == (ip1, ip2)
+
+
+def test_range_str_output_should_be_a_single_address_when_inputs_are_equal():
+    r = random.Random()
+    r.seed(3, version=2)
+    for totalbits, ipversion in ((32, 4), (128, 6)):
+        for _ in range(128):
+            ip = IPy.IP(r.randint(0, 2**totalbits - 1), ipversion=ipversion)
+            assert range_str(ip, ip) == str(ip)


### PR DESCRIPTION
## Scope and purpose

Fixes #2373. Another PR intends to add documentation and release notes.

### This pull request

* Adds DHCP stats graphs to VLAN and Prefix pages in NAV where recent-enough stats for that VLAN/Prefix are found in the Carbon/Graphite database:
  ![dhcp-frontend-delimited-timeseries-showcase](https://github.com/user-attachments/assets/19bbff15-ed78-4c36-8eca-2615cdd1511a)

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] ~Added/changed documentation~ see #3785 
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done **TODO: add a new issue for using Rickshaw graphs instead of PNG images in graph navlets**
* [x] If it's not obvious from a linked issue, describe how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions) **See screencast below**
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [x] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file


## Testing It For Yourself

You can use the script below to fill the prefixes  `192.0.0.0/24`, `192.0.1.0/24`, `192.0.0.0/26`, and `::2:0:0/96` with DHCP stats (you might need to install `socat` and `gawk`, and you might need to change `127.0.0.1` to the address of your Carbon/Graphite database):

```bash
#!/bin/sh

cat <<EOF |
4 example-1 admin 192.0.0.1 192.0.0.127 127 127 0 100000
4 example-1 admin 192.0.0.129 192.0.0.255 127 127 0 100000
4 example-1 admin 192.0.1.1 192.0.1.255 255 255 0 100000

4 example-1 guest 192.0.2.0 192.0.2.255 256 256 0 10000
4 example-1 guest 192.0.2.0 192.0.2.127 128 128 10001 50000
4 example-1 guest 192.0.2.128 192.0.2.191 64 64 10001 50000
4 example-1 guest 192.0.2.192 192.0.2.255 64 64 10001 50000

6 example-1 admin 0:0:0:0:0:2:0:0 0:0:0:0:0:2:ffff:ffff 4294967296 100 0 100000
6 example-1 guest 0:0:0:0:0:2:0:0 0:0:0:0:0:2:ffff:ffff 4294967296 100 0 100000
EOF

gawk '
BEGIN {
  NOW = systime()
  srand(11)
  INTERVAL = 300
  DAYS = 30
}

NF == 9 {
  a = rand()
  b = rand()
  c = rand()
  _ = 1 / (a + b + c)
  a = a * _
  b = b * _
  c = c * _
  d = rand()*3.14*2
  e = 20 + rand()*8
  f = rand()

  ip_version = $1
  server_name = $2
  group_name = $3
  first_ip = $4; gsub(/[.:]/, "_", first_ip)
  last_ip = $5; gsub(/[.:]/, "_", last_ip)
  total_ips = $6
  upper_limit = $7
  start_offset = $8 * INTERVAL
  end_offset = $9 * INTERVAL
  noise = rand()
  for (offset = start_offset; offset < end_offset; offset += INTERVAL) {
    sine = (sin((offset*3.14*2)/(3600*e) + d)+1)/2
    noise = noise*f + rand()*(1-f)
    assigned_ips = int(sine*upper_limit*a+upper_limit*b+noise*upper_limit*c)
    printf("nav.dhcp.servers.%s.range.custom_groups.%s.%d.%s.%s.unassigned %d %d\n", server_name, group_name, ip_version, first_ip, last_ip, total_ips - assigned_ips, NOW - offset)
    printf("nav.dhcp.servers.%s.range.custom_groups.%s.%d.%s.%s.assigned %d %d\n", server_name, group_name, ip_version, first_ip, last_ip, assigned_ips, NOW - offset)
    printf("nav.dhcp.servers.%s.range.custom_groups.%s.%d.%s.%s.total %d %d\n", server_name, group_name, ip_version, first_ip, last_ip, total_ips, NOW - offset)
  }
}' |

socat - tcp:127.0.0.1:2003
```

Here's a screencast (which, after the most recent changes, is a bit outdated, but still representative):

https://github.com/user-attachments/assets/57b7ccf9-4842-4e88-8e0d-fa3cd65de5b4

At `2:00` in the video, notice that the graph labelled `DHCP ranges in 'guest' on server 'kea-trd'` has stats from ranges in both `192.0.2.0/24` and `198.51.100.0/24` despite vlan 20 only containing `192.0.2.0/24`. This is because whenever a group (here: `'guest' on server 'kea-trd'`) has at least one range/pool/subnet overlapping with the VLAN/Prefix, the whole group will be displayed on that VLAN/Prefix's page.
