### PR TITLE
Strip null bytes from LLDP chassisid before lookup

### DIFF
--- a/changelog.d/+strip_null_bytes_from_chassis_ID_before_lookup.fixed.md
+++ b/changelog.d/+strip_null_bytes_from_chassis_ID_before_lookup.fixed.md
@@ -1,0 +1,1 @@
+lldp: strip null bytes from chassis ID before lookup

--- a/python/nav/ipdevpoll/plugins/lldp.py
+++ b/python/nav/ipdevpoll/plugins/lldp.py
@@ -228,7 +228,9 @@ class LLDPNeighbor(Neighbor):
                 lookup = self._netbox_from_local
 
             if lookup:
-                netbox = lookup(str(chassid))
+                chassid_str = str(chassid).strip('\x00')
+                if chassid_str:
+                    netbox = lookup(chassid_str)
 
         if not netbox and self.record.sysname:
             netbox = self._netbox_from_sysname(self.record.sysname)

--- a/tests/unittests/ipdevpoll/plugins_lldp_test.py
+++ b/tests/unittests/ipdevpoll/plugins_lldp_test.py
@@ -5,6 +5,8 @@ from mock import Mock
 
 
 def test_non_ascii_chassis_id_should_not_crash():
-    record = Mock(chassid_id='a\x9enon-ascii')
     plugin = LLDP(None, None, ContainerRepository())
+    record = Mock(chassid_id='a\x9enon-ascii')
+    plugin._store_unidentified(record)
+    record = Mock(chassid_id='\x00\x00anon-ascii')
     plugin._store_unidentified(record)


### PR DESCRIPTION
Some Aruba switches return LLDP chassis IDs containing null bytes. This caused NAV's ipdevpoll to fail when storing neighbor information, since Django does not allow null bytes in database fields. As a result, topology discovery broke for these devices.

This change strips null characters from the chassis ID string and only performs the lookup if the cleaned value is non-empty. With this fix, topology collection from affected Aruba switches works as expected.

## Scope and purpose
This commit does not fix a reported issue I think, but it is very closely related to #2479, #3552 and #3559 as it work on the same variables and situations, but where the content is a string, not bytes.

The chassis_id contains null bytes after it has been converted to a string, doing so ipdevpolld shows stacktraces for all switches which return null bytes in their chassis ID string. For the company i work for, this would be Aruba switches in the 6000, 6100 and 6200 series.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [X] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
