### PR TITLE
Use SNMPv3 contexts for collecting logical BRIDGE-MIB instances (primarily Cisco)

### DIFF
--- a/NOTES.rst
+++ b/NOTES.rst
@@ -8,6 +8,36 @@ existing bug reports, go to https://github.com/uninett/nav/issues .
 To see an overview of upcoming release milestones and the issues they resolve,
 please go to https://github.com/uninett/nav/milestones .
 
+Unreleased
+==========
+
+
+SNMPv3 context support for Cisco switches
+-----------------------------------------
+
+NAV now supports SNMPv3 contexts when collecting per-VLAN BRIDGE-MIB data from
+Cisco switches. Previously, this data collection only worked with SNMP v1/v2c
+using Cisco's *community string indexing* feature.
+
+Cisco switches maintain separate BRIDGE-MIB instances for each active VLAN.
+With SNMPv3, these are accessed using SNMP contexts (named ``vlan-1``,
+``vlan-2``, etc.) rather than modified community strings.
+
+.. important::
+
+   For this to work, your Cisco switches must be configured to allow the SNMPv3
+   user to query these VLAN contexts. This typically requires a command like::
+
+     snmp-server group YOUR-GROUP-NAME v3 auth context vlan- match prefix
+
+   Without this configuration, NAV will be unable to collect MAC address tables
+   and switching information, resulting in incomplete machine tracker data and
+   potentially missing network topology information.
+
+See the :doc:`/reference/management-profiles` documentation for more details on
+configuring SNMPv3 profiles.
+
+
 NAV 5.16
 ========
 

--- a/changelog.d/2811.fixed.md
+++ b/changelog.d/2811.fixed.md
@@ -1,0 +1,1 @@
+Add support for SNMP v3-based CAM data collection on Cisco switches (Adds support for SNMP v3 context switching for logical MIB instances)

--- a/doc/reference/management-profiles.rst
+++ b/doc/reference/management-profiles.rst
@@ -46,6 +46,46 @@ is assigned to.
 Otherwise, the procedure for creating an SNMP profile is documented in the
 :doc:`Getting started guide </intro/getting-started>`.
 
+SNMPv3
+------
+
+SNMPv3 profiles are configured separately from SNMP v1/v2c profiles, as they
+require different authentication settings. Instead of a simple community string,
+SNMPv3 uses security names, authentication protocols, and privacy protocols.
+
+.. _snmpv3-cisco-context-access:
+
+SNMPv3 and Cisco switches
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When using SNMPv3 with Cisco switches, additional switch configuration may be
+required to allow NAV to collect complete data.
+
+Cisco switches maintain separate BRIDGE-MIB instances for each active VLAN. NAV
+needs to query these instances to collect MAC address tables for machine
+tracking and to detect network topology. With SNMP v1/v2c, this is done using
+Cisco's *community string indexing* (e.g., ``public@20`` for VLAN 20). With
+SNMPv3, this is done using SNMP *contexts* (e.g., ``vlan-20``).
+
+By default, SNMPv3 users may not have access to these VLAN contexts. You must
+configure the switch to grant access. For example::
+
+  snmp-server group mygroup v3 auth context vlan- match prefix
+
+This grants the SNMPv3 group ``mygroup`` access to all contexts starting with
+``vlan-``, which covers all VLAN-specific BRIDGE-MIB instances.
+
+.. warning::
+
+   Without this configuration, NAV will be unable to collect per-VLAN switching
+   data from Cisco switches using SNMPv3. This results in:
+
+   * Incomplete or missing MAC address tracking (Machine Tracker)
+   * Potentially incomplete network topology detection
+
+   If you notice missing data after switching from SNMPv2c to SNMPv3, check your
+   switch's SNMPv3 context access configuration.
+
 NAPALM
 ------
 

--- a/python/nav/ipdevpoll/snmp/common.py
+++ b/python/nav/ipdevpoll/snmp/common.py
@@ -157,6 +157,8 @@ class SNMPParameters:
     auth_password: Optional[str] = None
     priv_protocol: Optional[PrivacyProtocol] = None
     priv_password: Optional[str] = None
+    context_name: Optional[str] = None
+    context_engine_id: Optional[str] = None
 
     # Specific to ipdevpoll-derived implementations
     throttle_delay: int = 0
@@ -254,6 +256,10 @@ class SNMPParameters:
                 params.extend(["-x", self.priv_protocol.value])
             if self.priv_password:
                 params.extend(["-X", self.priv_password])
+            if self.context_name:
+                params.extend(["-n", self.context_name])
+            if self.context_engine_id:
+                params.extend(["-E", self.context_engine_id])
             kwargs["cmdLineArgs"] = tuple(params)
 
         return kwargs

--- a/python/nav/ipdevpoll/utils.py
+++ b/python/nav/ipdevpoll/utils.py
@@ -17,8 +17,6 @@
 #
 """Utility functions for ipdevpoll."""
 
-from __future__ import annotations
-
 import logging
 import re
 from typing import TYPE_CHECKING

--- a/python/nav/ipdevpoll/utils.py
+++ b/python/nav/ipdevpoll/utils.py
@@ -201,8 +201,12 @@ def get_arista_vrf_instances(agentproxy) -> Deferred:
 
     vrf_mib = AristaVrfMib(agentproxy)
     states = yield vrf_mib.get_vrf_states(only='active')
-    vrfs = [('', agentproxy.community)]
-    vrfs.extend((vrf, f"{agentproxy.community}@{vrf}") for vrf in states)
+    # XXX: This part does not currently support SNMPv3, as we have no known way to
+    #      derive the correct SNMPv3 context name for each VRF.
+    vrfs = [LogicalMibInstance('', agentproxy.community)]
+    vrfs.extend(
+        LogicalMibInstance(vrf, f"{agentproxy.community}@{vrf}") for vrf in states
+    )
     return vrfs
 
 

--- a/python/nav/ipdevpoll/utils.py
+++ b/python/nav/ipdevpoll/utils.py
@@ -17,6 +17,8 @@
 #
 """Utility functions for ipdevpoll."""
 
+from __future__ import annotations
+
 import logging
 import re
 from typing import TYPE_CHECKING
@@ -33,6 +35,7 @@ from nav.enterprise.ids import VENDOR_ID_ARUBA_NETWORKS_INC
 
 if TYPE_CHECKING:
     from nav.mibs.bridge_mib import MultiBridgeMib
+    from nav.mibs.types import LogicalMibInstance
 
 _logger = logging.getLogger(__name__)
 MAX_MAC_ADDRESS_LENGTH = 6
@@ -144,15 +147,12 @@ async def get_multibridgemib(agentproxy) -> "MultiBridgeMib":
     return MultiBridgeMib(agentproxy, instances)
 
 
-async def get_dot1d_instances(agentproxy):
+async def get_dot1d_instances(agentproxy) -> "list[LogicalMibInstance]":
     """
     Gets a list of alternative BRIDGE-MIB instances from a Cisco or Aruba
     agent.
 
-    First
-
-    :returns: A list of [(description, community), ...] for each alternate
-              BRIDGE-MIB instance.
+    :returns: A list of LogicalMibInstance for each alternate BRIDGE-MIB instance.
 
     """
     from nav.mibs.snmpv2_mib import Snmpv2Mib

--- a/python/nav/mibs/cisco_vtp_mib.py
+++ b/python/nav/mibs/cisco_vtp_mib.py
@@ -18,6 +18,7 @@ from twisted.internet import defer
 from nav.bitvector import BitVector
 from nav.smidumps import get_mib
 from . import mibretriever
+from .types import LogicalMibInstance
 
 CHARS_IN_1024_BITS = 128
 
@@ -98,13 +99,14 @@ class CiscoVTPMib(mibretriever.MibRetriever):
         states = yield self.get_ethernet_vlan_states()
         return set(vlan for vlan, state in states.items() if state == 'operational')
 
-    async def retrieve_alternate_bridge_mibs(self):
+    async def retrieve_alternate_bridge_mibs(self) -> list[LogicalMibInstance]:
         """Retrieve a list of alternate bridge mib instances.
 
-        :returns: A list of (descr, community) tuples for each operational
-                  VLAN on this device.
+        :returns: A list of LogicalMibInstance for each operational VLAN on this device.
 
         """
         vlans = await self.get_operational_vlans()
         community = self.agent_proxy.community
-        return [("vlan%s" % vlan, "%s@%s" % (community, vlan)) for vlan in vlans]
+        return [
+            LogicalMibInstance(f"vlan{vlan}", f"{community}@{vlan}") for vlan in vlans
+        ]

--- a/python/nav/mibs/entity_mib.py
+++ b/python/nav/mibs/entity_mib.py
@@ -27,6 +27,7 @@ from twisted.internet import defer
 from nav.oids import OID
 from nav.smidumps import get_mib
 from nav.mibs import mibretriever
+from nav.mibs.types import LogicalMibInstance
 from nav.ipdevpoll.shadows import PowerSupplyOrFan, Device
 
 _logger = logging.getLogger(__name__)
@@ -37,13 +38,10 @@ class EntityMib(mibretriever.MibRetriever):
 
     mib = get_mib('ENTITY-MIB')
 
-    async def retrieve_alternate_bridge_mibs(self):
+    async def retrieve_alternate_bridge_mibs(self) -> list[LogicalMibInstance]:
         """Retrieves a list of alternate bridge mib instances.
 
-        This is accomplished by looking at entLogicalTable.  Returns a
-        list of tuples::
-
-          (entity_description, community)
+        This is accomplished by looking at entLogicalTable.
 
         :NOTE: Some devices will return entities with the same community.
                These should effectively be filtered out for polling purposes.
@@ -66,7 +64,9 @@ class EntityMib(mibretriever.MibRetriever):
             ['entLogicalDescr', 'entLogicalType', 'entLogicalCommunity']
         )
         return [
-            (r["entLogicalDescr"], r["entLogicalCommunity"].decode("utf-8"))
+            LogicalMibInstance(
+                r["entLogicalDescr"], r["entLogicalCommunity"].decode("utf-8")
+            )
             for r in result.values()
             if _is_bridge_mib_instance_with_valid_community(r)
         ]

--- a/python/nav/mibs/entity_mib.py
+++ b/python/nav/mibs/entity_mib.py
@@ -61,11 +61,20 @@ class EntityMib(mibretriever.MibRetriever):
             )
 
         result = await self.retrieve_columns(
-            ['entLogicalDescr', 'entLogicalType', 'entLogicalCommunity']
+            [
+                'entLogicalDescr',
+                'entLogicalType',
+                'entLogicalCommunity',
+                'entLogicalContextEngineID',
+                'entLogicalContextName',
+            ]
         )
         return [
             LogicalMibInstance(
-                r["entLogicalDescr"], r["entLogicalCommunity"].decode("utf-8")
+                r["entLogicalDescr"],
+                r["entLogicalCommunity"].decode("utf-8"),
+                r["entLogicalContextName"],
+                r["entLogicalContextEngineID"],
             )
             for r in result.values()
             if _is_bridge_mib_instance_with_valid_community(r)

--- a/python/nav/mibs/mibretriever.py
+++ b/python/nav/mibs/mibretriever.py
@@ -31,6 +31,7 @@ this to allow asynchronous data retrieval.
 
 """
 
+import dataclasses
 import logging
 from typing import Awaitable, Iterator
 
@@ -719,12 +720,18 @@ class MultiMibMixIn(MibRetriever):
                   described by a LogicalMibInstance object.
         """
         agent = self._base_agent
+        if agent.snmp_parameters.version == 3:
+            changes = {"context_name": instance.context}
+            if instance.context_engine_id:
+                changes["context_engine_id"] = instance.context_engine_id.hex()
+        else:
+            changes = {"community": instance.community}
+        new_parameters = dataclasses.replace(agent.snmp_parameters, **changes)
+
         alt_agent = agent.__class__(
             agent.ip,
             agent.port,
-            community=instance.community,
-            snmpVersion=agent.snmpVersion,
-            snmp_parameters=agent.snmp_parameters,
+            snmp_parameters=new_parameters,
         )
         if hasattr(agent, 'protocol'):
             alt_agent.protocol = agent.protocol

--- a/python/nav/mibs/mibretriever.py
+++ b/python/nav/mibs/mibretriever.py
@@ -649,6 +649,8 @@ class MultiMibMixIn(MibRetriever):
                 if agent is not self._base_agent:
                     agent.close()
                 self.agent_proxy = self._base_agent
+            if agent is not self._base_agent:
+                self._logger.debug("got result from %r: %r", descr, one_result)
             results.append((descr, one_result))
             yield lambda thing: fire_eventually(thing)
         return integrator(results)

--- a/python/nav/mibs/types.py
+++ b/python/nav/mibs/types.py
@@ -15,7 +15,7 @@
 #
 """Type definitions for nav.mibs package."""
 
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 
 class LogicalMibInstance(NamedTuple):
@@ -27,4 +27,6 @@ class LogicalMibInstance(NamedTuple):
     """
 
     description: str
-    community: str
+    community: Optional[str]
+    context: Optional[str] = None
+    context_engine_id: Optional[bytes] = None

--- a/python/nav/mibs/types.py
+++ b/python/nav/mibs/types.py
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2025 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.  You should have received a copy of the GNU General Public
+# License along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Type definitions for nav.mibs package."""
+
+from typing import NamedTuple
+
+
+class LogicalMibInstance(NamedTuple):
+    """A MIB instance identifier.
+
+    Some devices (like Cisco switches) provide multiple logical instances of a MIB (such
+    as BRIDGE-MIB) within a single physical device, and we need a way to reference them
+    and the settings needed to collect data from a specific logical instance.
+    """
+
+    description: str
+    community: str

--- a/tests/integration/ipdevpoll/utils_test.py
+++ b/tests/integration/ipdevpoll/utils_test.py
@@ -17,6 +17,7 @@ import pytest
 import pytest_twisted
 
 from nav.ipdevpoll.utils import get_arista_vrf_instances
+from nav.mibs.types import LogicalMibInstance
 
 
 @pytest.mark.twisted
@@ -27,10 +28,10 @@ def test_get_arista_vrf_instances_should_return_expected_instances(snmp_agent_pr
 
     result = yield get_arista_vrf_instances(snmp_agent_proxy)
     expected = [
-        ('', 'arista'),
-        ('IOT', 'arista@IOT'),
-        ('MGMT', 'arista@MGMT'),
-        ('STUDENT', 'arista@STUDENT'),
-        ('VR', 'arista@VR'),
+        LogicalMibInstance('', 'arista'),
+        LogicalMibInstance('IOT', 'arista@IOT'),
+        LogicalMibInstance('MGMT', 'arista@MGMT'),
+        LogicalMibInstance('STUDENT', 'arista@STUDENT'),
+        LogicalMibInstance('VR', 'arista@VR'),
     ]
     assert set(result) == set(expected)

--- a/tests/unittests/ipdevpoll/snmp/common_test.py
+++ b/tests/unittests/ipdevpoll/snmp/common_test.py
@@ -43,6 +43,26 @@ class TestSNMPParametersAsAgentProxyArgs:
         args = " ".join(kwargs["cmdLineArgs"])
         assert "-u foobar" in args
 
+    def test_should_contain_context_name_cmdline_argument(
+        self, snmpv3_params_with_context
+    ):
+        kwargs = snmpv3_params_with_context.as_agentproxy_args()
+        args = " ".join(kwargs["cmdLineArgs"])
+        assert "-n vlan100" in args
+
+    def test_should_contain_context_engine_id_cmdline_argument(
+        self, snmpv3_params_with_context
+    ):
+        kwargs = snmpv3_params_with_context.as_agentproxy_args()
+        args = " ".join(kwargs["cmdLineArgs"])
+        assert "-E 800000090300001234" in args
+
+    def test_should_not_contain_context_args_when_not_set(self, snmpv3_params):
+        kwargs = snmpv3_params.as_agentproxy_args()
+        args = " ".join(kwargs["cmdLineArgs"])
+        assert "-n" not in args
+        assert "-E" not in args
+
 
 class TestSNMPParametersFactory:
     @pytest.mark.parametrize("version_value", (2, "2", "2c"))
@@ -66,6 +86,22 @@ def snmpv3_params():
         auth_password="secret",
         priv_protocol=PrivacyProtocol.AES,
         priv_password="secret2",
+    )
+    yield param
+
+
+@pytest.fixture
+def snmpv3_params_with_context():
+    param = SNMPParameters(
+        version=3,
+        sec_level=SecurityLevel.AUTH_PRIV,
+        sec_name="foobar",
+        auth_protocol=AuthenticationProtocol.SHA,
+        auth_password="secret",
+        priv_protocol=PrivacyProtocol.AES,
+        priv_password="secret2",
+        context_name="vlan100",
+        context_engine_id="800000090300001234",
     )
     yield param
 

--- a/tests/unittests/ipdevpoll/utils_test.py
+++ b/tests/unittests/ipdevpoll/utils_test.py
@@ -1,0 +1,72 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Tests for nav.ipdevpoll.utils module"""
+
+from nav.ipdevpoll.utils import _workaround_broken_aruba_alternate_communities
+from nav.mibs.types import LogicalMibInstance
+
+
+class TestWorkaroundBrokenArubaAlternateCommunities:
+    """Tests for _workaround_broken_aruba_alternate_communities()"""
+
+    def test_should_append_vlan_index_when_missing(self):
+        instances = [LogicalMibInstance("vlan100", "public")]
+
+        result = _workaround_broken_aruba_alternate_communities(instances)
+
+        assert result[0].community == "public@100"
+
+    def test_should_not_modify_when_already_indexed(self):
+        instances = [LogicalMibInstance("vlan100", "public@100")]
+
+        result = _workaround_broken_aruba_alternate_communities(instances)
+
+        assert result[0].community == "public@100"
+
+    def test_should_preserve_context_fields(self):
+        engine_id = bytes.fromhex("800000090300001234")
+        instances = [LogicalMibInstance("vlan100", "public", "vlan-100", engine_id)]
+
+        result = _workaround_broken_aruba_alternate_communities(instances)
+
+        assert result[0].community == "public@100"
+        assert result[0].context == "vlan-100"
+        assert result[0].context_engine_id == engine_id
+
+    def test_should_not_modify_non_vlan_descriptions(self):
+        instances = [LogicalMibInstance("bridge1", "public")]
+
+        result = _workaround_broken_aruba_alternate_communities(instances)
+
+        assert result[0].community == "public"
+
+    def test_should_handle_case_insensitive_vlan_names(self):
+        instances = [
+            LogicalMibInstance("VLAN200", "public"),
+            LogicalMibInstance("Vlan300", "public"),
+        ]
+
+        result = _workaround_broken_aruba_alternate_communities(instances)
+
+        assert result[0].community == "public@200"
+        assert result[1].community == "public@300"
+
+    def test_should_not_modify_when_community_is_none(self):
+        instances = [LogicalMibInstance("vlan100", None)]
+
+        result = _workaround_broken_aruba_alternate_communities(instances)
+
+        assert result[0].community is None

--- a/tests/unittests/mibs/mibretriever_test.py
+++ b/tests/unittests/mibs/mibretriever_test.py
@@ -1,0 +1,101 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Tests for nav.mibs.mibretriever module"""
+
+from unittest.mock import Mock
+
+from nav.ipdevpoll.snmp.common import SNMPParameters
+from nav.mibs.mibretriever import MultiMibMixIn
+from nav.mibs.types import LogicalMibInstance
+
+
+class TestMultiMibMixInGetAlternateAgent:
+    """Tests for MultiMibMixIn._get_alternate_agent()"""
+
+    def test_should_use_community_for_snmpv2(self):
+        agent = Mock()
+        agent.community = "public"
+        agent.ip = "10.0.0.1"
+        agent.port = 161
+        agent.snmp_parameters = SNMPParameters(version=2, community="public")
+
+        mixin = MultiMibMixIn(agent, [])
+        instance = LogicalMibInstance("vlan100", "public@100", "vlan-100", None)
+
+        alt_agent = mixin._get_alternate_agent(instance)
+
+        assert alt_agent.snmp_parameters.community == "public@100"
+        assert alt_agent.snmp_parameters.context_name is None
+
+    def test_should_use_context_for_snmpv3(self):
+        agent = Mock()
+        agent.community = "public"
+        agent.ip = "10.0.0.1"
+        agent.port = 161
+        agent.snmp_parameters = SNMPParameters(version=3, sec_name="user")
+
+        mixin = MultiMibMixIn(agent, [])
+        instance = LogicalMibInstance("vlan100", "public@100", "vlan-100", None)
+
+        alt_agent = mixin._get_alternate_agent(instance)
+
+        assert alt_agent.snmp_parameters.context_name == "vlan-100"
+        # community should remain unchanged for v3
+        assert alt_agent.snmp_parameters.community == "public"
+
+    def test_should_include_context_engine_id_for_snmpv3_when_provided(self):
+        agent = Mock()
+        agent.community = "public"
+        agent.ip = "10.0.0.1"
+        agent.port = 161
+        agent.snmp_parameters = SNMPParameters(version=3, sec_name="user")
+
+        mixin = MultiMibMixIn(agent, [])
+        engine_id = bytes.fromhex("800000090300001234")
+        instance = LogicalMibInstance("vlan100", "public@100", "vlan-100", engine_id)
+
+        alt_agent = mixin._get_alternate_agent(instance)
+
+        assert alt_agent.snmp_parameters.context_engine_id == "800000090300001234"
+
+    def test_should_not_include_context_engine_id_when_not_provided(self):
+        agent = Mock()
+        agent.community = "public"
+        agent.ip = "10.0.0.1"
+        agent.port = 161
+        agent.snmp_parameters = SNMPParameters(version=3, sec_name="user")
+
+        mixin = MultiMibMixIn(agent, [])
+        instance = LogicalMibInstance("vlan100", "public@100", "vlan-100", None)
+
+        alt_agent = mixin._get_alternate_agent(instance)
+
+        assert alt_agent.snmp_parameters.context_engine_id is None
+
+    def test_should_copy_protocol_from_base_agent(self):
+        agent = Mock()
+        agent.community = "public"
+        agent.ip = "10.0.0.1"
+        agent.port = 161
+        agent.protocol = Mock()
+        agent.snmp_parameters = SNMPParameters(version=2, community="public")
+
+        mixin = MultiMibMixIn(agent, [])
+        instance = LogicalMibInstance("vlan100", "public@100")
+
+        alt_agent = mixin._get_alternate_agent(instance)
+
+        assert alt_agent.protocol is agent.protocol

--- a/tests/unittests/mibs/types_test.py
+++ b/tests/unittests/mibs/types_test.py
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Tests for nav.mibs.types module"""
+
+from nav.mibs.types import LogicalMibInstance
+
+
+class TestLogicalMibInstance:
+    """Tests for LogicalMibInstance NamedTuple"""
+
+    def test_should_have_default_none_for_context(self):
+        instance = LogicalMibInstance("vlan1", "public@1")
+        assert instance.context is None
+
+    def test_should_have_default_none_for_context_engine_id(self):
+        instance = LogicalMibInstance("vlan1", "public@1")
+        assert instance.context_engine_id is None
+
+    def test_should_accept_context_parameter(self):
+        instance = LogicalMibInstance("vlan1", "public@1", "vlan-1")
+        assert instance.context == "vlan-1"
+
+    def test_should_accept_context_engine_id_parameter(self):
+        engine_id = bytes.fromhex("800000090300001234")
+        instance = LogicalMibInstance("vlan1", "public@1", "vlan-1", engine_id)
+        assert instance.context_engine_id == engine_id
+
+    def test_should_be_hashable_for_set_operations(self):
+        instance1 = LogicalMibInstance("vlan1", "public@1")
+        instance2 = LogicalMibInstance("vlan1", "public@1")
+        instance3 = LogicalMibInstance("vlan2", "public@2")
+
+        instances = {instance1, instance2, instance3}
+        assert len(instances) == 2
+
+    def test_equal_instances_should_be_equal(self):
+        instance1 = LogicalMibInstance("vlan1", "public@1", "ctx", None)
+        instance2 = LogicalMibInstance("vlan1", "public@1", "ctx", None)
+        assert instance1 == instance2
+
+    def test_different_instances_should_not_be_equal(self):
+        instance1 = LogicalMibInstance("vlan1", "public@1")
+        instance2 = LogicalMibInstance("vlan2", "public@2")
+        assert instance1 != instance2
+
+    def test_can_access_fields_by_name(self):
+        instance = LogicalMibInstance("desc", "comm", "ctx", b"\x00\x01")
+        assert instance.description == "desc"
+        assert instance.community == "comm"
+        assert instance.context == "ctx"
+        assert instance.context_engine_id == b"\x00\x01"


### PR DESCRIPTION
## Scope and purpose

Fixes #2811. Dependent on #3664 (merged a long time ago by now)

I have been able to preliminarily verify this against actual Cisco switches now, but the need for configuring the proper context access for accessing VLAN contexts using SNMPv3 on a Cisco switch is not intuitive and may need a FAQ or some supporting documentation in NAV.

So, things still potentially missing from this PR:

- [x] Proper test coverage
- [x] Documenting how to configure Cisco switches for SNMPv3 access
  - The SNMPv3 user must be allowed to query context with the `vlan-` prefix, as these are added dynamically by the switch. References used:
    - https://community.cisco.com/t5/network-management/bridge-mib-with-snmp-v3/td-p/1179194
    - https://www.switchportmapper.com/support-mapping-a-cisco-switch-using-snmpv3.htm
- [ ] ~~Decide whether we need special handling of authentication failures~~
  - ~~I think I recall seeing nasty errors on Cisco switches that were incorrectly configured, but currently, when simulating the issue, I am only able to see nondescript errors from pynetsnmp like `[ERROR zen.pynetsnmp.callback] Unknown operation: 7`, while for the multimib-implementation this seems to be handled just like a "no response" from that particular instance.~~
  - It seems to me that this will be a valid report to add and fix only if it appears in production.  There doesn't currently seem to be anything crash-inducing I am able to provoke.


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [x] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
