### PR TITLE
Fix bug where enter in netbox form triggers a connectivity check

### DIFF
--- a/changelog.d/3694.fixed.md
+++ b/changelog.d/3694.fixed.md
@@ -1,0 +1,1 @@
+Fix bug in Netbox form where enter in a text field triggers a connectivity check

--- a/python/nav/web/templates/seeddb/_seeddb_netbox_form_content.html
+++ b/python/nav/web/templates/seeddb/_seeddb_netbox_form_content.html
@@ -27,6 +27,7 @@
                 hx-target="#connectivity-results"
                 hx-trigger="click"
                 hx-indicator=".connectivity-indicator"
+                type="button"
             >
                 Check connectivity
             </button>


### PR DESCRIPTION
## Scope and purpose

Resolves #3694

A customer reported that clicking enter in the Netbox Form (Seed DB) submits the connectivity check, instead of saving the form. This causes the connectivity check to throw an error if no profile has been selected, even if some categories of devices (like SRV) don't require an assignment. The fix was super simple... adding `type="button"` to the "Check connectivity" button, so all submit events go to the form.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
