### PR TITLE
Escape text in auditlog table to mitigate XSS vulnerability

### DIFF
--- a/changelog.d/2803.fixed.md
+++ b/changelog.d/2803.fixed.md
@@ -1,0 +1,1 @@
+Escape column text in audit log table to mitigate XSS vulnerability

--- a/python/nav/web/templates/auditlog/_logentry_list.html
+++ b/python/nav/web/templates/auditlog/_logentry_list.html
@@ -32,7 +32,7 @@
 </style>
 
 <script type="text/javascript">
- require(['libs/urijs/URI', 'moment', 'libs/datatables.min'], function(Uri, moment) {
+ require(['libs/urijs/URI', 'moment', 'libs/datatables.min'], function(Uri, moment, DataTable) {
      var api_parameters = {{ auditlog_api_parameters|safe|default:'{}' }};
      var columns = {
          0: 'timestamp',
@@ -42,6 +42,16 @@
          4: 'target',
          5: 'summary'
      };
+
+     /* Utility function to escape HTML special characters to prevent XSS */
+     function escapeHtml(text) {
+         if (!text) return text;
+
+         const div = document.createElement('div');
+         div.textContent = text; // The browser automatically escapes special characters
+         return div.innerHTML;
+     }
+
      var dt_config = {
          serverSide: true,  // Everything is done serverside - sorting, filtering, etc.
          ajax: {
@@ -75,19 +85,25 @@
                      return moment(data).format('YYYY-MM-DD HH:mm:ss');
                  }
              },
-             { data: columns[1] },
+             {
+                 data: columns[1],
+                 render: escapeHtml
+             },
              { data: columns[2] },
              {
                  data: columns[3],
-                 orderable: false
+                 orderable: false,
+                 render: escapeHtml
              },
              {
                  data: columns[4],
-                 orderable: false
+                 orderable: false,
+                 render: escapeHtml
              },
              {
                  data: columns[5],
-                 orderable: false
+                 orderable: false,
+                 render: escapeHtml
              }
          ],
          autowidth: false,


### PR DESCRIPTION
## Scope and purpose

Fixes #2803 

This PR adds HTML escaping to the auditlog table to mitigate the XSS vulnerability.

### Screenshots

#### Before
<img width="1278" height="179" alt="image" src="https://github.com/user-attachments/assets/a19bbc34-8b98-4bc9-805b-216b9d0e54a9" />

#### After
<img width="1324" height="438" alt="image" src="https://github.com/user-attachments/assets/9b9d4e08-e636-4a77-9fb7-113127e6bd87" />

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
