### PR TITLE
Add support for running integration tests directly from PyCharm (inside devcontainer)

### DIFF
--- a/.devcontainer/scripts/create-test-db.sh
+++ b/.devcontainer/scripts/create-test-db.sh
@@ -1,0 +1,64 @@
+#!/bin/bash -e
+# Creates and initializes a NAV database for integration tests in the devcontainer.
+# This script is designed to work with an external PostgreSQL container,
+# unlike the tests/docker/scripts/create-db.sh which manages PostgreSQL clusters directly.
+#
+# IMPORTANT: This uses a separate 'nav_test' database to avoid destroying the dev database.
+# The test config directory (NAV_CONFIG_DIR) is set up by tests/conftest.py before this runs.
+
+set -o pipefail
+
+# Configuration - use a separate test database!
+: "${PGHOST:=db}"
+: "${PGPORT:=5432}"
+: "${PGUSER:=nav}"
+: "${PGPASSWORD:=nav}"
+: "${PGDATABASE:=nav_test}"
+: "${ADMINPASSWORD:=admin}"
+
+# Find test data SQL
+WORKSPACE_DIR="${WORKSPACE:-/workspaces/nav}"
+TEST_DATA_SQL="${WORKSPACE_DIR}/tests/docker/scripts/test-data.sql"
+
+echo "=== Integration Test Database Setup ==="
+echo "Database: ${PGDATABASE} on ${PGHOST}:${PGPORT}"
+
+# Wait for PostgreSQL to be ready
+echo "Waiting for PostgreSQL to be ready..."
+for i in {1..30}; do
+    if pg_isready -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" > /dev/null 2>&1; then
+        echo "PostgreSQL is ready."
+        break
+    fi
+    if [ $i -eq 30 ]; then
+        echo "ERROR: PostgreSQL is not ready after 30 seconds"
+        exit 1
+    fi
+    sleep 1
+done
+
+# Fix collation version mismatch if present (needed for createdb to work)
+echo "Checking and fixing collation versions..."
+psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d postgres -c "ALTER DATABASE template1 REFRESH COLLATION VERSION;" 2>/dev/null || true
+psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d postgres -c "ALTER DATABASE postgres REFRESH COLLATION VERSION;" 2>/dev/null || true
+
+# Create database schema (drops existing if present)
+echo "Creating database schema with navsyncdb..."
+navsyncdb -c --drop-database
+
+# Set admin password
+if [ -n "$ADMINPASSWORD" ]; then
+    echo "Setting admin password..."
+    psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -c \
+        "UPDATE account SET password = '${ADMINPASSWORD}' WHERE login = 'admin'"
+fi
+
+# Load test data
+if [ -f "$TEST_DATA_SQL" ]; then
+    echo "Loading test data from ${TEST_DATA_SQL}..."
+    psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -f "$TEST_DATA_SQL"
+else
+    echo "WARNING: Test data file not found at ${TEST_DATA_SQL}"
+fi
+
+echo "=== Database setup complete ==="

--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,15 @@
 !.git-blame-ignore-revs
 !.github/
 !.gitkeep
+!.idea/
 !.mega-linter.yml
 !.pre-commit-config.yaml
 !.readthedocs.yaml
 !.sonarcloud.properties
+
+# Inside .idea, only track shared run configurations
+.idea/*
+!.idea/runConfigurations/
 
 *.orig
 *.rej

--- a/.idea/runConfigurations/Integration_Tests.xml
+++ b/.idea/runConfigurations/Integration_Tests.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Integration Tests" type="tests" factoryName="py.test">
+    <module name="nav" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="DJANGO_SETTINGS_MODULE" value="nav.django.settings" />
+      <env name="WORKSPACE" value="/workspaces/nav" />
+      <env name="PYTHONPATH" value="/workspaces/nav/tests" />
+      <env name="PGHOST" value="db" />
+      <env name="PGUSER" value="nav" />
+      <env name="PGPASSWORD" value="nav" />
+      <env name="PGDATABASE" value="nav_test" />
+      <env name="ADMINPASSWORD" value="admin" />
+      <env name="NAV_CONFIG_DIR" value="/tmp/nav_test_config" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="_new_additionalArguments" value="" />
+    <option name="_new_target" value="&quot;$PROJECT_DIR$/tests/integration&quot;" />
+    <option name="_new_targetType" value="PATH" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Unit_Tests.xml
+++ b/.idea/runConfigurations/Unit_Tests.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Unit Tests" type="tests" factoryName="py.test">
+    <module name="nav" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="DJANGO_SETTINGS_MODULE" value="nav.django.settings" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="_new_additionalArguments" value="" />
+    <option name="_new_target" value="&quot;$PROJECT_DIR$/tests/unittests&quot;" />
+    <option name="_new_targetType" value="PATH" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/_template__of_pytest.xml
+++ b/.idea/runConfigurations/_template__of_pytest.xml
@@ -1,0 +1,32 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="true" type="tests" factoryName="py.test">
+    <module name="nav" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="DJANGO_SETTINGS_MODULE" value="nav.django.settings" />
+      <env name="WORKSPACE" value="$PROJECT_DIR$" />
+      <env name="PYTHONPATH" value="$PROJECT_DIR$/tests" />
+      <env name="PGHOST" value="db" />
+      <env name="PGUSER" value="nav" />
+      <env name="PGPASSWORD" value="nav" />
+      <env name="PGDATABASE" value="nav_test" />
+      <env name="ADMINPASSWORD" value="admin" />
+      <env name="NAV_CONFIG_DIR" value="/tmp/nav_test_config" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <option name="RUN_TOOL" value="" />
+    <option name="_new_keywords" value="&quot;&quot;" />
+    <option name="_new_parameters" value="&quot;&quot;" />
+    <option name="_new_additionalArguments" value="&quot;&quot;" />
+    <option name="_new_target" value="&quot;&quot;" />
+    <option name="_new_targetType" value="&quot;PATH&quot;" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/doc/hacking/hacking.rst
+++ b/doc/hacking/hacking.rst
@@ -442,24 +442,42 @@ over 60%, and we aim to increase it further.
 All test suites (except those for Javascript) are located in the
 :file:`tests/` subdirectory.
 
+.. _running-tests:
+
 Running tests
 -------------
 
 We use pytest_ as our test runner, and tox_ to enable running the test suites
 in matrix environments for different combinations of Python and Django
-versions. For the time being, our test suite is divided into three parts
-(``unittests``, ``integration`` and ``functional``).  The unit test suite can
-usually be run just fine from your local computer as long as tox_ and pytest_
-are available, but the integration and functional test suites have lots of
-external requirements that make them best suited to be run in a containerized
-environment (we are, however, working on rebuilding this so the necessary
-environments are easier to achieve on your local computer.  Please see `PR#3248
-<https://github.com/Uninett/nav/pull/3248>`_ for ongoing work).
+versions. The test suite is divided into three parts: ``unittests``,
+``integration``, and ``functional``.
 
+Running tests from your IDE (devcontainer)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For now, there is a script to produce an entire test environment as a Docker
-image, and to run the entire test suite inside a Docker container created
-from that image. Take a look in the :file:`tests/docker/` directory.
+If you are working inside a devcontainer (recommended), you can run unit
+and integration tests directly from your IDE or command line without needing
+the Docker test environment.
+
+* **Unit tests** can be run anywhere with pytest
+* **Integration tests** can be run inside the devcontainer using pytest with
+  the appropriate environment variables
+
+The integration test setup automatically creates a separate ``nav_test``
+database to avoid affecting your development database.
+
+See :doc:`using-devcontainers` for detailed instructions on running tests
+from PyCharm or VS Code, including pre-configured run configurations.
+
+Running tests in Docker (CI environment)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For functional tests (which require Playwright/browser support) or to replicate
+the CI environment exactly, use the Docker-based test environment.
+
+There is a script to produce an entire test environment as a Docker image, and
+to run the entire test suite inside a Docker container created from that
+image. Take a look in the :file:`tests/docker/` directory.
 
 For an interactive testing session with tox_, you can utilize the Docker image
 like thus:
@@ -472,6 +490,8 @@ like thus:
    $ make shell
    ...
    $ tox run -e unit-py311-django42
+   $ tox run -e integration-py311-django42
+   $ tox run -e functional-py311-django42
    ...
 
 

--- a/doc/hacking/using-devcontainers.rst
+++ b/doc/hacking/using-devcontainers.rst
@@ -153,6 +153,92 @@ daemon programs in the foreground rather than using the :program:`nav` command,
 e.g. :samp:`ipdevpolld -f -s` instead of :samp:`nav start ipdevpolld`.
 
 
+Running tests
+-------------
+
+NAV's test suite is divided into three parts: unit tests, integration tests,
+and functional tests. When working inside the devcontainer, you can run unit
+and integration tests directly using pytest or your IDE's test runner.
+
+Unit tests
+~~~~~~~~~~
+
+Unit tests have no external dependencies and can be run anywhere:
+
+.. code-block:: console
+
+   $ pytest tests/unittests/
+   $ pytest tests/unittests/ipdevpoll/interfaces_test.py
+   $ pytest tests/unittests/ipdevpoll/interfaces_test.py::test_function_name
+
+To run with coverage reporting:
+
+.. code-block:: console
+
+   $ pytest tests/unittests/ --cov=python/nav --cov-report=html
+
+Integration tests
+~~~~~~~~~~~~~~~~~
+
+Integration tests require database access and use Django's test framework.
+Inside the devcontainer, these can be run directly using pytest with the
+appropriate environment variables:
+
+.. code-block:: console
+
+   $ export PGHOST=db PGDATABASE=nav_test NAV_CONFIG_DIR=/tmp/nav_test_config
+   $ pytest tests/integration/ -v --showlocals
+
+The test suite will automatically:
+
+1. Create a separate ``nav_test`` database (your development ``nav`` database
+   is never touched)
+2. Set up test-specific NAV configuration in :file:`/tmp/nav_test_config/`
+3. Load test data and configure the admin user with password ``admin``
+
+**Important:** Integration tests use an isolated test database to protect your
+development data. The ``nav_test`` database is created on the same PostgreSQL
+server (the ``db`` container) but is completely separate from your ``nav``
+development database.
+
+Using PyCharm run configurations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For PyCharm users, pre-configured run configurations are available in
+:file:`.idea/runConfigurations/`:
+
+* **Unit Tests** - Runs the unit test suite
+* **Integration Tests** - Runs integration tests with proper environment
+  variables pre-configured
+
+To use these:
+
+1. Open PyCharm inside the devcontainer
+2. Go to *Run -> Edit Configurations...*
+3. Select "Unit Tests" or "Integration Tests"
+4. Click the green run button
+
+The run configurations handle all necessary environment variable setup
+automatically.
+
+Functional tests
+~~~~~~~~~~~~~~~~
+
+Functional tests use Playwright for browser automation and require Chromium
+and a display server. Run these using the Docker-based test environment:
+
+.. code-block:: console
+
+   $ cd tests/docker
+   $ make
+   $ make shell
+   # Inside container:
+   $ tox run -e functional-py311-django42
+
+See :ref:`running-tests` in the main hacking guide for more details on the
+Docker-based test environment.
+
+
 (Re)building CSS stylesheets from SASS sources
 ----------------------------------------------
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,11 +22,27 @@ from django.test import Client
 #                                                                      #
 ########################################################################
 
-if os.environ.get('WORKSPACE'):
-    SCRIPT_PATH = os.path.join(os.environ['WORKSPACE'], 'tests/docker/scripts')
-else:
-    SCRIPT_PATH = '/'
-SCRIPT_CREATE_DB = os.path.join(SCRIPT_PATH, 'create-db.sh')
+
+def _find_create_db_script():
+    """Finds the appropriate database creation script.
+
+    Returns the devcontainer script if running in a devcontainer environment,
+    otherwise returns the standard test docker script.
+    """
+    # Check for devcontainer environment
+    devcontainer_script = '/workspaces/nav/.devcontainer/scripts/create-test-db.sh'
+    if os.path.exists(devcontainer_script):
+        return devcontainer_script
+
+    # Fall back to standard test docker script
+    if os.environ.get('WORKSPACE'):
+        script_path = os.path.join(os.environ['WORKSPACE'], 'tests/docker/scripts')
+    else:
+        script_path = '/'
+    return os.path.join(script_path, 'create-db.sh')
+
+
+SCRIPT_CREATE_DB = _find_create_db_script()
 
 
 def pytest_configure(config):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -46,6 +46,20 @@ SCRIPT_CREATE_DB = _find_create_db_script()
 
 
 def pytest_configure(config):
+    # Import and call setup from parent conftest to ensure test config is ready
+    # before DB creation script runs. This prevents navsyncdb from accidentally
+    # using the dev database config instead of the test database config.
+    import sys
+
+    parent_conftest_path = os.path.join(os.path.dirname(__file__), '..')
+    sys.path.insert(0, parent_conftest_path)
+    try:
+        from conftest import _setup_devcontainer_test_config
+
+        _setup_devcontainer_test_config()
+    finally:
+        sys.path.pop(0)
+
     subprocess.check_call([SCRIPT_CREATE_DB])
 
 


### PR DESCRIPTION
## Scope and purpose

Resolves #3810

### This pull request
- Adds support for running integration tests directly from PyCharm (inside devcontainer)
- Adds a separate `create-test-db.sh` script for setting up the test database independently of tox
- Adds PyCharm run configurations for Unit Tests and Integration Tests
- Updates documentation to explain both testing workflows (IDE and Docker)

### Key improvements
- Faster iteration: No need to rebuild Docker test container for integration tests
- Better debugging: Use IDE debugger directly on integration tests
- Database isolation: Tests use separate `nav_test` database, preserving development data
- No workflow changes: Docker/tox-based testing still works identically for CI

### How it works

The integration test configuration automatically:
1. Creates a separate `nav_test` database (your dev `nav` database is untouched)
2. Sets up test-specific NAV config in `/tmp/nav_test_config/`
3. Loads test data and configures admin user with password "admin"

The test setup dynamically detects whether it's running in:
- Devcontainer: Uses `.devcontainer/scripts/create-test-db.sh`
- Docker test container: Uses `tests/docker/scripts/create-db.sh`

### How to test (for reviewers)

**Prerequisites:** PyCharm or VS Code with devcontainer support

**Testing from PyCharm:**
1. Open the NAV project in PyCharm inside the devcontainer
2. Go to *Run -> Edit Configurations*
3. Verify "Integration Tests" and "Unit Tests" configurations exist
4. Run "Integration Tests" configuration
5. Verify:
   - Tests pass
   - Console shows database `nav_test` being created
   - Your development `nav` database is untouched (check with `psql -h db -U nav nav`)

**Testing from command line:**
```bash
# Set environment variables
export PGHOST=db PGDATABASE=nav_test NAV_CONFIG_DIR=/tmp/nav_test_config

# Run integration tests
pytest tests/integration/ -v

# Verify test database exists
psql -h db -U nav -l | grep nav_test

# Verify dev database is untouched
psql -h db -U nav nav -c "SELECT COUNT(*) FROM manage.netbox;"
```

**Testing Docker workflow (verify no regression):**
```bash
cd tests/docker
make
make shell
# Inside container:
tox run -e integration-py311-django42
```

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file