### PR TITLE
Add 'Last Seen' dropdown to Room view interface list

### DIFF
--- a/changelog.d/3313.added.md
+++ b/changelog.d/3313.added.md
@@ -1,0 +1,1 @@
+Added "more than" / "less than" option to the "Last Seen" filter on the Room view interface list

--- a/python/nav/web/sass/nav/info_room.scss
+++ b/python/nav/web/sass/nav/info_room.scss
@@ -104,3 +104,19 @@ img.textbottom {
         padding-bottom: 0.5rem;
     }
 }
+
+/* Custom styling for netbox interfaces last seen */
+
+#lastseenfilter .form-inline {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+/* Keep inputs no wider than is necessary */
+#lastseenfilter .form-inline select,
+#lastseenfilter .form-inline input[type="number"],
+#lastseenfilter .form-inline input[type="text"] {
+  max-width: 7rem;
+  flex: 0 0 auto;
+}

--- a/python/nav/web/static/js/src/info/global_dt_filters.js
+++ b/python/nav/web/static/js/src/info/global_dt_filters.js
@@ -68,13 +68,20 @@ define(['libs/datatables.min'], function () {
      * Secondary filters
      */
 
+    var last_seen_mode = 'ago';
+
+    function set_last_seen_mode(mode) {
+        last_seen_mode = mode;
+    }
     /* Filter on column 5 (last active) when column 4 (vlan) is not trunk.
      * Very reusable code! ;-P */
     function filter_last_seen(oSettings, aData, iDataIndex) {
-        var days = get_keyword(/\$days:\w+/) || getInputValue(filters.last_seen.node);
+        const days = get_keyword(/\$days:\w+/) || getInputValue(filters.last_seen.node);
         if (days) {
-            var rowdate = extract_date(aData[4]);
-            return (!is_trunk(aData[3]) && daysince(rowdate) >= days);
+            const rowdate = extract_date(aData[4]);
+            const isMoreThanMode = last_seen_mode === 'ago';
+            const diff = daysince(rowdate);
+            return !is_trunk(aData[3]) && (isMoreThanMode ? diff >= days : diff <= days);
         }
         return true;
     }
@@ -152,8 +159,9 @@ define(['libs/datatables.min'], function () {
         extract_date: extract_date,
         daysince: daysince,
         is_trunk: is_trunk,
-        remove_keywords: remove_keywords
+        remove_keywords: remove_keywords,
+        set_last_seen_mode: set_last_seen_mode,
+        refresh: do_primary_filter
     };
 
 });
-

--- a/python/nav/web/static/js/src/info_room.js
+++ b/python/nav/web/static/js/src/info_room.js
@@ -127,6 +127,11 @@ require(
             var primary_node = $('#netbox-global-search');
             var filters = ['last_seen', 'vlan'];
 
+
+            $('#lastseen-mode').on('change', function () {
+                global_dt_filters.set_last_seen_mode(this.value);
+                global_dt_filters.refresh();
+            });
             try {
                 global_dt_filters.add_filters(primary_node, tables, filters);
             } catch (error) {

--- a/python/nav/web/static/js/test/info/global_dt_filters-test.js
+++ b/python/nav/web/static/js/test/info/global_dt_filters-test.js
@@ -76,14 +76,48 @@ define(['info/global_dt_filters', 'jquery'], function (plugin) {
                 it("with no value should return true", function () {
                     assert.isTrue(plugin.filter_last_seen('', this.data, ''));
                 });
-                it("with value greater than cellvalue should return false", function () {
-                    this.input.value = '$days:10000';
-                    assert.isFalse(plugin.filter_last_seen('', this.data, ''));
+
+                describe("more than mode", function () {
+                    beforeEach(function () {
+                        plugin.set_last_seen_mode('ago');
+                    });
+
+                    it("with cellvalue 0 should return true", function () {
+                        this.input.value = '$days:0';
+                        assert.isTrue(plugin.filter_last_seen('', this.data, ''));
+                    });
+
+                    it("with value greater than cellvalue should return false", function () {
+                        this.input.value = '$days:10000';
+                        assert.isFalse(plugin.filter_last_seen('', this.data, ''));
+                    });
+                    it("with value less than cellvalue should return true", function () {
+                        this.input.value = '$days:3';
+                        assert.isTrue(plugin.filter_last_seen('', this.data, ''));
+                    });
                 });
-                it("with value less than cellvalue should return true", function () {
-                    this.input.value = '$days:3';
-                    assert.isTrue(plugin.filter_last_seen('', this.data, ''));
+
+                describe("less than mode", function () {
+                    beforeEach(function () {
+                        plugin.set_last_seen_mode('since');
+                    });
+
+                    it("with cellvalue 0 should return false", function () {
+                        this.input.value = '$days:0';
+                        assert.isFalse(plugin.filter_last_seen('', this.data, ''));
+                    });
+
+                    it("with value greater than cellvalue should return true", function () {
+                        this.input.value = '$days:10000';
+                        assert.isTrue(plugin.filter_last_seen('', this.data, ''));
+                    });
+                    it("with value less than cellvalue should return false", function () {
+                        this.input.value = '$days:3';
+                        assert.isFalse(plugin.filter_last_seen('', this.data, ''));
+                    });
                 });
+
+
                 describe("on trunk", function () {
                     beforeEach(function () {
                         this.data[3] = this.trunk_cell;

--- a/python/nav/web/templates/info/room/netboxview.html
+++ b/python/nav/web/templates/info/room/netboxview.html
@@ -32,11 +32,16 @@
     </div>
 
     <div id="lastseenfilter" class="small-3 columns">
-      <label>
-        Last Seen (days ago)
-        <input type="text">
-      </label>
+      <label for="lastseen-input">Last Seen</label>
+      <div class="form-inline">
+        <select id="lastseen-mode" name="lastseen_mode">
+          <option value="ago">more than</option>
+          <option value="since">less than</option>
+        </select>
 
+        <input id="lastseen-input" type="number" min="0">
+        <span>days ago</span>
+      </div>
     </div>
 
     <div class="small-3 columns">


### PR DESCRIPTION
## Scope and purpose

Fixes #3313 . 

old 

<img width="1335" height="418" alt="bilde" src="https://github.com/user-attachments/assets/c576f6ab-adc0-4cc6-9530-5f50d2e9a852" />


new

<img width="2699" height="281" alt="image" src="https://github.com/user-attachments/assets/db293e2c-200e-41b0-b121-e2a3277c8b62" />

<img width="2699" height="281" alt="image" src="https://github.com/user-attachments/assets/ce3c936b-f3b5-4578-ac13-87a9ec6c2ab6" />



## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [x] If this results in changes in the UI: Added screenshots of the before and after


<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
