### PR TITLE
Update Select2 to use modern v4 API for resetting filter dropdowns

### DIFF
--- a/python/nav/web/static/js/src/plugins/seeddb_datatables.js
+++ b/python/nav/web/static/js/src/plugins/seeddb_datatables.js
@@ -196,7 +196,7 @@ function() {
             table.draw();
         });
 
-        $('#id_room').select2(); // Apply select2 to the room dropdown
+        $('#id_room').select2({ width: '350px' });
 
         return table;
     }
@@ -282,19 +282,26 @@ function() {
          prepopulated. Do a new query when using the dropdowns. They reset each
          other.
          */
-        var $roomdropdown = $('#id_room'),
-            $netboxdropdown = $('#id_netbox');
+        const $roomdropdown = $('#id_room'),
+              $netboxdropdown = $('#id_netbox');
+        let clearing = false;
         $roomdropdown.appendTo('.filters').change(function() {
-            $netboxdropdown.select2('val', '');
+            if (clearing) return;
+            clearing = true;
+            $netboxdropdown.val(null).trigger('change');
+            clearing = false;
             table.draw();
         });
-        $roomdropdown.select2(); // Apply select2 to the room dropdown
+        $roomdropdown.select2({ width: '350px' });
 
         $netboxdropdown.appendTo('.filters').change(function() {
-            $roomdropdown.select2('val', '');
+            if (clearing) return;
+            clearing = true;
+            $roomdropdown.val(null).trigger('change');
+            clearing = false;
             table.draw();
         });
-        $netboxdropdown.select2(); // Apply select2 to the room dropdown
+        $netboxdropdown.select2({ width: '350px' });
 
         return table;
     }


### PR DESCRIPTION
## Scope and purpose

This PR is a follow-up to #3693, where some deprecated syntax was left-in, and the mutual exclusive Room/Netbox filters were not behaving as intended (both could be selected)

### This pull request
- Replaces deprecated `.select2('val', '')` with modern v4 API `.val(null).trigger('change')`
- Adds guard flag to prevent infinite loop when filters reset each other
- Sets explicit 350px width on filter dropdowns

## How to test

### Patch list page: /seeddb/patch/
* Select a room in the room dropdown -> verify the netbox dropdown clears
* Select a netbox in the netbox dropdown -> verify the room dropdown clears
* Verify the table refreshes correctly after each filter change
  
### Cabling list page: /seeddb/cabling/
* The room dropdown should still work

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [ ] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
