### PR TITLE
Use template tags for popovers to decrease duplication and improve DX

### DIFF
--- a/python/nav/django/templatetags/popover.py
+++ b/python/nav/django/templatetags/popover.py
@@ -1,0 +1,315 @@
+"""Template tags for popover components"""
+
+from typing import Literal, Optional, get_args
+
+from django import template
+from django.utils.html import conditional_escape, format_html, mark_safe
+
+register = template.Library()
+
+# Valid values for enum-like parameters
+TriggerElement = Literal['button', 'a', 'span']
+Side = Literal['top', 'bottom', 'left', 'right']
+Align = Literal['start', 'end']
+Size = Literal['tiny', 'small', 'medium', 'large']
+
+VALID_TRIGGER_ELEMENTS: tuple[TriggerElement, ...] = get_args(TriggerElement)
+VALID_SIDES: tuple[Side, ...] = get_args(Side)
+VALID_ALIGNS: tuple[Align, ...] = get_args(Align)
+VALID_SIZES: tuple[Size, ...] = get_args(Size)
+
+
+@register.inclusion_tag('components/popover/_confirm_popover.html', takes_context=True)
+def confirm_popover(
+    context: template.Context,
+    popover_id: str,
+    action_url: str,
+    title: str = "Are you sure?",
+    confirm_text: str = "Yes",
+    cancel_text: str = "No",
+    trigger_text: Optional[str] = None,
+    trigger_icon: str = "fa-times-circle",
+    trigger_classes: str = "secondary",
+    size: Size = "tiny",
+    side: Side = "bottom",
+    align: Align = "start",
+) -> dict:
+    """Renders a confirmation popover with a form action.
+
+    Usage::
+
+        {% load popover %}
+        {% confirm_popover popover_id="delete-item" action_url=delete_url %}
+
+    :param context: Django template context
+    :param popover_id: Unique identifier for the popover (required)
+    :param action_url: URL for the form action (required)
+    :param title: Confirmation question text
+    :param confirm_text: Text for the confirm button
+    :param cancel_text: Text for the cancel button
+    :param trigger_text: If set, uses a button with this text instead of an icon
+    :param trigger_icon: FontAwesome icon class (without 'fa' prefix)
+    :param trigger_classes: CSS classes for the trigger button (default: secondary)
+    :param size: Popover content size (tiny, small, medium, large)
+    :param side: Position relative to trigger (top, bottom, left, right)
+    :param align: Alignment (start, end)
+    """
+    return {
+        'id': popover_id,
+        'action_url': action_url,
+        'title': title,
+        'confirm_text': confirm_text,
+        'cancel_text': cancel_text,
+        'trigger_text': trigger_text,
+        'trigger_icon': trigger_icon,
+        'trigger_classes': trigger_classes,
+        'size': size,
+        'side': side,
+        'align': align,
+        'request': context.get('request'),
+    }
+
+
+@register.inclusion_tag('components/popover/_close_button.html')
+def popover_close_button(text: str = "Cancel", classes: str = "secondary") -> dict:
+    """Renders a close button for use inside popovers.
+
+    Usage::
+
+        {% load popover %}
+        {% popover_close_button "Cancel" classes="secondary" %}
+
+    :param text: Button text
+    :param classes: Additional CSS classes for the button
+    """
+    return {
+        'text': text,
+        'classes': classes,
+    }
+
+
+class PopoverNode(template.Node):
+    """Node for the {% popover %}...{% endpopover %} block tag."""
+
+    def __init__(
+        self,
+        nodelist,
+        id_var,
+        trigger_text_var,
+        trigger_element,
+        trigger_classes,
+        title_var,
+        size,
+        side,
+        align,
+        with_arrow,
+    ):
+        self.nodelist = nodelist
+        self.id_var = id_var
+        self.trigger_text_var = trigger_text_var
+        self.trigger_element = trigger_element
+        self.trigger_classes = trigger_classes
+        self.title_var = title_var
+        self.size = size
+        self.side = side
+        self.align = align
+        self.with_arrow = with_arrow
+
+    def render(self, context):
+        id_value = self.id_var.resolve(context)
+        trigger_text = self.trigger_text_var.resolve(context)
+        title = self.title_var.resolve(context) if self.title_var else None
+        trigger_classes = (
+            self.trigger_classes.resolve(context) if self.trigger_classes else ""
+        )
+
+        # Content is trusted template output, not user input
+        content = self.nodelist.render(context)
+
+        arrow_class = "with-arrow" if self.with_arrow else ""
+        side_attr = (
+            format_html('data-side="{}"', self.side) if self.side != "bottom" else ""
+        )
+        align_attr = (
+            format_html('data-align="{}"', self.align) if self.align != "start" else ""
+        )
+
+        trigger_html = _build_trigger_html(
+            self.trigger_element,
+            id_value,
+            trigger_text,
+            trigger_classes,
+        )
+
+        title_html = format_html("<h5>{}</h5>", title) if title else ""
+        # side_attr and align_attr are already safe from format_html,
+        # so mark the join as safe
+        attrs = mark_safe(" ".join(filter(None, [side_attr, align_attr])))
+
+        return format_html(
+            '<div id="{}" class="popover {}" {}>\n'
+            '  {}\n'
+            '  <div class="popover-content {}">\n'
+            '    {}\n'
+            '    {}\n'
+            '  </div>\n'
+            '</div>',
+            id_value,
+            arrow_class,
+            attrs,
+            trigger_html,
+            self.size,
+            title_html,
+            content,
+        )
+
+
+def _build_trigger_html(element, id_value, text, classes):
+    """Build the HTML for the popover trigger element."""
+    attrs = format_html(
+        'data-popover-target="#{}" aria-haspopup="true" aria-expanded="false"',
+        id_value,
+    )
+    text = conditional_escape(text)
+
+    tag = {"button": "button", "a": "a"}.get(element, "span")
+    if classes:
+        return format_html('<{} class="{}" {}>{}</{}>', tag, classes, attrs, text, tag)
+    return format_html('<{} {}>{}</{}>', tag, attrs, text, tag)
+
+
+def _parse_popover_kwargs(bits, tag_name):
+    """Parse keyword arguments from template tag tokens.
+
+    :param bits: Token contents split by whitespace
+    :param tag_name: Name of the tag (for error messages)
+    :returns: Dictionary of keyword arguments
+    :raises TemplateSyntaxError: If non-keyword arguments found or required args missing
+    """
+    kwargs = {}
+    for bit in bits[1:]:
+        if '=' in bit:
+            key, value = bit.split('=', 1)
+            kwargs[key] = value
+        else:
+            raise template.TemplateSyntaxError(
+                f"'{tag_name}' tag requires keyword arguments"
+            )
+
+    if 'popover_id' not in kwargs:
+        raise template.TemplateSyntaxError(
+            f"'{tag_name}' tag requires 'popover_id' argument"
+        )
+    if 'trigger_text' not in kwargs:
+        raise template.TemplateSyntaxError(
+            f"'{tag_name}' tag requires 'trigger_text' argument"
+        )
+
+    return kwargs
+
+
+def _validate_popover_params(trigger_element, size, side, align, tag_name):
+    """Validate enum-like parameters for the popover tag.
+
+    :raises TemplateSyntaxError: If any parameter has an invalid value
+    """
+    if trigger_element not in VALID_TRIGGER_ELEMENTS:
+        raise template.TemplateSyntaxError(
+            f"'{tag_name}' trigger_element must be one of {VALID_TRIGGER_ELEMENTS}, "
+            f"got '{trigger_element}'"
+        )
+
+    if size not in VALID_SIZES:
+        raise template.TemplateSyntaxError(
+            f"'{tag_name}' size must be one of {VALID_SIZES}, got '{size}'"
+        )
+
+    if side not in VALID_SIDES:
+        raise template.TemplateSyntaxError(
+            f"'{tag_name}' side must be one of {VALID_SIDES}, got '{side}'"
+        )
+
+    if align not in VALID_ALIGNS:
+        raise template.TemplateSyntaxError(
+            f"'{tag_name}' align must be one of {VALID_ALIGNS}, got '{align}'"
+        )
+
+
+@register.tag('popover')
+def do_popover(parser, token):
+    """Block tag for generic popovers with custom content.
+
+    Usage::
+
+        {% load popover %}
+        {% popover popover_id="info" trigger_text="About" title="About" %}
+          <p>Custom content here...</p>
+        {% endpopover %}
+
+    :param popover_id: Unique identifier for the popover (required)
+    :param trigger_text: Text/content for the trigger element (required)
+    :param trigger_element: Element type: button (default), a, span
+    :param trigger_classes: Additional CSS classes for the trigger
+    :param title: Optional header text
+    :param size: Content size (tiny, small, medium, large)
+    :param side: Position (top, bottom, left, right)
+    :param align: Alignment (start, end)
+    :param with_arrow: Show pointing arrow (default: True)
+    """
+    bits = token.split_contents()
+    tag_name = bits[0]
+
+    kwargs = _parse_popover_kwargs(bits, tag_name)
+
+    nodelist = parser.parse(('endpopover',))
+    parser.delete_first_token()
+
+    # Process arguments
+    id_var = parser.compile_filter(kwargs['popover_id'])
+    trigger_text_var = parser.compile_filter(kwargs['trigger_text'])
+    trigger_element = _strip_quotes(kwargs.get('trigger_element', '"button"'))
+    trigger_classes = (
+        parser.compile_filter(kwargs['trigger_classes'])
+        if 'trigger_classes' in kwargs
+        else None
+    )
+    title_var = parser.compile_filter(kwargs['title']) if 'title' in kwargs else None
+    size = _strip_quotes(kwargs.get('size', '"small"'))
+    side = _strip_quotes(kwargs.get('side', '"bottom"'))
+    align = _strip_quotes(kwargs.get('align', '"start"'))
+    with_arrow = _parse_bool(kwargs.get('with_arrow', 'True'))
+
+    _validate_popover_params(trigger_element, size, side, align, tag_name)
+
+    return PopoverNode(
+        nodelist,
+        id_var,
+        trigger_text_var,
+        trigger_element,
+        trigger_classes,
+        title_var,
+        size,
+        side,
+        align,
+        with_arrow,
+    )
+
+
+def _strip_quotes(value):
+    """Remove surrounding quotes from a string value."""
+    if value and len(value) >= 2:
+        if (value[0] == '"' and value[-1] == '"') or (
+            value[0] == "'" and value[-1] == "'"
+        ):
+            return value[1:-1]
+    return value
+
+
+def _parse_bool(value):
+    """Parse a string value as boolean."""
+    value = _strip_quotes(value).lower()
+    if value in ('true', '1', 'yes'):
+        return True
+    if value in ('false', '0', 'no', ''):
+        return False
+    raise ValueError(f"Cannot parse '{value}' as boolean")

--- a/python/nav/web/sass/nav/_popover.scss
+++ b/python/nav/web/sass/nav/_popover.scss
@@ -2,6 +2,12 @@
 .popover {
   position: relative;
   width: fit-content;
+
+  // Remove margin from trigger buttons
+  > button,
+  > .button {
+    margin-bottom: 0;
+  }
 }
 
 // Content positioning by side
@@ -241,5 +247,15 @@
 
   &.large {
     max-width: 800px;
+  }
+
+  // Remove bottom margin from elements to prevent extra space
+  > :last-child {
+    margin-bottom: 0;
+  }
+
+  button,
+  .button {
+    margin-bottom: 0;
   }
 }

--- a/python/nav/web/static/js/src/plugins/popover.js
+++ b/python/nav/web/static/js/src/plugins/popover.js
@@ -36,7 +36,7 @@ define([], function () {
     }
 
     // Handle close buttons
-    const closeButton = e.target.closest('[close-popover]');
+    const closeButton = e.target.closest('[data-close-popover]');
     if (closeButton) {
       closePopover(closeButton.closest('.popover'));
       return;

--- a/python/nav/web/templates/components/popover/_close_button.html
+++ b/python/nav/web/templates/components/popover/_close_button.html
@@ -1,0 +1,2 @@
+{# Close button for use inside popovers #}
+<button type="button" class="button small {{ classes }} close-button" data-close-popover>{{ text }}</button>

--- a/python/nav/web/templates/components/popover/_confirm_popover.html
+++ b/python/nav/web/templates/components/popover/_confirm_popover.html
@@ -1,0 +1,29 @@
+{# Confirmation popover with form action #}
+<div id="{{ id }}" class="popover with-arrow"{% if side != "bottom" %} data-side="{{ side }}"{% endif %}{% if align != "start" %} data-align="{{ align }}"{% endif %}>
+  {% if trigger_text %}
+  <button
+      class="{{ trigger_classes }}"
+      data-popover-target="#{{ id }}"
+      aria-haspopup="true"
+      aria-expanded="false"
+  >
+      {% if trigger_icon %}<i class="fa {{ trigger_icon }} deleteicon"></i> {% endif %}{{ trigger_text }}
+  </button>
+  {% else %}
+  <a
+      data-popover-target="#{{ id }}"
+      aria-haspopup="true"
+      aria-expanded="false"
+  >
+      <i class="fa {{ trigger_icon }} deleteicon"></i>
+  </a>
+  {% endif %}
+  <div class="popover-content {{ size }}">
+    <h5>{{ title }}</h5>
+    <form action="{{ action_url }}" method="POST">
+      {% csrf_token %}
+      <button type="submit" class="button small alert left">{{ confirm_text }}</button>
+      <button type="button" class="button small secondary close-button left" data-close-popover>{{ cancel_text }}</button>
+    </form>
+  </div>
+</div>

--- a/python/nav/web/templates/info/event/_about_acknowledge_info.html
+++ b/python/nav/web/templates/info/event/_about_acknowledge_info.html
@@ -1,14 +1,7 @@
-<div id="acknowledge-info" class="popover with-arrow">
-    <a data-popover-target="#acknowledge-info" aria-haspopup="true">
-      About
-    </a>
-
-    <div class="popover-content small">
-      <h5>About acknowledging</h5>
-
-      <p>
-        Acknowledged alerts will be hidden for all users, but not removed. When
-        an end event arrives the alert will be cleared normally.
-      </p>
-    </div>
-</div>
+{% load popover %}
+{% popover popover_id="acknowledge-info" trigger_text="About" trigger_element="a" title="About acknowledging" %}
+  <p>
+    Acknowledged alerts will be hidden for all users, but not removed. When
+    an end event arrives the alert will be cleared normally.
+  </p>
+{% endpopover %}

--- a/python/nav/web/templates/info/event/_about_delete_info.html
+++ b/python/nav/web/templates/info/event/_about_delete_info.html
@@ -1,15 +1,9 @@
-<div id="delete-info" class="popover with-arrow">
-    <a data-popover-target="#delete-info" aria-haspopup="true">
-      About
-    </a>
-
-    <div class="popover-content small">
-        <h5>About deleting module or chassis</h5>
-          <p>
-            NAV does not know if a module or chassis that has disappeared did so
-            because of an error or because it was removed on purpose. Thus, modules
-            and chassis that disappear are all listed in status until manually
-            deleted from NAV by a manual module/chassis delete.
-          </p>
-    </div>
-</div>
+{% load popover %}
+{% popover popover_id="delete-info" trigger_text="About" trigger_element="a" title="About deleting module or chassis" %}
+  <p>
+    NAV does not know if a module or chassis that has disappeared did so
+    because of an error or because it was removed on purpose. Thus, modules
+    and chassis that disappear are all listed in status until manually
+    deleted from NAV by a manual module/chassis delete.
+  </p>
+{% endpopover %}

--- a/python/nav/web/templates/info/event/_about_maintenance_info.html
+++ b/python/nav/web/templates/info/event/_about_maintenance_info.html
@@ -1,15 +1,7 @@
-<div id="maintenance-info" class="popover with-arrow">
-    <a data-popover-target="#maintenance-info" aria-haspopup="true">
-      About
-    </a>
-
-    <div class="popover-content small">
-      <h5>Put on maintenance</h5>
-
-      <p>
-        Putting an alert on maintenance only makes sense if the subject can be
-        put on maintenance, for instance IP Devices and Services.
-      </p>
-
-    </div>
-</div>
+{% load popover %}
+{% popover popover_id="maintenance-info" trigger_text="About" trigger_element="a" title="Put on maintenance" %}
+  <p>
+    Putting an alert on maintenance only makes sense if the subject can be
+    put on maintenance, for instance IP Devices and Services.
+  </p>
+{% endpopover %}

--- a/python/nav/web/templates/info/event/_about_resolve_info.html
+++ b/python/nav/web/templates/info/event/_about_resolve_info.html
@@ -1,18 +1,12 @@
-<div id="resolve-info" class="popover with-arrow">
-    <a data-popover-target="#resolve-info" aria-haspopup="true">
-        About
-    </a>
-
-    <div class="popover-content medium">
-        <h5>About clearing alerts</h5>
-        <p>
-            Clearing an alert will set its end time, thereby closing it and removing
-            it from the list of problems. Use this to remove alerts that have become
-            invalid, where there is no way for NAV to automatically detect this.
-        </p>
-        <p>
-            Be aware that if the root cause of the alert is still there, NAV may end
-            up posting a new alert for the same issue.
-        </p>
-    </div>
-</div>
+{% load popover %}
+{% popover popover_id="resolve-info" trigger_text="About" trigger_element="a" title="About clearing alerts" size="medium" %}
+  <p>
+    Clearing an alert will set its end time, thereby closing it and removing
+    it from the list of problems. Use this to remove alerts that have become
+    invalid, where there is no way for NAV to automatically detect this.
+  </p>
+  <p>
+    Be aware that if the root cause of the alert is still there, NAV may end
+    up posting a new alert for the same issue.
+  </p>
+{% endpopover %}

--- a/python/nav/web/templates/styleguide.html
+++ b/python/nav/web/templates/styleguide.html
@@ -464,7 +464,7 @@
           <li><strong>Side:</strong> <code>data-side</code> Options: <code>bottom</code> (default), <code>left</code>, <code>right</code>, <code>top</code></li>
           <li><strong>Size:</strong> <code>tiny</code>, <code>small</code>, <code>medium</code>, or <code>large</code> classes on popover-content</li>
           <li><strong>Arrow:</strong> Add <code>with-arrow</code> class to display a pointing arrow</li>
-          <li><strong>Close button:</strong> Add <code>close-popover</code> attribute to any element to make it close the popover when clicked</li>
+          <li><strong>Close button:</strong> Add <code>data-close-popover</code> attribute to any element to make it close the popover when clicked</li>
         </ul>
         <div style="margin-bottom: 1rem;">
             <h4>Example popover</h4>
@@ -481,7 +481,7 @@
                 <h5>Confirm Action</h5>
                 <p>Are you sure you want to delete this item?</p>
                 <button type="button" class="button small alert left">Confirm</button>
-                <button type="button" class="button small secondary close-button left" close-popover>Cancel</button>
+                <button type="button" class="button small secondary close-button left" data-close-popover>Cancel</button>
               </div>
             </div>
         </div>
@@ -504,7 +504,7 @@
         &lt;button class="button small alert left"&gt;Confirm&lt;/button&gt;
         &lt;button
             class="button small secondary close-button left"
-            close-popover
+            data-close-popover
         &gt;
             Cancel
         &lt;/button&gt;
@@ -513,6 +513,61 @@
           </div>
     </div>
 </div>
+
+<div class="row">
+    <div class="columns">
+        <h4>Template Tags</h4>
+        <p>Use Django template tags for cleaner, more maintainable popover markup with built-in ARIA attributes.</p>
+    </div>
+    <div class="columns large-6">
+        <h5>Confirmation Popover</h5>
+        <p>For delete/confirmation dialogs with a form action:</p>
+        {% load popover %}
+        {% confirm_popover popover_id="styleguide-demo" action_url="#" title="Delete this item?" trigger_text="Delete Action" confirm_text="Delete" cancel_text="Keep it" side="right" %}
+    </div>
+    <div class="columns large-6">
+        <div class="panel white">
+            <pre class="prettyprint">
+{&percnt; load popover &percnt;}
+{&percnt; confirm_popover popover_id="delete-item" action_url=delete_url title="Delete this item?" &percnt;}
+
+{# With all options: #}
+{&percnt; confirm_popover
+    popover_id="delete-rule"
+    action_url=rule.delete_url
+    title="Delete this rule?"
+    confirm_text="Yes"
+    cancel_text="No way!"
+    trigger_icon="fa-trash"
+    size="tiny"
+    side="bottom"
+    align="end"
+&percnt;}</pre>
+        </div>
+    </div>
+</div>
+
+<div class="row">
+    <div class="columns large-6">
+        <h5>Generic Popover Block</h5>
+        <p>For custom popover content:</p>
+        {% popover popover_id="styleguide-info" trigger_text="More Info" trigger_element="a" title="About This Feature" %}
+            <p>Custom HTML content goes here. You can include any markup needed.</p>
+            {% popover_close_button "Got it" classes="secondary" %}
+        {% endpopover %}
+    </div>
+    <div class="columns large-6">
+        <div class="panel white">
+            <pre class="prettyprint">
+{&percnt; load popover &percnt;}
+{&percnt; popover popover_id="info" trigger_text="About" trigger_element="a" title="About This" &percnt;}
+    &lt;p&gt;Custom content here...&lt;/p&gt;
+    {&percnt; popover_close_button "Close" classes="secondary" &percnt;}
+{&percnt; endpopover &percnt;}</pre>
+        </div>
+    </div>
+</div>
+
 <div class="row">
     <div class="column">
         <h3 class="underline">Tooltips</h3>

--- a/python/nav/web/templates/threshold/base.html
+++ b/python/nav/web/templates/threshold/base.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load tools %}
+{% load popover tools %}
 
 {% block footer_scripts %}
   <script>
@@ -49,24 +49,12 @@
           <td class="hide-for-medium-down">{{ rule.creator.name }}</td>
           <td class="hide-for-medium-down" data-sort-value="{{ rule.created|date:'c' }}">{{ rule.created }}</td>
           <td>
-            <div id="delete-popover-{{ rule.id }}" class="popover with-arrow" data-align="end">
-              <a
-                  href="#"
-                  data-popover-target="#delete-popover-{{ rule.id }}"
-                  aria-haspopup="true"
-                  aria-expanded="false"
-              >
-                  <i class="fa fa-times-circle deleteicon"></i>
-              </a>
-              <div class="popover-content tiny">
-                <h5>Delete this rule?</h5>
-                <form action="{% url 'threshold-delete' rule.id %}" method="POST">
-                  {% csrf_token %}
-                  <input type="submit" value="Yes" class="button small alert left" />
-                  <button type="button" class="button small secondary close-button left" close-popover>No way!</button>
-                </form>
-              </div>
-            </div>
+            {% with rule_id_str=rule.id|stringformat:"s" %}
+              {% with popover_id="delete-popover-"|add:rule_id_str %}
+                {% url 'threshold-delete' rule.id as delete_url %}
+                {% confirm_popover popover_id=popover_id action_url=delete_url title="Delete this rule?" cancel_text="No way!" align="end" %}
+              {% endwith %}
+            {% endwith %}
           </td>
         </tr>
       {% endfor %}

--- a/python/nav/web/templates/threshold/set_threshold.html
+++ b/python/nav/web/templates/threshold/set_threshold.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load popover %}
 
 {% block base_header_additional_head %}
   <script>require(['src/threshold']);</script>
@@ -30,25 +31,8 @@
         {% include 'custom_crispy_templates/flat_form.html' %}
       </div>
       {% if id %}
-      <div id="confirm-delete" class="popover with-arrow">
-          <button
-              data-popover-target="#confirm-delete"
-              aria-haspopup="true"
-              aria-expanded="false"
-              class="button alert"
-              style="margin-bottom: 0;"
-          >
-              Delete
-          </button>
-          <div class="popover-content tiny" style="width: 200px;">
-              <h5>Delete this rule?</h5>
-              <form action="{% url 'threshold-delete' id %}" method="POST">
-                  {% csrf_token %}
-                  <input type="submit" value="Yes" class="button small alert left">
-                  <button type="button" class="button small secondary close-button left" close-popover>No way!</button>
-              </form>
-          </div>
-      </div>
+        {% url 'threshold-delete' id as delete_url %}
+        {% confirm_popover popover_id="confirm-delete" action_url=delete_url title="Delete this rule?" trigger_text="Delete" trigger_icon="" trigger_classes="button alert" cancel_text="No way!" %}
       {% endif %}
     </div>
 

--- a/python/nav/web/templates/useradmin/_confirm_token_delete.html
+++ b/python/nav/web/templates/useradmin/_confirm_token_delete.html
@@ -1,26 +1,4 @@
 {# Display form for deleting a token #}
-<div id="confirm-token-delete" class="popover with-arrow" data-side="top">
-  <button
-          class="button small alert"
-          data-popover-target="#confirm-token-delete"
-          aria-haspopup="true"
-          style="margin-bottom: 0;"
-  >
-    Delete token
-  </button>
-  <div class="popover-content">
-    <form id="delete-token-form"
-          action="{% url delete_url token.pk %}"
-          method="post">
-      {% csrf_token %}
-      <button type="submit" class="button small alert expand">Yes, delete</button>
-      <button
-              class="button secondary small close-button expand"
-              type="button"
-              style="margin-bottom: 0;"
-              close-popover
-      >
-          No, don't delete
-      </button>
-    </form>
-  </div>
+{% load popover %}
+{% url delete_url token.pk as action_url %}
+{% confirm_popover popover_id="confirm-token-delete" action_url=action_url title="Delete this token?" confirm_text="Yes, delete" cancel_text="No, don't delete" trigger_text="Delete token" trigger_classes="button small alert" side="top" %}

--- a/python/nav/web/templates/webfront/_dashboard_settings_form.html
+++ b/python/nav/web/templates/webfront/_dashboard_settings_form.html
@@ -60,7 +60,7 @@
                         <button
                                 class="small alert expand"
                                 type="submit"
-                                close-popover
+                                data-close-popover
                         >
                             Delete dashboard
                         </button>

--- a/tests/unittests/django/templatetags/popover_test.py
+++ b/tests/unittests/django/templatetags/popover_test.py
@@ -1,0 +1,305 @@
+"""Tests for popover template tags"""
+
+import pytest
+from django.template import Context, Template, TemplateSyntaxError
+
+from nav.django.templatetags.popover import confirm_popover
+
+
+class TestConfirmPopover:
+    """Tests for the confirm_popover inclusion tag"""
+
+    def test_when_minimal_params_then_it_should_render_correctly(self):
+        template = Template(
+            '{% load popover %}'
+            '{% confirm_popover popover_id="test-id" action_url="/delete/" %}'
+        )
+        rendered = template.render(Context({}))
+
+        # Basic structure
+        assert 'id="test-id"' in rendered
+        assert 'class="popover with-arrow"' in rendered
+        assert 'action="/delete/"' in rendered
+        assert 'data-popover-target="#test-id"' in rendered
+        # ARIA attributes
+        assert 'aria-haspopup="true"' in rendered
+        assert 'aria-expanded="false"' in rendered
+        # Default values
+        assert 'Are you sure?' in rendered
+        assert '>Yes</button>' in rendered
+        assert '>No</button>' in rendered
+        assert 'fa-times-circle' in rendered
+        assert 'popover-content tiny' in rendered
+
+    def test_when_custom_title_then_it_should_render_title(self):
+        template = Template(
+            '{% load popover %}'
+            '{% confirm_popover popover_id="test-id" action_url="/delete/" '
+            'title="Delete this?" %}'
+        )
+        rendered = template.render(Context({}))
+
+        assert 'Delete this?' in rendered
+
+    def test_when_custom_button_text_then_it_should_render_button_text(self):
+        template = Template(
+            '{% load popover %}'
+            '{% confirm_popover popover_id="test-id" action_url="/delete/" '
+            'confirm_text="Confirm" cancel_text="Abort" %}'
+        )
+        rendered = template.render(Context({}))
+
+        assert '>Confirm</button>' in rendered
+        assert '>Abort</button>' in rendered
+
+    def test_when_trigger_text_then_it_should_pass_trigger_text_to_context(self):
+        result = confirm_popover(
+            context={},
+            popover_id="test-id",
+            action_url="/delete/",
+            trigger_text="Delete",
+            trigger_icon="",
+        )
+
+        assert result['trigger_text'] == "Delete"
+        assert result['trigger_icon'] == ""
+        assert result['trigger_classes'] == "secondary"
+
+    @pytest.mark.parametrize(
+        "param,value,expected",
+        [
+            ("align", "end", 'data-align="end"'),
+            ("side", "top", 'data-side="top"'),
+            ("size", "medium", "popover-content medium"),
+        ],
+    )
+    def test_when_param_set_then_it_should_render_in_output(
+        self, param, value, expected
+    ):
+        template = Template(
+            '{% load popover %}'
+            '{% confirm_popover popover_id="test-id" action_url="/delete/" '
+            f'{param}="{value}" %}}'
+        )
+        rendered = template.render(Context({}))
+
+        assert expected in rendered
+
+    def test_when_variable_id_then_it_should_resolve_variable(self):
+        template = Template(
+            '{% load popover %}'
+            '{% confirm_popover popover_id=item_id action_url=delete_url %}'
+        )
+        rendered = template.render(
+            Context({'item_id': 'dynamic-123', 'delete_url': '/items/123/delete/'})
+        )
+
+        assert 'id="dynamic-123"' in rendered
+        assert 'action="/items/123/delete/"' in rendered
+
+
+class TestPopoverCloseButton:
+    """Tests for the popover_close_button inclusion tag"""
+
+    def test_when_minimal_params_then_it_should_render_defaults(self):
+        template = Template('{% load popover %}{% popover_close_button %}')
+        rendered = template.render(Context({}))
+
+        assert '>Cancel</button>' in rendered
+        assert 'secondary' in rendered
+        assert 'data-close-popover' in rendered
+
+    def test_when_custom_text_then_it_should_render_text(self):
+        template = Template('{% load popover %}{% popover_close_button "Dismiss" %}')
+        rendered = template.render(Context({}))
+
+        assert '>Dismiss</button>' in rendered
+
+    def test_when_custom_classes_then_it_should_include_classes(self):
+        template = Template(
+            '{% load popover %}{% popover_close_button "Close" classes="alert" %}'
+        )
+        rendered = template.render(Context({}))
+
+        assert 'alert' in rendered
+
+
+class TestPopoverBlockTag:
+    """Tests for the {% popover %}...{% endpopover %} block tag"""
+
+    def test_when_basic_usage_then_it_should_render_correctly(self):
+        template = Template(
+            '{% load popover %}'
+            '{% popover popover_id="info" trigger_text="About" %}'
+            '<p>Content here</p>'
+            '{% endpopover %}'
+        )
+        rendered = template.render(Context({}))
+
+        # Basic structure
+        assert 'id="info"' in rendered
+        assert 'class="popover with-arrow"' in rendered
+        assert '<p>Content here</p>' in rendered
+        assert '>About</button>' in rendered
+        # ARIA attributes
+        assert 'aria-haspopup="true"' in rendered
+        assert 'aria-expanded="false"' in rendered
+
+    def test_when_trigger_element_a_then_it_should_render_anchor(self):
+        template = Template(
+            '{% load popover %}'
+            '{% popover popover_id="info" trigger_text="About" trigger_element="a" %}'
+            '<p>Content</p>'
+            '{% endpopover %}'
+        )
+        rendered = template.render(Context({}))
+
+        assert '<a ' in rendered
+        assert 'href' not in rendered  # No href to avoid scroll-to-top
+        assert '>About</a>' in rendered
+
+    def test_when_title_then_it_should_render_header(self):
+        template = Template(
+            '{% load popover %}'
+            '{% popover popover_id="info" trigger_text="About" title="Information" %}'
+            '<p>Content</p>'
+            '{% endpopover %}'
+        )
+        rendered = template.render(Context({}))
+
+        assert '<h5>Information</h5>' in rendered
+
+    def test_when_no_arrow_then_it_should_not_have_arrow_class(self):
+        template = Template(
+            '{% load popover %}'
+            '{% popover popover_id="info" trigger_text="About" with_arrow=False %}'
+            '<p>Content</p>'
+            '{% endpopover %}'
+        )
+        rendered = template.render(Context({}))
+
+        assert 'with-arrow' not in rendered
+
+    @pytest.mark.parametrize(
+        "params,expected",
+        [
+            ('size="medium"', "popover-content medium"),
+            ('side="right"', 'data-side="right"'),
+            ('align="end"', 'data-align="end"'),
+        ],
+    )
+    def test_when_param_set_then_it_should_render_in_output(self, params, expected):
+        template = Template(
+            '{% load popover %}'
+            f'{{% popover popover_id="info" trigger_text="About" {params} %}}'
+            '<p>Content</p>'
+            '{% endpopover %}'
+        )
+        rendered = template.render(Context({}))
+
+        assert expected in rendered
+
+    def test_when_variable_params_then_it_should_resolve_variables(self):
+        template = Template(
+            '{% load popover %}'
+            '{% popover popover_id=popover_id trigger_text=link_text title=header %}'
+            '<p>{{ body }}</p>'
+            '{% endpopover %}'
+        )
+        rendered = template.render(
+            Context(
+                {
+                    'popover_id': 'dynamic-info',
+                    'link_text': 'Click here',
+                    'header': 'Dynamic Title',
+                    'body': 'Dynamic content',
+                }
+            )
+        )
+
+        assert 'id="dynamic-info"' in rendered
+        assert '>Click here</button>' in rendered
+        assert '<h5>Dynamic Title</h5>' in rendered
+        assert '<p>Dynamic content</p>' in rendered
+
+    def test_when_missing_popover_id_then_it_should_raise_error(self):
+        with pytest.raises(TemplateSyntaxError) as exc_info:
+            Template(
+                '{% load popover %}'
+                '{% popover trigger_text="About" %}'
+                '<p>Content</p>'
+                '{% endpopover %}'
+            )
+        assert "requires 'popover_id' argument" in str(exc_info.value)
+
+    def test_when_missing_trigger_text_then_it_should_raise_error(self):
+        with pytest.raises(TemplateSyntaxError) as exc_info:
+            Template(
+                '{% load popover %}'
+                '{% popover popover_id="info" %}'
+                '<p>Content</p>'
+                '{% endpopover %}'
+            )
+        assert "requires 'trigger_text' argument" in str(exc_info.value)
+
+    def test_when_trigger_text_contains_html_then_it_should_escape(self):
+        template = Template(
+            '{% load popover %}'
+            '{% popover popover_id="info" trigger_text=malicious_text %}'
+            '<p>Content</p>'
+            '{% endpopover %}'
+        )
+        rendered = template.render(
+            Context({'malicious_text': '<script>alert("XSS")</script>'})
+        )
+
+        assert '<script>' not in rendered
+        assert '&lt;script&gt;' in rendered
+
+    def test_when_title_contains_html_then_it_should_escape(self):
+        template = Template(
+            '{% load popover %}'
+            '{% popover popover_id="info" trigger_text="About" title=malicious_title %}'
+            '<p>Content</p>'
+            '{% endpopover %}'
+        )
+        rendered = template.render(
+            Context({'malicious_title': '<img onerror="alert(1)">'})
+        )
+
+        assert '<img onerror' not in rendered
+        assert '&lt;img onerror' in rendered
+
+    def test_when_invalid_trigger_element_then_it_should_raise_error(self):
+        with pytest.raises(TemplateSyntaxError) as exc_info:
+            Template(
+                '{% load popover %}'
+                '{% popover popover_id="info" trigger_text="X" '
+                'trigger_element="div" %}'
+                '<p>Content</p>'
+                '{% endpopover %}'
+            )
+        assert "trigger_element must be one of" in str(exc_info.value)
+        assert "'div'" in str(exc_info.value)
+
+    def test_when_invalid_side_then_it_should_raise_error(self):
+        with pytest.raises(TemplateSyntaxError) as exc_info:
+            Template(
+                '{% load popover %}'
+                '{% popover popover_id="info" trigger_text="About" side="center" %}'
+                '<p>Content</p>'
+                '{% endpopover %}'
+            )
+        assert "side must be one of" in str(exc_info.value)
+        assert "'center'" in str(exc_info.value)
+
+    def test_when_invalid_align_then_it_should_raise_error(self):
+        with pytest.raises(TemplateSyntaxError) as exc_info:
+            Template(
+                '{% load popover %}'
+                '{% popover popover_id="info" trigger_text="About" align="middle" %}'
+                '<p>Content</p>'
+                '{% endpopover %}'
+            )
+        assert "align must be one of" in str(exc_info.value)
+        assert "'middle'" in str(exc_info.value)


### PR DESCRIPTION
## Scope and purpose

Resolves #3492

> **nonews** as this is purely a DX/maintainability change, and does not add anything detectable by users

Adds Django template tags for popover components, reducing boilerplate and ensuring consistent ARIA attributes across the codebase.

### Changes
- **`{% confirm_popover %}`** - Inclusion tag for delete/confirmation dialogs with built-in CSRF handling
- **`{% popover %}...{% endpopover %}`** - Block tag for custom popover content
- **`{% popover_close_button %}`** - Helper tag for close buttons inside popovers
- Migrated existing popovers in `info/event/` and `threshold/` templates to use the new tags
- Added documentation to the styleguide

### Assumptions
- Parameter renamed from `id` to `popover_id` to avoid collision with Python's built-in
- Input validation added for `trigger_element` (button/a/span), `side`, and `align` parameters
- HTML in `trigger_text` and `title` is escaped for XSS prevention

## Testing

1. **Styleguide** - `/styleguide/` scroll to Popovers section, verify template tag examples render correctly
2. **Threshold rules** - `/threshold/` click delete icon on any rule, verify confirmation popover appears
3. **Threshold edit** - `/threshold/edit/<id>/` verify Delete button popover works
4. **Status page** 
   - Go to "Status" tool
   - Click the info popover on an existing event, then "Event details"
   - Select an action in the "Available actions" dropdown
   - Verify that the "About" trigger toggles a popover for every option in the Actions dropdown

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

* [ ] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [x] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file