### PR TITLE
Fix SeedDB Patch and Cable pages so the search filters all visible columns

### DIFF
--- a/changelog.d/3760.fixed.md
+++ b/changelog.d/3760.fixed.md
@@ -1,0 +1,1 @@
+Filtering on SeedDB Patch and Cable pages now searches all visible columns instead of only the jack field

--- a/python/nav/web/api/v1/views.py
+++ b/python/nav/web/api/v1/views.py
@@ -577,7 +577,7 @@ class PatchViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):
 
     Search
     ------
-    Searches in the cables *jack*-field
+    Searches in *jack*, *room*, *sysname*, *ifname*, *ifalias*
 
     Filters
     -------
@@ -597,7 +597,13 @@ class PatchViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):
     ).all()
     serializer_class = serializers.PatchSerializer
     filterset_fields = ('cabling', 'cabling__room', 'interface', 'interface__netbox')
-    search_fields = ('cabling__jack',)
+    search_fields = (
+        'cabling__jack',
+        'cabling__room__id',
+        'interface__netbox__sysname',
+        'interface__ifname',
+        'interface__ifalias',
+    )
 
 
 class CablingViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):
@@ -605,7 +611,7 @@ class CablingViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):
 
     Search
     ------
-    Searches in *jack*, *target_room*, *building*
+    Searches in *jack*, *target_room*, *building*, *description*, *category*, *room*
 
     Filters
     -------
@@ -620,7 +626,14 @@ class CablingViewSet(NAVAPIMixin, viewsets.ReadOnlyModelViewSet):
 
     serializer_class = serializers.CablingSerializer
     filterset_fields = ('room', 'jack', 'building', 'target_room', 'category')
-    search_fields = ('jack', 'target_room', 'building')
+    search_fields = (
+        'jack',
+        'target_room',
+        'building',
+        'description',
+        'category',
+        'room__id',
+    )
 
     def get_queryset(self):
         queryset = cabling.Cabling.objects.all()


### PR DESCRIPTION
## Scope and purpose

Fixes #3760

This PR fixes the search filter on the SeedDB Patch and Cable pages so that all visible columns are filterable.

## Screenshots

https://github.com/user-attachments/assets/04224d67-8c2e-483e-8364-a09c0fcf232f

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
