### PR TITLE
Add backend functionality necessary for graphing DHCP stats

### DIFF
--- a/changelog.d/3766.changed.md
+++ b/changelog.d/3766.changed.md
@@ -1,0 +1,1 @@
+Refactor dhcpstats backend. Users beware: option `user_context_poolname_key` in `dhcpstats.conf` renamed to `user_context_groupname_key` and its default value changed from "name" to "group".

--- a/python/nav/bin/dhcpstats.py
+++ b/python/nav/bin/dhcpstats.py
@@ -15,7 +15,8 @@
 # along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 """
-Collects statistics from DHCP servers and sends them to the Carbon backend.
+Collects statistics from DHCP servers and sends them to the Graphite/Carbon
+backend.
 """
 
 import argparse
@@ -36,7 +37,7 @@ LOGFILE = "dhcpstats.log"
 CONFIGFILE = "dhcpstats.conf"
 PIDFILE = "dhcpstats.pid"
 
-ENDPOINT_CLIENTS = {
+CLIENTS = {
     "kea-dhcp4": partial(kea_dhcp.Client, dhcp_version=4),
 }
 
@@ -66,27 +67,27 @@ def parse_args():
     """
     parser = argparse.ArgumentParser(
         description="Collects statistics from DHCP servers and sends them to the "
-        "Carbon backend",
-        epilog="Statistics are collected from each DHCP API endpoint configured in "
-        "'CONFDIR/dhcpstats.conf', and then sent to the Carbon backend configured in "
-        "'CONFDIR/graphite.conf'.",
+        "Graphite/Carbon backend",
+        epilog="Statistics are collected from each DHCP server configured in "
+        "'CONFDIR/dhcpstats.conf', and then sent to the Graphite/Carbon backend "
+        "configured in 'CONFDIR/graphite.conf'.",
     )
     return parser.parse_args()
 
 
 def collect_stats(config):
     """
-    Collects current stats from each configured endpoint.
+    Collects current stats from each configured server.
 
     :param config: dhcpstats.conf INI-parsed into a dict specifying
-    endpoints to collect metrics from.
+    servers to collect metrics from.
     """
 
     _logger.info("--> Starting stats collection <--")
 
     all_stats = []
 
-    for client in get_endpoint_clients(config):
+    for client in get_clients(config):
         _logger.info(
             "Collecting stats using %s...",
             client,
@@ -96,13 +97,13 @@ def collect_stats(config):
             fetched_stats = client.fetch_stats()
         except ConfigurationError as err:
             _logger.warning(
-                "%s is badly configured: %s, skipping endpoint...",
+                "%s is badly configured: %s, skipping server...",
                 client,
                 err,
             )
         except CommunicationError as err:
             _logger.warning(
-                "Error while collecting stats using %s: %s, skipping endpoint...",
+                "Error while collecting stats using %s: %s, skipping server...",
                 client,
                 err,
             )
@@ -118,46 +119,48 @@ def collect_stats(config):
     _logger.info("--> Stats collection done <--")
 
 
-def get_endpoint_clients(config):
+def get_clients(config):
     """
-    Yields one client per correctly configured endpoint in config. A section
-    of the config correctly configures an endpoint if:
+    Yields one client per correctly configured server in config. A section
+    of the config correctly configures a server if:
 
-    * Its name starts with 'endpoint_'.
+    * Its name starts with 'endpoint_' or 'server_'.
     * It has the mandatory option 'type'.
     * The value of the 'type' option is mapped to a client initializer
-      by ENDPOINT_CLIENTS, and the client doesn't raise a
+      by the global CLIENTS dictionary, and the client doesn't raise a
       ConfigurationError when it is initialized with the rest of the
       options of the section as keyword arguments.
 
     :param config: dhcpstats.conf INI-parsed into a dict specifying
-    endpoints to collect metrics from.
+    servers to collect metrics from.
     """
     for section, options in config.items():
-        if not section.startswith("endpoint_"):
+        if section.startswith("endpoint_"):
+            server_name = section.removeprefix("endpoint_")
+        elif section.startswith("server_"):
+            server_name = section.removeprefix("server_")
+        else:
             continue
-        endpoint_name = section.removeprefix("endpoint_")
-        endpoint_type = options.get("type")
+        server_type = options.get("type")
         kwargs = {opt: val for opt, val in options.items() if opt != "type"}
         try:
-            cls = ENDPOINT_CLIENTS[endpoint_type]
+            cls = CLIENTS[server_type]
         except KeyError:
             _logger.warning(
-                "Invalid endpoint type '%s' defined in config section [%s], skipping "
-                "endpoint...",
-                endpoint_type,
+                "Invalid server type '%s' defined in config section [%s], skipping "
+                "server...",
+                server_type,
                 section,
             )
             continue
 
         try:
-            client = cls(endpoint_name, **kwargs)
+            client = cls(server_name, **kwargs)
         except (ConfigurationError, TypeError) as err:
             _logger.warning(
-                "Endpoint type '%s' defined in config section [%s] is badly "
-                "configured: %s, skipping endpoint...",
-                endpoint_type,
+                "Section [%s] of %s is badly configured: %s, skipping server...",
                 section,
+                CONFIGFILE,
                 err,
             )
         else:

--- a/python/nav/bin/dhcpstats.py
+++ b/python/nav/bin/dhcpstats.py
@@ -26,6 +26,7 @@ import sys
 
 from nav.config import getconfig
 from nav.dhcpstats import kea_dhcp
+from nav.dhcpstats.common import GraphiteMetric
 from nav.dhcpstats.errors import CommunicationError
 from nav.errors import ConfigurationError
 from nav.logs import init_generic_logging
@@ -85,7 +86,7 @@ def collect_stats(config):
 
     _logger.info("--> Starting stats collection <--")
 
-    all_stats = []
+    all_stats: list[GraphiteMetric] = []
 
     for client in get_clients(config):
         _logger.info(

--- a/python/nav/dhcpstats/common.py
+++ b/python/nav/dhcpstats/common.py
@@ -27,6 +27,11 @@ from nav.metrics.names import safe_name
 from nav.metrics.templates import metric_path_for_dhcp
 
 
+# Type expected by functions in NAV that send stats to a Graphite/Carbon backend. Values
+# of this type are interpreted as (path, (timestamp, value)).
+GraphiteMetric = tuple[str, tuple[float, int]]
+
+
 @dataclass(frozen=True, order=True)
 class DhcpPath:
     """

--- a/python/nav/dhcpstats/common.py
+++ b/python/nav/dhcpstats/common.py
@@ -1,0 +1,247 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.  You should have received a copy of the GNU General Public License
+# along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Common classes and functions used by DHCP API clients and various other parts of
+NAV that wants to make use of DHCP stats.
+"""
+
+from dataclasses import dataclass
+from typing import Iterable, Literal, Optional, Union
+
+import IPy
+
+from nav.metrics.names import safe_name
+from nav.metrics.templates import metric_path_for_dhcp
+
+
+@dataclass(frozen=True, order=True)
+class DhcpPath:
+    """
+    Represents a path to a DHCP stat in Graphite sans the stat's metric_name.
+    The absence of metric_name means that all of the following DHCP stat paths
+    in Graphite:
+
+      nav.dhcp.servers.kea-osl.range.custom_groups.staff.4.1_0_1_1.1_0_1_255.assigned
+      nav.dhcp.servers.kea-osl.range.custom_groups.staff.4.1_0_1_1.1_0_1_255.total
+      nav.dhcp.servers.kea-osl.range.custom_groups.staff.4.1_0_1_1.1_0_1_255.declined
+
+    are represented by:
+
+      DhcpPath(
+          ip_version=4,
+          server_name"kea-osl",
+          allocation_type="range",
+          group_name_source="custom_groups",
+          group_name="staff",
+          first_ip=IP("1.0.1.1"),
+          last_ip=IP("1.0.1.255"),
+      )
+
+    Instantiate me via :meth from_external_info: if path data is sourced from an
+     external source such as a DHCP server.
+    Instantiate me via :meth from_graphite_path: if path data is sourced from
+     NAV's Graphite database.
+    Use me to do the following translations, with validity checks:
+     external info (from DHCP server) --> DhcpPath <--> Graphite path
+    """
+
+    # Fields are ordered according to how we want instances to be sorted,
+    # *not* how fields occur in the respective paths in Graphite
+    server_name: str
+    group_name_source: Literal["special_groups", "custom_groups"]
+    group_name: str
+    allocation_type: Literal["range", "pool", "subnet"]
+    ip_version: int
+    first_ip: IPy.IP
+    last_ip: IPy.IP
+
+    @classmethod
+    def from_graphite_path(cls, graphite_path: str):
+        """
+        Instantiate me from a path to a DHCP stat (either sans metric_name or
+        not) from Graphite.
+
+        >>> d = {"server_name": "foo", "allocation_type": "pool",
+        ...   "group_name": None, "first_ip": "::1", "last_ip": "::2"}
+        >>> my_path = DhcpPath.from_external_info(**d)
+        >>> graphite_path = my_path.to_graphite_path("bar")
+        >>> graphite_path
+        'nav.dhcp.servers.foo.pool.special_groups.standalone.6.0_0_0_0_0_0_0_1.0_0_0_0_0_0_0_2.bar'
+        >>> DhcpPath.from_graphite_path(graphite_path) == my_path
+        True
+        """
+        parts = graphite_path.split(".")
+        if not len(parts) >= 10:
+            raise ValueError(
+                f"Expected graphite_path {graphite_path!r} to have at least 10 "
+                f"dot-separated segments"
+            )
+        server_name = parts[3]
+        allocation_type = parts[4]
+        group_name_source = parts[5]
+        group_name = parts[6]
+        ip_version = parts[7]
+        first_ip = parts[8]
+        last_ip = parts[9]
+
+        allowed_group_sources = ("special_groups", "custom_groups")
+        if group_name_source not in allowed_group_sources:
+            raise ValueError(
+                f"group_source_name {group_name_source!r} is not in "
+                f"{allowed_group_sources!r}"
+            )
+
+        allowed_allocation_types = ("range", "pool", "subnet")
+        if allocation_type not in allowed_allocation_types:
+            raise ValueError(
+                f"allocation_type {allocation_type!r} is not in "
+                f"{allowed_allocation_types!r}"
+            )
+
+        first_ip = cls._unescape_graphite_address(first_ip)
+        last_ip = cls._unescape_graphite_address(last_ip)
+        cls._check_ip_pair(first_ip, last_ip)
+
+        if (
+            str(first_ip.version()) != ip_version
+            or str(last_ip.version()) != ip_version
+        ):
+            raise ValueError(
+                f"first_ip {first_ip!r} or last_ip {last_ip!r} not of same version as "
+                f"expected ip_version {ip_version!r}"
+            )
+
+        return cls(
+            ip_version=first_ip.version(),
+            server_name=server_name,
+            allocation_type=allocation_type,
+            group_name_source=group_name_source,
+            group_name=group_name,
+            first_ip=first_ip,
+            last_ip=last_ip,
+        )
+
+    @classmethod
+    def from_external_info(
+        cls,
+        server_name: str,
+        allocation_type: Literal["range", "pool", "subnet"],
+        group_name: Optional[str],
+        first_ip: Union[str, IPy.IP],
+        last_ip: Union[str, IPy.IP],
+    ):
+        """
+        Instantiate me with path data sourced from an external source such as a
+        DHCP server.
+
+        if group_name is missing, group_name_source is set to "special_groups"
+         and group_name is set to "standalone" such that the returned instance
+         will be treated as belonging to a group of size one.
+        otherwise, group_name_source is set to "custom_groups".
+
+        if first_ip cannot be parsed to an IP address, raises a ValueError
+        if last_ip cannot be parsed to an IP address, raises a ValueError
+        if first_ip and last_ip does not have the same IP version, raises a ValueError
+        if first_ip > last_ip, raises a ValueError
+        otherwise, returns a DhcpPath instance.
+        """
+        if group_name is None:
+            group_name_source = "special_groups"
+            group_name = "standalone"
+        else:
+            group_name_source = "custom_groups"
+
+        first_ip = IPy.IP(first_ip)
+        last_ip = IPy.IP(last_ip)
+        cls._check_ip_pair(first_ip, last_ip)
+
+        return cls(
+            ip_version=first_ip.version(),
+            server_name=server_name,
+            allocation_type=allocation_type,
+            group_name_source=group_name_source,
+            group_name=group_name,
+            first_ip=first_ip,
+            last_ip=last_ip,
+        )
+
+    def to_graphite_path(self, metric_name, wildcard_for_group=False):
+        """
+        Return me as a path recognized by Graphite.
+        """
+        if wildcard_for_group and not self.is_standalone():
+            first_ip = safe_name("*")
+            last_ip = safe_name("*")
+        else:
+            first_ip = self.first_ip.strNormal()
+            last_ip = self.last_ip.strNormal()
+
+        return metric_path_for_dhcp(
+            ip_version=self.ip_version,
+            server_name=self.server_name,
+            allocation_type=self.allocation_type,
+            group_name_source=self.group_name_source,
+            group_name=self.group_name,
+            first_ip=first_ip,
+            last_ip=last_ip,
+            metric_name=metric_name,
+        )
+
+    def intersects(self, prefixes: Iterable[IPy.IP]):
+        """
+        Check if the range of IP addresses between self.first_ip and self.last_ip
+        intersect with any of the given prefixes.
+        """
+        return any(
+            self.first_ip in prefix
+            or self.last_ip in prefix
+            or self.first_ip < prefix < self.last_ip
+            for prefix in prefixes
+        )
+
+    @staticmethod
+    def _unescape_graphite_address(escaped_address: str) -> IPy.IP:
+        parts = escaped_address.split("_")
+        if len(parts) == 4:
+            return IPy.IP(".".join(parts))
+        elif len(parts) == 8:
+            return IPy.IP(":".join(parts))
+        else:
+            raise ValueError(
+                f"{escaped_address!r} does not look like an escaped IP address"
+            )
+
+    @staticmethod
+    def _check_ip_pair(first_ip: IPy.IP, last_ip: IPy.IP):
+        if len(first_ip) != 1:
+            raise ValueError(f"first_ip {first_ip!r} must be an IP address")
+
+        if len(last_ip) != 1:
+            raise ValueError(f"last_ip {last_ip!r} must be an IP address")
+
+        if first_ip.version() != last_ip.version():
+            raise ValueError(
+                f"first_ip {first_ip!r} is not of same version as last_ip {last_ip!r}"
+            )
+
+        if first_ip > last_ip:
+            raise ValueError(f"first_ip {first_ip!r} greater than last_ip {last_ip!r}")
+
+    def is_standalone(self):
+        return (
+            self.group_name_source == "special_groups"
+            and self.group_name == "standalone"
+        )

--- a/python/nav/dhcpstats/kea_dhcp.py
+++ b/python/nav/dhcpstats/kea_dhcp.py
@@ -352,7 +352,7 @@ class Client:
         session.mount("https://", HTTPAdapter(max_retries=retries))
         session.mount("http://", HTTPAdapter(max_retries=retries))
 
-        https = self._url.startswith("https://")
+        https = self._url.lower().startswith("https://")
 
         if https:
             _logger.debug("Using HTTPS")

--- a/python/nav/dhcpstats/kea_dhcp.py
+++ b/python/nav/dhcpstats/kea_dhcp.py
@@ -509,11 +509,11 @@ class Client:
         element is the last IP of a string used in the Kea DHCP configuration
         file for representing a range of IP addresses. Example:
 
-        > self._bounds_of_pool_range("10.0.0.0 - 10.0.0.10")
-        > IP(10.0.0.0), IP(10.0.0.10)
-
-        > self._bounds_of_pool_range("10.0.0.0/24")
-        > IP(10.0.0.0), IP(10.0.0.255)
+        >>> client = Client("foo", "https://example.org")
+        >>> client._bounds_of_pool_range("10.0.0.0 - 10.0.0.10")
+        (IP('10.0.0.0'), IP('10.0.0.10'))
+        >>> client._bounds_of_pool_range("10.0.0.0/24")
+        (IP('10.0.0.0'), IP('10.0.0.255'))
         """
         if "-" in pool_range:
             # x.x.x.x - x.x.x.x

--- a/python/nav/dhcpstats/kea_dhcp.py
+++ b/python/nav/dhcpstats/kea_dhcp.py
@@ -30,7 +30,7 @@ from IPy import IP
 from requests import RequestException, JSONDecodeError, Session
 from requests.adapters import HTTPAdapter, Retry
 
-from nav.dhcpstats.common import DhcpPath
+from nav.dhcpstats.common import DhcpPath, GraphiteMetric
 from nav.dhcpstats.errors import (
     CommunicationError,
     KeaEmpty,
@@ -70,9 +70,6 @@ class Pool:
             f"Kea pool {self.pool_id} from {self.first_ip} to {self.last_ip} "
             f"in Kea subnet {self.subnet_id}{group_subsentence}"
         )
-
-
-GraphiteMetric = tuple[str, tuple[float, int]]
 
 
 class Client:

--- a/python/nav/dhcpstats/kea_dhcp.py
+++ b/python/nav/dhcpstats/kea_dhcp.py
@@ -236,7 +236,7 @@ class Client:
                 .get("arguments", {})
                 .get("hash", None)
             )
-        except KeaUnsupported as err:
+        except CommunicationError as err:
             _logger.debug(str(err))
             return None
 

--- a/python/nav/dhcpstats/kea_dhcp.py
+++ b/python/nav/dhcpstats/kea_dhcp.py
@@ -93,20 +93,25 @@ class Client:
         server_name: str,
         url: str,
         dhcp_version: int = 4,
-        http_basic_username: str = "",
-        http_basic_password: str = "",
-        client_cert_path: str = "",
-        client_cert_key_path: str = "",
+        http_basic_username: Optional[str] = None,
+        http_basic_password: Optional[str] = None,
+        client_cert_path: Optional[str] = None,
+        client_cert_key_path: Optional[str] = None,
         user_context_groupname_key: str = "group",
         timeout: float = 5.0,
     ):
+        if not (
+            url.lower().startswith("https://") or url.lower().startswith("http://")
+        ):
+            raise ConfigurationError("url must have an HTTPS or HTTP scheme")
+
         self._server_name: str = server_name
         self._url: str = url
         self._dhcp_version: int = dhcp_version
-        self._http_basic_username: str = http_basic_username
-        self._http_basic_password: str = http_basic_password
-        self._client_cert_path: str = client_cert_path
-        self._client_key_path: str = client_cert_key_path
+        self._http_basic_username: Optional[str] = http_basic_username
+        self._http_basic_password: Optional[str] = http_basic_password
+        self._client_cert_path: Optional[str] = client_cert_path
+        self._client_key_path: Optional[str] = client_cert_key_path
         self._user_context_groupname_key: str = user_context_groupname_key
         self._timeout: float = timeout
 
@@ -361,7 +366,10 @@ class Client:
                 "Using HTTP to request potentially sensitive data such as API passwords"
             )
 
-        if self._http_basic_username and self._http_basic_password:
+        if (
+            self._http_basic_username is not None
+            and self._http_basic_password is not None
+        ):
             _logger.debug("Using HTTP Basic Authentication")
             if not https:
                 _logger.warning("Using HTTP Basic Authentication without HTTPS")
@@ -369,7 +377,7 @@ class Client:
         else:
             _logger.debug("Not using HTTP Basic Authentication")
 
-        if self._client_cert_path:
+        if self._client_cert_path is not None:
             _logger.debug("Using client certificate authentication")
             if not https:
                 raise ConfigurationError(
@@ -377,7 +385,7 @@ class Client:
                     "urls with HTTPS scheme"
                 )
             _logger.debug("Certificate path: '%s'", self._client_cert_path)
-            if self._client_key_path:
+            if self._client_key_path is not None:
                 _logger.debug("Certificate key path: '%s'", self._client_key_path)
                 session.cert = (self._client_cert_path, self._client_key_path)
             else:

--- a/python/nav/metrics/names.py
+++ b/python/nav/metrics/names.py
@@ -28,12 +28,25 @@ import string
 LEGAL_METRIC_CHARACTERS = string.ascii_letters + string.digits + "-_"
 
 
+class safe_name(str):
+    """
+    Marks a string as not needing to be escaped by :func escape_metric_name:
+    """
+
+    def __str__(self):
+        # This assures that safe_name strings aren't weakened to normal
+        # strings on calls to str()
+        return self
+
+
 def escape_metric_name(name):
     """
     Escapes any character of `name` that may not be used in graphite metric
     names.
     """
     if name is None:
+        return name
+    if isinstance(name, safe_name):
         return name
     name = name.replace('\x00', '')  # some devices have crazy responses!
     name = ''.join([c if c in LEGAL_METRIC_CHARACTERS else "_" for c in name])

--- a/python/nav/metrics/templates.py
+++ b/python/nav/metrics/templates.py
@@ -20,7 +20,6 @@ Graphite.
 """
 
 from nav.metrics.names import escape_metric_name
-import IPy
 
 
 def metric_prefix_for_ipdevpoll_job(sysname, job_name):
@@ -186,20 +185,27 @@ def metric_path_for_multicast_usage(group, sysname):
     )
 
 
-def metric_path_for_dhcp_pool(
-    ip_version, server_name, pool_name, range_start, range_end, metric_name
+def metric_path_for_dhcp(
+    ip_version,
+    server_name,
+    allocation_type,
+    group_name_source,
+    group_name,
+    first_ip,
+    last_ip,
+    metric_name,
 ):
     tmpl = (
-        "nav.dhcp.{ip_version}.pool.{server_name}.{pool_name}."
-        "{range_start}.{range_end}.{metric_name}"
+        "nav.dhcp.servers.{server_name}.{allocation_type}.{group_name_source}"
+        ".{group_name}.{ip_version}.{first_ip}.{last_ip}.{metric_name}"
     )
-    range_start = IPy.IP(range_start).strNormal()
-    range_end = IPy.IP(range_end).strNormal()
     return tmpl.format(
         ip_version=escape_metric_name(str(ip_version)),
         server_name=escape_metric_name(server_name),
-        pool_name=escape_metric_name(pool_name),
-        range_start=escape_metric_name(range_start),
-        range_end=escape_metric_name(range_end),
+        allocation_type=escape_metric_name(allocation_type),
+        group_name_source=escape_metric_name(group_name_source),
+        group_name=escape_metric_name(group_name),
+        first_ip=escape_metric_name(str(first_ip)),
+        last_ip=escape_metric_name(str(last_ip)),
         metric_name=escape_metric_name(metric_name),
     )

--- a/tests/unittests/dhcpstats/common_test.py
+++ b/tests/unittests/dhcpstats/common_test.py
@@ -1,0 +1,271 @@
+from dataclasses import dataclass
+
+import IPy
+import pytest
+
+from nav.dhcpstats.common import DhcpPath
+from nav.metrics.templates import metric_path_for_dhcp
+
+
+@dataclass
+class Path:
+    native: DhcpPath
+    graphite: str
+
+
+@pytest.fixture(
+    params=[
+        Path(
+            DhcpPath(
+                ip_version=4,
+                server_name="server1",
+                allocation_type="range",
+                group_name="group1",
+                group_name_source="custom_groups",
+                first_ip=IPy.IP("192.0.0.1"),
+                last_ip=IPy.IP("192.0.0.255"),
+            ),
+            "nav.dhcp.servers.server1.range.custom_groups.group1.4.192_0_0_1.192_0_0_255",
+        ),
+        Path(
+            DhcpPath(
+                ip_version=6,
+                server_name="server1",
+                allocation_type="range",
+                group_name="group1",
+                group_name_source="custom_groups",
+                first_ip=IPy.IP("::1"),
+                last_ip=IPy.IP("::ffff"),
+            ),
+            "nav.dhcp.servers.server1.range.custom_groups.group1.6.0_0_0_0_0_0_0_1.0_0_0_0_0_0_0_ffff",
+        ),
+        Path(
+            DhcpPath(
+                ip_version=6,
+                server_name="server1",
+                allocation_type="range",
+                group_name="standalone",
+                group_name_source="special_groups",
+                first_ip=IPy.IP("::1"),
+                last_ip=IPy.IP("::ffff"),
+            ),
+            "nav.dhcp.servers.server1.range.special_groups.standalone.6.0_0_0_0_0_0_0_1.0_0_0_0_0_0_0_ffff",
+        ),
+    ]
+)
+def path(request):
+    return request.param
+
+
+class TestDhcpPath:
+    def test_to_graphite_path_should_return_expected_value(self, path):
+        assert path.native.to_graphite_path(metric_name="foo") == path.graphite + ".foo"
+
+    def test_to_graphite_path_should_be_reversed_by_from_graphite_path(self, path):
+        assert (
+            DhcpPath.from_graphite_path(path.native.to_graphite_path(metric_name="foo"))
+            == path.native
+        )
+
+    def test_from_graphite_path_should_be_reversed_by_to_graphite_path(self, path):
+        assert (
+            DhcpPath.from_graphite_path(path.graphite).to_graphite_path(
+                metric_name="foo"
+            )
+            == path.graphite + ".foo"
+        )
+
+    @pytest.mark.parametrize(
+        "graphite_path",
+        [
+            "nav.dhcp.servers.server1.range.custom_groups.group1.6.0_0_0_1.0_0_0_255",
+            "nav.dhcp.servers.server1.range.custom_groups.group1.4.0_0_0_0_0_0_0_1.0_0_0_0_0_0_0_ffff",
+            "nav.dhcp.servers.server1.range.custom_groups.group1.6.0_0_0_1.0_0_0_0_0_0_0_ffff",
+            "nav.dhcp.servers.server1.range.custom_groups.group1.6.0_0_0_0_0_0_0_1.0_0_0_255",
+        ],
+    )
+    def test_from_graphite_path_should_fail_on_ip_version_mismatch(self, graphite_path):
+        with pytest.raises(ValueError):
+            DhcpPath.from_graphite_path(graphite_path)
+
+    @pytest.mark.parametrize(
+        "graphite_path,reason",
+        [
+            (
+                "nav.dhcp.servers.server1.range.custom_groups.group1.6.0_0_0_0_0_0_0_1",
+                "missing <last_ip> segment",
+            ),
+            (
+                "nav.dhcp.servers.server1.range.invalid.group1.6.0_0_0_0_0_0_0_1.0_0_0_0_0_0_0_ffff",
+                "invalid <group_name_source> segment",
+            ),
+            (
+                "nav.dhcp.servers.server1.invalid.custom_groups.group1.6.0_0_0_0_0_0_0_1.0_0_0_0_0_0_0_ffff",
+                "invalid <allocation_type> segment",
+            ),
+            (
+                "nav.dhcp.servers.server1.range.custom_groups.group1.invalid.0_0_0_0_0_0_0_1.0_0_0_0_0_0_0_ffff",
+                "invalid <ip_version> segment",
+            ),
+        ],
+    )
+    def test_from_graphite_path_should_fail_on_invalid_names(
+        self, graphite_path, reason
+    ):
+        with pytest.raises(ValueError):
+            DhcpPath.from_graphite_path(graphite_path)
+            pytest.fail(f"Didn't fail when {reason!r}")
+
+    def test_from_graphite_path_should_work_with_metric_path_for_dhcp(self):
+        path_kwargs = {
+            "ip_version": 4,
+            "server_name": "server1",
+            "allocation_type": "range",
+            "group_name_source": "custom_groups",
+            "group_name": "group1",
+            "first_ip": IPy.IP("192.0.0.1"),
+            "last_ip": IPy.IP("192.0.0.255"),
+        }
+        assert DhcpPath.from_graphite_path(
+            metric_path_for_dhcp(metric_name="foo", **path_kwargs)
+        ) == DhcpPath(**path_kwargs)
+        assert DhcpPath.from_graphite_path(
+            metric_path_for_dhcp(metric_name="foo", **path_kwargs)
+        ).to_graphite_path(metric_name="foo") == metric_path_for_dhcp(
+            metric_name="foo", **path_kwargs
+        )
+
+    @pytest.mark.parametrize(
+        "server_name,allocation_type,group_name,first_ip,last_ip,expected",
+        [
+            (
+                "server1",
+                "range",
+                "group1",
+                "192.0.0.1",
+                "192.0.0.255",
+                DhcpPath(
+                    ip_version=4,
+                    server_name="server1",
+                    allocation_type="range",
+                    group_name="group1",
+                    group_name_source="custom_groups",
+                    first_ip=IPy.IP("192.0.0.1"),
+                    last_ip=IPy.IP("192.0.0.255"),
+                ),
+            ),
+            (
+                "server1",
+                "subnet",
+                None,
+                "0.0.0.0",
+                "255.255.255.255",
+                DhcpPath(
+                    ip_version=4,
+                    server_name="server1",
+                    allocation_type="subnet",
+                    group_name="standalone",
+                    group_name_source="special_groups",
+                    first_ip=IPy.IP("0.0.0.0"),
+                    last_ip=IPy.IP("255.255.255.255"),
+                ),
+            ),
+            (
+                "server2",
+                "pool",
+                "group2",
+                "::1",
+                "::ffff",
+                DhcpPath(
+                    ip_version=6,
+                    server_name="server2",
+                    allocation_type="pool",
+                    group_name="group2",
+                    group_name_source="custom_groups",
+                    first_ip=IPy.IP("::1"),
+                    last_ip=IPy.IP("::ffff"),
+                ),
+            ),
+        ],
+    )
+    def test_from_external_info_should_work_when_given_valid_arguments(
+        self, server_name, allocation_type, group_name, first_ip, last_ip, expected
+    ):
+        assert (
+            DhcpPath.from_external_info(
+                server_name, allocation_type, group_name, first_ip, last_ip
+            )
+            == expected
+        )
+
+    @pytest.mark.parametrize(
+        "server_name,allocation_type,group_name,first_ip,last_ip,reason",
+        [
+            (
+                "server1",
+                "range",
+                "group1",
+                "::1",
+                "0.0.0.255",
+                "first_ip being IPv6 and last_ip being IPv4",
+            ),
+            (
+                "server1",
+                "range",
+                "group1",
+                "0.0.0.1",
+                "::ffff",
+                "first_ip being IPv4 and last_ip being IPv6",
+            ),
+            (
+                "server1",
+                "range",
+                "192.0.0.1",
+                "192.0.0.255",
+                "group1",
+                "last_ip being an invalid IP address",
+            ),
+            (
+                "server1",
+                "range",
+                "group1",
+                "192.0.0.255",
+                "192.0.0.1",
+                "first_ip being a greater IP address than last_ip",
+            ),
+            (
+                "server2",
+                "pool",
+                "group2",
+                "::1:",
+                "::ffff",
+                "first_ip being an invalid IP address",
+            ),
+            (
+                "server2",
+                "pool",
+                "group2",
+                "::1",
+                "::fffff",
+                "last_ip being an invalid IP address",
+            ),
+            (
+                "server2",
+                "pool",
+                "group2",
+                "::1",
+                "::ffff:",
+                "last_ip being an invalid IP address",
+            ),
+        ],
+    )
+    def test_from_external_info_should_fail_when_given_invalid_arguments(
+        self, server_name, allocation_type, group_name, first_ip, last_ip, reason
+    ):
+        # We skip checking for errors that should be caught by a static type
+        # checker such as invalid argument types
+        with pytest.raises(ValueError):
+            DhcpPath.from_external_info(
+                server_name, allocation_type, group_name, first_ip, last_ip
+            )
+            pytest.fail(f"Didn't fail when {reason!r}")

--- a/tests/unittests/dhcpstats/kea_dhcp_test.py
+++ b/tests/unittests/dhcpstats/kea_dhcp_test.py
@@ -16,7 +16,7 @@ from nav.dhcpstats.kea_dhcp import _KeaStatus
 from nav.errors import ConfigurationError
 
 
-ENDPOINT_NAME = "dhcp-server-foo"
+SERVER_NICKNAME = "dhcp-server-foo"
 
 
 class TestExpectedAPIResponses:
@@ -33,7 +33,7 @@ class TestExpectedAPIResponses:
 
         config, statistics, expected_stats = valid_dhcp4
         api_mock.autofill("dhcp4", config=config, statistics=statistics)
-        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client = Client(SERVER_NICKNAME, "http://example.org/")
 
         actual_stats = client.fetch_stats()
 
@@ -61,7 +61,7 @@ class TestExpectedAPIResponses:
 
         config, statistics, expected_stats = valid_dhcp4
         api_mock.autofill("dhcp4", config=config, statistics=statistics)
-        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client = Client(SERVER_NICKNAME, "http://example.org/")
 
         actual_stats = client.fetch_stats()
         assert len(actual_stats) > 0
@@ -85,7 +85,7 @@ class TestExpectedAPIResponses:
             "config-get",
             lambda kea_arguments, kea_service: make_api_response({"Dhcp4": {}}),
         )
-        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client = Client(SERVER_NICKNAME, "http://example.org/")
         assert list(client.fetch_stats()) == []
 
     def test_fetch_stats_should_handle_empty_statistic_in_statistics_api_response(
@@ -100,7 +100,7 @@ class TestExpectedAPIResponses:
         config, statistics, expected_stats = valid_dhcp4
         statistics = {key: [] for key, value in statistics.items()}
         api_mock.autofill("dhcp4", config=config, statistics=statistics)
-        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client = Client(SERVER_NICKNAME, "http://example.org/")
         assert list(client.fetch_stats()) == []
 
     def test_fetch_stats_should_handle_empty_statistics_api_response(
@@ -119,7 +119,7 @@ class TestExpectedAPIResponses:
             "statistic-get-all",
             lambda kea_arguments, kea_service: make_api_response({}),
         )
-        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client = Client(SERVER_NICKNAME, "http://example.org/")
         assert list(client.fetch_stats()) == []
 
     @pytest.mark.parametrize("http_status", chain(range(400, 430), range(500, 530)))
@@ -139,7 +139,7 @@ class TestExpectedAPIResponses:
             attrs={"status_code": http_status},
         )
 
-        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client = Client(SERVER_NICKNAME, "http://example.org/")
 
         with pytest.raises(CommunicationError):
             client.fetch_stats()
@@ -162,7 +162,7 @@ class TestExpectedAPIResponses:
                 config, status=kea_status
             ),
         )
-        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client = Client(SERVER_NICKNAME, "http://example.org/")
         with pytest.raises(CommunicationError):
             client.fetch_stats()
 
@@ -189,7 +189,7 @@ class TestExpectedAPIResponses:
                 statistics, status=status
             ),
         )
-        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client = Client(SERVER_NICKNAME, "http://example.org/")
         with pytest.raises(CommunicationError):
             client.fetch_stats()
 
@@ -211,7 +211,7 @@ class TestExpectedAPIResponses:
         """
         foohash = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
         config, statistics, expected_stats = valid_dhcp4
-        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client = Client(SERVER_NICKNAME, "http://example.org/")
         config["Dhcp4"]["hash"] = foohash
         api_mock.autofill("dhcp4", config=config, statistics=statistics)
         api_mock.add(
@@ -236,7 +236,7 @@ class TestExpectedAPIResponses:
         a bad mapping from configuration to statistics.
         """
         config, statistics, expected_stats = valid_dhcp4
-        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client = Client(SERVER_NICKNAME, "http://example.org/")
         api_mock.autofill("dhcp4", config=None, statistics=statistics)
         api_mock.add("config-get", make_api_response(config))
         updated_config = deepcopy(config)
@@ -265,7 +265,7 @@ class TestUnexpectedAPIResponses:
         self, valid_dhcp4, api_mock, invalid_response
     ):
         config, statistics, expected_stats = valid_dhcp4
-        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client = Client(SERVER_NICKNAME, "http://example.org/")
 
         api_mock.autofill("dhcp4", config=None, statistics=statistics)
         api_mock.add("config-get", invalid_response)
@@ -276,7 +276,7 @@ class TestUnexpectedAPIResponses:
         self, valid_dhcp4, api_mock, invalid_response
     ):
         config, statistics, expected_stats = valid_dhcp4
-        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client = Client(SERVER_NICKNAME, "http://example.org/")
 
         api_mock.autofill("dhcp4", config=config, statistics=None)
         api_mock.add("statistic-get-all", invalid_response)
@@ -287,7 +287,7 @@ class TestUnexpectedAPIResponses:
         self, valid_dhcp4, api_mock, invalid_response
     ):
         config, statistics, expected_stats = valid_dhcp4
-        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client = Client(SERVER_NICKNAME, "http://example.org/")
         config["Dhcp4"]["hash"] = "foo"
         api_mock.autofill("dhcp4", config=config, statistics=statistics)
         api_mock.add("config-hash-get", invalid_response)
@@ -315,7 +315,7 @@ class TestConfigCaching:
             lambda kea_arguments, kea_service: make_api_response({"hash": "1"}),
         )
 
-        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client = Client(SERVER_NICKNAME, "http://example.org/")
         client._fetch_kea_config()
         client._fetch_kea_config()
 
@@ -335,7 +335,7 @@ class TestConfigCaching:
             lambda kea_arguments, kea_service: make_api_response({"hash": "2"}),
         )
 
-        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client = Client(SERVER_NICKNAME, "http://example.org/")
         client._fetch_kea_config()
         client._fetch_kea_config()
 
@@ -353,7 +353,7 @@ class TestConfigCaching:
             lambda kea_arguments, kea_service: make_api_response({"hash": "1"}),
         )
 
-        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client = Client(SERVER_NICKNAME, "http://example.org/")
         client._fetch_kea_config()
         client._fetch_kea_config()
 
@@ -369,7 +369,7 @@ class TestConfigCaching:
             ),
         )
 
-        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client = Client(SERVER_NICKNAME, "http://example.org/")
         client._fetch_kea_config()
         client._fetch_kea_config()
 
@@ -387,7 +387,7 @@ class TestHTTPSession:
         from the Kea API may contain sensitive data such as passwords in plaintext.
         """
         config, statistics, expected_stats = valid_dhcp4
-        client = Client(ENDPOINT_NAME, "http://example.org/")
+        client = Client(SERVER_NICKNAME, "http://example.org/")
         api_mock.autofill("dhcp4", config=config, statistics=statistics)
 
         with caplog.at_level(logging.WARNING):
@@ -408,7 +408,7 @@ class TestHTTPSession:
         """
         config, statistics, expected_stats = valid_dhcp4
         client = Client(
-            ENDPOINT_NAME,
+            SERVER_NICKNAME,
             "http://example.org/",
             http_basic_username="nav",
             http_basic_password="nav",
@@ -431,7 +431,7 @@ class TestHTTPSession:
         """
         config, statistics, expected_stats = valid_dhcp4
         client = Client(
-            ENDPOINT_NAME, "http://example.org/", client_cert_path="/bar/baz.pem"
+            SERVER_NICKNAME, "http://example.org/", client_cert_path="/bar/baz.pem"
         )
         api_mock.autofill("dhcp4", config=config, statistics=statistics)
 
@@ -449,7 +449,7 @@ class TestHTTPSession:
         """
         config, statistics, expected_stats = valid_dhcp4
         client = Client(
-            ENDPOINT_NAME,
+            SERVER_NICKNAME,
             "http://example.org/",
             http_basic_username="bar",
             http_basic_password="baz",
@@ -480,7 +480,7 @@ class TestHTTPSession:
         """
         config, statistics, expected_stats = valid_dhcp4
         client = Client(
-            ENDPOINT_NAME,
+            SERVER_NICKNAME,
             "https://example.org/",
             client_cert_path="/bar/baz.pem",
         )
@@ -716,108 +716,108 @@ def valid_dhcp4():
     # the api response.
     expected_stats = [
         (
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-staff.4.42_0_1_1.42_0_1_10.assigned",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-staff.4.42_0_1_1.42_0_1_10.assigned",
             ("2025-05-30 05:49:49.467993", 2),
         ),
         (
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-staff.4.42_0_1_1.42_0_1_10.declined",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-staff.4.42_0_1_1.42_0_1_10.declined",
             ("2025-05-30 05:49:49.467993", 1),
         ),
         (
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-staff.4.42_0_1_1.42_0_1_10.total",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-staff.4.42_0_1_1.42_0_1_10.total",
             ("2025-05-30 05:49:49.467993", 10),
         ),
         (
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-student.4.42_0_2_1.42_0_2_10.assigned",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-student.4.42_0_2_1.42_0_2_10.assigned",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-student.4.42_0_2_1.42_0_2_10.declined",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-student.4.42_0_2_1.42_0_2_10.declined",
             ("2025-05-30 05:49:49.467993", 1),
         ),
         (
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-student.4.42_0_2_1.42_0_2_10.total",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-student.4.42_0_2_1.42_0_2_10.total",
             ("2025-05-30 05:49:49.467993", 10),
         ),
         (
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-student.4.42_0_2_128.42_0_2_255.assigned",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-student.4.42_0_2_128.42_0_2_255.assigned",
             ("2025-05-30 05:49:49.467993", 1),
         ),
         (
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-student.4.42_0_2_128.42_0_2_255.declined",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-student.4.42_0_2_128.42_0_2_255.declined",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-student.4.42_0_2_128.42_0_2_255.total",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-student.4.42_0_2_128.42_0_2_255.total",
             ("2025-05-30 05:49:49.467993", 128),
         ),
         (
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-student.4.42_0_2_32.42_0_2_47.assigned",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-student.4.42_0_2_32.42_0_2_47.assigned",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-student.4.42_0_2_32.42_0_2_47.declined",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-student.4.42_0_2_32.42_0_2_47.declined",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-student.4.42_0_2_32.42_0_2_47.total",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-student.4.42_0_2_32.42_0_2_47.total",
             ("2025-05-30 05:49:49.467993", 16),
         ),
         (
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.oslo-student.4.42_0_3_1.42_0_3_10.assigned",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.oslo-student.4.42_0_3_1.42_0_3_10.assigned",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.oslo-student.4.42_0_3_1.42_0_3_10.declined",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.oslo-student.4.42_0_3_1.42_0_3_10.declined",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.oslo-student.4.42_0_3_1.42_0_3_10.total",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.oslo-student.4.42_0_3_1.42_0_3_10.total",
             ("2025-05-30 05:49:49.467993", 10),
         ),
         (
             # From Kea pool with 'group': 'oslo-staff' in 'user-context'
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.oslo-staff.4.42_0_4_1.42_0_4_5.assigned",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.oslo-staff.4.42_0_4_1.42_0_4_5.assigned",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
             # From Kea pool with 'group': 'oslo-staff' in 'user-context'
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.oslo-staff.4.42_0_4_1.42_0_4_5.declined",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.oslo-staff.4.42_0_4_1.42_0_4_5.declined",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
             # From Kea pool with 'group': 'oslo-staff' in 'user-context'
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.oslo-staff.4.42_0_4_1.42_0_4_5.total",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.oslo-staff.4.42_0_4_1.42_0_4_5.total",
             ("2025-05-30 05:49:49.467993", 5),
         ),
         (
             # From Kea pool without 'user-context'
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.special_groups.standalone.4.42_0_5_1.42_0_5_5.assigned",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.special_groups.standalone.4.42_0_5_1.42_0_5_5.assigned",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
             # From Kea pool without 'user-context'
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.special_groups.standalone.4.42_0_5_1.42_0_5_5.declined",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.special_groups.standalone.4.42_0_5_1.42_0_5_5.declined",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
             # From Kea pool without 'user-context'
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.special_groups.standalone.4.42_0_5_1.42_0_5_5.total",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.special_groups.standalone.4.42_0_5_1.42_0_5_5.total",
             ("2025-05-30 05:49:49.467993", 5),
         ),
         (
             # From Kea pool with 'user-context' but without 'group' in 'user-context'
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.special_groups.standalone.4.42_0_6_1.42_0_6_5.assigned",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.special_groups.standalone.4.42_0_6_1.42_0_6_5.assigned",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
             # From Kea pool with 'user-context' but without 'group' in 'user-context'
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.special_groups.standalone.4.42_0_6_1.42_0_6_5.declined",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.special_groups.standalone.4.42_0_6_1.42_0_6_5.declined",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
             # From Kea pool with 'user-context' but without 'group' in 'user-context'
-            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.special_groups.standalone.4.42_0_6_1.42_0_6_5.total",
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.special_groups.standalone.4.42_0_6_1.42_0_6_5.total",
             ("2025-05-30 05:49:49.467993", 5),
         ),
     ]

--- a/tests/unittests/dhcpstats/kea_dhcp_test.py
+++ b/tests/unittests/dhcpstats/kea_dhcp_test.py
@@ -530,7 +530,7 @@ def valid_dhcp4():
                                     "pool": "42.0.3.1-42.0.3.10",
                                     "pool-id": 1,
                                     "user-context": {
-                                        "name": "oslo-student",
+                                        "group": "oslo-student",
                                     },
                                 },
                             ],
@@ -544,9 +544,9 @@ def valid_dhcp4():
                                     "option-data": [],
                                     "pool": "42.0.4.1-42.0.4.5",
                                     "pool-id": 1,
-                                    # Pool with 'user-context'
+                                    # This is a Kea pool with 'group' in 'user-context'
                                     "user-context": {
-                                        "name": "oslo-staff",
+                                        "group": "oslo-staff",
                                     },
                                 },
                             ],
@@ -566,7 +566,7 @@ def valid_dhcp4():
                                     "option-data": [],
                                     "pool": "42.0.5.1-42.0.5.5",
                                     "pool-id": 1,
-                                    # Pool without 'user-context'
+                                    # This is a Kea pool without 'user-context'
                                 },
                             ],
                             "subnet": "42.0.5.0/24",
@@ -585,7 +585,7 @@ def valid_dhcp4():
                             "pool": "42.0.1.1-42.0.1.10",
                             "pool-id": 1,
                             "user-context": {
-                                "name": "bergen-staff",
+                                "group": "bergen-staff",
                             },
                         },
                     ],
@@ -601,7 +601,7 @@ def valid_dhcp4():
                             "pool": "42.0.2.1-42.0.2.10",
                             "pool-id": 1,
                             "user-context": {
-                                "name": "bergen-student",
+                                "group": "bergen-student",
                             },
                         },
                         {
@@ -610,7 +610,7 @@ def valid_dhcp4():
                             "pool": "42.0.2.32/28",
                             "pool-id": 3,
                             "user-context": {
-                                "name": "bergen-student",
+                                "group": "bergen-student",
                             },
                         },
                         {
@@ -618,7 +618,7 @@ def valid_dhcp4():
                             "pool": "42.0.2.128/25",
                             "pool-id": 2,
                             "user-context": {
-                                "name": "bergen-student",
+                                "group": "bergen-student",
                             },
                         },
                     ],
@@ -690,87 +690,87 @@ def valid_dhcp4():
     # the api response.
     expected_stats = [
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-staff.42_0_1_1.42_0_1_10.assigned",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-staff.4.42_0_1_1.42_0_1_10.assigned",
             ("2025-05-30 05:49:49.467993", 2),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-staff.42_0_1_1.42_0_1_10.declined",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-staff.4.42_0_1_1.42_0_1_10.declined",
             ("2025-05-30 05:49:49.467993", 1),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-staff.42_0_1_1.42_0_1_10.total",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-staff.4.42_0_1_1.42_0_1_10.total",
             ("2025-05-30 05:49:49.467993", 10),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-student.42_0_2_1.42_0_2_10.assigned",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-student.4.42_0_2_1.42_0_2_10.assigned",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-student.42_0_2_1.42_0_2_10.declined",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-student.4.42_0_2_1.42_0_2_10.declined",
             ("2025-05-30 05:49:49.467993", 1),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-student.42_0_2_1.42_0_2_10.total",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-student.4.42_0_2_1.42_0_2_10.total",
             ("2025-05-30 05:49:49.467993", 10),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-student.42_0_2_128.42_0_2_255.assigned",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-student.4.42_0_2_128.42_0_2_255.assigned",
             ("2025-05-30 05:49:49.467993", 1),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-student.42_0_2_128.42_0_2_255.declined",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-student.4.42_0_2_128.42_0_2_255.declined",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-student.42_0_2_128.42_0_2_255.total",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-student.4.42_0_2_128.42_0_2_255.total",
             ("2025-05-30 05:49:49.467993", 128),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-student.42_0_2_32.42_0_2_47.assigned",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-student.4.42_0_2_32.42_0_2_47.assigned",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-student.42_0_2_32.42_0_2_47.declined",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-student.4.42_0_2_32.42_0_2_47.declined",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.bergen-student.42_0_2_32.42_0_2_47.total",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.bergen-student.4.42_0_2_32.42_0_2_47.total",
             ("2025-05-30 05:49:49.467993", 16),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.oslo-student.42_0_3_1.42_0_3_10.assigned",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.oslo-student.4.42_0_3_1.42_0_3_10.assigned",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.oslo-student.42_0_3_1.42_0_3_10.declined",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.oslo-student.4.42_0_3_1.42_0_3_10.declined",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.oslo-student.42_0_3_1.42_0_3_10.total",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.oslo-student.4.42_0_3_1.42_0_3_10.total",
             ("2025-05-30 05:49:49.467993", 10),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.oslo-staff.42_0_4_1.42_0_4_5.assigned",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.oslo-staff.4.42_0_4_1.42_0_4_5.assigned",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.oslo-staff.42_0_4_1.42_0_4_5.declined",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.oslo-staff.4.42_0_4_1.42_0_4_5.declined",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.oslo-staff.42_0_4_1.42_0_4_5.total",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.oslo-staff.4.42_0_4_1.42_0_4_5.total",
             ("2025-05-30 05:49:49.467993", 5),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.pool-42_0_5_1-42_0_5_5.42_0_5_1.42_0_5_5.assigned",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.special_groups.standalone.4.42_0_5_1.42_0_5_5.assigned",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.pool-42_0_5_1-42_0_5_5.42_0_5_1.42_0_5_5.declined",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.special_groups.standalone.4.42_0_5_1.42_0_5_5.declined",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
-            f"nav.dhcp.4.pool.{ENDPOINT_NAME}.pool-42_0_5_1-42_0_5_5.42_0_5_1.42_0_5_5.total",
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.special_groups.standalone.4.42_0_5_1.42_0_5_5.total",
             ("2025-05-30 05:49:49.467993", 5),
         ),
     ]

--- a/tests/unittests/dhcpstats/kea_dhcp_test.py
+++ b/tests/unittests/dhcpstats/kea_dhcp_test.py
@@ -728,6 +728,10 @@ def valid_dhcp4():
             ("2025-05-30 05:49:49.467993", 10),
         ),
         (
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-staff.4.42_0_1_1.42_0_1_10.unassigned",
+            ("2025-05-30 05:49:49.467993", 8),
+        ),
+        (
             f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-student.4.42_0_2_1.42_0_2_10.assigned",
             ("2025-05-30 05:49:49.467993", 0),
         ),
@@ -737,6 +741,10 @@ def valid_dhcp4():
         ),
         (
             f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-student.4.42_0_2_1.42_0_2_10.total",
+            ("2025-05-30 05:49:49.467993", 10),
+        ),
+        (
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-student.4.42_0_2_1.42_0_2_10.unassigned",
             ("2025-05-30 05:49:49.467993", 10),
         ),
         (
@@ -752,6 +760,10 @@ def valid_dhcp4():
             ("2025-05-30 05:49:49.467993", 128),
         ),
         (
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-student.4.42_0_2_128.42_0_2_255.unassigned",
+            ("2025-05-30 05:49:49.467993", 127),
+        ),
+        (
             f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-student.4.42_0_2_32.42_0_2_47.assigned",
             ("2025-05-30 05:49:49.467993", 0),
         ),
@@ -764,6 +776,10 @@ def valid_dhcp4():
             ("2025-05-30 05:49:49.467993", 16),
         ),
         (
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.bergen-student.4.42_0_2_32.42_0_2_47.unassigned",
+            ("2025-05-30 05:49:49.467993", 16),
+        ),
+        (
             f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.oslo-student.4.42_0_3_1.42_0_3_10.assigned",
             ("2025-05-30 05:49:49.467993", 0),
         ),
@@ -773,6 +789,10 @@ def valid_dhcp4():
         ),
         (
             f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.oslo-student.4.42_0_3_1.42_0_3_10.total",
+            ("2025-05-30 05:49:49.467993", 10),
+        ),
+        (
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.oslo-student.4.42_0_3_1.42_0_3_10.unassigned",
             ("2025-05-30 05:49:49.467993", 10),
         ),
         (
@@ -791,6 +811,11 @@ def valid_dhcp4():
             ("2025-05-30 05:49:49.467993", 5),
         ),
         (
+            # From Kea pool with 'group': 'oslo-staff' in 'user-context'
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.custom_groups.oslo-staff.4.42_0_4_1.42_0_4_5.unassigned",
+            ("2025-05-30 05:49:49.467993", 5),
+        ),
+        (
             # From Kea pool without 'user-context'
             f"nav.dhcp.servers.{SERVER_NICKNAME}.range.special_groups.standalone.4.42_0_5_1.42_0_5_5.assigned",
             ("2025-05-30 05:49:49.467993", 0),
@@ -806,6 +831,11 @@ def valid_dhcp4():
             ("2025-05-30 05:49:49.467993", 5),
         ),
         (
+            # From Kea pool without 'user-context'
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.special_groups.standalone.4.42_0_5_1.42_0_5_5.unassigned",
+            ("2025-05-30 05:49:49.467993", 5),
+        ),
+        (
             # From Kea pool with 'user-context' but without 'group' in 'user-context'
             f"nav.dhcp.servers.{SERVER_NICKNAME}.range.special_groups.standalone.4.42_0_6_1.42_0_6_5.assigned",
             ("2025-05-30 05:49:49.467993", 0),
@@ -818,6 +848,11 @@ def valid_dhcp4():
         (
             # From Kea pool with 'user-context' but without 'group' in 'user-context'
             f"nav.dhcp.servers.{SERVER_NICKNAME}.range.special_groups.standalone.4.42_0_6_1.42_0_6_5.total",
+            ("2025-05-30 05:49:49.467993", 5),
+        ),
+        (
+            # From Kea pool with 'user-context' but without 'group' in 'user-context'
+            f"nav.dhcp.servers.{SERVER_NICKNAME}.range.special_groups.standalone.4.42_0_6_1.42_0_6_5.unassigned",
             ("2025-05-30 05:49:49.467993", 5),
         ),
     ]

--- a/tests/unittests/dhcpstats/kea_dhcp_test.py
+++ b/tests/unittests/dhcpstats/kea_dhcp_test.py
@@ -574,6 +574,29 @@ def valid_dhcp4():
                     ],
                     "valid-lifetime": 4000,
                 },
+                {
+                    "name": "shared-network-3",
+                    "subnet4": [
+                        {
+                            "id": 6,
+                            "option-data": [],
+                            "pools": [
+                                {
+                                    "option-data": [],
+                                    "pool": "42.0.6.1-42.0.6.5",
+                                    "pool-id": 1,
+                                    # This is a Kea pool with 'user-context' but
+                                    # without 'group' in 'user-context'
+                                    "user-context": {
+                                        "name": "bob",
+                                    },
+                                },
+                            ],
+                            "subnet": "42.0.6.0/24",
+                        },
+                    ],
+                    "valid-lifetime": 4000,
+                },
             ],
             "subnet4": [
                 {
@@ -675,6 +698,9 @@ def valid_dhcp4():
         "subnet[5].pool[1].assigned-addresses": [[0, "2025-05-30 05:49:49.468085"]],
         "subnet[5].pool[1].declined-addresses": [[0, "2025-05-30 05:49:49.468087"]],
         "subnet[5].pool[1].total-addresses": [[5, "2025-05-30 05:49:49.467976"]],
+        "subnet[6].pool[1].assigned-addresses": [[0, "2025-05-30 05:49:49.468085"]],
+        "subnet[6].pool[1].declined-addresses": [[0, "2025-05-30 05:49:49.468087"]],
+        "subnet[6].pool[1].total-addresses": [[5, "2025-05-30 05:49:49.467976"]],
         # Some irrelevant values that won't be used by the client:
         "subnet[1].cumulative-assigned-addresses": [[0, "2022-02-11 17:54:17.487528"]],
         "subnet[1].declined-addresses": [[0, "2022-02-11 17:54:17.487585"]],
@@ -750,27 +776,48 @@ def valid_dhcp4():
             ("2025-05-30 05:49:49.467993", 10),
         ),
         (
+            # From Kea pool with 'group': 'oslo-staff' in 'user-context'
             f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.oslo-staff.4.42_0_4_1.42_0_4_5.assigned",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
+            # From Kea pool with 'group': 'oslo-staff' in 'user-context'
             f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.oslo-staff.4.42_0_4_1.42_0_4_5.declined",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
+            # From Kea pool with 'group': 'oslo-staff' in 'user-context'
             f"nav.dhcp.servers.{ENDPOINT_NAME}.range.custom_groups.oslo-staff.4.42_0_4_1.42_0_4_5.total",
             ("2025-05-30 05:49:49.467993", 5),
         ),
         (
+            # From Kea pool without 'user-context'
             f"nav.dhcp.servers.{ENDPOINT_NAME}.range.special_groups.standalone.4.42_0_5_1.42_0_5_5.assigned",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
+            # From Kea pool without 'user-context'
             f"nav.dhcp.servers.{ENDPOINT_NAME}.range.special_groups.standalone.4.42_0_5_1.42_0_5_5.declined",
             ("2025-05-30 05:49:49.467993", 0),
         ),
         (
+            # From Kea pool without 'user-context'
             f"nav.dhcp.servers.{ENDPOINT_NAME}.range.special_groups.standalone.4.42_0_5_1.42_0_5_5.total",
+            ("2025-05-30 05:49:49.467993", 5),
+        ),
+        (
+            # From Kea pool with 'user-context' but without 'group' in 'user-context'
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.special_groups.standalone.4.42_0_6_1.42_0_6_5.assigned",
+            ("2025-05-30 05:49:49.467993", 0),
+        ),
+        (
+            # From Kea pool with 'user-context' but without 'group' in 'user-context'
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.special_groups.standalone.4.42_0_6_1.42_0_6_5.declined",
+            ("2025-05-30 05:49:49.467993", 0),
+        ),
+        (
+            # From Kea pool with 'user-context' but without 'group' in 'user-context'
+            f"nav.dhcp.servers.{ENDPOINT_NAME}.range.special_groups.standalone.4.42_0_6_1.42_0_6_5.total",
             ("2025-05-30 05:49:49.467993", 5),
         ),
     ]

--- a/tests/unittests/dhcpstats/kea_dhcp_test.py
+++ b/tests/unittests/dhcpstats/kea_dhcp_test.py
@@ -201,13 +201,11 @@ class TestExpectedAPIResponses:
             if status not in (_KeaStatus.SUCCESS, _KeaStatus.UNSUPPORTED)
         ],
     )
-    def test_fetch_stats_should_raise_an_exception_on_error_status_in_config_hash_api_response(  # noqa: E501
+    def test_fetch_stats_should_not_raise_an_exception_on_error_status_in_config_hash_api_response(  # noqa: E501
         self, valid_dhcp4, api_mock, status
     ):
         """
-        If the server reports an API-specific error regarding serving its
-        configuration's hash, other than that functionality being unsupported,
-        the client should raise an error.
+        We don't depend on get-config-hash to work
         """
         foohash = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
         config, statistics, expected_stats = valid_dhcp4
@@ -217,8 +215,7 @@ class TestExpectedAPIResponses:
         api_mock.add(
             "config-hash-get", make_api_response({"hash": foohash}, status=status)
         )
-        with pytest.raises(CommunicationError):
-            client.fetch_stats()
+        client.fetch_stats()
 
     def test_fetch_stats_should_check_and_warn_if_server_config_changed_during_call(
         self, valid_dhcp4, api_mock, caplog
@@ -283,16 +280,18 @@ class TestUnexpectedAPIResponses:
         with pytest.raises(KeaUnexpected):
             client.fetch_stats()
 
-    def test_fetch_stats_should_raise_an_exception_on_unrecognizable_config_hash_api_response(  # noqa: E501
+    def test_fetch_stats_should_not_raise_an_exception_on_unrecognizable_config_hash_api_response(  # noqa: E501
         self, valid_dhcp4, api_mock, invalid_response
     ):
+        """
+        We don't depend on get-config-hash to work
+        """
         config, statistics, expected_stats = valid_dhcp4
         client = Client(SERVER_NICKNAME, "http://example.org/")
         config["Dhcp4"]["hash"] = "foo"
         api_mock.autofill("dhcp4", config=config, statistics=statistics)
         api_mock.add("config-hash-get", invalid_response)
-        with pytest.raises(KeaUnexpected):
-            client.fetch_stats()
+        client.fetch_stats()
 
 
 class TestConfigCaching:

--- a/tests/unittests/metrics/names_test.py
+++ b/tests/unittests/metrics/names_test.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest import TestCase
-from nav.metrics.names import join_series, escape_metric_name
+from nav.metrics.names import join_series, escape_metric_name, safe_name
 
 
 class MetricNamingTests(TestCase):
@@ -29,5 +29,10 @@ class MetricNamingTests(TestCase):
         ('temperature, top', 'temperature__top'),
     ],
 )
-def test_escape_metric_name(test_input, expected):
-    assert escape_metric_name(test_input) == expected
+class TestEscapeMetricName:
+    def test_should_escape_by_default(self, test_input, expected):
+        assert escape_metric_name(test_input) == expected
+
+    def test_should_not_escape_safe_names(self, test_input, expected):
+        assert escape_metric_name(safe_name(test_input)) == str(test_input)
+        assert escape_metric_name(str(safe_name(test_input))) == str(test_input)

--- a/tests/unittests/metrics/templates_test.py
+++ b/tests/unittests/metrics/templates_test.py
@@ -1,0 +1,92 @@
+import pytest
+
+from nav.metrics.names import safe_name
+from nav.metrics.templates import metric_path_for_dhcp
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        (
+            dict(
+                allocation_type="range",
+                ip_version=4,
+                server_name="foo",
+                group_name="bar",
+                group_name_source="custom_groups",
+                first_ip="192.0.2.0",
+                last_ip="192.0.2.9",
+                metric_name="baz",
+            ),
+            "nav.dhcp.servers.foo.range.custom_groups.bar.4.192_0_2_0.192_0_2_9.baz",
+        ),
+        (
+            dict(
+                allocation_type="range",
+                ip_version=4,
+                server_name="foo",
+                group_name="bar",
+                group_name_source="custom_groups",
+                first_ip=safe_name("192.0.2.0"),
+                last_ip=safe_name("192.0.2.9"),
+                metric_name="baz",
+            ),
+            "nav.dhcp.servers.foo.range.custom_groups.bar.4.192.0.2.0.192.0.2.9.baz",
+        ),
+        (
+            dict(
+                allocation_type="range",
+                ip_version=4,
+                server_name="foo",
+                group_name="bar",
+                group_name_source="custom_groups",
+                first_ip="*",
+                last_ip="*",
+                metric_name="baz",
+            ),
+            "nav.dhcp.servers.foo.range.custom_groups.bar.4._._.baz",
+        ),
+        (
+            dict(
+                allocation_type="range",
+                ip_version=4,
+                server_name="foo",
+                group_name="bar",
+                group_name_source="custom_groups",
+                first_ip=safe_name("*"),
+                last_ip=safe_name("*"),
+                metric_name="baz",
+            ),
+            "nav.dhcp.servers.foo.range.custom_groups.bar.4.*.*.baz",
+        ),
+        (
+            dict(
+                allocation_type="range*",
+                ip_version="4!",
+                server_name="foo?",
+                group_name="bar{",
+                group_name_source="special_groups}",
+                first_ip="*_*_0_0",
+                last_ip="*.*.0.1",
+                metric_name="baz baz!",
+            ),
+            "nav.dhcp.servers.foo_.range_.special_groups_.bar_.4_.____0_0.____0_1.baz_baz_",
+        ),
+        (
+            dict(
+                allocation_type=safe_name("range*"),
+                ip_version=safe_name("4!"),
+                server_name=safe_name("foo?"),
+                group_name=safe_name("bar{"),
+                group_name_source=safe_name("special_groups}"),
+                first_ip=safe_name("*_*_0_0"),
+                last_ip=safe_name("*.*.0.1"),
+                metric_name=safe_name("baz baz!"),
+            ),
+            "nav.dhcp.servers.foo?.range*.special_groups}.bar{.4!.*_*_0_0"
+            ".*.*.0.1.baz baz!",
+        ),
+    ],
+)
+def test_metric_path_for_dhcp(test_input, expected):
+    assert metric_path_for_dhcp(**test_input) == expected


### PR DESCRIPTION
## Scope and purpose

First part of fix for #2373 (partly; see #3633 as well).

### This pull request 

Refactors #3397 by:
* Moving generic dhcpstats functionality away from kea_dhcp.py and into common.py
* Consolidating much of this generic dhcpstats functionality into a DhcpPath class that contains most data about a dhcpstats metric.  Data contained in this class is e.g. `<server-name>`, `<first-ip>`, `<last-ip>`, `<allocation-type>`, `<group-name>` (but, perhaps surprisingly, not metric names such as `assigned`, `total`, etc.). The DhcpPath class makes it easy to convert to/from dhcpstats Graphite metric paths, which will be used in up-and-coming frontend functionality.
* Making the kea_dhcp.py client also start collecting stats about unassigned addresses, so that the frontend can show this without needing to do arithmetic on total and assigned addresses, which would be inflexible (for consumers of Graphite stats)  and also either complicated (when done right) or brittle (when done in a simple way). 
* Changing the format of dhcpstats Graphite metric paths from
  ```
  nav.dhcp.<ip-version>.pools.<server-name>.<pool-name>.<first-ip>.<last-ip>.{assigned,total,declined}
  ``` 
  to the more explicit format of
  ```
  nav.dhcp.servers.<server-name>.{range,pool,subnet}.{custom_groups,special_groups}.<group-name>.<ip-version>.<first-ip>.<last-ip>.{assigned,total,declined,unassigned}
  ``` 
  which first and foremost allows for 
    * using the third component in the path (which here is `servers`) as a namespace,
    * differentiating between a `range` of addresses (which cannot contain gaps), a `pool` of addresses  (which can contain gaps), and a `subnet`; three different kinds of fidelity a DHCP server may serve its statistics in.
    * namespacing `group-name`s (previously `pool-name`s) into either `custom-groups` for `group-name`s sourced externally or `special-group`s for `group-name`s generated by NAV e.g. when a `group-name` is missing.
* Expecting `[server_<server-name>]` sections in `dhcpstats.conf` instead of `[endpoint_<server-name>]` for sake of consistency (the new code has backwards-compability with the old naming-scheme)
* Renaming the `user_context_poolname_key` option in `dhcpstats.conf` (used by `kea_dhcp.py`) to `user_context_groupname_key` and also changing its default value from "name" to "group" (the new code does not have backwards-compability with the old naming-scheme; NAV works fine when this option is absent, but old configurations with relied on the default value of "name" must now explicitly set it since the default value is now "group")


## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] ~Added/changed documentation~ see #3785 
* [x] Linted/formatted the code with ruff
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [x] ~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~
* [x] ~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~ see #3633
* [ ] ~If this results in changes in the UI: Added screenshots of the before and after~
* [x] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file
