### PR TITLE
Refactor LogicalMibInstance to dataclass with explicit kwargs

### DIFF
--- a/python/nav/ipdevpoll/utils.py
+++ b/python/nav/ipdevpoll/utils.py
@@ -204,9 +204,10 @@ def get_arista_vrf_instances(agentproxy) -> Deferred:
     states = yield vrf_mib.get_vrf_states(only='active')
     # XXX: This part does not currently support SNMPv3, as we have no known way to
     #      derive the correct SNMPv3 context name for each VRF.
-    vrfs = [LogicalMibInstance('', agentproxy.community)]
+    vrfs = [LogicalMibInstance(description='', community=agentproxy.community)]
     vrfs.extend(
-        LogicalMibInstance(vrf, f"{agentproxy.community}@{vrf}") for vrf in states
+        LogicalMibInstance(description=vrf, community=f"{agentproxy.community}@{vrf}")
+        for vrf in states
     )
     return vrfs
 
@@ -236,10 +237,10 @@ def _workaround_broken_aruba_alternate_communities(
             index = '@' + vlan
             if instance.community and not instance.community.endswith(index):
                 instance = LogicalMibInstance(
-                    instance.description,
-                    instance.community + index,
-                    instance.context,
-                    instance.context_engine_id,
+                    description=instance.description,
+                    community=instance.community + index,
+                    context=instance.context,
+                    context_engine_id=instance.context_engine_id,
                 )
         output.append(instance)
     return output

--- a/python/nav/mibs/cisco_vtp_mib.py
+++ b/python/nav/mibs/cisco_vtp_mib.py
@@ -108,5 +108,8 @@ class CiscoVTPMib(mibretriever.MibRetriever):
         vlans = await self.get_operational_vlans()
         community = self.agent_proxy.community
         return [
-            LogicalMibInstance(f"vlan{vlan}", f"{community}@{vlan}") for vlan in vlans
+            LogicalMibInstance(
+                description=f"vlan{vlan}", community=f"{community}@{vlan}"
+            )
+            for vlan in vlans
         ]

--- a/python/nav/mibs/entity_mib.py
+++ b/python/nav/mibs/entity_mib.py
@@ -71,10 +71,10 @@ class EntityMib(mibretriever.MibRetriever):
         )
         return [
             LogicalMibInstance(
-                r["entLogicalDescr"],
-                r["entLogicalCommunity"].decode("utf-8"),
-                r["entLogicalContextName"],
-                r["entLogicalContextEngineID"],
+                description=r["entLogicalDescr"],
+                community=r["entLogicalCommunity"].decode("utf-8"),
+                context=r["entLogicalContextName"],
+                context_engine_id=r["entLogicalContextEngineID"],
             )
             for r in result.values()
             if _is_bridge_mib_instance_with_valid_community(r)

--- a/python/nav/mibs/types.py
+++ b/python/nav/mibs/types.py
@@ -15,10 +15,12 @@
 #
 """Type definitions for nav.mibs package."""
 
-from typing import NamedTuple, Optional
+from dataclasses import dataclass
+from typing import Optional
 
 
-class LogicalMibInstance(NamedTuple):
+@dataclass(frozen=True)
+class LogicalMibInstance:
     """A MIB instance identifier.
 
     Some devices (like Cisco switches) provide multiple logical instances of a MIB (such

--- a/tests/integration/ipdevpoll/utils_test.py
+++ b/tests/integration/ipdevpoll/utils_test.py
@@ -28,10 +28,10 @@ def test_get_arista_vrf_instances_should_return_expected_instances(snmp_agent_pr
 
     result = yield get_arista_vrf_instances(snmp_agent_proxy)
     expected = [
-        LogicalMibInstance('', 'arista'),
-        LogicalMibInstance('IOT', 'arista@IOT'),
-        LogicalMibInstance('MGMT', 'arista@MGMT'),
-        LogicalMibInstance('STUDENT', 'arista@STUDENT'),
-        LogicalMibInstance('VR', 'arista@VR'),
+        LogicalMibInstance(description='', community='arista'),
+        LogicalMibInstance(description='IOT', community='arista@IOT'),
+        LogicalMibInstance(description='MGMT', community='arista@MGMT'),
+        LogicalMibInstance(description='STUDENT', community='arista@STUDENT'),
+        LogicalMibInstance(description='VR', community='arista@VR'),
     ]
     assert set(result) == set(expected)

--- a/tests/unittests/ipdevpoll/utils_test.py
+++ b/tests/unittests/ipdevpoll/utils_test.py
@@ -23,14 +23,14 @@ class TestWorkaroundBrokenArubaAlternateCommunities:
     """Tests for _workaround_broken_aruba_alternate_communities()"""
 
     def test_should_append_vlan_index_when_missing(self):
-        instances = [LogicalMibInstance("vlan100", "public")]
+        instances = [LogicalMibInstance(description="vlan100", community="public")]
 
         result = _workaround_broken_aruba_alternate_communities(instances)
 
         assert result[0].community == "public@100"
 
     def test_should_not_modify_when_already_indexed(self):
-        instances = [LogicalMibInstance("vlan100", "public@100")]
+        instances = [LogicalMibInstance(description="vlan100", community="public@100")]
 
         result = _workaround_broken_aruba_alternate_communities(instances)
 
@@ -38,7 +38,14 @@ class TestWorkaroundBrokenArubaAlternateCommunities:
 
     def test_should_preserve_context_fields(self):
         engine_id = bytes.fromhex("800000090300001234")
-        instances = [LogicalMibInstance("vlan100", "public", "vlan-100", engine_id)]
+        instances = [
+            LogicalMibInstance(
+                description="vlan100",
+                community="public",
+                context="vlan-100",
+                context_engine_id=engine_id,
+            )
+        ]
 
         result = _workaround_broken_aruba_alternate_communities(instances)
 
@@ -47,7 +54,7 @@ class TestWorkaroundBrokenArubaAlternateCommunities:
         assert result[0].context_engine_id == engine_id
 
     def test_should_not_modify_non_vlan_descriptions(self):
-        instances = [LogicalMibInstance("bridge1", "public")]
+        instances = [LogicalMibInstance(description="bridge1", community="public")]
 
         result = _workaround_broken_aruba_alternate_communities(instances)
 
@@ -55,8 +62,8 @@ class TestWorkaroundBrokenArubaAlternateCommunities:
 
     def test_should_handle_case_insensitive_vlan_names(self):
         instances = [
-            LogicalMibInstance("VLAN200", "public"),
-            LogicalMibInstance("Vlan300", "public"),
+            LogicalMibInstance(description="VLAN200", community="public"),
+            LogicalMibInstance(description="Vlan300", community="public"),
         ]
 
         result = _workaround_broken_aruba_alternate_communities(instances)
@@ -65,7 +72,7 @@ class TestWorkaroundBrokenArubaAlternateCommunities:
         assert result[1].community == "public@300"
 
     def test_should_not_modify_when_community_is_none(self):
-        instances = [LogicalMibInstance("vlan100", None)]
+        instances = [LogicalMibInstance(description="vlan100", community=None)]
 
         result = _workaround_broken_aruba_alternate_communities(instances)
 

--- a/tests/unittests/mibs/mibretriever_test.py
+++ b/tests/unittests/mibs/mibretriever_test.py
@@ -33,7 +33,9 @@ class TestMultiMibMixInGetAlternateAgent:
         agent.snmp_parameters = SNMPParameters(version=2, community="public")
 
         mixin = MultiMibMixIn(agent, [])
-        instance = LogicalMibInstance("vlan100", "public@100", "vlan-100", None)
+        instance = LogicalMibInstance(
+            description="vlan100", community="public@100", context="vlan-100"
+        )
 
         alt_agent = mixin._get_alternate_agent(instance)
 
@@ -48,7 +50,9 @@ class TestMultiMibMixInGetAlternateAgent:
         agent.snmp_parameters = SNMPParameters(version=3, sec_name="user")
 
         mixin = MultiMibMixIn(agent, [])
-        instance = LogicalMibInstance("vlan100", "public@100", "vlan-100", None)
+        instance = LogicalMibInstance(
+            description="vlan100", community="public@100", context="vlan-100"
+        )
 
         alt_agent = mixin._get_alternate_agent(instance)
 
@@ -65,7 +69,12 @@ class TestMultiMibMixInGetAlternateAgent:
 
         mixin = MultiMibMixIn(agent, [])
         engine_id = bytes.fromhex("800000090300001234")
-        instance = LogicalMibInstance("vlan100", "public@100", "vlan-100", engine_id)
+        instance = LogicalMibInstance(
+            description="vlan100",
+            community="public@100",
+            context="vlan-100",
+            context_engine_id=engine_id,
+        )
 
         alt_agent = mixin._get_alternate_agent(instance)
 
@@ -79,7 +88,9 @@ class TestMultiMibMixInGetAlternateAgent:
         agent.snmp_parameters = SNMPParameters(version=3, sec_name="user")
 
         mixin = MultiMibMixIn(agent, [])
-        instance = LogicalMibInstance("vlan100", "public@100", "vlan-100", None)
+        instance = LogicalMibInstance(
+            description="vlan100", community="public@100", context="vlan-100"
+        )
 
         alt_agent = mixin._get_alternate_agent(instance)
 
@@ -94,7 +105,7 @@ class TestMultiMibMixInGetAlternateAgent:
         agent.snmp_parameters = SNMPParameters(version=2, community="public")
 
         mixin = MultiMibMixIn(agent, [])
-        instance = LogicalMibInstance("vlan100", "public@100")
+        instance = LogicalMibInstance(description="vlan100", community="public@100")
 
         alt_agent = mixin._get_alternate_agent(instance)
 

--- a/tests/unittests/mibs/types_test.py
+++ b/tests/unittests/mibs/types_test.py
@@ -19,45 +19,61 @@ from nav.mibs.types import LogicalMibInstance
 
 
 class TestLogicalMibInstance:
-    """Tests for LogicalMibInstance NamedTuple"""
+    """Tests for LogicalMibInstance dataclass"""
 
     def test_should_have_default_none_for_context(self):
-        instance = LogicalMibInstance("vlan1", "public@1")
+        instance = LogicalMibInstance(description="vlan1", community="public@1")
         assert instance.context is None
 
     def test_should_have_default_none_for_context_engine_id(self):
-        instance = LogicalMibInstance("vlan1", "public@1")
+        instance = LogicalMibInstance(description="vlan1", community="public@1")
         assert instance.context_engine_id is None
 
     def test_should_accept_context_parameter(self):
-        instance = LogicalMibInstance("vlan1", "public@1", "vlan-1")
+        instance = LogicalMibInstance(
+            description="vlan1", community="public@1", context="vlan-1"
+        )
         assert instance.context == "vlan-1"
 
     def test_should_accept_context_engine_id_parameter(self):
         engine_id = bytes.fromhex("800000090300001234")
-        instance = LogicalMibInstance("vlan1", "public@1", "vlan-1", engine_id)
+        instance = LogicalMibInstance(
+            description="vlan1",
+            community="public@1",
+            context="vlan-1",
+            context_engine_id=engine_id,
+        )
         assert instance.context_engine_id == engine_id
 
     def test_should_be_hashable_for_set_operations(self):
-        instance1 = LogicalMibInstance("vlan1", "public@1")
-        instance2 = LogicalMibInstance("vlan1", "public@1")
-        instance3 = LogicalMibInstance("vlan2", "public@2")
+        instance1 = LogicalMibInstance(description="vlan1", community="public@1")
+        instance2 = LogicalMibInstance(description="vlan1", community="public@1")
+        instance3 = LogicalMibInstance(description="vlan2", community="public@2")
 
         instances = {instance1, instance2, instance3}
         assert len(instances) == 2
 
     def test_equal_instances_should_be_equal(self):
-        instance1 = LogicalMibInstance("vlan1", "public@1", "ctx", None)
-        instance2 = LogicalMibInstance("vlan1", "public@1", "ctx", None)
+        instance1 = LogicalMibInstance(
+            description="vlan1", community="public@1", context="ctx"
+        )
+        instance2 = LogicalMibInstance(
+            description="vlan1", community="public@1", context="ctx"
+        )
         assert instance1 == instance2
 
     def test_different_instances_should_not_be_equal(self):
-        instance1 = LogicalMibInstance("vlan1", "public@1")
-        instance2 = LogicalMibInstance("vlan2", "public@2")
+        instance1 = LogicalMibInstance(description="vlan1", community="public@1")
+        instance2 = LogicalMibInstance(description="vlan2", community="public@2")
         assert instance1 != instance2
 
     def test_can_access_fields_by_name(self):
-        instance = LogicalMibInstance("desc", "comm", "ctx", b"\x00\x01")
+        instance = LogicalMibInstance(
+            description="desc",
+            community="comm",
+            context="ctx",
+            context_engine_id=b"\x00\x01",
+        )
         assert instance.description == "desc"
         assert instance.community == "comm"
         assert instance.context == "ctx"


### PR DESCRIPTION
## Scope and purpose

Dependent on #3668.

Refactors `LogicalMibInstance` from a `NamedTuple` to a `@dataclass(frozen=True)` based on review feedback. This change:
- Allows fields to be supplied out of order using keyword arguments
- Provides better support for optional fields with default values
- Makes instantiation more readable and explicit

All instantiation sites have been updated to use explicit keyword argument names for clarity.

### This pull request
* (none of the above apply)


## Contributor Checklist

* [ ] ~~Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)~~
* [X] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [X] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~