### PR TITLE
Render PortAdmin feedback modal from pre-loaded template

### DIFF
--- a/changelog.d/3772.fixed.md
+++ b/changelog.d/3772.fixed.md
@@ -1,0 +1,1 @@
+PortAdmin's save feedback modal now appears instantly instead of being delayed by a network round-trip

--- a/python/nav/web/portadmin/urls.py
+++ b/python/nav/web/portadmin/urls.py
@@ -56,7 +56,4 @@ urlpatterns = [
         views.render_trunk_edit,
         name="portadmin-render-trunk-edit",
     ),
-    path(
-        'feedback_modal/', views.render_feedback_modal, name='portadmin-feedback-modal'
-    ),
 ]

--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -35,7 +35,6 @@ from nav.web.auth.utils import get_account
 from nav.util import is_valid_ip
 from nav.web.utils import create_title
 from nav.models.manage import Netbox, Interface
-from nav.web.modals import render_modal
 from nav.web.portadmin.utils import (
     get_and_populate_livedata,
     find_and_populate_allowed_vlans,
@@ -891,15 +890,3 @@ def get_management_handler(netbox: Netbox) -> ManagementHandler:
         return ManagementFactory.get_instance(netbox, timeout=timeout, retries=retries)
     except ManagementError as error:
         _logger.error('Error getting ManagementHandler instance %s: %s', netbox, error)
-
-
-def render_feedback_modal(request):
-    """Renders a modal that is used to display feedback when saving interface changes"""
-    return render_modal(
-        request,
-        'portadmin/_feedback_modal.html',
-        modal_id="portadmin-feedback-modal",
-        close_on_outside_click=False,
-        show_close_button=False,
-        size="small",
-    )

--- a/python/nav/web/static/js/src/portadmin.js
+++ b/python/nav/web/static/js/src/portadmin.js
@@ -11,18 +11,15 @@ require(['libs/spin.min', 'jquery-ui'], function (Spinner) {
     }
 
     Feedbacker.prototype = {
-        modalOpen: async function() {
+        modalOpen: function() {
             if (this.isOpen) {
-                return Promise.resolve();
+                return;
             }
-            return htmx.ajax('GET', '/portadmin/feedback_modal', {
-                target: 'body',
-                swap: 'beforeend'
-            }).then(() => {
-                this.modal = document.getElementById('portadmin-feedback-modal');
-                this.list = this.modal.querySelector('ul');
-                this.isOpen = true;
-            })
+            const template = document.getElementById('portadmin-feedback-template');
+            document.body.appendChild(template.content.cloneNode(true));
+            this.modal = document.getElementById('portadmin-feedback-modal');
+            this.list = this.modal.querySelector('ul');
+            this.isOpen = true;
         },
         modalClose: function() {
             this.modal.remove();

--- a/python/nav/web/templates/portadmin/base.html
+++ b/python/nav/web/templates/portadmin/base.html
@@ -8,6 +8,10 @@
 
 {% block base_content %}
 
+  <template id="portadmin-feedback-template">
+    {% include 'modals/_nav_modal.html' with modal_id='portadmin-feedback-modal' content_template='portadmin/_feedback_modal.html' modal_size='small' show_close_button=False close_on_outside_click=False %}
+  </template>
+
   {% with tool=current_user_data.tools|get_tool:'Port Admin' %}
     {% include 'nav_header.html' %}
   {% endwith %}

--- a/tests/integration/web/portadmin_test.py
+++ b/tests/integration/web/portadmin_test.py
@@ -13,13 +13,6 @@ from nav.portadmin.handlers import ManagementHandler
 from nav.web.portadmin.views import populate_infodict, load_portadmin_data_by_kwargs
 
 
-class TestFeedbackModal:
-    def test_should_render_feedback_modal(self, client):
-        url = reverse('portadmin-feedback-modal')
-        response = client.get(url)
-        assert 'id="portadmin-feedback-modal"' in smart_str(response.content)
-
-
 class TestPortadminSearchViews:
     """Combined tests for all search view types"""
 


### PR DESCRIPTION
Fixes #3772

## Scope and purpose

An administrator from the nav-ref group reported and demonstrated a bug in Portadmin where the feedback modal does not open before a long delay. I was _not_ able to reproduce their bug, but the only identified probable culprit is the network call to load the initial modal with HTMX.

This PR changes the feedback modal to load from a pre-rendered template, which is cloned and destroyed when the modal is closed. This should show the modal immediately without requiring a round-trip to the server first, while using the server-rendered modal template.

Since we simplified the modal loading, I also removed the render modal view and related tests.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
