### PR TITLE
Fix crash in `nav config where` error message

### DIFF
--- a/changelog.d/+nav-config-where-crash.fixed.md
+++ b/changelog.d/+nav-config-where-crash.fixed.md
@@ -1,0 +1,1 @@
+Fixed a crash in `nav config where` when no config file directory could be found

--- a/python/nav/bin/navmain.py
+++ b/python/nav/bin/navmain.py
@@ -302,7 +302,7 @@ def command_config_where(_args):
     else:
         sys.exit(
             "Could not find nav.conf in any of these locations:\n{}".format(
-                '\n'.join(get_config_locations())
+                '\n'.join(str(loc) for loc in get_config_locations())
             )
         )
 


### PR DESCRIPTION
## Scope and purpose

`nav config where` would crash with a `TypeError` when no config file directory could be found, because `get_config_locations()` was refactored to return `Path` objects but this caller was not updated to convert them to strings before joining.

## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] ~~Added/amended tests for new/changed code~~
* [ ] ~~Added/changed documentation~~
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~