### PR TITLE
Fix popover arrow position when aligned to end without explicit side

### DIFF
--- a/changelog.d/3770.fixed.md
+++ b/changelog.d/3770.fixed.md
@@ -1,0 +1,1 @@
+Popover arrow is now correctly positioned when aligned to the end

--- a/python/nav/web/sass/nav/_popover.scss
+++ b/python/nav/web/sass/nav/_popover.scss
@@ -116,6 +116,7 @@
   }
 }
 
+.popover.with-arrow:not([data-side])[data-align="end"] .popover-content,
 .popover.with-arrow[data-side="bottom"][data-align="end"] .popover-content {
   &:before {
     top: -12px;


### PR DESCRIPTION
## Scope and purpose

Fixes #3770

This PR fixes the placement of the popover arrow when alignment is set to "end".

<img width="227" height="226" alt="image" src="https://github.com/user-attachments/assets/13a857a6-40e7-4d2f-a221-1a89ac04f74a" />

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
