### PR TITLE
Improve auditlog table and model

### DIFF
--- a/changelog.d/3757.changed.md
+++ b/changelog.d/3757.changed.md
@@ -1,0 +1,3 @@
+Auditlog entries now store sortable display names for actor, object, and target, enabling sorting and searching on these columns. Links to detail pages are shown when the referenced object still exists.
+
+**Note:** The database migration includes backfill operations to populate sortkey columns for existing log entries. On deployments with millions of log entries, this migration may take some time to complete.

--- a/python/nav/auditlog/api.py
+++ b/python/nav/auditlog/api.py
@@ -34,6 +34,15 @@ ENTITY_FIELDS = (
 )
 
 
+class LGFKRelatedField(serializers.RelatedField):
+    """
+    Custom field for any LegacyGenericForeignKey
+    """
+
+    def to_representation(self, value):
+        return str(value)
+
+
 def _collect_entity_references(entries):
     """Collect all (model_name, pk) pairs from a page of log entries,
     grouped by model name for batch fetching."""
@@ -102,9 +111,9 @@ def _resolve_entity(log_entry, model_field, pk_field, sortkey_field, object_cach
 class LogEntrySerializer(serializers.ModelSerializer):
     """V1 serializer - returns plain strings for backward compatibility"""
 
-    actor = serializers.CharField(source='actor_sortkey')
-    object = serializers.CharField(source='object_sortkey')
-    target = serializers.CharField(source='target_sortkey')
+    actor = LGFKRelatedField(read_only=True)
+    object = LGFKRelatedField(read_only=True)
+    target = LGFKRelatedField(read_only=True)
 
     class Meta:
         model = LogEntry

--- a/python/nav/auditlog/api.py
+++ b/python/nav/auditlog/api.py
@@ -13,34 +13,98 @@
 # more details.  You should have received a copy of the GNU General Public
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 
-from django.db.models import Case, F, IntegerField, OuterRef, Q, Subquery, When
-from django.db.models.functions import Cast
+from django.db.models import Q
 
 from django_filters.rest_framework import DjangoFilterBackend
 
 from rest_framework import filters, serializers, viewsets
+from rest_framework.response import Response
 
+from nav.models.fields import LegacyGenericForeignKey
 from nav.web.api.v1.views import NAVAPIMixin
 
 from nav.models.manage import Interface
-from nav.models.profiles import Account
 
 from .models import LogEntry
 
+ENTITY_FIELDS = (
+    ('actor_model', 'actor_pk'),
+    ('object_model', 'object_pk'),
+    ('target_model', 'target_pk'),
+)
 
-class LGFKRelatedField(serializers.RelatedField):
-    """
-    Custom field for any LegacyGenericForeignKey
-    """
 
-    def to_representation(self, value):
-        return str(value)
+def _collect_entity_references(entries):
+    """Collect all (model_name, pk) pairs from a page of log entries,
+    grouped by model name for batch fetching."""
+    lookups = {}
+    for entry in entries:
+        for model_field, pk_field in ENTITY_FIELDS:
+            model_name = getattr(entry, model_field)
+            pk = getattr(entry, pk_field)
+            if model_name and pk:
+                lookups.setdefault(model_name, set()).add(pk)
+    return lookups
+
+
+def _batch_resolve_objects(entries):
+    """Batch-resolve referenced objects for a page of log entries.
+
+    Returns a dict of (model_name, pk) -> {'name': str, 'url': str|None}
+    with one query per distinct model type instead of one per entity.
+    """
+    references = _collect_entity_references(entries)
+    resolved = {}
+    for model_name, pks in references.items():
+        rel_model = LegacyGenericForeignKey.get_model_class(model_name)
+        if not rel_model:
+            continue
+        try:
+            for obj in rel_model.objects.filter(id__in=pks):
+                url = getattr(obj, 'get_absolute_url', lambda: None)()
+                resolved[(model_name, str(obj.pk))] = {
+                    'name': str(obj),
+                    'url': url,
+                }
+        except (TypeError, ValueError):
+            pass
+
+    return resolved
+
+
+def _resolve_entity(log_entry, model_field, pk_field, sortkey_field, object_cache):
+    """Resolve a LGFK entity to {name, url}.
+
+    Prefers the live object name from the object_cache (built by
+    _batch_resolve_objects), falling back to the stored sortkey for deleted
+    objects, and finally to a raw "model (pk)" label.
+    """
+    model_name = getattr(log_entry, model_field)
+    pk = getattr(log_entry, pk_field)
+
+    if not model_name or not pk:
+        return None
+
+    sortkey = getattr(log_entry, sortkey_field)
+    cached = object_cache.get((model_name, pk))
+
+    if cached:
+        name = cached['name']
+    elif sortkey:
+        name = sortkey
+    else:
+        name = '{} ({})'.format(model_name, pk)
+    url = cached['url'] if cached else None
+
+    return {'name': name, 'url': url}
 
 
 class LogEntrySerializer(serializers.ModelSerializer):
-    actor = LGFKRelatedField(read_only=True)
-    object = LGFKRelatedField(read_only=True)
-    target = LGFKRelatedField(read_only=True)
+    """V1 serializer - returns plain strings for backward compatibility"""
+
+    actor = serializers.CharField(source='actor_sortkey')
+    object = serializers.CharField(source='object_sortkey')
+    target = serializers.CharField(source='target_sortkey')
 
     class Meta:
         model = LogEntry
@@ -56,6 +120,48 @@ class LogEntrySerializer(serializers.ModelSerializer):
             'after',
         ]
         read_only_fields = ['timestamp']
+
+
+class LogEntrySerializerV2(serializers.ModelSerializer):
+    """V2 serializer - returns objects with {name, url} for entity linking"""
+
+    actor = serializers.SerializerMethodField()
+    object = serializers.SerializerMethodField()
+    target = serializers.SerializerMethodField()
+
+    class Meta:
+        model = LogEntry
+        fields = [
+            'timestamp',
+            'subsystem',
+            'actor',
+            'verb',
+            'object',
+            'target',
+            'summary',
+            'before',
+            'after',
+        ]
+        read_only_fields = ['timestamp']
+
+    @property
+    def _object_cache(self):
+        return self.context.get('object_cache', {})
+
+    def get_actor(self, obj):
+        return _resolve_entity(
+            obj, 'actor_model', 'actor_pk', 'actor_sortkey', self._object_cache
+        )
+
+    def get_object(self, obj):
+        return _resolve_entity(
+            obj, 'object_model', 'object_pk', 'object_sortkey', self._object_cache
+        )
+
+    def get_target(self, obj):
+        return _resolve_entity(
+            obj, 'target_model', 'target_pk', 'target_sortkey', self._object_cache
+        )
 
 
 class MultipleFilter(filters.BaseFilterBackend):
@@ -74,35 +180,6 @@ class MultipleFilter(filters.BaseFilterBackend):
                 object_model__in=request.query_params.getlist('object_model')
             )
         return queryset
-
-
-class LogEntryOrderingFilter(filters.OrderingFilter):
-    """Custom ordering filter that handles the 'actor' field specially.
-
-    The 'actor' field is a LegacyGenericForeignKey and cannot be used with
-    Django's queryset order_by(). Instead, we use a subquery to fetch the
-    actor's login from the Account table for efficient database-level sorting.
-    """
-
-    def filter_queryset(self, request, queryset, view):
-        ordering = request.query_params.get('ordering')
-        if ordering in ['-actor', 'actor']:
-            actor_login = Case(
-                When(
-                    actor_pk__regex=r'^\d+$',
-                    then=Subquery(
-                        Account.objects.filter(
-                            id=Cast(OuterRef('actor_pk'), IntegerField())
-                        ).values('login')[:1]
-                    ),
-                ),
-                default=F('actor_pk'),
-            )
-            queryset = queryset.annotate(actor_login=actor_login)
-            if ordering == '-actor':
-                return queryset.order_by(F('actor_login').desc(nulls_last=True))
-            return queryset.order_by(F('actor_login').asc(nulls_last=True))
-        return super().filter_queryset(request, queryset, view)
 
 
 class NetboxFilter(filters.BaseFilterBackend):
@@ -133,6 +210,8 @@ class NetboxFilter(filters.BaseFilterBackend):
 
 
 class NAVDefaultsMixin(object):
+    """Applies default NAV API authentication, permissions, and rendering."""
+
     authentication_classes = NAVAPIMixin.authentication_classes
     permission_classes = NAVAPIMixin.permission_classes
     renderer_classes = NAVAPIMixin.renderer_classes
@@ -140,19 +219,70 @@ class NAVDefaultsMixin(object):
 
 
 class LogEntryViewSet(NAVDefaultsMixin, viewsets.ReadOnlyModelViewSet):
-    """Read only api endpoint for logentries.
+    """V1 API endpoint - returns plain strings for backward compatibility.
 
     Logentries are created behind the scenes by the subsystems themselves."""
 
     filter_backends = (
         filters.SearchFilter,
         DjangoFilterBackend,
-        LogEntryOrderingFilter,
+        filters.OrderingFilter,
         MultipleFilter,
         NetboxFilter,
     )
     queryset = LogEntry.objects.all()
     serializer_class = LogEntrySerializer
     filterset_fields = ('subsystem', 'object_pk', 'verb')
-    search_fields = ('summary',)
+    search_fields = ('summary', 'actor_sortkey', 'object_sortkey', 'target_sortkey')
     ordering = ('timestamp',)
+    ordering_fields = (
+        'timestamp',
+        'actor_sortkey',
+        'verb',
+        'object_sortkey',
+        'target_sortkey',
+    )
+
+
+class LogEntryViewSetV2(NAVDefaultsMixin, viewsets.ReadOnlyModelViewSet):
+    """V2 API endpoint - returns objects with {name, url} for entity linking.
+
+    Logentries are created behind the scenes by the subsystems themselves."""
+
+    filter_backends = (
+        filters.SearchFilter,
+        DjangoFilterBackend,
+        filters.OrderingFilter,
+        MultipleFilter,
+        NetboxFilter,
+    )
+    queryset = LogEntry.objects.all()
+    serializer_class = LogEntrySerializerV2
+    filterset_fields = ('subsystem', 'object_pk', 'verb')
+    search_fields = ('summary', 'actor_sortkey', 'object_sortkey', 'target_sortkey')
+    ordering = ('timestamp',)
+    ordering_fields = (
+        'timestamp',
+        'actor_sortkey',
+        'verb',
+        'object_sortkey',
+        'target_sortkey',
+    )
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        entries = page if page is not None else list(queryset)
+        object_cache = _batch_resolve_objects(entries)
+        context = {**self.get_serializer_context(), 'object_cache': object_cache}
+        serializer = self.get_serializer(entries, many=True, context=context)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
+
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        object_cache = _batch_resolve_objects([instance])
+        context = {**self.get_serializer_context(), 'object_cache': object_cache}
+        serializer = self.get_serializer(instance, context=context)
+        return Response(serializer.data)

--- a/python/nav/auditlog/models.py
+++ b/python/nav/auditlog/models.py
@@ -55,6 +55,10 @@ class LogEntry(models.Model):
     target_pk = VarcharField(null=True)
     target = LegacyGenericForeignKey('target_model', 'target_pk')
 
+    actor_sortkey = VarcharField(null=True)
+    object_sortkey = VarcharField(null=True)
+    target_sortkey = VarcharField(null=True)
+
     timestamp = models.DateTimeField()
 
     verb = models.SlugField()
@@ -80,11 +84,11 @@ class LogEntry(models.Model):
     ):
         """LogEntry factory"""
         self = cls()
-        dict = {'actor': actor, 'object': object, 'target': target}
-        for k, v in dict.items():
-            dict[k] = getattr(v, 'audit_logname', '%s' % v)
+        names = {'actor': actor, 'object': object, 'target': target}
+        for k, v in names.items():
+            names[k] = getattr(v, 'audit_logname', str(v)) if v is not None else ''
         try:
-            self.summary = template.format(**dict)
+            self.summary = template.format(**names)
         except KeyError as error:
             self.summary = 'Error creating summary - see error log'
             _logger.error('KeyError when creating summary: %s', error)
@@ -95,6 +99,9 @@ class LogEntry(models.Model):
         self.actor_pk = actor.pk
         self.object_pk = object.pk if object else None
         self.target_pk = target.pk if target else None
+        self.actor_sortkey = names['actor']
+        self.object_sortkey = names['object'] if object else None
+        self.target_sortkey = names['target'] if target else None
         self.timestamp = utcnow()
         self.subsystem = subsystem if subsystem else None
         self.before = force_str(before)

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -1241,6 +1241,10 @@ class Organization(models.Model, TreeMixin):
         else:
             return '{o.id}'.format(o=self)
 
+    def get_absolute_url(self):
+        """Returns the URL to this organization's edit page"""
+        return reverse('seeddb-organization-edit', kwargs={'organization_id': self.id})
+
     def extract_emails(self):
         """Naively extract email addresses from the contact string"""
         contact = self.contact if self.contact else ""

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -144,6 +144,10 @@ class Account(AbstractBaseUser):
         """Returns the natural key for an account as a tuple"""
         return (self.login,)
 
+    def get_absolute_url(self):
+        """Returns the URL to this account's detail page"""
+        return reverse('useradmin-account_detail', kwargs={'account_id': self.id})
+
     def get_active_profile(self):
         """Returns the account's active alert profile"""
         try:

--- a/python/nav/models/sql/changes/sc.05.18.0505.sql
+++ b/python/nav/models/sql/changes/sc.05.18.0505.sql
@@ -1,0 +1,7 @@
+ALTER TABLE manage.auditlog_logentry ADD COLUMN actor_sortkey VARCHAR;
+ALTER TABLE manage.auditlog_logentry ADD COLUMN object_sortkey VARCHAR;
+ALTER TABLE manage.auditlog_logentry ADD COLUMN target_sortkey VARCHAR;
+
+CREATE INDEX auditlog_logentry_actor_sortkey ON manage.auditlog_logentry (actor_sortkey);
+CREATE INDEX auditlog_logentry_object_sortkey ON manage.auditlog_logentry (object_sortkey);
+CREATE INDEX auditlog_logentry_target_sortkey ON manage.auditlog_logentry (target_sortkey);

--- a/python/nav/models/sql/changes/sc.05.18.0506.sql
+++ b/python/nav/models/sql/changes/sc.05.18.0506.sql
@@ -1,0 +1,99 @@
+-- Backfill actor_sortkey from account
+UPDATE manage.auditlog_logentry le
+SET actor_sortkey = a.login
+FROM profiles.account a
+WHERE le.actor_model = 'account'
+  AND le.actor_pk = a.id::text
+  AND le.actor_sortkey IS NULL;
+
+-- Backfill object/target sortkeys from account
+UPDATE manage.auditlog_logentry le
+SET object_sortkey = a.login
+FROM profiles.account a
+WHERE le.object_model = 'account'
+  AND le.object_pk = a.id::text
+  AND le.object_sortkey IS NULL;
+
+UPDATE manage.auditlog_logentry le
+SET target_sortkey = a.login
+FROM profiles.account a
+WHERE le.target_model = 'account'
+  AND le.target_pk = a.id::text
+  AND le.target_sortkey IS NULL;
+
+-- Backfill from netbox (sysname)
+UPDATE manage.auditlog_logentry le
+SET object_sortkey = n.sysname
+FROM manage.netbox n
+WHERE le.object_model = 'netbox'
+  AND le.object_pk = n.netboxid::text
+  AND le.object_sortkey IS NULL;
+
+UPDATE manage.auditlog_logentry le
+SET target_sortkey = n.sysname
+FROM manage.netbox n
+WHERE le.target_model = 'netbox'
+  AND le.target_pk = n.netboxid::text
+  AND le.target_sortkey IS NULL;
+
+-- Backfill from interface (sysname:ifname, matching audit_logname format)
+UPDATE manage.auditlog_logentry le
+SET object_sortkey = n.sysname || ':' || i.ifname
+FROM manage.interface i
+JOIN manage.netbox n ON i.netboxid = n.netboxid
+WHERE le.object_model = 'interface'
+  AND le.object_pk = i.interfaceid::text
+  AND le.object_sortkey IS NULL;
+
+UPDATE manage.auditlog_logentry le
+SET target_sortkey = n.sysname || ':' || i.ifname
+FROM manage.interface i
+JOIN manage.netbox n ON i.netboxid = n.netboxid
+WHERE le.target_model = 'interface'
+  AND le.target_pk = i.interfaceid::text
+  AND le.target_sortkey IS NULL;
+
+-- Backfill from room (id with optional description)
+UPDATE manage.auditlog_logentry le
+SET object_sortkey = CASE WHEN r.descr != '' THEN r.roomid || ' (' || r.descr || ')' ELSE r.roomid END
+FROM manage.room r
+WHERE le.object_model = 'room'
+  AND le.object_pk = r.roomid
+  AND le.object_sortkey IS NULL;
+
+UPDATE manage.auditlog_logentry le
+SET target_sortkey = CASE WHEN r.descr != '' THEN r.roomid || ' (' || r.descr || ')' ELSE r.roomid END
+FROM manage.room r
+WHERE le.target_model = 'room'
+  AND le.target_pk = r.roomid
+  AND le.target_sortkey IS NULL;
+
+-- Backfill from location (id with optional description)
+UPDATE manage.auditlog_logentry le
+SET object_sortkey = CASE WHEN l.descr != '' THEN l.locationid || ' (' || l.descr || ')' ELSE l.locationid END
+FROM manage.location l
+WHERE le.object_model = 'location'
+  AND le.object_pk = l.locationid
+  AND le.object_sortkey IS NULL;
+
+UPDATE manage.auditlog_logentry le
+SET target_sortkey = CASE WHEN l.descr != '' THEN l.locationid || ' (' || l.descr || ')' ELSE l.locationid END
+FROM manage.location l
+WHERE le.target_model = 'location'
+  AND le.target_pk = l.locationid
+  AND le.target_sortkey IS NULL;
+
+-- Backfill from org (id with optional description)
+UPDATE manage.auditlog_logentry le
+SET object_sortkey = CASE WHEN o.descr != '' THEN o.orgid || ' (' || o.descr || ')' ELSE o.orgid END
+FROM manage.org o
+WHERE le.object_model = 'org'
+  AND le.object_pk = o.orgid
+  AND le.object_sortkey IS NULL;
+
+UPDATE manage.auditlog_logentry le
+SET target_sortkey = CASE WHEN o.descr != '' THEN o.orgid || ' (' || o.descr || ')' ELSE o.orgid END
+FROM manage.org o
+WHERE le.target_model = 'org'
+  AND le.target_pk = o.orgid
+  AND le.target_sortkey IS NULL;

--- a/python/nav/web/api/v2/__init__.py
+++ b/python/nav/web/api/v2/__init__.py
@@ -1,0 +1,1 @@
+# API v2 package

--- a/python/nav/web/api/v2/urls.py
+++ b/python/nav/web/api/v2/urls.py
@@ -1,6 +1,5 @@
 #
-# Copyright (C) 2014 Uninett AS
-# Copyright (C) 2022 Sikt
+# Copyright (C) 2026 Sikt
 #
 # This file is part of Network Administration Visualized (NAV).
 #
@@ -14,15 +13,13 @@
 # more details.  You should have received a copy of the GNU General Public
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
-"""URL mapping for the various API versions"""
+"""Urlconf for the NAV REST API v2"""
 
-from django.urls import path
-from django.urls import include
-from nav.web.api.v1 import urls as v1_urls
-from nav.web.api.v2 import urls as v2_urls
+from rest_framework import routers
 
-urlpatterns = [
-    path('', include((v1_urls, 'api'))),
-    path('1/', include((v1_urls, 'api'), namespace='1')),
-    path('2/', include((v2_urls, 'api'), namespace='2')),
-]
+from nav.auditlog import api as auditlogapi
+
+router = routers.SimpleRouter()
+router.register(r'auditlog', auditlogapi.LogEntryViewSetV2, basename='auditlog')
+
+urlpatterns = router.urls

--- a/python/nav/web/templates/auditlog/_logentry_list.html
+++ b/python/nav/web/templates/auditlog/_logentry_list.html
@@ -34,13 +34,12 @@
 <script type="text/javascript">
  require(['libs/urijs/URI', 'moment', 'libs/datatables.min', 'dt_config'], function(Uri, moment, DataTable) {
      var api_parameters = {{ auditlog_api_parameters|safe|default:'{}' }};
-     var columns = {
+     var orderingFields = {
          0: 'timestamp',
-         1: 'actor',
+         1: 'actor_sortkey',
          2: 'verb',
-         3: 'object',
-         4: 'target',
-         5: 'summary'
+         3: 'object_sortkey',
+         4: 'target_sortkey'
      };
 
      /* Utility function to escape HTML special characters to prevent XSS */
@@ -52,10 +51,20 @@
          return div.innerHTML;
      }
 
+     /* Render an entity (actor/object/target) as a link if URL is available */
+     function renderEntity(data) {
+         if (!data) return '';
+         const name = escapeHtml(data.name);
+         if (data.url) {
+             return '<a href="' + escapeHtml(data.url) + '">' + name + '</a>';
+         }
+         return name;
+     }
+
      var dt_config = {
          serverSide: true,  // Everything is done serverside - sorting, filtering, etc.
          ajax: {
-             url: '/api/1/auditlog/',
+             url: '/api/2/auditlog/',
              data: function(d) {
                  // Override the original parameters that we get when using serverSide rendering
                  var parameters = {
@@ -64,7 +73,7 @@
                      page_size: d.length,
                      ordering: d.order.map(function(order) {
                          var direction = order.dir === 'asc' ? '' : '-';
-                         return direction + columns[order.column];
+                         return direction + orderingFields[order.column];
                      }).join(',')
                  }
                  return Object.assign(parameters, api_parameters);
@@ -80,28 +89,26 @@
          },
          columns: [
              {
-                 data: columns[0],
+                 data: 'timestamp',
                  render: function(data, type, row, meta) {
                      return moment(data).format('YYYY-MM-DD HH:mm:ss');
                  }
              },
              {
-                 data: columns[1],
-                 render: escapeHtml
+                 data: 'actor',
+                 render: renderEntity
              },
-             { data: columns[2] },
+             { data: 'verb' },
              {
-                 data: columns[3],
-                 orderable: false,
-                 render: escapeHtml
-             },
-             {
-                 data: columns[4],
-                 orderable: false,
-                 render: escapeHtml
+                 data: 'object',
+                 render: renderEntity
              },
              {
-                 data: columns[5],
+                 data: 'target',
+                 render: renderEntity
+             },
+             {
+                 data: 'summary',
                  orderable: false,
                  render: escapeHtml
              }
@@ -122,7 +129,7 @@
          ],
          language: {
              lengthMenu: "Rows _MENU_",
-             search: "Search in summary"
+             search: "Search"
          },
          drawCallback: drawCallback,
      };

--- a/tests/integration/auditlog_test.py
+++ b/tests/integration/auditlog_test.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
 from nav.models.arnold import Justification
+from nav.models.profiles import Account
 
 from nav.auditlog import find_modelname
 from nav.auditlog.models import LogEntry
@@ -86,6 +87,51 @@ class AuditlogModelTestCase(TestCase):
         name = find_modelname(self.justification)
         self.assertEqual(name, 'blocked_reason')
 
+    def test_when_log_entry_created_then_actor_sortkey_should_be_set(self):
+        LogEntry.add_log_entry(
+            self.justification, 'sortkey test', '{actor} did something'
+        )
+        log_entry = LogEntry.objects.filter(verb='sortkey test').get()
+        self.assertEqual(log_entry.actor_sortkey, str(self.justification))
+
+    def test_when_log_entry_has_object_then_object_sortkey_should_be_set(self):
+        other = Justification.objects.create(name='object_test')
+        LogEntry.add_log_entry(
+            self.justification,
+            'object sortkey test',
+            '{actor} edited {object}',
+            object=other,
+        )
+        log_entry = LogEntry.objects.filter(verb='object sortkey test').get()
+        self.assertEqual(log_entry.object_sortkey, str(other))
+
+    def test_when_log_entry_has_no_object_then_object_sortkey_should_be_null(self):
+        LogEntry.add_log_entry(
+            self.justification, 'no object test', '{actor} did something'
+        )
+        log_entry = LogEntry.objects.filter(verb='no object test').get()
+        self.assertIsNone(log_entry.object_sortkey)
+
+    def test_when_log_entry_has_target_then_target_sortkey_should_be_set(self):
+        obj = Justification.objects.create(name='target_obj')
+        target = Justification.objects.create(name='target_test')
+        LogEntry.add_log_entry(
+            self.justification,
+            'target sortkey test',
+            '{actor} sent {object} to {target}',
+            object=obj,
+            target=target,
+        )
+        log_entry = LogEntry.objects.filter(verb='target sortkey test').get()
+        self.assertEqual(log_entry.target_sortkey, str(target))
+
+    def test_when_log_entry_has_no_target_then_target_sortkey_should_be_null(self):
+        LogEntry.add_log_entry(
+            self.justification, 'no target test', '{actor} did something'
+        )
+        log_entry = LogEntry.objects.filter(verb='no target test').get()
+        self.assertIsNone(log_entry.target_sortkey)
+
 
 class AuditlogUtilsTestCase(TestCase):
     def setUp(self):
@@ -118,3 +164,114 @@ class AuditlogUtilsTestCase(TestCase):
         self.assertEqual(entries.count(), 1)
         entries = get_auditlog_entries(modelname=modelname, pks=[justification_1.pk])
         self.assertEqual(entries.count(), 2)
+
+
+def test_v1_api_should_return_plain_strings_for_backward_compatibility(
+    db, token, api_client
+):
+    """Test that v1 API returns plain strings (backward compatibility)"""
+    # Configure token to allow access to v1 auditlog endpoint
+    token.endpoints = {'auditlog': '/auditlog/'}
+    token.save()
+
+    # Create an account that will be the actor
+    account = Account.objects.create(
+        login='testuser', name='Test User', password='unused'
+    )
+    # Create a justification as the object
+    justification = Justification.objects.create(name='test_object')
+
+    # Create a log entry
+    entry = LogEntry.add_log_entry(
+        account,
+        'test-action',
+        '{actor} performed action on {object}',
+        object=justification,
+    )
+
+    # Fetch the entry via v1 API
+    response = api_client.get(f'/api/1/auditlog/{entry.id}/')
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # Verify v1 returns plain strings
+    assert isinstance(data['actor'], str)
+    assert data['actor'] == 'testuser'
+    assert isinstance(data['object'], str)
+    assert data['object'] == 'test_object'
+
+
+def test_v2_api_retrieve_should_return_entity_objects_with_urls(db, token, api_client):
+    """Test that v2 retrieve endpoint returns objects with {name, url}"""
+    # Configure token to allow access to v2 auditlog endpoint
+    # Note: TokenPermission.version=1 strips /api/1, so v2 paths become /2/auditlog/
+    token.endpoints = {'auditlog': '/2/auditlog/'}
+    token.save()
+
+    # Create an account that will be the actor (accounts have get_absolute_url)
+    account = Account.objects.create(
+        login='testuser', name='Test User', password='unused'
+    )
+    # Create a justification as the object
+    justification = Justification.objects.create(name='test_object')
+
+    # Create a log entry
+    entry = LogEntry.add_log_entry(
+        account,
+        'test-action',
+        '{actor} performed action on {object}',
+        object=justification,
+    )
+
+    # Fetch the entry via v2 API retrieve endpoint
+    response = api_client.get(f'/api/2/auditlog/{entry.id}/')
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # Verify actor has both name and url
+    assert isinstance(data['actor'], dict)
+    assert data['actor']['name'] == 'testuser'
+    assert data['actor']['url'] is not None
+    assert '/useradmin/account/' in data['actor']['url']
+
+    # Verify object has name (url may be None if Justification lacks get_absolute_url)
+    assert isinstance(data['object'], dict)
+    assert data['object']['name'] == 'test_object'
+
+
+def test_v2_api_list_should_return_entity_objects_with_urls(db, token, api_client):
+    """Test that v2 list endpoint returns objects with {name, url}"""
+    # Configure token to allow access to v2 auditlog endpoint
+    # Note: TokenPermission.version=1 strips /api/1, so v2 paths become /2/auditlog/
+    token.endpoints = {'auditlog': '/2/auditlog/'}
+    token.save()
+
+    # Create an account that will be the actor
+    account = Account.objects.create(
+        login='testuser', name='Test User', password='unused'
+    )
+    # Create a justification as the object
+    justification = Justification.objects.create(name='test_object')
+
+    # Create a log entry
+    LogEntry.add_log_entry(
+        account,
+        'test-action',
+        '{actor} performed action on {object}',
+        object=justification,
+    )
+
+    # Fetch entries via v2 API list endpoint
+    response = api_client.get('/api/2/auditlog/')
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data['results']) > 0
+
+    # Check the first entry
+    first_entry = data['results'][0]
+    assert isinstance(first_entry['actor'], dict)
+    assert 'name' in first_entry['actor']
+    assert 'url' in first_entry['actor']


### PR DESCRIPTION
## Scope and purpose

Resolves #3757
                                                                                                                                                                                                                                      
Adds sortable display name columns (`actor_sortkey`, `object_sortkey`, `target_sortkey`) to auditlog entries. This enables sorting and searching on these columns, and allows showing entity links when the referenced objects still exist.

**Key decisions:**
- Sortkeys preserve display names after objects are deleted
- Batch resolution pattern loads entities without causing N+1 queries
- Created API v2 to add entity linking while maintaining v1 backward compatibility

**API v2 added:** New `/api/2/auditlog/` endpoint returns `actor`, `object`, and `target` as objects with `{name, url}` for entity linking. The existing `/api/1/auditlog/` endpoint continues to return plain strings and remains unchanged. The web UI now uses v2.

**Migration note:** The backfill operation may take some time on deployments with millions of log entries.

### Testing backfill and entity links

Filter by `verb=edit-account-add-org`, `verb=disable-interface`, `verb=create-netbox`, `verb=delete-netbox`, or `verb=create-account` to observe:

- **Clickable links** when entities still exist - The actor/object/target names are clickable and navigate to the entity's detail page (e.g., clicking an account name goes to the account detail page)
- **Placeholder text** when entities are deleted - Shows `model_name (ID)` format (e.g., `account (123)`) since the object no longer exists, but the sortkey preserved the searchable text

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file