### PR TITLE
Improve maintenance component selector ux

### DIFF
--- a/changelog.d/3778.added.md
+++ b/changelog.d/3778.added.md
@@ -1,0 +1,1 @@
+Add browse tree and description search for maintenance task component selection

--- a/python/nav/web/maintenance/urls.py
+++ b/python/nav/web/maintenance/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
     path('planned/', views.planned, name='maintenance-planned'),
     path('historic/', views.historic, name='maintenance-historic'),
     path('search/', views.component_search, name='maintenance-component-search'),
+    path('browse/', views.component_browse, name='maintenance-component-browse'),
     path(
         'selectcomponents/',
         views.component_select,

--- a/python/nav/web/maintenance/utils.py
+++ b/python/nav/web/maintenance/utils.py
@@ -157,6 +157,8 @@ def get_component_keys(post):
     errors = []
     raw_component_keys = {key: post.getlist(key) for key in ALLOWED_COMPONENTS}
     raw_component_keys['location'].extend(post.getlist('loc'))
+    raw_component_keys['location'].extend(post.getlist('add_loc'))
+    raw_component_keys['room'].extend(post.getlist('add_room'))
     if 'remove' in post:
         remove = {key: post.getlist(f"remove_{key}") for key in ALLOWED_COMPONENTS}
     component_keys = {key: [] for key in ALLOWED_COMPONENTS}

--- a/python/nav/web/sass/nav.scss
+++ b/python/nav/web/sass/nav.scss
@@ -23,6 +23,7 @@
 @import "nav/modal";
 @import "nav/tooltip";
 @import "nav/popover";
+@import "nav/maintenance";
 
 // Custom css for libraries
 @import "libs/driver";

--- a/python/nav/web/sass/nav/maintenance.scss
+++ b/python/nav/web/sass/nav/maintenance.scss
@@ -1,0 +1,141 @@
+// Maintenance task form styles
+
+#new-task-form {
+  textarea {
+    height: 8em;
+  }
+
+  select[multiple] {
+    height: 8em;
+  }
+}
+
+#component-list {
+  li {
+    overflow: auto;
+
+    div:first-child {
+      float: left;
+      width: 8em;
+    }
+
+    div:last-child {
+      margin-left: 8em;
+    }
+  }
+}
+
+.component-search-section {
+  label {
+    position: relative;
+  }
+
+  .htmx-indicator {
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  input[type="search"] {
+    margin-bottom: 0.25em;
+  }
+
+  .browse-hint {
+    margin: 0;
+    text-align: right;
+
+    button {
+      background: none;
+      border: none;
+      padding: 0;
+      margin: 0;
+      color: #008cba;
+      cursor: pointer;
+      text-decoration: underline;
+      font-size: inherit;
+    }
+  }
+
+  #search-results:not(:empty) {
+    margin-top: 0.5em;
+  }
+}
+
+.browse-actions {
+  margin-bottom: 0;
+
+  .button {
+    margin-bottom: 0;
+  }
+}
+
+.browse-tree {
+  border: 1px solid #ddd;
+  padding: 0.5em;
+  margin-top: 0.5em;
+  max-height: 20em;
+  overflow-y: auto;
+  background:
+    linear-gradient(white 30%, rgba(255, 255, 255, 0)) top,
+    linear-gradient(rgba(255, 255, 255, 0), white 70%) bottom,
+    radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0)) top,
+    radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0)) bottom;
+  background-repeat: no-repeat;
+  background-size: 100% 2em, 100% 2em, 100% 0.6em, 100% 0.6em;
+  background-attachment: local, local, scroll, scroll;
+
+  .fa {
+    cursor: pointer;
+  }
+
+  .room-connector {
+    cursor: default;
+    color: #999;
+    font-family: monospace;
+  }
+
+  .child {
+    display: none;
+    overflow: hidden;
+
+    &.open {
+      display: block;
+    }
+  }
+
+  li {
+    list-style: none;
+    margin: 0.2em 0;
+  }
+
+  ul {
+    padding-left: 1.2em;
+    margin: 0;
+  }
+
+  .browse-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3em;
+
+    .button {
+      margin-bottom: 0;
+    }
+  }
+
+  .nav-tooltip {
+    [role="tooltip"] {
+      position: fixed;
+    }
+  }
+
+  .browse-description {
+    color: #666;
+    max-width: 12em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: inline-block;
+    vertical-align: bottom;
+  }
+}

--- a/python/nav/web/templates/maintenance/_component-browse-location.html
+++ b/python/nav/web/templates/maintenance/_component-browse-location.html
@@ -1,0 +1,56 @@
+{% if location.browse_children or location.browse_rooms %}
+    <i class="fa fa-toggle-right"></i>
+{% endif %}
+<span class="browse-item">
+    <strong>{{ location.id }}</strong>
+    {% if location.description %}
+        <span class="browse-description">{{ location.description }}</span>
+        <div class="nav-tooltip">
+            <i class="fa fa-question-circle-o unstyled-tooltip" aria-describedby="#loc-tooltip-{{ location.pk }}"></i>
+            <span id="loc-tooltip-{{ location.pk }}" role="tooltip" class="small">{{ location.description }}</span>
+        </div>
+    {% endif %}
+    <button
+        type="button"
+        class="button tiny secondary"
+        hx-post="{% url 'maintenance-component-select' %}"
+        hx-target="#selected-components"
+        hx-include="#selected-components input"
+        hx-vals='{"add_loc": "{{ location.pk|escapejs }}"}'
+    >Add</button>
+</span>
+
+{% if location.browse_children or location.browse_rooms %}
+<ul class="child">
+    {% for child in location.browse_children %}
+        <li>
+            {% with location=child %}
+                {% include 'maintenance/_component-browse-location.html' %}
+            {% endwith %}
+        </li>
+    {% endfor %}
+    {% for room in location.browse_rooms %}
+        <li>
+            <span class="browse-item">
+                <span class="room-connector">{% if forloop.last %}└─{% else %}├─{% endif %}</span>
+                <strong>{{ room.id }}</strong>
+                {% if room.description %}
+                    <span class="browse-description">{{ room.description }}</span>
+                    <div class="nav-tooltip">
+                        <i class="fa fa-question-circle-o unstyled-tooltip" aria-describedby="#room-tooltip-{{ room.pk }}"></i>
+                        <span id="room-tooltip-{{ room.pk }}" role="tooltip" class="small">{{ room.description }}</span>
+                    </div>
+                {% endif %}
+                <button
+                    type="button"
+                    class="button tiny secondary"
+                    hx-post="{% url 'maintenance-component-select' %}"
+                    hx-target="#selected-components"
+                    hx-include="#selected-components input"
+                    hx-vals='{"add_room": "{{ room.pk|escapejs }}"}'
+                >Add</button>
+            </span>
+        </li>
+    {% endfor %}
+</ul>
+{% endif %}

--- a/python/nav/web/templates/maintenance/_component-browse.html
+++ b/python/nav/web/templates/maintenance/_component-browse.html
@@ -1,0 +1,77 @@
+<div id="browse-panel">
+    <div class="browse-actions">
+        <button type="button" class="button tiny secondary" id="browse-expand-all">Expand all</button>
+        <button type="button" class="button tiny secondary" id="browse-collapse-all">Collapse all</button>
+        <button type="button" class="button tiny" id="browse-close">Close</button>
+    </div>
+
+    <div class="browse-tree">
+        <ul class="no-bullet">
+            {% for location in locations %}
+                <li>
+                    {% include 'maintenance/_component-browse-location.html' %}
+                </li>
+            {% empty %}
+                <li>No locations found.</li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>
+
+<script>
+    (() => {
+        const tree = document.querySelector('.browse-tree');
+        const panel = document.getElementById('browse-panel');
+
+        const collapseAll = () => {
+            tree.querySelectorAll('.child').forEach(el => el.classList.remove('open'));
+            tree.querySelectorAll('.fa-toggle-down').forEach(el => {
+                el.classList.replace('fa-toggle-down', 'fa-toggle-right');
+            });
+        };
+
+        tree.addEventListener('click', (event) => {
+            const icon = event.target.closest('.fa-toggle-right, .fa-toggle-down');
+            if (icon) {
+                icon.classList.toggle('fa-toggle-right');
+                icon.classList.toggle('fa-toggle-down');
+                const childList = icon.closest('li').querySelector(':scope > .child');
+                if (childList) {
+                    childList.classList.toggle('open');
+                }
+            }
+        });
+
+        document.getElementById('browse-expand-all').addEventListener('click', () => {
+            tree.querySelectorAll('.child').forEach(el => el.classList.add('open'));
+            tree.querySelectorAll('.fa-toggle-right').forEach(el => {
+                el.classList.replace('fa-toggle-right', 'fa-toggle-down');
+            });
+        });
+
+        document.getElementById('browse-collapse-all').addEventListener('click', collapseAll);
+
+        document.getElementById('browse-close').addEventListener('click', () => {
+            panel.style.display = 'none';
+            collapseAll();
+        });
+
+        tree.querySelectorAll('.nav-tooltip').forEach(tooltip => {
+            tooltip.addEventListener('mouseenter', () => {
+                const trigger = tooltip.querySelector('[aria-describedby]');
+                const popup = tooltip.querySelector('[role="tooltip"]');
+                if (!trigger || !popup) return;
+                popup.style.display = '';
+                const rect = trigger.getBoundingClientRect();
+                popup.style.top = `${rect.bottom + 8}px`;
+                popup.style.left = `${rect.left}px`;
+            });
+        });
+
+        tree.addEventListener('scroll', () => {
+            tree.querySelectorAll('[role="tooltip"]').forEach(popup => {
+                popup.style.display = 'none';
+            });
+        });
+    })();
+</script>

--- a/python/nav/web/templates/maintenance/new_task.html
+++ b/python/nav/web/templates/maintenance/new_task.html
@@ -1,27 +1,6 @@
 {% extends "maintenance/base.html" %}
 {% load maintenance %}
 
-{% block base_header_additional_head %}
-  {{ block.super }}
-  <style>
-   #new-task-form textarea {
-       height: 8em;
-   }
-   #new-task-form select[multiple] {
-       height: 8em;
-   }
-   #component-list li { overflow: auto; }
-   #component-list li div:first-child {
-       float: left;
-       width: 8em;
-   }
-   #component-list li div:last-child {
-       margin-left: 8em;
-   }
-  </style>
-{% endblock %}
-
-
 {% block content %}
 
   {% include 'maintenance/back.html' %}
@@ -39,27 +18,36 @@
         </div>
 
         <div class="large-4 columns">
-            <fieldset>
-                <legend>Select components</legend>
-                <label for="component-search">
-                    Search
-                </label>
-                <input
-                    id="component-search"
-                    class="form-control" type="search"
-                    name="search"
-                    placeholder="Begin typing to search for components..."
-                    hx-post="{% url 'maintenance-component-search' %}"
-                    hx-trigger="input changed delay:500ms, search"
-                    hx-target="#search-results"
-                    hx-indicator=".htmx-indicator"
-                />
+          <fieldset>
+            <legend>Select components</legend>
+            <div class="component-search-section">
+              <label for="component-search">
+                Search
                 <span class="htmx-indicator">
-                    <img src="/static/images/select2/select2-spinner.gif" alt="Loading spinner" /> Searching...
+                  <img src="/static/images/select2/select2-spinner.gif" alt="Loading spinner" /> Searching...
                 </span>
-                <div id="search-results"></div>
-            </fieldset>
-
+              </label>
+              <input
+                id="component-search"
+                class="form-control" type="search"
+                name="search"
+                placeholder="Search for components..."
+                hx-post="{% url 'maintenance-component-search' %}"
+                hx-trigger="input changed delay:500ms, search"
+                hx-target="#search-results"
+                hx-indicator=".htmx-indicator"
+              />
+              <div class="browse-hint">
+                or
+                <button type="button"
+                  hx-get="{% url 'maintenance-component-browse' %}"
+                  hx-target="#search-results"
+                  hx-indicator=".htmx-indicator"
+                >browse locations &amp; rooms</button>
+              </div>
+              <div id="search-results"></div>
+            </div>
+          </fieldset>
         </div>
 
         <div class="large-4 columns">


### PR DESCRIPTION
## Scope and purpose

Fixes #3778

Improves component selection UX in the maintenance task form:                                                                                                                                                                             

- Search by description: Users can now search rooms and locations by description in addition to ID
- Browse tree: New collapsible tree view shows all locations and rooms with their hierarchy. Users can expand/collapse nodes and add components directly from the tree
- Scroll shadow: Tree uses CSS scroll shadows to indicate when content is scrollable

Technical notes:
- Fetches all locations/rooms in 2 queries, builds tree in Python to avoid N+1 queries
- Uses HTMX for browse panel loading and component selection
- CSS extracted to maintenance.scss for maintainability
- Component selection uses add_room/add_loc parameters to properly merge with existing selections

### Screen recording
https://github.com/user-attachments/assets/d7476083-4d85-40e7-864c-7d96c9d5e2d8

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
