### PR TITLE
Add global CSRF token handlers for all jQuery AJAX and HTMX POST requests

### DIFF
--- a/changelog.d/+global-htmx-and-jquery-csrf.fixed.md
+++ b/changelog.d/+global-htmx-and-jquery-csrf.fixed.md
@@ -1,0 +1,1 @@
+Add global CSRF token handlers for all HTMX and jQuery AJAX POST requests, to ensure things do not break unintentionally when CSRF validation is enabled

--- a/python/nav/web/static/js/src/plugins/csrf-utils.js
+++ b/python/nav/web/static/js/src/plugins/csrf-utils.js
@@ -2,22 +2,33 @@
  * CSRF utility functions for AJAX requests.
  * Django's recommended approach is to read the token from the cookie.
  * See: https://docs.djangoproject.com/en/5.0/howto/csrf/
+ *
+ * This module works as both a standalone script (exposes window.getCsrfToken)
+ * and as a RequireJS module for compatibility with existing code.
  */
-function getCsrfToken() {
-    const name = 'csrftoken=';
-    if (document.cookie && document.cookie !== '') {
-        for (const part of document.cookie.split(';')) {
-            const cookie = part.trim();
-            if (cookie.startsWith(name)) {
-                return decodeURIComponent(cookie.substring(name.length));
+(function(root) {
+    function getCsrfToken() {
+        const name = 'csrftoken=';
+        if (document.cookie && document.cookie !== '') {
+            for (const part of document.cookie.split(';')) {
+                const cookie = part.trim();
+                if (cookie.startsWith(name)) {
+                    return decodeURIComponent(cookie.substring(name.length));
+                }
             }
         }
+        return null;
     }
-    return null;
-}
 
-define([], function () {
-    return {
-        getCsrfToken: getCsrfToken
-    };
-});
+    // Expose globally for standalone usage
+    root.getCsrfToken = getCsrfToken;
+
+    // Also define as RequireJS module if available
+    if (typeof define === 'function' && define.amd) {
+        define([], function () {
+            return {
+                getCsrfToken: getCsrfToken
+            };
+        });
+    }
+})(window);

--- a/python/nav/web/templates/base.html
+++ b/python/nav/web/templates/base.html
@@ -18,6 +18,20 @@
     {% comment %} Javascript global variables {% endcomment %}
     <script src="{{ STATIC_URL }}js/libs/jquery-4.0.0.min.js"></script>
     <script src="{{ STATIC_URL }}js/libs/htmx-2.0.4.min.js"></script>
+    <script src="{{ STATIC_URL }}js/src/plugins/csrf-utils.js"></script>
+    <script>
+      // Global CSRF token setup for all HTMX requests.
+      // This approach is used because we have 7+ locations in the codebase with
+      // hx-post elements outside forms that lack CSRF tokens, which would break
+      // when CSRF protection is enabled. A global handler provides a safety net.
+      // See: https://docs.djangoproject.com/en/5.0/howto/csrf/
+      document.addEventListener('htmx:configRequest', function(event) {
+          const token = getCsrfToken();
+          if (token) {
+              event.detail.headers['X-CSRFToken'] = token;
+          }
+      });
+    </script>
     {% include 'navurls.html' %}
     <script src="{{ STATIC_URL }}js/require_config.js"></script>
     {% if debug %}


### PR DESCRIPTION
## Scope and purpose

I tested #3396 once more. While we remain pretty confident all Django/Python forms now provide CSRF tokens in a correct manner, the same cannot be said for various JS code that runs POST requests against the backend.

I kindly asked Claude to analyze the code base and find potential issues.  It found a lot, and I sampled some of them and confirmed them to have issues when #3396 applied.

The fix Claude suggested (again) was to simply add a global handler for HTMX requests, and a similar handler for jQuery AJAX requests.  

This PR provides both those solutions, and I hope @Simrayz can do a proper evaluation (I guess we should potentially add some tests as well)

### The Claude analysis conclusion

Claude purported to find these issues with the codebase:

```
A. jQuery $.post() / $.ajax() calls without CSRF tokens
┌─────┬───────────────────────────────────────────────────────────┬──────┬──────────────────────────────────────┐
│  #  │                           File                            │ Line │          Function / Context          │
├─────┼───────────────────────────────────────────────────────────┼──────┼──────────────────────────────────────┤
│ 1   │ python/nav/web/static/js/src/portadmin.js                 │ 476  │ restartInterfaces()                  │
├─────┼───────────────────────────────────────────────────────────┼──────┼──────────────────────────────────────┤
│ 2   │ python/nav/web/static/js/src/business.js                  │ 99   │ addRemoveSubscriptionListener()      │
├─────┼───────────────────────────────────────────────────────────┼──────┼──────────────────────────────────────┤
│ 3   │ python/nav/web/static/js/src/business.js                  │ 112  │ addUndoUnsubscribeListener()         │
├─────┼───────────────────────────────────────────────────────────┼──────┼──────────────────────────────────────┤
│ 4   │ python/nav/web/static/js/src/webfront.js                  │ 68   │ addDroppableDashboardTargets()       │
├─────┼───────────────────────────────────────────────────────────┼──────┼──────────────────────────────────────┤
│ 5   │ python/nav/web/static/js/src/sensor_details.js            │ 50   │ add-to-dashboard button              │
├─────┼───────────────────────────────────────────────────────────┼──────┼──────────────────────────────────────┤
│ 6   │ python/nav/web/static/js/src/plugins/graphfetcher.js      │ 149  │ add graph widget to dashboard        │
├─────┼───────────────────────────────────────────────────────────┼──────┼──────────────────────────────────────┤
│ 7   │ python/nav/web/static/js/src/plugins/sensor_controller.js │ 78   │ addDashboardListener()               │
├─────┼───────────────────────────────────────────────────────────┼──────┼──────────────────────────────────────┤
│ 8   │ python/nav/web/static/js/src/plugins/navlet_pdu.js        │ 38   │ fetch PDU data via Graphite proxy    │
├─────┼───────────────────────────────────────────────────────────┼──────┼──────────────────────────────────────┤
│ 9   │ python/nav/web/static/js/src/plugins/navlet_ups.js        │ 38   │ fetch UPS data via Graphite proxy    │
├─────┼───────────────────────────────────────────────────────────┼──────┼──────────────────────────────────────┤
│ 10  │ python/nav/web/static/js/src/ipdevinfo.js                 │ 83   │ fetch sensor data via Graphite proxy │
└─────┴───────────────────────────────────────────────────────────┴──────┴──────────────────────────────────────┘
Not an issue: main.js:36 POSTs to refresh_session which is @csrf_exempt.

Already protected (no changes needed): portadmin.js (save/commit), report.js, image_upload.js, info_room_rack.js, netmap/control_view.js, netmap/models.js, navlet_controller.js (title), navlets_htmx_controller.js, status2/views.js, neighbors.js —
these already include X-CSRFToken header or csrfmiddlewaretoken field.

Form-serialized (already safe): business.js:73 (subscription form), webfront.js:221,236 (add/rename dashboard), navlet_controller.js:210 (edit form submit) — these use $(form).serialize() on forms that contain {% csrf_token %}.

B. HTMX hx-post elements NOT inside a <form> (missing CSRF token)
┌─────┬────────────────────────────────────────────┬────────────┬───────────────────────────────────┐
│  #  │                    File                    │    Line    │              Element              │
├─────┼────────────────────────────────────────────┼────────────┼───────────────────────────────────┤
│ 11  │ webfront/index.html                        │ 78         │ "Set as default dashboard" button │
├─────┼────────────────────────────────────────────┼────────────┼───────────────────────────────────┤
│ 12  │ maintenance/new_task.html                  │ 52         │ Component search input            │
├─────┼────────────────────────────────────────────┼────────────┼───────────────────────────────────┤
│ 13  │ devicehistory/_component_search_input.html │ 10         │ Component search input            │
├─────┼────────────────────────────────────────────┼────────────┼───────────────────────────────────┤
│ 14  │ info/room/fragment_rack.html               │ 56, 74, 92 │ Add sensor buttons                │
├─────┼────────────────────────────────────────────┼────────────┼───────────────────────────────────┤
│ 15  │ webfront/_dashboard_subscribe_button.html  │ 4, 8       │ Subscribe/unsubscribe buttons     │
├─────┼────────────────────────────────────────────┼────────────┼───────────────────────────────────┤
│ 16  │ maintenance/_selected-components-list.html │ 42         │ Remove selected button            │
├─────┼────────────────────────────────────────────┼────────────┼───────────────────────────────────┤
│ 17  │ maintenance/_component-search-results.html │ 24         │ Add component button              │
└─────┴────────────────────────────────────────────┴────────────┴───────────────────────────────────┘
Already safe: HTMX hx-post elements that ARE inside <form> tags with {% csrf_token %} (all navlet edit forms, dashboard settings forms, seeddb forms, etc.) — HTMX automatically includes enclosing form values for POST requests.
```

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
