### PR TITLE
Add missing index on netboxentity.deviceid

### DIFF
--- a/changelog.d/+netboxentity-deviceid-index.fixed.md
+++ b/changelog.d/+netboxentity-deviceid-index.fixed.md
@@ -1,0 +1,1 @@
+Added missing index on `netboxentity.deviceid` to speed up lookups by device.

--- a/python/nav/models/sql/changes/sc.05.17.0005.sql
+++ b/python/nav/models/sql/changes/sc.05.17.0005.sql
@@ -1,0 +1,3 @@
+-- Add missing index on netboxentity.deviceid to speed up lookups by device
+DROP INDEX IF EXISTS netboxentity_deviceid_btree;
+CREATE INDEX netboxentity_deviceid_btree ON netboxentity (deviceid) WHERE deviceid IS NOT NULL;


### PR DESCRIPTION
## Scope and purpose

Add a partial btree index on `netboxentity.deviceid` to speed up lookups by device. Without this index, Django-generated queries filtering `netboxentity` by `deviceid` result in sequential scans.

On a large production install, this reduced mean execution time of device-related entity lookups from 30265ms to 0.076ms (~400,000x improvement).

The schema change script drops any existing index by the same name before creating the standard one, to handle installations that may have already defined a local index.

## Contributor Checklist

- [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
- [ ] ~~Added/amended tests for new/changed code~~
- [ ] ~~Added/changed documentation~~
- [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
- [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
- [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
- [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
- [X] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
- [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
- [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~