### PR TITLE
Fix Netmap crash on oversized cache objects

### DIFF
--- a/changelog.d/+netmap-cache-too-large.fixed.md
+++ b/changelog.d/+netmap-cache-too-large.fixed.md
@@ -1,0 +1,1 @@
+Fixed a crash in Netmap when the topology graph exceeds memcached's max item size. The graph is now returned successfully even when it cannot be cached.

--- a/python/nav/web/netmap/cache.py
+++ b/python/nav/web/netmap/cache.py
@@ -16,8 +16,11 @@
 
 """Cache utils for NetMap"""
 
+import logging
 from functools import wraps
 from django.core.cache import cache
+
+_logger = logging.getLogger(__name__)
 
 # TODO: This cache should be shared by all of NAV?
 # TODO: This cache should be invalidated only when the topology is
@@ -46,7 +49,7 @@ def cache_traffic(layer):
             if cached is not None:
                 return cached
             result = func(location_or_room_id)
-            cache.set(cache_key, result, TRAFFIC_CACHE_TIMEOUT)
+            _safe_cache_set(cache_key, result, TRAFFIC_CACHE_TIMEOUT)
             return result
 
         return get_traffic
@@ -73,7 +76,7 @@ def cache_topology(layer):
             except ValueError:
                 pass
             result = func(*args, **kwargs)
-            cache.set(cache_key, result, CACHE_TIMEOUT)
+            _safe_cache_set(cache_key, result, CACHE_TIMEOUT)
             return result
 
         return get_traffic
@@ -95,13 +98,21 @@ def update_cached_node_positions(viewid, layer, updated_nodes):
             continue
         diff = {"x": node["x"], "y": node["y"]}
         to_update["nodes"][node["id"]]["position"] = diff
-    cache.set(cache_key, to_update, CACHE_TIMEOUT)
+    _safe_cache_set(cache_key, to_update, CACHE_TIMEOUT)
 
 
 def invalidate_topology_cache(viewid, layer):
     "Resets the topology cache, prompting NAV to rebuild it"
     cache_key = _cache_key("topology", viewid, layer)
     cache.delete(cache_key)
+
+
+def _safe_cache_set(key, value, timeout):
+    """Attempt to set a cache key, logging a warning on failure."""
+    try:
+        cache.set(key, value, timeout)
+    except Exception as error:  # noqa: BLE001
+        _logger.warning("Failed to set cache key %s: %s", key, error)
 
 
 # TODO: Consider using a proper slug generator for this

--- a/tests/unittests/netmap/cache_test.py
+++ b/tests/unittests/netmap/cache_test.py
@@ -1,0 +1,63 @@
+"""Tests for netmap cache utilities"""
+
+from unittest.mock import patch
+
+from nav.web.netmap.cache import (
+    _safe_cache_set,
+    cache_topology,
+    cache_traffic,
+)
+
+
+class TestSafeCacheSet:
+    def test_when_cache_set_succeeds_it_should_call_cache_set(self):
+        with patch('nav.web.netmap.cache.cache') as mock_cache:
+            _safe_cache_set('key', 'value', 60)
+            mock_cache.set.assert_called_once_with('key', 'value', 60)
+
+    def test_when_cache_set_raises_it_should_log_warning_not_raise(self):
+        with patch('nav.web.netmap.cache.cache') as mock_cache:
+            mock_cache.set.side_effect = Exception('object too large for cache')
+            with patch('nav.web.netmap.cache._logger') as mock_logger:
+                _safe_cache_set('key', 'value', 60)
+                mock_logger.warning.assert_called_once()
+
+
+class TestCacheTopology:
+    def test_when_cache_set_fails_it_should_still_return_result(self):
+        with patch('nav.web.netmap.cache.cache') as mock_cache:
+            mock_cache.get.return_value = None
+            mock_cache.set.side_effect = Exception('object too large for cache')
+
+            @cache_topology("layer 2")
+            def my_func(view=None):
+                return {'nodes': {}, 'links': []}
+
+            result = my_func(view=None)
+            assert result == {'nodes': {}, 'links': []}
+
+    def test_when_cached_data_exists_it_should_return_cached_data(self):
+        cached_data = {'nodes': {'a': 1}, 'links': []}
+        with patch('nav.web.netmap.cache.cache') as mock_cache:
+            mock_cache.get.return_value = cached_data
+
+            @cache_topology("layer 2")
+            def my_func(view=None):
+                return {'nodes': {}, 'links': []}
+
+            result = my_func(view=None)
+            assert result == cached_data
+
+
+class TestCacheTraffic:
+    def test_when_cache_set_fails_it_should_still_return_result(self):
+        with patch('nav.web.netmap.cache.cache') as mock_cache:
+            mock_cache.get.return_value = None
+            mock_cache.set.side_effect = Exception('object too large for cache')
+
+            @cache_traffic("layer 2")
+            def my_func(location_or_room_id):
+                return [{'source': 1, 'target': 2}]
+
+            result = my_func(None)
+            assert result == [{'source': 1, 'target': 2}]


### PR DESCRIPTION
## Scope and purpose

Fixes a production crash where Netmap returns a 500 error when the layer 2 topology graph exceeds memcached's default max item size (1MB). The `MemcacheServerError: b'object too large for cache'` exception propagated up from `cache.set()` even though the graph data was computed successfully.

### This pull request
* [ ] ~~adds/changes/removes a dependency~~
* [ ] ~~changes the database~~
* [ ] ~~changes the API~~

## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [X] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [X] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~