### PR TITLE
Collapsed multiselects in status tool filters

### DIFF
--- a/changelog.d/3797.fixed.md
+++ b/changelog.d/3797.fixed.md
@@ -1,0 +1,1 @@
+Fix collapsed multiselects in status tool filters

--- a/python/nav/web/status2/forms.py
+++ b/python/nav/web/status2/forms.py
@@ -35,6 +35,16 @@ from nav.web.crispyforms import (
 from . import STATELESS_THRESHOLD
 
 
+class Select2Multiple(forms.SelectMultiple):
+    """A SelectMultiple widget with select2 styling and full width"""
+
+    def __init__(self, attrs=None, choices=()):
+        default_attrs = {'class': 'select2', 'style': 'width: 100%'}
+        if attrs:
+            default_attrs.update(attrs)
+        super().__init__(attrs=default_attrs, choices=choices)
+
+
 class StatusPanelForm(forms.Form):
     """Form representing the status panel options for the user"""
 
@@ -53,62 +63,48 @@ class StatusPanelForm(forms.Form):
         alert_types = get_alert_types()
 
         self.fields['event_type'] = forms.MultipleChoiceField(
-            choices=get_event_types(), required=False
+            choices=get_event_types(), required=False, widget=Select2Multiple()
         )
-        self.fields['event_type'].widget.attrs.update({'class': 'select2'})
         self.fields['alert_type'] = forms.MultipleChoiceField(
-            choices=alert_types, required=False
+            choices=alert_types, required=False, widget=Select2Multiple()
         )
-        self.fields['alert_type'].widget.attrs.update({'class': 'select2'})
         self.fields['category'] = forms.MultipleChoiceField(
-            choices=get_categories(), required=False
+            choices=get_categories(), required=False, widget=Select2Multiple()
         )
-        self.fields['category'].widget.attrs.update({'class': 'select2'})
         self.fields['organization'] = forms.MultipleChoiceField(
-            choices=get_organizations(), required=False
+            choices=get_organizations(), required=False, widget=Select2Multiple()
         )
-        self.fields['organization'].widget.attrs.update({'class': 'select2'})
         self.fields['device_group'] = forms.MultipleChoiceField(
-            choices=get_device_groups(), required=False
+            choices=get_device_groups(), required=False, widget=Select2Multiple()
         )
-        self.fields['device_group'].widget.attrs.update({'class': 'select2'})
         self.fields['location'] = forms.MultipleChoiceField(
-            choices=get_locations(), required=False
+            choices=get_locations(), required=False, widget=Select2Multiple()
         )
-        self.fields['location'].widget.attrs.update({'class': 'select2'})
         self.fields['severity'] = forms.MultipleChoiceField(
-            choices=get_severity(), required=False
+            choices=get_severity(), required=False, widget=Select2Multiple()
         )
-        self.fields['severity'].widget.attrs.update({'class': 'select2'})
 
         self.fields['not_event_type'] = forms.MultipleChoiceField(
-            choices=get_event_types(), required=False
+            choices=get_event_types(), required=False, widget=Select2Multiple()
         )
-        self.fields['not_event_type'].widget.attrs.update({'class': 'select2'})
         self.fields['not_alert_type'] = forms.MultipleChoiceField(
-            choices=alert_types, required=False
+            choices=alert_types, required=False, widget=Select2Multiple()
         )
-        self.fields['not_alert_type'].widget.attrs.update({'class': 'select2'})
         self.fields['not_category'] = forms.MultipleChoiceField(
-            choices=get_categories(), required=False
+            choices=get_categories(), required=False, widget=Select2Multiple()
         )
-        self.fields['not_category'].widget.attrs.update({'class': 'select2'})
         self.fields['not_organization'] = forms.MultipleChoiceField(
-            choices=get_organizations(), required=False
+            choices=get_organizations(), required=False, widget=Select2Multiple()
         )
-        self.fields['not_organization'].widget.attrs.update({'class': 'select2'})
         self.fields['not_device_group'] = forms.MultipleChoiceField(
-            choices=get_device_groups(), required=False
+            choices=get_device_groups(), required=False, widget=Select2Multiple()
         )
-        self.fields['not_device_group'].widget.attrs.update({'class': 'select2'})
         self.fields['not_location'] = forms.MultipleChoiceField(
-            choices=get_locations(), required=False
+            choices=get_locations(), required=False, widget=Select2Multiple()
         )
-        self.fields['not_location'].widget.attrs.update({'class': 'select2'})
         self.fields['not_severity'] = forms.MultipleChoiceField(
-            choices=get_severity(), required=False
+            choices=get_severity(), required=False, widget=Select2Multiple()
         )
-        self.fields['not_severity'].widget.attrs.update({'class': 'select2'})
 
         self.fields['status_filters'] = forms.MultipleChoiceField(
             choices=[
@@ -118,8 +114,8 @@ class StatusPanelForm(forms.Form):
             ],
             required=False,
             label='Choose fields to filter status by',
+            widget=Select2Multiple(),
         )
-        self.fields['status_filters'].widget.attrs.update({'class': 'select2'})
 
         column_class = 'medium-6'
 
@@ -201,24 +197,6 @@ class StatusWidgetForm(StatusPanelForm):
 
     def __init__(self, *args, **kwargs):
         super(StatusWidgetForm, self).__init__(*args, **kwargs)
-
-        for field_name in (
-            "event_type",
-            "not_event_type",
-            "category",
-            "not_category",
-            "alert_type",
-            "not_alert_type",
-            "organization",
-            "not_organization",
-            "device_group",
-            "not_device_group",
-            "location",
-            "not_location",
-            "severity",
-            "not_severity",
-        ):
-            self.fields[field_name].widget.attrs.update({'class': 'select2'})
 
         column_class = 'medium-6'
 


### PR DESCRIPTION
## Scope and purpose

After upgrading jQuery in #3730 and select2 compatibility in #3768, the multiselects in the Status tool filters are collapsed. This PR fixes it by adding explicit width, and a re-usable Select2 widget. We might want to move this and re-use it in other tools.

## Screenshots

| Before | After |
| -------| ------|
| <img width="416" height="376" alt="image" src="https://github.com/user-attachments/assets/c9aa7253-aed2-47c7-9538-0b9f5d7efb7a" /> |  <img width="410" height="390" alt="image" src="https://github.com/user-attachments/assets/b7cd2438-972a-4e7c-8525-5789f690c789" /> |
## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
