### PR TITLE
Unblock event processing on overdue scheduler callbacks

### DIFF
--- a/changelog.d/3798.fixed.md
+++ b/changelog.d/3798.fixed.md
@@ -1,0 +1,1 @@
+Event engine now yields to overdue scheduler callbacks between processing queued events, preventing long event batches from blocking time-critical tasks.

--- a/python/nav/eventengine/engine.py
+++ b/python/nav/eventengine/engine.py
@@ -176,6 +176,11 @@ class EventEngine(object):
             self.CHECK_INTERVAL, action=self._load_new_events_and_reschedule
         )
 
+    def _has_overdue_callbacks(self):
+        """Checks whether the scheduler has any callbacks that are past due."""
+        queue = self._scheduler.queue
+        return bool(queue) and queue[0].time <= time.time()
+
     def _schedule_next_queuecheck(self, delay=0, action=None):
         if not action:
             action = self.load_new_events

--- a/python/nav/eventengine/engine.py
+++ b/python/nav/eventengine/engine.py
@@ -202,6 +202,7 @@ class EventEngine(object):
                 len(old_events),
             )
             batch_start = time.monotonic()
+            events_processed = 0
             for event in new_events:
                 handler_start = time.monotonic()
                 unresolved.update()
@@ -214,6 +215,7 @@ class EventEngine(object):
                     )
                     if event.id:
                         event.delete()
+                events_processed += 1
                 handler_duration = time.monotonic() - handler_start
                 self._logger.debug(
                     "spent %.3fs handling event %s (%s for %s)",
@@ -222,11 +224,19 @@ class EventEngine(object):
                     event.event_type_id,
                     event.netbox,
                 )
-            if new_events:
+                if self._has_overdue_callbacks():
+                    self._logger.debug(
+                        "yielding to overdue scheduler entries after %d of %d events",
+                        events_processed,
+                        len(new_events),
+                    )
+                    self._schedule_next_queuecheck()
+                    break
+            if events_processed:
                 batch_duration = time.monotonic() - batch_start
                 self._logger.info(
                     "processed %d events in %.3fs",
-                    len(new_events),
+                    events_processed,
                     batch_duration,
                 )
 

--- a/python/nav/eventengine/engine.py
+++ b/python/nav/eventengine/engine.py
@@ -196,7 +196,9 @@ class EventEngine(object):
                 len(new_events),
                 len(old_events),
             )
+            batch_start = time.monotonic()
             for event in new_events:
+                handler_start = time.monotonic()
                 unresolved.update()
                 try:
                     self.handle_event(event)
@@ -207,6 +209,21 @@ class EventEngine(object):
                     )
                     if event.id:
                         event.delete()
+                handler_duration = time.monotonic() - handler_start
+                self._logger.debug(
+                    "spent %.3fs handling event %s (%s for %s)",
+                    handler_duration,
+                    event.id,
+                    event.event_type_id,
+                    event.netbox,
+                )
+            if new_events:
+                batch_duration = time.monotonic() - batch_start
+                self._logger.info(
+                    "processed %d events in %.3fs",
+                    len(new_events),
+                    batch_duration,
+                )
 
         self._log_task_queue()
 

--- a/tests/unittests/eventengine/engine_test.py
+++ b/tests/unittests/eventengine/engine_test.py
@@ -1,0 +1,121 @@
+"""Unit tests for EventEngine scheduler yield behavior"""
+
+import time
+from unittest.mock import Mock, patch
+
+import pytest
+
+from nav.eventengine.config import EventEngineConfig
+from nav.eventengine.engine import EventEngine
+
+
+class TestHasOverdueCallbacks:
+    def test_when_queue_is_empty_it_should_return_false(self, engine):
+        assert engine._has_overdue_callbacks() is False
+
+    def test_when_entry_is_in_future_it_should_return_false(self, engine):
+        engine._scheduler.enter(1000, 0, lambda: None, ())
+        assert engine._has_overdue_callbacks() is False
+
+    def test_when_entry_is_past_due_it_should_return_true(self, engine):
+        engine._scheduler.enter(0, 0, lambda: None, ())
+        future = time.time() + 10
+        with patch("time.time", return_value=future):
+            assert engine._has_overdue_callbacks() is True
+
+
+class TestLoadNewEventsYieldBehavior:
+    """Tests for the yield-to-scheduler logic inside load_new_events()"""
+
+    @patch("nav.eventengine.engine.unresolved")
+    def test_when_nothing_is_overdue_then_load_new_events_should_process_all_events(
+        self, mock_unresolved, engine
+    ):
+        events = [_make_fake_event(i) for i in range(1, 4)]
+
+        with (
+            patch("nav.eventengine.engine.Event.objects") as mock_objects,
+            patch.object(engine, "handle_event") as mock_handle,
+            patch.object(engine, "_has_overdue_callbacks", return_value=False),
+            patch.object(engine, "_schedule_next_queuecheck") as mock_reschedule,
+        ):
+            mock_objects.filter.return_value.order_by.return_value = events
+            engine.load_new_events.__wrapped__.__wrapped__(engine)
+
+            assert mock_handle.call_count == 3
+            mock_reschedule.assert_not_called()
+
+    @patch("nav.eventengine.engine.unresolved")
+    def test_when_callbacks_are_overdue_then_load_new_events_should_break_early(
+        self, mock_unresolved, engine
+    ):
+        events = [_make_fake_event(i) for i in range(1, 4)]
+
+        with (
+            patch("nav.eventengine.engine.Event.objects") as mock_objects,
+            patch.object(engine, "handle_event") as mock_handle,
+            patch.object(
+                engine,
+                "_has_overdue_callbacks",
+                side_effect=[False, True],
+            ),
+            patch.object(engine, "_schedule_next_queuecheck") as mock_reschedule,
+        ):
+            mock_objects.filter.return_value.order_by.return_value = events
+            engine.load_new_events.__wrapped__.__wrapped__(engine)
+
+            assert mock_handle.call_count == 2
+            mock_reschedule.assert_called_once()
+
+    @patch("nav.eventengine.engine.unresolved")
+    def test_when_resumed_after_yield_then_load_new_events_should_process_remaining(
+        self, mock_unresolved, engine
+    ):
+        events = [_make_fake_event(i) for i in range(1, 4)]
+
+        def track_as_unfinished(event):
+            engine._unfinished.add(event.id)
+
+        with (
+            patch("nav.eventengine.engine.Event.objects") as mock_objects,
+            patch.object(
+                engine, "handle_event", side_effect=track_as_unfinished
+            ) as mock_handle,
+            patch.object(
+                engine,
+                "_has_overdue_callbacks",
+                side_effect=[False, True],
+            ),
+            patch.object(engine, "_schedule_next_queuecheck"),
+        ):
+            mock_objects.filter.return_value.order_by.return_value = events
+            engine.load_new_events.__wrapped__.__wrapped__(engine)
+            assert mock_handle.call_count == 2
+
+        # Second run: all 3 events still in queue, but the 2 already handled
+        # are in _unfinished, so only event 3 is new
+        with (
+            patch("nav.eventengine.engine.Event.objects") as mock_objects,
+            patch.object(engine, "handle_event") as mock_handle,
+            patch.object(engine, "_has_overdue_callbacks", return_value=False),
+            patch.object(engine, "_schedule_next_queuecheck"),
+        ):
+            mock_objects.filter.return_value.order_by.return_value = events
+            engine.load_new_events.__wrapped__.__wrapped__(engine)
+            assert mock_handle.call_count == 1
+            mock_handle.assert_called_once_with(events[2])
+
+
+@pytest.fixture
+def engine():
+    config = EventEngineConfig()
+    config.DEFAULT_CONFIG_FILES = ()
+    return EventEngine(config=config)
+
+
+def _make_fake_event(event_id, event_type_id="boxState"):
+    event = Mock()
+    event.id = event_id
+    event.event_type_id = event_type_id
+    event.netbox = Mock()
+    return event


### PR DESCRIPTION
## Scope and purpose

Fixes #3798.

When the event engine processes a large batch of queued events, it now checks between each event whether the scheduler has overdue callbacks.  If so, it yields control back to the scheduler and reschedules the remaining events for immediate processing afterward. This prevents long event batches from starving time-critical scheduled tasks (e.g.  delayed state transitions).

### This pull request
* ~~adds/changes/removes a dependency~~
* ~~changes the database~~
* ~~changes the API~~


## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [X] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~