### PR TITLE
Return 503 from portadmin `commit_configuration`

### DIFF
--- a/changelog.d/+portadmin-commit-503.fixed.md
+++ b/changelog.d/+portadmin-commit-503.fixed.md
@@ -1,0 +1,3 @@
+PortAdmin's "commit configuration" endpoint now returns 503 instead of 500 when the
+device is unreachable or does not support configuration commits, and no longer triggers
+spurious admin error emails for these expected operational failures.

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -17,6 +17,7 @@
 
 """Django configuration wrapper around the NAV configuration files"""
 
+import logging
 import os
 import sys
 import copy
@@ -52,6 +53,24 @@ LOGGING = copy.deepcopy(DEFAULT_LOGGING)
 _handlers = LOGGING.get('handlers', {})
 _mail_admin_handler = _handlers.get('mail_admins', {})
 _mail_admin_handler['include_html'] = True
+
+
+class Suppress503(logging.Filter):
+    """Prevents 503 responses from generating admin error emails.
+
+    NAV returns 503 for expected operational errors such as unreachable managed
+    devices.  These are already logged by NAV's own loggers; the Django admin
+    emails would be redundant noise.
+    """
+
+    def filter(self, record):
+        return getattr(record, 'status_code', None) != 503
+
+
+_filters = LOGGING.setdefault('filters', {})
+_filters['suppress_503'] = {'()': Suppress503}
+_mail_admin_filters = _mail_admin_handler.setdefault('filters', [])
+_mail_admin_filters.append('suppress_503')
 
 # Admins
 ADMINS = (('NAV Administrator', NAV_CONFIG.get('ADMIN_MAIL', 'root@localhost')),)

--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -868,17 +868,21 @@ def commit_configuration(request):
                 handler.netbox, error
             )
             _logger.error(error_message)
-            return HttpResponse(error_message, status=500)
+            return HttpResponse(error_message, status=503)
         except (AttributeError, NotImplementedError):
             error_message = 'Error committing configuration on {}: {}'.format(
                 handler.netbox, 'Configuration commit not supported'
             )
             _logger.error(error_message)
-            return HttpResponse(error_message, status=500)
+            return HttpResponse(error_message, status=503)
 
         return HttpResponse()
     else:
-        return HttpResponse(status=500)
+        error_message = 'Could not obtain management handler for {}'.format(
+            interface.netbox
+        )
+        _logger.error(error_message)
+        return HttpResponse(error_message, status=503)
 
 
 def get_management_handler(netbox: Netbox) -> ManagementHandler:

--- a/tests/unittests/django/settings_test.py
+++ b/tests/unittests/django/settings_test.py
@@ -1,0 +1,22 @@
+import logging
+
+from nav.django.settings import Suppress503
+
+
+class TestSuppress503:
+    def test_when_status_code_is_503_it_should_reject_record(self):
+        record = logging.LogRecord("test", logging.ERROR, "", 0, "msg", (), None)
+        record.status_code = 503
+
+        assert Suppress503().filter(record) is False
+
+    def test_when_status_code_is_500_it_should_accept_record(self):
+        record = logging.LogRecord("test", logging.ERROR, "", 0, "msg", (), None)
+        record.status_code = 500
+
+        assert Suppress503().filter(record) is True
+
+    def test_when_no_status_code_it_should_accept_record(self):
+        record = logging.LogRecord("test", logging.ERROR, "", 0, "msg", (), None)
+
+        assert Suppress503().filter(record) is True

--- a/tests/unittests/web/portadmin/views_test.py
+++ b/tests/unittests/web/portadmin/views_test.py
@@ -1,0 +1,84 @@
+from unittest.mock import Mock, patch
+
+from django.test import RequestFactory
+
+from nav.portadmin.handlers import ManagementError
+from nav.web.portadmin.views import commit_configuration
+
+
+class TestCommitConfiguration:
+    @patch("nav.web.portadmin.views.CONFIG")
+    def test_when_commit_disabled_it_should_return_200(self, mock_config):
+        mock_config.is_commit_enabled.return_value = False
+        response = commit_configuration(_make_post_request())
+        assert response.status_code == 200
+
+    @patch("nav.web.portadmin.views.get_management_handler")
+    @patch("nav.web.portadmin.views.get_object_or_404")
+    @patch("nav.web.portadmin.views.CONFIG")
+    def test_when_handler_succeeds_it_should_return_200(
+        self, mock_config, mock_get_obj, mock_get_handler
+    ):
+        mock_config.is_commit_enabled.return_value = True
+        mock_get_obj.return_value = Mock(netbox=Mock())
+        mock_handler = Mock()
+        mock_get_handler.return_value = mock_handler
+
+        response = commit_configuration(_make_post_request())
+
+        mock_handler.commit_configuration.assert_called_once()
+        assert response.status_code == 200
+
+    @patch("nav.web.portadmin.views.get_management_handler")
+    @patch("nav.web.portadmin.views.get_object_or_404")
+    @patch("nav.web.portadmin.views.CONFIG")
+    def test_when_management_error_it_should_return_503(
+        self, mock_config, mock_get_obj, mock_get_handler
+    ):
+        mock_config.is_commit_enabled.return_value = True
+        mock_get_obj.return_value = Mock(netbox=Mock())
+        mock_handler = Mock()
+        mock_handler.commit_configuration.side_effect = ManagementError("timeout")
+        mock_get_handler.return_value = mock_handler
+
+        response = commit_configuration(_make_post_request())
+
+        assert response.status_code == 503
+        assert b"timeout" in response.content
+
+    @patch("nav.web.portadmin.views.get_management_handler")
+    @patch("nav.web.portadmin.views.get_object_or_404")
+    @patch("nav.web.portadmin.views.CONFIG")
+    def test_when_commit_not_supported_it_should_return_503(
+        self, mock_config, mock_get_obj, mock_get_handler
+    ):
+        mock_config.is_commit_enabled.return_value = True
+        mock_get_obj.return_value = Mock(netbox=Mock())
+        mock_handler = Mock()
+        mock_handler.commit_configuration.side_effect = NotImplementedError
+        mock_get_handler.return_value = mock_handler
+
+        response = commit_configuration(_make_post_request())
+
+        assert response.status_code == 503
+        assert b"not supported" in response.content.lower()
+
+    @patch("nav.web.portadmin.views.get_management_handler")
+    @patch("nav.web.portadmin.views.get_object_or_404")
+    @patch("nav.web.portadmin.views.CONFIG")
+    def test_when_no_handler_it_should_return_503(
+        self, mock_config, mock_get_obj, mock_get_handler
+    ):
+        mock_config.is_commit_enabled.return_value = True
+        mock_get_obj.return_value = Mock(netbox=Mock())
+        mock_get_handler.return_value = None
+
+        response = commit_configuration(_make_post_request())
+
+        assert response.status_code == 503
+        assert b"Could not obtain" in response.content
+
+
+def _make_post_request(interfaceid=1):
+    factory = RequestFactory()
+    return factory.post("/portadmin/commit", {"interfaceid": str(interfaceid)})


### PR DESCRIPTION
## Scope and purpose

PortAdmin's `commit_configuration` endpoint returned 500 for expected operational errors (unreachable device, unsupported commit, missing management handler).  This would trigger unnecessary Django admin error emails with empty tracebacks that misrepresented the nature of the problem.

This PR changes those error paths to return 503 with descriptive messages, and adds a `Suppress503` logging filter so that 503 responses don't generate admin emails.

### This pull request
* ~~adds/changes/removes a dependency~~
* ~~changes the database~~
* ~~changes the API~~

## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [X] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [X] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~

### How to observe

Trigger the commit endpoint for a device that is unreachable or doesn't support config commits.  Previously this returned an HTTP 500 with an empty body; now it returns 503 with a message like `Error committing configuration on <netbox>: <reason>`.  The Django `mail_admins` handler will no longer send emails for these 503 responses.
