### PR TITLE
Fix crash in navlet htmx error responses

### DIFF
--- a/changelog.d/3802.fixed.md
+++ b/changelog.d/3802.fixed.md
@@ -1,0 +1,1 @@
+Fix crash when rendering navlet error responses due to missing navlet ID

--- a/python/nav/web/navlets/__init__.py
+++ b/python/nav/web/navlets/__init__.py
@@ -325,12 +325,15 @@ def dispatcher(request, navlet_id):
 
 
 def _handle_htmx_error_response(
-    request, navlet: Optional[AccountNavlet], error_message: str
+    request, account_navlet: Optional[AccountNavlet], error_message: str
 ):
     """Render error response for htmx dispatcher requests"""
-    if navlet:
-        cls = get_navlet_from_name(navlet.navlet)
+    navlet = None
+    if account_navlet:
+        cls = get_navlet_from_name(account_navlet.navlet)
         navlet = cls(request=request)
+        navlet.navlet_id = account_navlet.id
+        navlet.account_navlet = account_navlet
 
     return render(
         request,

--- a/tests/integration/widget_test.py
+++ b/tests/integration/widget_test.py
@@ -168,6 +168,34 @@ def test_given_htmx_request_with_unauthorized_navlet_then_it_should_return_htmx_
     assert response.context['error_message'] == 'Not authorized to view this widget'
 
 
+def test_when_sudoer_requests_unauthorized_navlet_via_htmx_then_it_should_not_crash(
+    client, admin_account, non_admin_account
+):
+    """Regression test: the error response template should render without
+    NoReverseMatch even when the user is a sudoer (which causes the navlet
+    header action buttons to be rendered).
+    """
+    dashboard = AccountDashboard.objects.create(
+        account=non_admin_account, name="Private Dashboard", is_shared=False
+    )
+    private_navlet = AccountNavlet.objects.create(
+        navlet="nav.web.navlets.welcome.WelcomeNavlet",
+        account=non_admin_account,
+        dashboard=dashboard,
+    )
+
+    # Simulate admin having sudoed into another account
+    session = client.session
+    session['sudoer'] = admin_account.id
+    session.save()
+
+    url = reverse('get-user-navlet', kwargs={'navlet_id': private_navlet.id})
+    response = client.get(url, HTTP_HX_REQUEST='true')
+
+    assert response.status_code == 200
+    assert response.context['error_message'] == 'Not authorized to view this widget'
+
+
 #
 # Fixtures
 #


### PR DESCRIPTION
## Scope and purpose

Fix navlet error responses crashing with `NoReverseMatch` because `navlet_id` was never set on the Navlet instance created in `_handle_htmx_error_response`.

## Contributor Checklist

- [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
- [ ] Added/amended tests for new/changed code
- [ ] Added/changed documentation
- [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
- [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
- [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.