### PR TITLE
Fix login crash and password leak in error emails

### DIFF
--- a/changelog.d/3803.fixed.md
+++ b/changelog.d/3803.fixed.md
@@ -1,0 +1,2 @@
+Fixed a session crash (`UpdateError`) on the login page that could leak
+cleartext passwords in Django error emails.

--- a/python/nav/django/filter.py
+++ b/python/nav/django/filter.py
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License version 3 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Custom exception reporter filter that masks password fields unconditionally.
+
+Django's default SafeExceptionReporterFilter only masks POST parameters when
+the view has been decorated with @sensitive_post_parameters. If a crash occurs
+in middleware before the view runs, the decorator never executes and cleartext
+passwords end up in error emails.
+
+This filter adds a defence-in-depth layer: any POST key whose name contains
+"password" (case-insensitive) is always replaced with '********************',
+regardless of whether the request has a sensitive_post_parameters attribute.
+"""
+
+import re
+
+from django.views.debug import SafeExceptionReporterFilter
+
+_PASSWORD_RE = re.compile(r"password", re.IGNORECASE)
+
+
+class NAVExceptionReporterFilter(SafeExceptionReporterFilter):
+    """Masks password-like POST parameters unconditionally."""
+
+    def get_post_parameters(self, request):
+        post_data = super().get_post_parameters(request)
+        if isinstance(post_data, dict):
+            post_data = {
+                key: self.cleansed_substitute if _PASSWORD_RE.search(key) else value
+                for key, value in post_data.items()
+            }
+        return post_data

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -75,6 +75,7 @@ _mail_admin_filters.append('suppress_503')
 # Admins
 ADMINS = (('NAV Administrator', NAV_CONFIG.get('ADMIN_MAIL', 'root@localhost')),)
 MANAGERS = ADMINS
+DEFAULT_EXCEPTION_REPORTER_FILTER = 'nav.django.filter.NAVExceptionReporterFilter'
 
 # Database / ORM configuration
 try:

--- a/python/nav/web/auth/utils.py
+++ b/python/nav/web/auth/utils.py
@@ -22,6 +22,7 @@ import logging
 import re
 
 from django.contrib.auth import SESSION_KEY as DJANGO_USER_SESSION_KEY
+from django.contrib.sessions.backends.base import UpdateError
 from django.core.cache import cache
 
 from nav.models.profiles import Account
@@ -66,7 +67,11 @@ def set_account(request, account, cycle_session_id=True):
     _logger.debug('Set active account to "%s"', account.login)
     if cycle_session_id:
         request.session.cycle_key()
-    request.session.save()
+    try:
+        request.session.save()
+    except UpdateError:
+        _logger.debug("Session save failed (stale session key?); creating new session")
+        request.session.create()
 
 
 def clear_session(request):

--- a/tests/unittests/django/filter_test.py
+++ b/tests/unittests/django/filter_test.py
@@ -1,0 +1,57 @@
+import pytest
+
+from django.test import RequestFactory
+
+from nav.django.filter import NAVExceptionReporterFilter
+
+
+@pytest.fixture
+def reporter_filter():
+    return NAVExceptionReporterFilter()
+
+
+class TestNAVExceptionReporterFilter:
+    """Tests for NAVExceptionReporterFilter.get_post_parameters()"""
+
+    def test_when_sensitive_post_parameters_not_used_then_password_should_still_be_masked(  # noqa: E501
+        self, reporter_filter
+    ):
+        request = RequestFactory().post(
+            '/', data={'username': 'admin', 'password': 's3cret'}
+        )
+        result = reporter_filter.get_post_parameters(request)
+        assert result['password'] == reporter_filter.cleansed_substitute
+        assert result['username'] == 'admin'
+
+    def test_password_like_post_fields_should_be_masked(self, reporter_filter):
+        request = RequestFactory().post(
+            '/',
+            data={
+                'password': 's3cret',
+                'old_password': 'old',
+                'new_password1': 'new1',
+                'new_password2': 'new2',
+            },
+        )
+        result = reporter_filter.get_post_parameters(request)
+        for key in ('password', 'old_password', 'new_password1', 'new_password2'):
+            assert result[key] == reporter_filter.cleansed_substitute
+
+    def test_non_password_fields_should_pass_through(self, reporter_filter):
+        request = RequestFactory().post(
+            '/', data={'username': 'admin', 'next': '/foo/'}
+        )
+        result = reporter_filter.get_post_parameters(request)
+        assert result['username'] == 'admin'
+        assert result['next'] == '/foo/'
+
+    def test_when_sensitive_post_parameters_set_password_it_should_still_be_masked(
+        self, reporter_filter
+    ):
+        request = RequestFactory().post(
+            '/', data={'username': 'admin', 'password': 's3cret'}
+        )
+        request.sensitive_post_parameters = ('password',)
+        result = reporter_filter.get_post_parameters(request)
+        assert result['password'] == reporter_filter.cleansed_substitute
+        assert result['username'] == 'admin'

--- a/tests/unittests/general/web_middleware_test.py
+++ b/tests/unittests/general/web_middleware_test.py
@@ -3,9 +3,10 @@ import os
 
 import pytest
 
-from django.http import HttpResponseRedirect
 from django.contrib.auth.models import AnonymousUser
+from django.contrib.sessions.backends.base import UpdateError
 from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpResponseRedirect
 from django.test import RequestFactory
 from django_htmx.http import HttpResponseClientRedirect
 
@@ -299,3 +300,29 @@ class TestNAVAuthenticationMiddleware:
             side_effect=set_account(fake_request, DEFAULT_ACCOUNT),
         ):
             assert fake_request.user == DEFAULT_ACCOUNT
+
+
+class TestSetAccountSessionRecovery:
+    """Tests for UpdateError recovery in set_account()"""
+
+    def test_when_session_save_raises_update_error_it_should_create_new_session(
+        self, fake_session
+    ):
+        request = RequestFactory().get('/')
+        request.session = fake_session
+        request.session.save = Mock(side_effect=UpdateError)
+        request.session.create = Mock()
+
+        set_account(request, DEFAULT_ACCOUNT)
+
+        request.session.create.assert_called_once()
+
+    def test_when_session_save_succeeds_it_should_not_call_create(self, fake_session):
+        request = RequestFactory().get('/')
+        request.session = fake_session
+        request.session.save = Mock()
+        request.session.create = Mock()
+
+        set_account(request, DEFAULT_ACCOUNT)
+
+        request.session.create.assert_not_called()


### PR DESCRIPTION
## Scope and purpose

Fixes #3803.

`set_account()` crashes with `UpdateError` when the session row has been cleaned from the database. Because this crash occurs in middleware — before the `login()` view's `@sensitive_post_parameters('password')` decorator runs — cleartext passwords end up in Django error emails.

This PR fixes both problems:

1. Catch `UpdateError` in `set_account()` and fall back to `session.create()`
2. Add `NAVExceptionReporterFilter` as `DEFAULT_EXCEPTION_REPORTER_FILTER` to unconditionally mask any POST key matching "password", regardless of where the crash occurs

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [x] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file