### PR TITLE
Fix chart widget image loading for URLs without query params

### DIFF
--- a/changelog.d/3805.fixed.md
+++ b/changelog.d/3805.fixed.md
@@ -1,0 +1,1 @@
+Fix chart widget failing to load images from URLs without query parameters

--- a/python/nav/web/navlets/__init__.py
+++ b/python/nav/web/navlets/__init__.py
@@ -195,7 +195,8 @@ class Navlet(TemplateView):
         :return: The URL with the cache-busting parameter added
         """
         timestamp = int(datetime.now().timestamp())
-        return f'{url}&bust={timestamp}'
+        separator = '&' if '?' in url else '?'
+        return f'{url}{separator}bust={timestamp}'
 
 
 def list_navlets():

--- a/tests/unittests/web/navlets_test.py
+++ b/tests/unittests/web/navlets_test.py
@@ -1,0 +1,12 @@
+from nav.web.navlets import Navlet
+
+
+class TestAddBustParamToUrl:
+    def test_when_url_has_no_query_params_then_it_should_use_question_mark(self):
+        result = Navlet.add_bust_param_to_url('http://example.com/image.jpg')
+        assert '?bust=' in result
+
+    def test_when_url_has_existing_query_params_then_it_should_use_ampersand(self):
+        result = Navlet.add_bust_param_to_url('http://example.com/graph?target=foo')
+        assert '&bust=' in result
+        assert result.startswith('http://example.com/graph?target=foo&bust=')


### PR DESCRIPTION
## Scope and purpose

The `add_bust_param_to_url` method always uses `&` to append the cache-busting parameter. This works fine for Graphite URLs which always have existing query parameters, but breaks for plain image URLs (like `http://example.com/cam.jpg`) that don't have a `?` yet. The result is an invalid URL like `http://example.com/cam.jpg&bust=123` where the bust parameter becomes part of the path, causing the image to fail to load.

The fix checks whether the URL already contains a `?` before choosing the separator.

### Screenshots
<img width="1200" height="1120" alt="image" src="https://github.com/user-attachments/assets/59168a9d-f7aa-473d-a8f9-c193472bb125" />

## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [X] Added/amended tests for new/changed code
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.