### PR TITLE
Fix PG14 operator ambiguity in `sc.05.16.0001.sql`

### DIFF
--- a/changelog.d/3806.fixed.md
+++ b/changelog.d/3806.fixed.md
@@ -1,0 +1,1 @@
+Fixed `sc.05.16.0001.sql` migration failure on PostgreSQL 14 caused by ambiguous `||` operator when concatenating an integer without an explicit `::TEXT` cast.

--- a/python/nav/models/sql/changes/sc.05.16.0001.sql
+++ b/python/nav/models/sql/changes/sc.05.16.0001.sql
@@ -25,9 +25,9 @@ BEGIN
             ELSE
                 truncated_comment := token_rec.comment;
             END IF;
-            new_token_str := 'token #' || token_rec.id || ' (' || truncated_comment || ')';
+            new_token_str := 'token #' || token_rec.id::TEXT || ' (' || truncated_comment || ')';
         ELSE
-            new_token_str := 'token #' || token_rec.id;
+            new_token_str := 'token #' || token_rec.id::TEXT;
         END IF;
 
         -- Update summary field (only for entries that reference this specific token)


### PR DESCRIPTION
## Scope and purpose

Fixes #3806.

### This pull request
* ~~adds/changes/removes a dependency~~
* changes the database
* ~~changes the API~~

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] ~~Added/amended tests for new/changed code~~
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~