### PR TITLE
Use urllib.parse for cache bust to handle URL fragments

### DIFF
--- a/python/nav/web/navlets/__init__.py
+++ b/python/nav/web/navlets/__init__.py
@@ -49,6 +49,7 @@ import json
 from datetime import datetime
 from operator import attrgetter
 from typing import Optional
+from urllib.parse import urlencode, urlparse, urlunparse, parse_qs
 
 from django.conf import settings
 from django.http import HttpResponse, JsonResponse
@@ -195,8 +196,11 @@ class Navlet(TemplateView):
         :return: The URL with the cache-busting parameter added
         """
         timestamp = int(datetime.now().timestamp())
-        separator = '&' if '?' in url else '?'
-        return f'{url}{separator}bust={timestamp}'
+        parsed = urlparse(url)
+        existing_params = parse_qs(parsed.query, keep_blank_values=True)
+        existing_params['bust'] = [str(timestamp)]
+        new_query = urlencode(existing_params, doseq=True)
+        return urlunparse(parsed._replace(query=new_query))
 
 
 def list_navlets():

--- a/tests/unittests/web/navlets_test.py
+++ b/tests/unittests/web/navlets_test.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse, parse_qs
+
 from nav.web.navlets import Navlet
 
 
@@ -6,7 +8,29 @@ class TestAddBustParamToUrl:
         result = Navlet.add_bust_param_to_url('http://example.com/image.jpg')
         assert '?bust=' in result
 
-    def test_when_url_has_existing_query_params_then_it_should_use_ampersand(self):
-        result = Navlet.add_bust_param_to_url('http://example.com/graph?target=foo')
-        assert '&bust=' in result
-        assert result.startswith('http://example.com/graph?target=foo&bust=')
+    def test_when_url_has_existing_query_params_then_it_should_preserve_them(self):
+        result = Navlet.add_bust_param_to_url(
+            'http://example.com/graph?target=foo&filter=a&filter=b&simple'
+        )
+        parsed = urlparse(result)
+        params = parse_qs(parsed.query, keep_blank_values=True)
+        assert params['target'] == ['foo']
+        assert sorted(params['filter']) == ['a', 'b']
+        assert params['simple'] == ['']
+        assert 'bust' in params
+
+    def test_when_url_has_fragment_then_bust_should_be_in_query_not_fragment(self):
+        result = Navlet.add_bust_param_to_url('http://example.com/image.jpg#section')
+        parsed = urlparse(result)
+        assert 'bust' in parse_qs(parsed.query)
+        assert parsed.fragment == 'section'
+
+    def test_when_url_has_params_and_fragment_then_bust_should_be_in_query(self):
+        result = Navlet.add_bust_param_to_url(
+            'http://example.com/graph?target=foo#section'
+        )
+        parsed = urlparse(result)
+        params = parse_qs(parsed.query)
+        assert 'target' in params
+        assert 'bust' in params
+        assert parsed.fragment == 'section'


### PR DESCRIPTION
## Scope and purpose

Follow-up to #3805.

The string-based approach to appending the cache bust parameter does not account for URL fragments. If a URL contains a fragment (e.g. `http://example.com/img.png#section`), the bust parameter gets appended after the fragment, becoming part of it instead of a query parameter. This means the browser ignores it for caching purposes.

This replaces the string concatenation with `urllib.parse` to properly decompose the URL and inject `bust` into the query string, ensuring correct placement regardless of URL structure.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.