### PR TITLE
Add alias CRUD for rooms and locations in SeedDB

### DIFF
--- a/changelog.d/3315.added.md
+++ b/changelog.d/3315.added.md
@@ -1,0 +1,1 @@
+Add CRUD for room and location aliases in SeedDB edit pages.

--- a/python/nav/django/forms.py
+++ b/python/nav/django/forms.py
@@ -71,3 +71,66 @@ class HStoreField(Field):
 
     def to_python(self, value):
         return validators.validate_hstore(value)
+
+
+class AliasListWidget(forms.Widget):
+    """Widget that renders a dynamic list of alias text inputs"""
+
+    template_name = 'seeddb/widgets/alias_list.html'
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        if isinstance(value, str):
+            value = _parse_json_list(value)
+        context['aliases'] = value or []
+        return context
+
+    def value_from_datadict(self, data, files, name):
+        return _parse_json_list(data.get(f'{name}_json', '[]'))
+
+
+class AliasListField(forms.Field):
+    """Form field for editing a list of alias strings"""
+
+    MAX_ALIAS_LENGTH = 64
+    widget = AliasListWidget
+
+    def __init__(self, *args, verbose_name='entry', **kwargs):
+        kwargs.setdefault(
+            'help_text',
+            "Alternative names that can be used to find"
+            f" this {verbose_name} in searches.",
+        )
+        super().__init__(*args, **kwargs)
+
+    def prepare_value(self, value):
+        if isinstance(value, str):
+            return _parse_json_list(value)
+        return value or []
+
+    def clean(self, value):
+        if not value:
+            return []
+        cleaned = []
+        for item in value:
+            if not isinstance(item, str):
+                raise forms.ValidationError("All aliases must be strings.")
+            stripped = item.strip()
+            if len(stripped) > self.MAX_ALIAS_LENGTH:
+                raise forms.ValidationError(
+                    f"Alias must be {self.MAX_ALIAS_LENGTH} characters or fewer."
+                )
+            if stripped and stripped not in cleaned:
+                cleaned.append(stripped)
+        return cleaned
+
+
+def _parse_json_list(value):
+    """Parse a JSON string as a list, returning [] on failure."""
+    try:
+        result = json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    if not isinstance(result, list):
+        return []
+    return result

--- a/python/nav/web/sass/nav/seeddb.scss
+++ b/python/nav/web/sass/nav/seeddb.scss
@@ -63,6 +63,75 @@
 }
 
 
+/* Style alias tags widget */
+.alias-tags {
+  --alias-tag-bg: #d9edf7;
+  --alias-tag-border: #bce8f1;
+
+  margin-top: 0.25rem;
+  margin-bottom: 1rem;
+
+  .alias-tags-list {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .alias-tag {
+    font-size: 0.85rem;
+    padding: 0.25rem 0.4rem;
+    background: var(--alias-tag-bg);
+    border-color: var(--alias-tag-border);
+
+    &--pending {
+      opacity: 0.5;
+    }
+  }
+
+  .alias-tag-remove {
+    all: unset;
+    cursor: pointer;
+    opacity: 0.7;
+
+    &:hover {
+      opacity: 1;
+    }
+
+    &:focus-visible {
+      outline: 2px solid currentColor;
+      outline-offset: 1px;
+    }
+  }
+
+  .alias-tags-input-wrapper {
+    flex: 1;
+    min-width: 10rem;
+    max-width: 15rem;
+    position: relative;
+  }
+
+  .alias-tags-counter {
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 0.7rem;
+    color: #888;
+    padding-right: 0.4rem;
+    pointer-events: none;
+  }
+
+  .alias-tags-input {
+    width: 100%;
+    margin-bottom: 0;
+    padding: 0.25rem 0.4rem;
+    font-size: 0.85rem;
+    line-height: inherit;
+    height: auto;
+  }
+}
+
 /* Style thekey value pairs for editing hstore fields */
 .hstoreValues {
     .remove-hstore-row {

--- a/python/nav/web/seeddb/forms/__init__.py
+++ b/python/nav/web/seeddb/forms/__init__.py
@@ -20,7 +20,7 @@ import logging
 from django import forms
 from django.utils.safestring import mark_safe
 
-from nav.django.forms import HStoreField
+from nav.django.forms import AliasListField, HStoreField
 from nav.models.manage import (
     Location,
     Room,
@@ -181,6 +181,7 @@ class RoomForm(forms.ModelForm):
 
     location = forms.ChoiceField(choices=())
     data = HStoreField(label='Attributes', required=False)
+    aliases = AliasListField(label='Aliases', required=False, verbose_name='room')
 
     def __init__(self, *args, **kwargs):
         super(RoomForm, self).__init__(*args, **kwargs)
@@ -190,7 +191,7 @@ class RoomForm(forms.ModelForm):
 
     class Meta(object):
         model = Room
-        fields = '__all__'
+        fields = ('id', 'location', 'description', 'aliases', 'position', 'data')
 
     def clean_location(self):
         data = self.cleaned_data.get('location')
@@ -210,10 +211,11 @@ class LocationForm(forms.ModelForm):
 
     parent = forms.ChoiceField(required=False)
     data = HStoreField(label='Attributes', required=False)
+    aliases = AliasListField(label='Aliases', required=False, verbose_name='location')
 
     class Meta(object):
         model = Location
-        fields = ('parent', 'id', 'description', 'data')
+        fields = ('parent', 'id', 'description', 'aliases', 'data')
 
     def __init__(self, *args, **kwargs):
         super(LocationForm, self).__init__(*args, **kwargs)

--- a/python/nav/web/templates/seeddb/widgets/alias_list.html
+++ b/python/nav/web/templates/seeddb/widgets/alias_list.html
@@ -1,0 +1,137 @@
+<div class="alias-tags" id="alias-tags-{{ widget.name }}">
+  <div class="alias-tags-list">
+    {% for alias in aliases %}
+    <span class="badge alias-tag" data-value="{{ alias }}">
+      {{ alias }}
+      <button type="button" class="alias-tag-remove" aria-label="Remove {{ alias }}">&times;</button>
+    </span>
+    {% endfor %}
+    <span class="alias-tags-input-wrapper">
+      <input type="text" class="alias-tags-input"
+             placeholder="Add alias..."
+             aria-label="Add alias"
+             maxlength="64">
+      <small class="alias-tags-counter" id="alias-counter-{{ widget.name }}" hidden></small>
+    </span>
+  </div>
+  <input type="hidden" name="{{ widget.name }}_json" value="">
+  <span class="sr-only" aria-live="polite" id="alias-status-{{ widget.name }}"></span>
+  <script>
+    (function() {
+      const container = document.getElementById('alias-tags-{{ widget.name }}');
+      const list = container.querySelector('.alias-tags-list');
+      const inputWrapper = container.querySelector('.alias-tags-input-wrapper');
+      const input = container.querySelector('.alias-tags-input');
+      const hidden = container.querySelector('input[type=hidden]');
+      const status = document.getElementById('alias-status-{{ widget.name }}');
+      const counter = document.getElementById('alias-counter-{{ widget.name }}');
+
+      function announce(message) {
+        status.textContent = message;
+      }
+
+      function syncHidden() {
+        const tags = list.querySelectorAll('.alias-tag');
+        const values = Array.from(tags).map(t => t.dataset.value);
+        hidden.value = JSON.stringify(values);
+      }
+
+      function addTag(value) {
+        const trimmed = value.trim();
+        if (!trimmed) return;
+        const existing = Array.from(list.querySelectorAll('.alias-tag'))
+          .map(t => t.dataset.value);
+        if (existing.includes(trimmed)) return;
+
+        const tag = document.createElement('span');
+        tag.className = 'badge alias-tag';
+        tag.dataset.value = trimmed;
+
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'alias-tag-remove';
+        btn.setAttribute('aria-label', 'Remove ' + trimmed);
+        btn.innerHTML = '&times;';
+        tag.append(trimmed + ' ', btn);
+        inputWrapper.before(tag);
+        syncHidden();
+      }
+
+      const SEPARATORS = new Set([',', ';', 'Enter', 'Tab']);
+      let pendingBackspace = false;
+
+      input.addEventListener('keydown', function(e) {
+        if (SEPARATORS.has(e.key)) {
+          if (input.value.trim()) {
+            e.preventDefault();
+            addTag(input.value);
+            input.value = '';
+          } else if (e.key !== 'Tab') {
+            e.preventDefault();
+          }
+          pendingBackspace = false;
+          return;
+        }
+        if (e.key === 'Backspace' && input.value === '') {
+          const tags = list.querySelectorAll('.alias-tag');
+          if (tags.length) {
+            if (pendingBackspace) {
+              const value = tags[tags.length - 1].dataset.value;
+              tags[tags.length - 1].remove();
+              syncHidden();
+              announce('Removed alias ' + value);
+              pendingBackspace = false;
+            } else {
+              tags[tags.length - 1].classList.add('alias-tag--pending');
+              announce('Press backspace again to remove ' + tags[tags.length - 1].dataset.value);
+              pendingBackspace = true;
+            }
+          }
+          return;
+        }
+        pendingBackspace = false;
+        const dimmed = list.querySelector('.alias-tag--pending');
+        if (dimmed) dimmed.classList.remove('alias-tag--pending');
+      });
+
+      const COUNTER_THRESHOLD = 0.75;
+      input.addEventListener('input', function() {
+        const len = input.value.length;
+        const max = input.maxLength;
+        if (len >= max * COUNTER_THRESHOLD) {
+          counter.textContent = len + '/' + max;
+          counter.hidden = false;
+          input.style.paddingRight = '3rem';
+        } else {
+          counter.hidden = true;
+          input.style.paddingRight = '';
+        }
+      });
+
+      input.addEventListener('blur', function() {
+        pendingBackspace = false;
+        const dimmed = list.querySelector('.alias-tag--pending');
+        if (dimmed) dimmed.classList.remove('alias-tag--pending');
+      });
+
+      input.addEventListener('paste', function(e) {
+        e.preventDefault();
+        const text = e.clipboardData.getData('text');
+        text.split(/[,;\n]/).forEach(v => addTag(v));
+      });
+
+      list.addEventListener('click', function(e) {
+        const btn = e.target.closest('.alias-tag-remove');
+        if (btn) {
+          const value = btn.closest('.alias-tag').dataset.value;
+          btn.closest('.alias-tag').remove();
+          syncHidden();
+          announce('Removed alias ' + value);
+          input.focus();
+        }
+      });
+
+      syncHidden();
+    })();
+  </script>
+</div>

--- a/tests/unittests/django/aliases_field_test.py
+++ b/tests/unittests/django/aliases_field_test.py
@@ -1,0 +1,83 @@
+"""Tests for AliasListField and AliasListWidget"""
+
+import pytest
+from django import forms
+from django.http import QueryDict
+
+from nav.django.forms import AliasListField, AliasListWidget
+
+
+class TestAliasListFieldClean:
+    def test_when_value_is_none_then_it_should_return_empty_list(self):
+        field = AliasListField(required=False)
+        assert field.clean(None) == []
+
+    def test_when_value_is_empty_list_then_it_should_return_empty_list(self):
+        field = AliasListField(required=False)
+        assert field.clean([]) == []
+
+    def test_when_value_has_strings_then_it_should_return_them(self):
+        field = AliasListField(required=False)
+        assert field.clean(['foo', 'bar']) == ['foo', 'bar']
+
+    def test_when_value_has_whitespace_then_it_should_strip(self):
+        field = AliasListField(required=False)
+        assert field.clean(['  foo  ', ' bar ']) == ['foo', 'bar']
+
+    def test_when_value_has_empty_strings_then_it_should_remove_them(self):
+        field = AliasListField(required=False)
+        assert field.clean(['foo', '', '  ', 'bar']) == ['foo', 'bar']
+
+    def test_when_value_has_duplicates_then_it_should_deduplicate(self):
+        field = AliasListField(required=False)
+        assert field.clean(['foo', 'bar', 'foo']) == ['foo', 'bar']
+
+    def test_when_value_has_non_string_then_it_should_raise_validation_error(self):
+        field = AliasListField(required=False)
+        with pytest.raises(forms.ValidationError):
+            field.clean([123])
+
+    def test_when_alias_exceeds_max_length_then_it_should_raise_validation_error(self):
+        field = AliasListField(required=False)
+        long_alias = 'a' * (AliasListField.MAX_ALIAS_LENGTH + 1)
+        with pytest.raises(forms.ValidationError):
+            field.clean([long_alias])
+
+
+class TestAliasListWidgetValueFromDatadict:
+    def test_when_data_has_json_then_it_should_return_list(self):
+        widget = AliasListWidget()
+        data = QueryDict(mutable=True)
+        data['aliases_json'] = '["foo", "bar"]'
+        assert widget.value_from_datadict(data, {}, 'aliases') == ['foo', 'bar']
+
+    def test_when_data_has_no_json_then_it_should_return_empty_list(self):
+        widget = AliasListWidget()
+        data = QueryDict(mutable=True)
+        assert widget.value_from_datadict(data, {}, 'aliases') == []
+
+    def test_when_data_has_invalid_json_then_it_should_return_empty_list(self):
+        widget = AliasListWidget()
+        data = QueryDict(mutable=True)
+        data['aliases_json'] = 'not valid json'
+        assert widget.value_from_datadict(data, {}, 'aliases') == []
+
+    def test_when_data_has_non_list_json_then_it_should_return_empty_list(self):
+        widget = AliasListWidget()
+        data = QueryDict(mutable=True)
+        data['aliases_json'] = '{"key": "value"}'
+        assert widget.value_from_datadict(data, {}, 'aliases') == []
+
+
+class TestAliasListFieldPrepareValue:
+    def test_when_value_is_list_then_it_should_return_it(self):
+        field = AliasListField(required=False)
+        assert field.prepare_value(['a', 'b']) == ['a', 'b']
+
+    def test_when_value_is_json_string_then_it_should_parse(self):
+        field = AliasListField(required=False)
+        assert field.prepare_value('["a", "b"]') == ['a', 'b']
+
+    def test_when_value_is_none_then_it_should_return_empty_list(self):
+        field = AliasListField(required=False)
+        assert field.prepare_value(None) == []


### PR DESCRIPTION
## Scope and purpose

Fixes #3315. Dependent on #3826.

Adds the ability to create, edit, and delete aliases for rooms and locations in the SeedDB edit pages. Aliases are rendered as an interactive tag-style widget.

### Alias input features
* Press Enter, Tab, or comma to add a new tag
* Backspace on an empty input dims the last tag; a second backspace removes it
* Pasting comma-separated values splits them into individual tags
* Duplicates and empty values are automatically filtered out
* Remove buttons have a visible focus ring for keyboard accessibility
* Screen reader announcements via `aria-live` for alias tag additions and removals

### This pull request
* adds a new `AliasListField`/`AliasListWidget` for managing alias lists

### Screenshots
https://github.com/user-attachments/assets/8a84f8ac-57cf-4c96-a1f3-ee8350b20846

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file