### PR TITLE
Add Timer context manager and log search provider runtimes

### DIFF
--- a/changelog.d/+timer.added.md
+++ b/changelog.d/+timer.added.md
@@ -1,0 +1,1 @@
+Debug log runtimes of individual NAVbar search providers

--- a/python/nav/util.py
+++ b/python/nav/util.py
@@ -20,6 +20,7 @@ import os
 import re
 import stat
 import socket
+import time
 import datetime
 from functools import wraps
 from importlib.resources import as_file, files as resource_files
@@ -410,6 +411,28 @@ def synchronized(lock):
         return _wrapper
 
     return _decorator
+
+
+class Timer:
+    """Context manager that measures wall-clock elapsed time.
+
+    Usage::
+
+        timer = Timer()
+        with timer:
+            do_something()
+        print(timer.elapsed)  # float, in seconds
+    """
+
+    def __init__(self):
+        self.elapsed = None
+
+    def __enter__(self):
+        self._start = time.monotonic()
+        return self
+
+    def __exit__(self, *args):
+        self.elapsed = time.monotonic() - self._start
 
 
 def parse_interval(string):

--- a/python/nav/web/info/views.py
+++ b/python/nav/web/info/views.py
@@ -26,6 +26,7 @@ from django_htmx.http import trigger_client_event, HttpResponseClientRedirect
 
 from nav.web.info.forms import SearchForm
 from nav.web.info import searchproviders as providers
+from nav.util import Timer
 from nav.web.modals import render_modal
 from nav.web.utils import create_title
 
@@ -148,7 +149,15 @@ def process_form(form):
         try:
             providermodule = importlib.import_module(modulestring)
             provider = getattr(providermodule, functionstring)
-            searchproviders.append(provider(query))
+            timer = Timer()
+            with timer:
+                searchproviders.append(provider(query))
+            _logger.debug(
+                "Search provider %s fetched results for %r in %.3f msecs",
+                providerpath,
+                query,
+                timer.elapsed * 1000,
+            )
         except (AttributeError, ImportError) as error:
             providers_with_errors.append((providerpath, error))
             _logger.error('Could not import %s', providerpath)

--- a/tests/unittests/general/util_test.py
+++ b/tests/unittests/general/util_test.py
@@ -12,6 +12,7 @@
 # more details.  You should have received a copy of the GNU General Public
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
+import time
 import pytest
 
 from nav import util
@@ -160,3 +161,27 @@ class TestFirstTrue(object):
     def test_first_true_should_parse_predicate_correctly(self):
         elems = ["foo", "bar", "baz", "frobnicate"]
         assert first_true(elems, pred=lambda x: x == "baz") == "baz"
+
+
+class TestTimer:
+    def test_when_block_completes_elapsed_should_be_a_positive_float(self):
+        timer = util.Timer()
+        with timer:
+            time.sleep(0.01)
+        assert isinstance(timer.elapsed, float)
+        assert timer.elapsed > 0
+
+    def test_before_entering_context_elapsed_should_be_none(self):
+        timer = util.Timer()
+        assert timer.elapsed is None
+
+    def test_when_block_raises_elapsed_should_still_be_set(self):
+        timer = util.Timer()
+        with pytest.raises(ValueError):
+            with timer:
+                raise ValueError("boom")
+        assert timer.elapsed is not None
+
+    def test_when_used_as_context_variable_it_should_return_self(self):
+        with util.Timer() as t:
+            assert isinstance(t, util.Timer)


### PR DESCRIPTION
## Scope and purpose

Adds a small `Timer` context manager to `nav.util` that measures wall-clock elapsed time of a `with` block, and uses it to debug-log how long each search provider takes in the NAVbar search view.

This is mostly as a response to a non-nav search provider plugin being extremely slow in a production install of ours; it's nice to be able to debug log how long individual provider plugins took.

### This pull request
* ~~adds/changes/removes a dependency~~
* ~~changes the database~~
* ~~changes the API~~


## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [X] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~