### PR TITLE
Mark CSRF cookie as secure when TLS is required

### DIFF
--- a/changelog.d/3829.security.md
+++ b/changelog.d/3829.security.md
@@ -1,0 +1,1 @@
+The CSRF cookie is now marked as secure when `needs_tls` is enabled in `webfront.conf`, matching the existing behavior of the session cookie.

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -308,6 +308,7 @@ SECURE_BROWSER_XSS_FILTER = True  # Does no harm
 _websecurity_config = WebSecurityConfigParser()
 _needs_tls = bool(_websecurity_config.getboolean('needs_tls'))
 SESSION_COOKIE_SECURE = _needs_tls
+CSRF_COOKIE_SECURE = _needs_tls
 X_FRAME_OPTIONS = _websecurity_config.get_x_frame_options()
 
 # Hack for hackers to use features like debug_toolbar etc.


### PR DESCRIPTION
## Scope and purpose

Fixes #3829.

When `needs_tls = yes` in `webfront.conf`, the session cookie is already marked `Secure`, but the CSRF cookie is not. This sets `CSRF_COOKIE_SECURE` to the same `_needs_tls` value.


## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] ~~Added/amended tests for new/changed code~~
* [ ] ~~Added/changed documentation~~
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~