### PR TITLE
Show room/location aliases in search results

### DIFF
--- a/changelog.d/3851.added.md
+++ b/changelog.d/3851.added.md
@@ -1,0 +1,1 @@
+Show aliases in room/location search results

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -1116,6 +1116,10 @@ class Room(models.Model):
         return reverse('room-info', kwargs={'roomid': self.pk})
 
     @property
+    def aliases_string(self) -> str:
+        return ", ".join(self.aliases)
+
+    @property
     def latitude(self):
         if self.position:
             return self.position[0]
@@ -1185,6 +1189,10 @@ class Location(models.Model, TreeMixin):
             return '{} ({})'.format(self.id, self.description)
         else:
             return '{}'.format(self.id)
+
+    @property
+    def aliases_string(self) -> str:
+        return ", ".join(self.aliases)
 
     def get_all_rooms(self):
         """Return a queryset returning all rooms in this location and

--- a/python/nav/web/status2/forms.py
+++ b/python/nav/web/status2/forms.py
@@ -328,7 +328,7 @@ def get_device_groups():
 def get_locations():
     """Gets all locations formatted as choices"""
     return [
-        (location.id, f"{location.id} ({', '.join(location.aliases)})")
+        (location.id, f"{location.id} ({location.aliases_string})")
         if location.aliases
         else (location.id, location.id)
         for location in Location.objects.all()

--- a/python/nav/web/templates/info/location/_search_results.html
+++ b/python/nav/web/templates/info/location/_search_results.html
@@ -8,6 +8,7 @@
     <tr>
       <th>Location</th>
       <th>Description</th>
+      <th>Aliases</th>
     </tr>
   </thead>
 
@@ -19,6 +20,9 @@
         </td>
         <td>
           {{ location.description }}
+        </td>
+        <td>
+          {{ location.aliases_string }}
         </td>
       </tr>
     {% endfor %}

--- a/python/nav/web/templates/info/room/_search_results.html
+++ b/python/nav/web/templates/info/room/_search_results.html
@@ -9,6 +9,7 @@
       <th>Room</th>
       <th>Location</th>
       <th>Description</th>
+      <th>Aliases</th>
       <th>#Netboxes</th>
     </tr>
   </thead>
@@ -24,6 +25,9 @@
         </td>
         <td>
           {{ room.description }}
+        </td>
+        <td>
+          {{ room.aliases_string }}
         </td>
         <td>
           {{ room.filtered_netboxes.count }}


### PR DESCRIPTION
## Scope and purpose

Follow up to #3832. Now after searching for a room by its alias one also is shown the aliases of a room/location. 

I have factored out the controversial string representation change and will make  a new PR for that where we can discuss that separately. 

How to manually test:

1. Add an alias to a room, another to a location.
2. Search for the alias of the room in the room search `/search/room/`. See that that the aliases are shown.
3. Search for the alias of the location in the location search `/search/location/`. See that the aliases are shown.

Screenshots:
Before:
<img width="729" height="367" alt="image" src="https://github.com/user-attachments/assets/16b63419-6eda-46b2-880a-4b9f8fafd19a" />

After:
<img width="813" height="362" alt="image" src="https://github.com/user-attachments/assets/e5f2c80c-1cf5-46bf-9f66-ba896d64ac2f" />

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [X] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [X] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
