### PR TITLE
Switch to using uv for dependency management in tox

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,24 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
-      - uses: kenchan0130/actions-system-info@59699597e84e80085a750998045983daa49274c4
-        id: system-info
-
-      - name: "Cache pip packages"
-        uses: actions/cache@v5
-        id: pip-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ steps.system-info.outputs.release }}-pip-${{ hashFiles('**/requirements.txt', '**/requirements/*.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.system-info.outputs.release }}-pip-
-
-      - name: "Cache tox environments"
-        uses: actions/cache@v5
-        id: tox-cache
-        with:
-          path: .tox
-          key: ${{ runner.os }}-${{ steps.system-info.outputs.release }}-tox-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt', '**/requirements/*.txt', 'tox.ini') }}
+          cache-dependency-glob: |
+            pyproject.toml
+            **/requirements/*.txt
 
       - name: "Set up Python ${{ matrix.python-version }}"
         uses: actions/setup-python@v6

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,6 +20,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
       - uses: kenchan0130/actions-system-info@59699597e84e80085a750998045983daa49274c4
         id: system-info
 
@@ -58,7 +59,7 @@ jobs:
       - name: "Install test runner dependencies"
         run: |
           set -xe
-          python3 -m pip install --upgrade pip setuptools wheel tox tox-gh-actions coverage virtualenv
+          uv pip install --system tox tox-uv tox-gh-actions coverage
           sudo apt-get install -y nbtscan
 
       # virtualenv seems to currently be embedding a broken version of

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -62,12 +62,6 @@ jobs:
           uv pip install --system tox tox-uv tox-gh-actions coverage
           sudo apt-get install -y nbtscan
 
-      # virtualenv seems to currently be embedding a broken version of
-      # setuptools (2022-03-31).  this ensures these embedded wheels are always
-      # up to date, but can potentially be removed again down the road.
-      - name: "Upgrade embedded virtualenv wheels"
-        run: |
-          virtualenv --upgrade-embed-wheel
 
       - name: "Install libraries needed to build external dependencies"
         run: |

--- a/changelog.d/3859.changed.md
+++ b/changelog.d/3859.changed.md
@@ -1,0 +1,1 @@
+Tox environments and GitHub workflows switched over to  for dependency management

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ dev = [
     "towncrier",
     "pre-commit",
     "tox",
+    "tox-uv",
 ]
 test = [
     "coverage>=7.0.0",

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@
 [tox]
 envlist =
     {unit,integration}-py{39,310,311}-django{42}
-    {unit,integration}-py{310,311,313}-django{52}
     javascript
     docs
 basepython = python3.9

--- a/tox.ini
+++ b/tox.ini
@@ -28,19 +28,15 @@ python =
 
 [testenv]
 # Baseline test environment
-deps =
-    pip
-    -r tests/requirements.txt
-    -r requirements/base.txt
-    -r requirements/optional.txt
-    -r requirements/django{env:DJANGO_VER}.txt
-    -c constraints.txt
+dependency_groups =
+    test
+extras =
+    ldap
 
 setenv =
     LC_ALL=C.UTF-8
     LANG=C.UTF-8
     PYTHONPATH = {toxinidir}/tests
-    VIRTUALENV_PIP=23.1.0
     BUILDDIR = {envdir}
     DJANGO_SETTINGS_MODULE = nav.django.settings
     COVERAGE_FILE = {toxinidir}/reports/coverage/.coverage
@@ -50,6 +46,8 @@ setenv =
     django50: DJANGO_VER=50
     django51: DJANGO_VER=51
     django52: DJANGO_VER=52
+    UV_OVERRIDE=requirements/django{env:DJANGO_VER}.txt
+
 passenv =
     C_INCLUDE_PATH
     GITHUB_ACTIONS

--- a/tox.ini
+++ b/tox.ini
@@ -92,16 +92,16 @@ commands =
 
 [testenv:docs]
 description = Just build the Sphinx documentation
-deps =
-    -r doc/requirements.txt
+extras =
+    docs
+    ldap
 
-usedevelop = true
+package = editable
 setenv =
     PYTHONPATH = {toxinidir}/python:{toxinidir}/tests
     DJANGO_SETTINGS_MODULE = nav.django.settings
     LC_ALL=C.UTF-8
     LANG=C.UTF-8
-    VIRTUALENV_PIP=23.1.0
 allowlist_externals = sh
 commands_pre =
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -110,10 +110,8 @@ commands =
 
 [testenv:django-warnings]
 description = Fail if Django produces warnings at or above the configured level
-deps =
-    -r requirements/base.txt
-    -r requirements/django42.txt
-    -c constraints.txt
+extras =
+    ldap
 setenv =
     DJANGO_SETTINGS_MODULE = nav.django.settings
 commands =


### PR DESCRIPTION
## Scope and purpose

For speed and modernity, this switches tox environments over to use uv for dependency management (as we do in the devcontainer), by introducing the `tox-uv` package.

This means that dependencies for test runs are now also entirely defined by `pyproject.toml` and not `requirements/*.txt` files—with one exception: Test environments that need to override the dependencies specified by `pyproject.toml` will have to do so by using overrides arguments to uv, such as this PR does for managing Django 5.2 environments (which aren't officially supported by NAV yet).

To top off the changes, the GitHub build-and-test workflow is updated to follow suit: uv replaces plain pip, and Astral's uv-setup action ensures we both have uv present and also includes caching steps that obsolete the ones we custom-wrote for our own workflows.

I would like to remove most of the `requirements/*` files, but the old `/docker-compose.yml` environment still uses it, and only @hmpf appears to still use that environment, so I'll leave it up to her to look at fixing that environment specifically.

## Followup

It seems the single constraint in `constraints.txt` has been obsoleted a long time ago. The problem was the `snowballstemmer` 3.0.0 release, which was yanked from PyPI on May 8th 2025 due to the very bug that hit us and many others. The issue has been fixed upstream, so the constraint is no longer useful for NAV and could be removed. This PR inactivates it in the test suite, but I suspect it is still used by the old `docker-compose.yml` dev environment.  Maybe also a case for @hmpf?

## How to test

Checkout the branch, run `tox -a` to get a list of environments as usual, pick one to run using `tox run -e <env-name>`.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] ~~Added/amended tests for new/changed code~~
* [ ] Added/changed documentation
* [ ] ~~Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)~~
* [ ] ~~Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/~~
* [ ] ~~Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.~~
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
