### PR TITLE
Add/factor out validation of aliases

### DIFF
--- a/changelog.d/3852.added.md
+++ b/changelog.d/3852.added.md
@@ -1,0 +1,1 @@
+Add validation for room/location aliases in API

--- a/python/nav/django/forms.py
+++ b/python/nav/django/forms.py
@@ -19,10 +19,13 @@
 import json
 
 from django import forms
+from django.core.exceptions import ValidationError
 from django.forms import Field, Textarea
 
 from nav.util import is_valid_cidr
 from nav.django import validators, widgets
+
+MAX_ALIAS_LENGTH = 64
 
 
 class CIDRField(forms.CharField):
@@ -71,6 +74,31 @@ class HStoreField(Field):
 
     def to_python(self, value):
         return validators.validate_hstore(value)
+
+
+def validate_aliases(aliases: list[str]) -> list[str]:
+    """
+    Validates a given list of aliases and raises a ValidationError if any of the
+    aliases contain the pipe character or are too long
+
+    Returns a deduplicated and stripped version of the given list
+    """
+    if not aliases:
+        return []
+    cleaned = []
+    for item in aliases:
+        if not isinstance(item, str):
+            raise ValidationError("All aliases must be strings.")
+        stripped = item.strip()
+        if "|" in stripped:
+            raise ValidationError("Aliases cannot contain the pipe character ('|')")
+        if len(stripped) > MAX_ALIAS_LENGTH:
+            raise ValidationError(
+                f"Alias must be {MAX_ALIAS_LENGTH} characters or fewer."
+            )
+        if stripped and stripped not in cleaned:
+            cleaned.append(stripped)
+    return cleaned
 
 
 class AliasListWidget(forms.Widget):

--- a/python/nav/django/forms.py
+++ b/python/nav/django/forms.py
@@ -120,7 +120,6 @@ class AliasListWidget(forms.Widget):
 class AliasListField(forms.Field):
     """Form field for editing a list of alias strings"""
 
-    MAX_ALIAS_LENGTH = 64
     widget = AliasListWidget
 
     def __init__(self, *args, verbose_name='entry', **kwargs):
@@ -137,20 +136,7 @@ class AliasListField(forms.Field):
         return value or []
 
     def clean(self, value):
-        if not value:
-            return []
-        cleaned = []
-        for item in value:
-            if not isinstance(item, str):
-                raise forms.ValidationError("All aliases must be strings.")
-            stripped = item.strip()
-            if len(stripped) > self.MAX_ALIAS_LENGTH:
-                raise forms.ValidationError(
-                    f"Alias must be {self.MAX_ALIAS_LENGTH} characters or fewer."
-                )
-            if stripped and stripped not in cleaned:
-                cleaned.append(stripped)
-        return cleaned
+        return validate_aliases(value)
 
 
 def _parse_json_list(value):

--- a/python/nav/web/api/v1/serializers.py
+++ b/python/nav/web/api/v1/serializers.py
@@ -17,9 +17,11 @@
 
 from decimal import Decimal
 
+from django.core.exceptions import ValidationError as DjangoValidationError
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
+from nav.django.forms import validate_aliases
 from nav.web.api.v1.fields import DisplayNameWritableField
 from nav.models import manage, cabling, rack, profiles
 from nav.web.seeddb.page.netbox.edit import get_sysname
@@ -103,6 +105,13 @@ class LocationSerializer(serializers.ModelSerializer):
         model = manage.Location
         fields = '__all__'
 
+    def validate_aliases(self, value):
+        try:
+            validate_aliases(value)
+        except DjangoValidationError as e:
+            raise serializers.ValidationError(e)
+        return value
+
 
 class RoomSerializer(serializers.ModelSerializer):
     """Serializer for the room model"""
@@ -125,6 +134,13 @@ class RoomSerializer(serializers.ModelSerializer):
             lat, lon = attrs.get("position")
             attrs["position"] = (Decimal(lat), Decimal(lon))
         return attrs
+
+    def validate_aliases(self, value):
+        try:
+            validate_aliases(value)
+        except DjangoValidationError as e:
+            raise serializers.ValidationError(e)
+        return value
 
 
 class OrganizationSerializer(serializers.ModelSerializer):

--- a/tests/integration/api_test.py
+++ b/tests/integration/api_test.py
@@ -6,6 +6,7 @@ import json
 import pytest
 from django.urls import reverse
 
+from nav.django.forms import MAX_ALIAS_LENGTH
 from nav.models.event import AlertHistory
 from nav.models.fields import INFINITY
 from nav.web.api.v1.views import get_endpoints
@@ -291,6 +292,40 @@ def test_patch_alias(db, api_client, token, endpoint):
 
     data = json.loads(response.content.decode('utf-8'))
     assert data.get('aliases') == new_aliases
+
+
+@pytest.mark.parametrize("endpoint", ['room', 'location'])
+def test_patch_alias_with_pipe(db, api_client, token, endpoint):
+    create_token_endpoint(token, endpoint)
+    create(api_client, endpoint, TEST_DATA.get(endpoint))
+
+    object_id = TEST_DATA[endpoint]['id']
+
+    new_aliases = ['aliaswithpipe|']
+    response = api_client.patch(
+        f'/api/1/{endpoint}/{object_id}/',
+        {'aliases': new_aliases},
+        format='json',
+    )
+    print(response)
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize("endpoint", ['room', 'location'])
+def test_patch_alias_too_long(db, api_client, token, endpoint):
+    create_token_endpoint(token, endpoint)
+    create(api_client, endpoint, TEST_DATA.get(endpoint))
+
+    object_id = TEST_DATA[endpoint]['id']
+
+    new_aliases = ['a' * (MAX_ALIAS_LENGTH + 1)]
+    response = api_client.patch(
+        f'/api/1/{endpoint}/{object_id}/',
+        {'aliases': new_aliases},
+        format='json',
+    )
+    print(response)
+    assert response.status_code == 400
 
 
 def test_delete_room_wrong_room(db, api_client, token):

--- a/tests/integration/api_test.py
+++ b/tests/integration/api_test.py
@@ -94,10 +94,7 @@ def test_delete(db, api_client, token, endpoint):
     response_delete = delete(api_client, endpoint, res.get('id'))
     response_get = get(api_client, endpoint, res.get('id'))
 
-    print(response_delete)
     assert response_delete.status_code == 204
-
-    print(response_get)
     assert response_get.status_code == 404
 
 
@@ -105,7 +102,7 @@ def test_delete(db, api_client, token, endpoint):
 def test_create(db, api_client, token, endpoint):
     create_token_endpoint(token, endpoint)
     response = create(api_client, endpoint, TEST_DATA.get(endpoint))
-    print(response)
+
     assert response.status_code == 201
 
 
@@ -115,7 +112,7 @@ def test_page_size(db, api_client, token):
     create(api_client, endpoint, {'id': 'blapp1', 'location': 'mylocation'})
     create(api_client, endpoint, {'id': 'blapp2', 'location': 'mylocation'})
     response = api_client.get('/api/1/room/?page_size=1')
-    print(response.data)
+
     assert len(response.data.get('results')) == 1
 
 
@@ -123,7 +120,7 @@ def test_ordering_should_not_crash(db, api_client, token):
     endpoint = 'room'
     create_token_endpoint(token, endpoint)
     response = api_client.get('/api/1/room/?ordering=whatever')
-    print(response.data)
+
     assert response.status_code == 200
 
 
@@ -135,12 +132,12 @@ def test_update_org_on_account(db, api_client, token):
     create_token_endpoint(token, endpoint)
     data = {"organizations": ["myorg"]}
     response = update(api_client, endpoint, 1, data)
-    print(response)
+
     assert response.status_code == 200
 
     data = {"organizations": []}
     response = update(api_client, endpoint, 1, data)
-    print(response)
+
     assert response.status_code == 200
 
 
@@ -150,7 +147,7 @@ def test_update_group_on_org(db, api_client, token):
     # Only admin group
     data = {"accountgroups": [1]}
     response = update(api_client, endpoint, 1, data)
-    print(response)
+
     assert response.status_code == 200
 
 
@@ -160,7 +157,7 @@ def test_update_group_on_org(db, api_client, token):
 def test_filter_netbox_by_invalid_ip(db, api_client, token):
     create_token_endpoint(token, 'netbox')
     response = api_client.get('{}?ip=10'.format(ENDPOINTS['netbox']))
-    print(response)
+
     assert response.status_code == 200
 
 
@@ -169,7 +166,7 @@ def test_filter_netbox_by_invalid_ip_that_cannot_be_converted_throws_error(
 ):
     create_token_endpoint(token, 'netbox')
     response = api_client.get('{}?ip=x'.format(ENDPOINTS['netbox']))
-    print(response)
+
     assert response.status_code == 400
 
 
@@ -180,7 +177,7 @@ def test_update_netbox(db, api_client, token):
     res = json.loads(response_create.content.decode('utf-8'))
     data = {'categoryid': 'GW'}
     response_update = update(api_client, endpoint, res['id'], data)
-    print(response_update)
+
     assert response_update.status_code == 200
 
 
@@ -193,9 +190,6 @@ def test_delete_netbox(db, api_client, token):
     response_get = get(api_client, endpoint, json_create['id'])
     json_get = json.loads(response_get.content.decode('utf-8'))
 
-    print(response_delete)
-    print(json_get['deleted_at'])
-
     assert response_delete.status_code == 204
     assert json_get['deleted_at'] is not None
 
@@ -206,7 +200,7 @@ def test_delete_netbox(db, api_client, token):
 def test_get_wrong_room(db, api_client, token):
     create_token_endpoint(token, 'room')
     response = api_client.get('{}blapp/'.format(ENDPOINTS['room']))
-    print(response)
+
     assert response.status_code == 404
 
 
@@ -215,7 +209,7 @@ def test_get_new_room(db, api_client, token):
     create_token_endpoint(token, endpoint)
     create(api_client, endpoint, TEST_DATA.get(endpoint))
     response = api_client.get('/api/1/room/blapp/')
-    print(response)
+
     assert response.status_code == 200
 
 
@@ -227,7 +221,7 @@ def test_when_room_has_dot_in_id_the_api_should_still_find_it(db, api_client, to
     room.save()
 
     response = api_client.get(f"/api/1/room/{room.id}/")
-    print(response)
+
     assert response.status_code == 200
 
 
@@ -241,7 +235,7 @@ def test_when_location_has_dot_in_id_the_api_should_still_find_it(
     location.save()
 
     response = api_client.get(f"/api/1/location/{location.id}/")
-    print(response)
+
     assert response.status_code == 200
 
 
@@ -249,7 +243,7 @@ def test_patch_room_not_found(db, api_client, token):
     create_token_endpoint(token, 'room')
     data = {'location': 'mylocation'}
     response = api_client.patch('/api/1/room/blapp/', data, format='json')
-    print(response)
+
     assert response.status_code == 404
 
 
@@ -259,7 +253,7 @@ def test_patch_room_wrong_location(db, api_client, token):
     create(api_client, endpoint, TEST_DATA.get(endpoint))
     data = {'location': 'mylocatio'}
     response = api_client.patch('/api/1/room/blapp/', data, format='json')
-    print(response)
+
     assert response.status_code == 400
 
 
@@ -270,7 +264,6 @@ def test_patch_room(db, api_client, token):
     data = {'location': 'mylocation'}
     response = api_client.patch('/api/1/room/blapp/', data, format='json')
 
-    print(response)
     assert response.status_code == 200
 
 
@@ -287,7 +280,7 @@ def test_patch_alias(db, api_client, token, endpoint):
         {'aliases': new_aliases},
         format='json',
     )
-    print(response)
+
     assert response.status_code == 200
 
     data = json.loads(response.content.decode('utf-8'))
@@ -307,7 +300,7 @@ def test_patch_alias_with_pipe(db, api_client, token, endpoint):
         {'aliases': new_aliases},
         format='json',
     )
-    print(response)
+
     assert response.status_code == 400
 
 
@@ -324,7 +317,7 @@ def test_patch_alias_too_long(db, api_client, token, endpoint):
         {'aliases': new_aliases},
         format='json',
     )
-    print(response)
+
     assert response.status_code == 400
 
 
@@ -334,7 +327,6 @@ def test_delete_room_wrong_room(db, api_client, token):
     create(api_client, endpoint, TEST_DATA.get(endpoint))
     response = api_client.delete('/api/1/room/blap/')
 
-    print(response)
     assert response.status_code == 404
 
 
@@ -345,7 +337,6 @@ def test_validate_vlan(db, api_client, token):
     testdata.update({'net_type': 'core'})
     response = create(api_client, endpoint, testdata)
 
-    print(response)
     assert response.status_code == 400
 
 
@@ -365,7 +356,6 @@ def test_create_prefix(db, api_client, token):
     testdata = prepare_prefix_test(db, api_client, token)
     response = create(api_client, endpoint, testdata)
 
-    print(response)
     assert response.status_code == 201
 
 
@@ -398,7 +388,7 @@ def test_update_prefix_remove_usage(db, api_client, token, serializer_models):
 def test_nonexistent_alert_should_give_404(db, api_client, token):
     create_token_endpoint(token, 'alert')
     response = api_client.get('{}9999/'.format(ENDPOINTS['alert']))
-    print(response)
+
     assert response.status_code == 404
 
 
@@ -406,7 +396,7 @@ def test_alert_should_be_visible_in_api(db, api_client, token, serializer_models
     create_token_endpoint(token, 'alert')
     alert = AlertHistory.objects.all()[0]
     response = api_client.get('{url}{id}/'.format(url=ENDPOINTS['alert'], id=alert.id))
-    print(response)
+
     assert response.status_code == 200
     content = response.content.decode('utf-8')
     # Simple string tests, but they might just as well parse the JSON structure
@@ -423,7 +413,7 @@ def test_interface_with_last_used_should_be_listable(
     endpoint = 'interface'
     create_token_endpoint(token, endpoint)
     response = api_client.get('/api/1/interface/?last_used=on')
-    print(response.data)
+
     assert response.status_code == 200
 
 

--- a/tests/unittests/django/aliases_field_test.py
+++ b/tests/unittests/django/aliases_field_test.py
@@ -1,10 +1,15 @@
 """Tests for AliasListField and AliasListWidget"""
 
 import pytest
-from django import forms
+from django.core.exceptions import ValidationError
 from django.http import QueryDict
 
-from nav.django.forms import AliasListField, AliasListWidget
+from nav.django.forms import (
+    MAX_ALIAS_LENGTH,
+    AliasListField,
+    AliasListWidget,
+    validate_aliases,
+)
 
 
 class TestAliasListFieldClean:
@@ -34,14 +39,19 @@ class TestAliasListFieldClean:
 
     def test_when_value_has_non_string_then_it_should_raise_validation_error(self):
         field = AliasListField(required=False)
-        with pytest.raises(forms.ValidationError):
+        with pytest.raises(ValidationError):
             field.clean([123])
 
     def test_when_alias_exceeds_max_length_then_it_should_raise_validation_error(self):
         field = AliasListField(required=False)
-        long_alias = 'a' * (AliasListField.MAX_ALIAS_LENGTH + 1)
-        with pytest.raises(forms.ValidationError):
+        long_alias = 'a' * (MAX_ALIAS_LENGTH + 1)
+        with pytest.raises(ValidationError):
             field.clean([long_alias])
+
+    def test_when_alias_contains_pipe_then_it_should_raise_validation_error(self):
+        field = AliasListField(required=False)
+        with pytest.raises(ValidationError):
+            field.clean(['foo|bar'])
 
 
 class TestAliasListWidgetValueFromDatadict:
@@ -81,3 +91,36 @@ class TestAliasListFieldPrepareValue:
     def test_when_value_is_none_then_it_should_return_empty_list(self):
         field = AliasListField(required=False)
         assert field.prepare_value(None) == []
+
+
+class TestValidateAliases:
+    def test_when_value_is_none_then_it_should_return_empty_list(self):
+        assert validate_aliases(None) == []
+
+    def test_when_value_is_empty_list_then_it_should_return_empty_list(self):
+        assert validate_aliases([]) == []
+
+    def test_when_value_has_strings_then_it_should_return_them(self):
+        assert validate_aliases(['foo', 'bar']) == ['foo', 'bar']
+
+    def test_when_value_has_whitespace_then_it_should_strip(self):
+        assert validate_aliases(['  foo  ', ' bar ']) == ['foo', 'bar']
+
+    def test_when_value_has_empty_strings_then_it_should_remove_them(self):
+        assert validate_aliases(['foo', '', '  ', 'bar']) == ['foo', 'bar']
+
+    def test_when_value_has_duplicates_then_it_should_deduplicate(self):
+        assert validate_aliases(['foo', 'bar', 'foo']) == ['foo', 'bar']
+
+    def test_when_value_has_non_string_then_it_should_raise_validation_error(self):
+        with pytest.raises(ValidationError):
+            validate_aliases([123])
+
+    def test_when_alias_exceeds_max_length_then_it_should_raise_validation_error(self):
+        long_alias = 'a' * (MAX_ALIAS_LENGTH + 1)
+        with pytest.raises(ValidationError):
+            validate_aliases([long_alias])
+
+    def test_when_alias_contains_pipe_then_it_should_raise_validation_error(self):
+        with pytest.raises(ValidationError):
+            validate_aliases(['foo|bar'])


### PR DESCRIPTION
## Scope and purpose

Fixes #3852.

I was uncertain where to put the validation function, so I put it with the forms, but open for better suggestions! 

I wish I could have just added a `clean` method to `Room` and `Location`, but DRF does not call that method anymore  when validating (https://www.django-rest-framework.org/community/3.0-announcement/#differences-between-modelserializer-validation-and-modelform), so the API would have anyway had to explicitly call the validation.

How to test:
Go to `/seeddb/location/add/`/`/seeddb/room/add/` and try to create a room/location with an alias containing the pipe character. 

Try to create a location/room with an alias containing the pipe character via the API:

```
curl -X POST -H "Content-type: application/json" -H "Authorization: Token  sometoken" http://localhost:8000/api/location/ -d '{"id":"Illegal", "aliases":["illegal|"]}'
```
```
curl -X POST -H "Content-type: application/json" -H "Authorization: Token  sometoken" http://localhost:8000/api/room/ -d '{"id":"Illegal","location":"locationid", "aliases":["illegal|"]}'
```

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [X] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [X] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
