### PR TITLE
Add local dev setup without devcontainers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dummy clean distclean testclean docclean doc cssclean sassbuild sasswatch setup-playwright .FORCE
+.PHONY: dummy clean distclean testclean docclean doc cssclean sassbuild sasswatch setup-playwright local-setup local-up local-down .FORCE
 
 dummy:
 	@echo "'make' is no longer used for deployment. See 'doc/intro/install.rst'"
@@ -56,5 +56,14 @@ PLAYWRIGHT_BROWSERS ?= chromium
 
 setup-playwright:
 	uv run playwright install --with-deps $(PLAYWRIGHT_BROWSERS)
+
+local-setup:
+	tools/local-dev/setup.sh
+
+local-up:
+	docker compose -f docker-compose.local.yml up -d
+
+local-down:
+	docker compose -f docker-compose.local.yml down
 
 .FORCE:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,32 @@
+# Lightweight infrastructure services for local NAV development.
+# Usage: make local-up / make local-down
+#
+# This runs only PostgreSQL and Graphite — NAV itself runs natively
+# on your machine. Run 'make local-setup' for first-time setup.
+
+services:
+  db:
+    image: postgres:17
+    restart: unless-stopped
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: nav
+      POSTGRES_DB: nav
+      POSTGRES_PASSWORD: nav
+
+  graphite:
+    build: tools/docker/graphite
+    restart: unless-stopped
+    ports:
+      - "2003:2003"
+      - "2003:2003/udp"
+      - "8088:8000"
+    volumes:
+      - ./python/nav/etc/graphite/storage-schemas.conf:/etc/carbon/storage-schemas.conf
+      - ./python/nav/etc/graphite/storage-aggregation.conf:/etc/carbon/storage-aggregation.conf
+
+volumes:
+  postgres-data:

--- a/python/nav/Snmp/__init__.py
+++ b/python/nav/Snmp/__init__.py
@@ -21,9 +21,6 @@ multiple implementations
 
 """
 
-import os
-import sys
-
 BACKEND = None
 
 try:
@@ -34,16 +31,14 @@ except ImportError:
 else:
     BACKEND = 'pynetsnmp'
 
-if BACKEND == 'pynetsnmp':
-    if sys.platform == "darwin" and not os.getenv("DYLD_LIBRARY_PATH"):
-        # horrible workaround for MacOS problems, described at length at
-        # https://hynek.me/articles/macos-dyld-env/
-        os.environ["DYLD_LIBRARY_PATH"] = os.getenv(
-            "LD_LIBRARY_PATH", "/usr/local/opt/openssl/lib"
-        )
-    from .pynetsnmp import *
-else:
+if BACKEND is None:
     raise ImportError("No supported SNMP backend was found")
+
+
+from ._macos_workaround import safe_libcrypto_import
+
+with safe_libcrypto_import():
+    from .pynetsnmp import *  # noqa: E402, F403
 
 
 def safestring(string, encodings_to_try=('utf-8', 'latin-1')):

--- a/python/nav/Snmp/_macos_workaround.py
+++ b/python/nav/Snmp/_macos_workaround.py
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.  You should have received a copy of the GNU General Public License
+# along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Workaround for pynetsnmp crashing on macOS.
+
+pynetsnmp loads libcrypto with RTLD_GLOBAL at import time, which on macOS
+conflicts with Python's own OpenSSL/LibreSSL and aborts the process with
+"loading libcrypto in an unsafe way".
+
+This module provides a context manager that intercepts ctypes.CDLL calls
+and skips loading libcrypto.dylib, so pynetsnmp can be imported safely.
+"""
+
+import sys
+from contextlib import contextmanager, nullcontext
+
+
+@contextmanager
+def _patched_libcrypto():  # NOSONAR(python:S1720)
+    import ctypes
+    from unittest.mock import patch
+
+    real_init = ctypes.CDLL.__init__
+
+    def skip_libcrypto(self, name, *args, **kwargs):  # NOSONAR(python:S1720)
+        if name and str(name).endswith('libcrypto.dylib'):
+            return real_init(self, None, *args, **kwargs)
+        return real_init(self, name, *args, **kwargs)
+
+    with patch.object(ctypes.CDLL, '__init__', skip_libcrypto):
+        yield
+
+
+safe_libcrypto_import = _patched_libcrypto if sys.platform == "darwin" else nullcontext

--- a/python/nav/django/templatetags/breadcrumbs.py
+++ b/python/nav/django/templatetags/breadcrumbs.py
@@ -1,39 +1,45 @@
+from functools import cache
+
 from django import template
 from django.urls import reverse
 
 register = template.Library()
 
-BASE_CRUMB = ('Home', reverse('webfront-index'))
 
-# Account-related Breadcrumbs
-BASE_ACCOUNT_CRUMB = ('Account', reverse('webfront-preferences'))
-CURRENT_PATH = ''
-ACCOUNTS_BREADCRUMB_MAP = {
-    reverse('webfront-preferences'): [BASE_ACCOUNT_CRUMB],
-    reverse('account_change_password'): [
-        BASE_ACCOUNT_CRUMB,
-        ('Change Password', CURRENT_PATH),
-    ],
-    reverse('account_reauthenticate'): [
-        BASE_ACCOUNT_CRUMB,
-        ('Re-authenticate', CURRENT_PATH),
-    ],
-    reverse('socialaccount_connections'): [
-        BASE_ACCOUNT_CRUMB,
-        ('Account Connections', CURRENT_PATH),
-    ],
-}
+@cache
+def _get_breadcrumb_config():
+    """Build breadcrumb configuration on first use.
 
-# Combine all breadcrumb mappings
-BREADCRUMB_MAP = {
-    **ACCOUNTS_BREADCRUMB_MAP,
-}
+    Deferred to avoid calling reverse() at module import time, which forces
+    all URL configs and their views to be loaded eagerly.
+    """
+    base_crumb = ('Home', reverse('webfront-index'))
+    base_account_crumb = ('Account', reverse('webfront-preferences'))
 
-# 2FA Breadcrumbs
-TWO_FACTOR_AUTH_CRUMB = [
-    BASE_ACCOUNT_CRUMB,
-    ('Two-Factor Authentication', CURRENT_PATH),
-]
+    breadcrumb_map = {
+        reverse('webfront-preferences'): [base_account_crumb],
+        reverse('account_change_password'): [
+            base_account_crumb,
+            ('Change Password', ''),
+        ],
+        reverse('account_reauthenticate'): [
+            base_account_crumb,
+            ('Re-authenticate', ''),
+        ],
+        reverse('socialaccount_connections'): [
+            base_account_crumb,
+            ('Account Connections', ''),
+        ],
+    }
+
+    two_factor_auth_crumb = [
+        base_account_crumb,
+        ('Two-Factor Authentication', ''),
+    ]
+
+    mfa_prefix = reverse('mfa_index')
+
+    return base_crumb, breadcrumb_map, two_factor_auth_crumb, mfa_prefix
 
 
 @register.filter
@@ -47,16 +53,18 @@ def to_breadcrumbs(path):
         of each breadcrumb.
     :rtype: list
     """
-    # Remove leading and trailing slashes and split the path
+    base_crumb, breadcrumb_map, two_factor_auth_crumb, mfa_prefix = (
+        _get_breadcrumb_config()
+    )
+
     path = clean_path(path)
-    if path in BREADCRUMB_MAP:
-        crumbs = [BASE_CRUMB] + BREADCRUMB_MAP[path]
-        return crumbs
+    if path in breadcrumb_map:
+        return [base_crumb] + breadcrumb_map[path]
 
-    if path.startswith(reverse('mfa_index')):
-        return [BASE_CRUMB] + TWO_FACTOR_AUTH_CRUMB
+    if path.startswith(mfa_prefix):
+        return [base_crumb] + two_factor_auth_crumb
 
-    return [BASE_CRUMB]
+    return [base_crumb]
 
 
 def clean_path(path):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,6 +14,7 @@ from django.contrib.staticfiles.handlers import StaticFilesHandler
 from django.test import Client
 from django.test.testcases import LiveServerThread
 
+SNMP_TEST_PORT = 1024
 
 ########################################################################
 #                                                                      #
@@ -305,15 +306,20 @@ def snmpsim():
             snmpsimd,
             '--data-dir={}/tests/integration/snmp_fixtures'.format(workspace),
             '--log-level=error',
-            '--agent-udpv4-endpoint=127.0.0.1:1024',
+            '--agent-udpv4-endpoint=127.0.0.1:{}'.format(SNMP_TEST_PORT),
         ],
         env={'HOME': workspace},
     )
 
-    while not _lookfor('0100007F:0400', '/proc/net/udp'):
+    for _ in range(10):
+        if _verify_localhost_snmp_response():
+            break
+        if proc.poll() is not None:
+            raise RuntimeError(f"snmpsimd exited with code {proc.returncode}")
         print("Still waiting for snmpsimd to listen for queries")
-        proc.poll()
-        time.sleep(0.1)
+        time.sleep(0.5)
+    else:
+        raise TimeoutError("snmpsimd did not start in time")
 
     yield
     proc.kill()
@@ -330,7 +336,7 @@ def snmp_agent_proxy(snmpsim, snmp_ports):
     port = next(snmp_ports)
     agent = AgentProxy(
         '127.0.0.1',
-        1024,
+        SNMP_TEST_PORT,
         community='placeholder',
         snmpVersion='v2c',
         protocol=port.protocol,
@@ -354,10 +360,19 @@ def snmp_ports():
     return _ports
 
 
-def _lookfor(string, filename):
-    """Very simple grep-like function"""
-    data = io.open(filename, 'r', encoding='utf-8').read()
-    return string in data
+def _verify_localhost_snmp_response(port=SNMP_TEST_PORT):
+    """Verifies that the snmpsimd fixture process is responding, by using NAV's own
+    SNMP framework to query it.
+    """
+    from nav.Snmp import Snmp
+    from nav.Snmp.errors import SnmpError
+
+    try:
+        session = Snmp(host="127.0.0.1", community="public", version="2c", port=port)
+        resp = session.jog("1.3.6.1.2.1.47.1.1.1.1.2")
+        return bool(resp)
+    except (SnmpError, OSError):
+        return False
 
 
 @pytest.fixture

--- a/tests/integration/web/seeddb_netbox_test.py
+++ b/tests/integration/web/seeddb_netbox_test.py
@@ -161,7 +161,7 @@ class TestCheckConnectivityView:
 
         assert response.status_code == 200
         assert response.context['status'] == 'error'
-        assert 'Name or service not known' in response.context['message']
+        assert 'not known' in response.context['message']
 
     @patch('socket.getaddrinfo')
     def test_given_unicode_error_then_return_error_message(

--- a/tests/setup_test_config.py
+++ b/tests/setup_test_config.py
@@ -79,7 +79,7 @@ def _write_db_conf(config_dir: Path) -> None:
     host = os.environ.get("PGHOST", "localhost")
     port = os.environ.get("PGPORT", "5432")
     user = os.environ.get("PGUSER", "nav")
-    password = os.environ.get("PGPASSWORD", "")
+    password = os.environ.get("PGPASSWORD", "nav")
     dbname = _get_test_database_name()
 
     db_conf = config_dir / "db.conf"

--- a/tools/local-dev/setup.sh
+++ b/tools/local-dev/setup.sh
@@ -1,0 +1,296 @@
+#!/bin/bash
+set -euo pipefail
+
+# One-time setup for local NAV development (without devcontainers).
+#
+# Prerequisites:
+#   - Python 3.9+ and uv (https://docs.astral.sh/uv/)
+#   - Node.js and npm
+#   - Docker (for PostgreSQL and Graphite)
+#   - System libraries: libpq, net-snmp, libjpeg, zlib
+#     Optional: libldap + libsasl2 (for LDAP authentication)
+#
+# Usage:
+#   make local-setup
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$PROJECT_DIR"
+
+# --- Colors ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info()  { echo -e "${GREEN}==>${NC} $*"; }
+warn()  { echo -e "${YELLOW}==> WARNING:${NC} $*"; }
+error() { echo -e "${RED}==> ERROR:${NC} $*" >&2; }
+
+# --- Check basic prerequisites ---
+check_command() {
+    if ! command -v "$1" &>/dev/null; then
+        error "$1 is not installed. $2"
+        return 1
+    fi
+}
+
+info "Checking prerequisites..."
+MISSING=0
+check_command uv "Install from https://docs.astral.sh/uv/" || MISSING=1
+check_command node "Install Node.js from your package manager or https://nodejs.org/" || MISSING=1
+check_command npm "Comes with Node.js" || MISSING=1
+check_command docker "Install from https://docs.docker.com/get-docker/" || MISSING=1
+
+# pg_dump must match or exceed the Docker PostgreSQL version (17)
+if command -v pg_dump &>/dev/null; then
+    PG_DUMP_VERSION=$(pg_dump --version | grep -oE '[0-9]+' | head -1)
+    if [ "$PG_DUMP_VERSION" -lt 17 ] 2>/dev/null; then
+        warn "pg_dump is version $PG_DUMP_VERSION, but PostgreSQL 17 is used."
+        echo "    macOS:  brew install postgresql@17"
+        MISSING=1
+    fi
+else
+    warn "pg_dump is not installed."
+    echo "    macOS:  brew install postgresql@17"
+    MISSING=1
+fi
+
+if [ "$MISSING" -eq 1 ]; then
+    error "Please install the missing prerequisites and re-run this script."
+    exit 1
+fi
+
+# --- Check system libraries ---
+info "Checking system libraries..."
+LIBS_MISSING=0
+
+find_header() {
+    local header="$1"
+
+    # Standard system paths
+    for dir in /usr/include /usr/local/include; do
+        [ -f "$dir/$header" ] && return 0
+    done
+
+    # Homebrew (macOS) — check both Apple Silicon and Intel prefixes
+    for prefix in /opt/homebrew /usr/local; do
+        if [ -d "$prefix/include" ]; then
+            find -L "$prefix/include" -path "*/$header" -print -quit 2>/dev/null | grep -q . && return 0
+        fi
+        if [ -d "$prefix/opt" ]; then
+            find -L "$prefix/opt" -path "*/include*/$header" -print -quit 2>/dev/null | grep -q . && return 0
+        fi
+    done
+
+    return 1
+}
+
+check_lib() {
+    local name="$1"
+    local pkg_config_name="$2"
+    local header="$3"
+    local install_hint="$4"
+
+    # Try pkg-config first
+    if pkg-config --exists "$pkg_config_name" 2>/dev/null; then
+        return 0
+    fi
+
+    # Search common header paths (handles Homebrew, Nix, standard locations)
+    if find_header "$header"; then
+        return 0
+    fi
+
+    warn "$name not found. Install it:"
+    echo "    $install_hint"
+    LIBS_MISSING=1
+}
+
+check_lib "PostgreSQL client library (libpq)" "libpq" "libpq-fe.h" \
+    "Debian/Ubuntu: sudo apt install libpq-dev
+    Fedora/RHEL:   sudo dnf install libpq-devel
+    Arch:          sudo pacman -S postgresql-libs
+    macOS:         brew install libpq
+    Nix:           nix-shell -p postgresql"
+
+check_lib "Net-SNMP library" "netsnmp" "net-snmp/net-snmp-config.h" \
+    "Debian/Ubuntu: sudo apt install libsnmp-dev
+    Fedora/RHEL:   sudo dnf install net-snmp-devel
+    Arch:          sudo pacman -S net-snmp
+    macOS:         brew install net-snmp
+    Nix:           nix-shell -p net-snmp"
+
+check_lib "libjpeg (for Pillow)" "libjpeg" "jpeglib.h" \
+    "Debian/Ubuntu: sudo apt install libjpeg-dev
+    Fedora/RHEL:   sudo dnf install libjpeg-turbo-devel
+    Arch:          sudo pacman -S libjpeg-turbo
+    macOS:         brew install jpeg
+    Nix:           nix-shell -p libjpeg"
+
+if [ "$LIBS_MISSING" -eq 1 ]; then
+    warn "Some system libraries appear to be missing."
+    echo "    Python package installation may fail without them."
+    echo ""
+    read -r -p "Continue anyway? [y/N] " response
+    if [[ ! "$response" =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+# --- Install Python dependencies ---
+info "Installing Python dependencies (Python 3.11)..."
+uv sync --python 3.11 --all-extras --all-groups
+
+# --- Get the virtualenv path ---
+read -r VENV_DIR SITE_PACKAGES <<< "$(uv run python -c "import sys, site; print(sys.prefix, site.getsitepackages()[0])")"
+NAV_CONFIG_DIR="$VENV_DIR/etc/nav"
+
+info "Virtualenv: $VENV_DIR"
+info "NAV config: $NAV_CONFIG_DIR"
+
+# --- Configure virtualenv defaults ---
+# sitecustomize.py runs on every Python startup from this venv.
+# setdefault ensures explicit exports still take precedence.
+# The macOS libcrypto patch must live here (not just in nav.Snmp) because
+# multiple modules import pynetsnmp independently.
+info "Configuring virtualenv defaults..."
+cat > "$SITE_PACKAGES/sitecustomize.py" <<'PYEOF'
+import os
+import sys
+
+for key, value in {
+    "DJANGO_SETTINGS_MODULE": "nav.django.settings",
+    "PGHOST": "127.0.0.1",
+    "PGPORT": "5433",
+    "PGUSER": "nav",
+    "PGPASSWORD": "nav",
+}.items():
+    os.environ.setdefault(key, value)
+
+if sys.platform == "darwin":
+    import ctypes
+    import ctypes.util
+    from pathlib import Path
+
+    _real_init = ctypes.CDLL.__init__
+
+    class _PatchedCDLL(ctypes.CDLL):
+        def __init__(self, name, *args, **kwargs):
+            if name and str(name).endswith("libcrypto.dylib"):
+                return _real_init(self, None, *args, **kwargs)
+            return _real_init(self, name, *args, **kwargs)
+
+    ctypes.CDLL = _PatchedCDLL
+
+    # macOS ships a 2006-era libtidy; prefer Homebrew's modern version
+    # so that pytidylib (used by integration tests) gets consistent results.
+    _find_library = ctypes.util.find_library
+    def _patched_find_library(name):
+        if name == "tidy":
+            for prefix in ("/opt/homebrew", "/usr/local"):
+                _tidy = Path(prefix) / "opt/tidy-html5/lib/libtidy.dylib"
+                if _tidy.exists():
+                    return str(_tidy)
+        return _find_library(name)
+    ctypes.util.find_library = _patched_find_library
+PYEOF
+
+# --- Install NAV config files ---
+info "Installing NAV configuration files..."
+uv run nav config install "$NAV_CONFIG_DIR" 2>/dev/null
+
+# --- Configure db.conf for local Docker PostgreSQL ---
+DB_CONF="$NAV_CONFIG_DIR/db.conf"
+info "Configuring $DB_CONF..."
+cat > "$DB_CONF" <<EOF
+dbhost=127.0.0.1
+dbport=5433
+db_nav=nav
+script_default=nav
+userpw_nav=nav
+EOF
+
+# --- Configure nav.conf for local development ---
+NAV_CONF="$NAV_CONFIG_DIR/nav.conf"
+UPLOAD_DIR="$VENV_DIR/var/nav/uploads"
+mkdir -p "$UPLOAD_DIR"
+
+info "Configuring $NAV_CONF..."
+sed -i.bak \
+    -e "s/^NAV_USER=.*/NAV_USER=$(whoami)/" \
+    -e 's/^#DJANGO_DEBUG=True/DJANGO_DEBUG=True/' \
+    -e "s,^#UPLOAD_DIR=.*,UPLOAD_DIR=$UPLOAD_DIR," \
+    "$NAV_CONF"
+rm -f "$NAV_CONF.bak"
+# Append settings that weren't present as comments in the template
+grep -q '^DJANGO_DEBUG=True' "$NAV_CONF" || echo "DJANGO_DEBUG=True" >> "$NAV_CONF"
+grep -q '^UPLOAD_DIR=' "$NAV_CONF" || echo "UPLOAD_DIR=$UPLOAD_DIR" >> "$NAV_CONF"
+
+# --- Configure graphite.conf for local Docker Graphite ---
+GRAPHITE_CONF="$NAV_CONFIG_DIR/graphite.conf"
+info "Configuring $GRAPHITE_CONF..."
+cat > "$GRAPHITE_CONF" <<EOF
+[carbon]
+host=localhost
+port=2003
+
+[graphiteweb]
+base=http://localhost:8088/
+EOF
+
+# --- Install frontend dependencies ---
+info "Installing npm dependencies..."
+npm install
+
+# --- Build CSS ---
+info "Building SASS/CSS..."
+npm run build:sass
+
+# --- Start infrastructure services ---
+info "Starting PostgreSQL and Graphite containers..."
+docker compose -f docker-compose.local.yml up -d
+
+# --- Wait for PostgreSQL to be ready ---
+pg_ready() { PGPASSWORD=nav psql -h 127.0.0.1 -p 5433 -U nav -d nav -c "SELECT 1" &>/dev/null; }
+
+info "Waiting for PostgreSQL to accept connections..."
+for _ in $(seq 1 30); do
+    pg_ready && break
+    sleep 1
+done
+
+if ! pg_ready; then
+    error "PostgreSQL did not become ready in time."
+    exit 1
+fi
+
+# --- Sync database ---
+# navsyncdb needs superuser access for hstore extension creation.
+# In our Docker setup, the "nav" user IS the superuser, so we pass
+# these env vars so navsyncdb uses "nav" for both regular and superuser ops.
+info "Syncing NAV database schema..."
+PGHOST=127.0.0.1 PGPORT=5433 PGUSER=nav PGPASSWORD=nav uv run navsyncdb
+
+# --- Install pre-commit hooks ---
+info "Installing pre-commit hooks..."
+uv run pre-commit install
+
+# --- Done ---
+echo ""
+info "Local development environment is ready!"
+echo ""
+echo "  Start the web server:"
+echo "    uv run django-admin runserver"
+echo ""
+echo "  Watch SASS for changes (optional):"
+echo "    make sasswatch"
+echo ""
+echo "  Infrastructure services:"
+echo "    make local-up       # start"
+echo "    make local-down     # stop"
+echo ""
+echo "  Run tests:"
+echo "    uv run pytest tests/unittests/"
+echo ""


### PR DESCRIPTION
## Scope and purpose

Alternative to devcontainers for local NAV development. Only PostgreSQL, Graphite, and snmpsim run in Docker — NAV itself runs natively on the host.

`make local-setup` handles first-time setup: installing dependencies, configuring NAV, starting containers, and syncing the database. `make local-up` / `make local-down` manage the infrastructure services.

### macOS workarounds

Running natively on macOS uncovered several platform-specific issues:

- **libcrypto crash**: pynetsnmp loads `libcrypto.dylib` with `RTLD_GLOBAL`, which macOS blocks. Patched via `sitecustomize.py` in the virtualenv so all entry points are covered.
- **Ancient system libtidy (2006)**: macOS ships a tidy from 2006 that misvalidates HTML. `sitecustomize.py` redirects to Homebrew's `tidy-html5` if available.
- **Homebrew symlinks invisible to `find`**: keg-only packages need `find -L` to be detected.
- **`/proc/net/udp`**: the snmpsim test fixture used this Linux-only file. Replaced with a cross-platform socket probe, and snmpsim now runs in a container.
- **DNS error wording**: macOS uses different error messages than Linux. Relaxed assertion to match both.

### Other changes

- Breadcrumbs templatetag deferred `reverse()` calls to avoid circular imports during local startup
- Test database password default changed to `nav` to match both devcontainer and local Docker setup
- Setup script checks `pg_dump` version against Docker PostgreSQL

## Contributor Checklist

* [ ] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch
* [x] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file