### PR TITLE
Fix l2trace crash when netbox has no associated prefix

### DIFF
--- a/changelog.d/3866.fixed.md
+++ b/changelog.d/3866.fixed.md
@@ -1,0 +1,1 @@
+Fixed l2trace crash when tracing through a netbox with no associated prefix.

--- a/python/nav/web/l2trace/__init__.py
+++ b/python/nav/web/l2trace/__init__.py
@@ -187,7 +187,9 @@ def get_vlan_from_ip(ip):
 
 
 def get_netbox_vlan(netbox):
-    return netbox.get_prefix().vlan
+    prefix = netbox.get_prefix()
+    if prefix:
+        return prefix.vlan
 
 
 def get_vlan_uplink_from_netbox(netbox, vlan=None):

--- a/tests/integration/l2trace_test.py
+++ b/tests/integration/l2trace_test.py
@@ -23,6 +23,21 @@ class L2TraceTestCase(DjangoTransactionTestCase):
         self.admin_vlan = Vlan.objects.get(net_ident='adminvlan')
 
 
+class GetNetboxVlanTest(L2TraceTestCase):
+    def test_when_netbox_has_no_prefix_it_should_return_none(self):
+        """Regression test: get_netbox_vlan should not crash when the netbox
+        has no associated prefix (GitHub issue from prod error report)."""
+        orphan = Netbox(
+            ip='192.168.99.1',
+            sysname='orphan-sw.example.org',
+            room=self.foo_gw.room,
+            organization=self.foo_gw.organization,
+            category_id='SW',
+        )
+        orphan.save()
+        self.assertIsNone(l2trace.get_netbox_vlan(orphan))
+
+
 class GetVlanFromThingsTest(L2TraceTestCase):
     def test_arbitrary_ip_is_on_vlan_10(self):
         vlan = l2trace.get_vlan_from_ip('10.0.0.99')


### PR DESCRIPTION
## Scope and purpose

Fixes #3866.

`get_netbox_vlan()` crashed with an `AttributeError` when the netbox had no associated prefix, since `netbox.get_prefix()` returns `None` in that case. This adds a guard so the function returns `None` instead of crashing, which causes l2trace to show "Path not found" for that segment.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~