### PR TITLE
Mask passwords in LDAP auth error reports

### DIFF
--- a/changelog.d/3870.security.md
+++ b/changelog.d/3870.security.md
@@ -1,0 +1,1 @@
+Passwords are no longer leaked in cleartext in Django error emails when LDAP authentication crashes.

--- a/python/nav/web/auth/ldap.py
+++ b/python/nav/web/auth/ldap.py
@@ -21,6 +21,8 @@ import logging
 from os.path import join
 from typing import Union, Optional
 
+from django.views.decorators.debug import sensitive_variables
+
 import nav.errors
 from nav.config import NAVConfigParser
 
@@ -118,6 +120,7 @@ def open_ldap() -> "ldap.ldapobject.LDAPObject":
     return lconn
 
 
+@sensitive_variables('password')
 def authenticate(login: str, password: str) -> Union["LDAPUser", bool]:
     """
     Attempt to authenticate the login name with password against the
@@ -202,6 +205,7 @@ class LDAPUser(object):
         self.ldap = ldap_conn
         self.user_dn = None
 
+    @sensitive_variables('password')
     def bind(self, password: str) -> None:
         """Performs an authenticated bind for this user using password"""
         suffix = _config.get('ldap', 'suffix')

--- a/python/nav/web/auth/ldap_auth_backend.py
+++ b/python/nav/web/auth/ldap_auth_backend.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Optional
 from django.contrib.auth.backends import ModelBackend
 from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest
+from django.views.decorators.debug import sensitive_variables
 
 from nav.models.profiles import Account, AccountGroup
 from nav.web.auth import ldap
@@ -51,6 +52,7 @@ class LdapBackend(ModelBackend):
     explicitly removed their local NAV accounts.
     """
 
+    @sensitive_variables('password')
     def authenticate(
         self,
         request: Optional[HttpRequest] = None,
@@ -87,6 +89,7 @@ class LdapBackend(ModelBackend):
         return nav_user.ext_sync == 'ldap'
 
     @staticmethod
+    @sensitive_variables('password')
     def _ldap_authenticate(username: str, password: str) -> Optional["LDAPUser"]:
         """Attempts to authenticate the user against LDAP, logging errors"""
         try:
@@ -103,6 +106,7 @@ class LdapBackend(ModelBackend):
             return ldap_user
 
     @staticmethod
+    @sensitive_variables('password')
     def _create_nav_account(ldap_user: "LDAPUser", password: str) -> Account:
         """Creates a new local NAV account based on LDAP user details."""
         nav_account = Account(
@@ -115,6 +119,7 @@ class LdapBackend(ModelBackend):
         return nav_account
 
     @classmethod
+    @sensitive_variables('password')
     def _sync_nav_account(
         cls, ldap_user: "LDAPUser", nav_user: Account, password: str
     ) -> None:


### PR DESCRIPTION
## Scope and purpose

Fixes #3870.

The fix from #3804 added a custom `NAVExceptionReporterFilter` to mask password POST parameters in Django error emails. However, the HTML version of these emails also includes local variables from each stack frame. The `password` variable was still visible in cleartext in the LDAP authentication functions' stack frames.

This PR adds `@sensitive_variables('password')` to all functions in the LDAP authentication chain that handle passwords, so Django's `ExceptionReporter` masks them in error reports.

## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] ~~Added/amended tests for new/changed code~~
* [ ] ~~Added/changed documentation~~
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~