### PR TITLE
Handle UserNotFound during LDAP group membership check

### DIFF
--- a/changelog.d/3871.fixed.md
+++ b/changelog.d/3871.fixed.md
@@ -1,0 +1,1 @@
+LDAP login no longer crashes with a 500 error when a user cannot be found during group membership verification.

--- a/python/nav/web/auth/ldap.py
+++ b/python/nav/web/auth/ldap.py
@@ -160,7 +160,15 @@ def authenticate(login: str, password: str) -> Union["LDAPUser", bool]:
     # the final verdict is made
     group_dn = _config.get('ldap', 'require_group')
     if group_dn:
-        if user.is_group_member(group_dn):
+        try:
+            is_member = user.is_group_member(group_dn)
+        except UserNotFound:
+            _logger.warning(
+                "Could not find %s in LDAP catalog while verifying group membership",
+                login,
+            )
+            return False
+        if is_member:
             _logger.info("%s is verified to be a member of %s", login, group_dn)
             return user
         else:

--- a/tests/unittests/web/ldapauth_test.py
+++ b/tests/unittests/web/ldapauth_test.py
@@ -2,7 +2,7 @@ import importlib.util
 import pytest
 
 from nav.config import NAVConfigParser
-from nav.web.auth.ldap import LDAPUser, open_ldap
+from nav.web.auth.ldap import LDAPUser, authenticate, open_ldap
 from mock import Mock, patch
 
 found = importlib.util.find_spec('ldap')
@@ -76,3 +76,45 @@ debug=true
 def test_when_encryption_setting_is_invalid_open_ldap_should_run_without_encryption():
     with patch('ldap.initialize'):
         assert open_ldap()
+
+
+class LdapGroupTestConfig(NAVConfigParser):
+    DEFAULT_CONFIG_FILES = []
+    DEFAULT_CONFIG = """
+[ldap]
+server=ldap.example.org
+port=389
+encryption=none
+basedn=cn=people,dc=example,dc=org
+uid_attr=sAMAccountName
+name_attr=cn
+manager=cn=admin,dc=example,dc=org
+manager_password=secret
+encoding=utf-8
+lookupmethod=search
+require_group=cn=navusers,cn=groups,dc=example,dc=org
+timeout=2
+debug=no
+suffix=
+group_search=(member=%%s)
+require_entitlement=
+admin_entitlement=
+entitlement_attribute=eduPersonEntitlement
+"""
+
+
+class TestAuthenticate:
+    @patch('nav.web.auth.ldap._config', LdapGroupTestConfig())
+    @patch('nav.web.auth.ldap.open_ldap')
+    def test_when_user_not_found_during_group_check_it_should_return_false(  # noqa: E501
+        self, open_ldap_mock
+    ):
+        """A UserNotFound during group membership verification should not crash"""
+        connection = open_ldap_mock.return_value
+        # bind succeeds (user authenticates)
+        connection.simple_bind_s.return_value = None
+        # But DN search during group check returns no results
+        connection.search_s.return_value = []
+
+        result = authenticate('rudolf', 'secret')
+        assert result is False


### PR DESCRIPTION
## Scope and purpose

Fixes #3871.

When a user authenticates successfully via LDAP bind but cannot be found by DN search during the subsequent group membership verification, `UserNotFound` was raised unhandled, causing a 500 Internal Server Error.

This happens when `require_group` is configured and the LDAP lookup method is `search`: after a successful bind, `is_group_member()` calls `get_user_dn()` → `search_dn()`, which raises `UserNotFound` if the search returns no results. The `authenticate()` function already caught `UserNotFound` during the bind phase, but not during the post-bind group verification.

This PR catches `UserNotFound` during group membership verification and treats it as a failed login instead of crashing.

### To verify

Trigger a `UserNotFound` during group membership check (e.g. configure `lookupmethod=search` with a `require_group` and have a user that can bind but whose DN search returns no results). Login should now fail gracefully with an "invalid credentials" message instead of a 500 error.

## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [X] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~