### PR TITLE
Install Playwright browsers in devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   "dockerComposeFile": "docker-compose.yml",
   "service": "nav",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-  "postCreateCommand": "uv sync --all-extras --all-groups; git config --global --add safe.directory /workspaces/${localWorkspaceFolderBasename}; uv run playwright install --with-deps chromium",
+  "postCreateCommand": "uv sync --all-extras --all-groups; git config --global --add safe.directory /workspaces/${localWorkspaceFolderBasename}; make setup-playwright",
   "postStartCommand": "uvx pre-commit install; bash /workspaces/${localWorkspaceFolderBasename}/.devcontainer/scripts/init-nav-config.sh",
   "forwardPorts": [
     8000

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   "dockerComposeFile": "docker-compose.yml",
   "service": "nav",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-  "postCreateCommand": "uv sync --all-extras --all-groups; git config --global --add safe.directory /workspaces/${localWorkspaceFolderBasename}",
+  "postCreateCommand": "uv sync --all-extras --all-groups; git config --global --add safe.directory /workspaces/${localWorkspaceFolderBasename}; uv run playwright install --with-deps chromium",
   "postStartCommand": "uvx pre-commit install; bash /workspaces/${localWorkspaceFolderBasename}/.devcontainer/scripts/init-nav-config.sh",
   "forwardPorts": [
     8000

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dummy clean distclean testclean docclean doc cssclean sassbuild sasswatch .FORCE
+.PHONY: dummy clean distclean testclean docclean doc cssclean sassbuild sasswatch setup-playwright .FORCE
 
 dummy:
 	@echo "'make' is no longer used for deployment. See 'doc/intro/install.rst'"
@@ -51,5 +51,10 @@ sassbuild: cssclean
 
 sasswatch:
 	-npm run watch:sass
+
+PLAYWRIGHT_BROWSERS ?= chromium
+
+setup-playwright:
+	uv run playwright install --with-deps $(PLAYWRIGHT_BROWSERS)
 
 .FORCE:

--- a/doc/hacking/using-devcontainers.rst
+++ b/doc/hacking/using-devcontainers.rst
@@ -178,6 +178,21 @@ will monitor all the documentation source files for changes and automatically
 rebuild the HTML output on every change.
 
 
+Running JavaScript tests
+------------------------
+
+The JavaScript test suite uses Karma with headless Chrome to run tests.
+Playwright's Chromium is automatically installed when the devcontainer is
+created, but if you need to install or update it manually, run::
+
+  make setup-playwright
+
+This installs Playwright's Chromium binary along with its required system
+libraries.  Once installed, you can run the JavaScript tests with::
+
+  tox -e javascript
+
+
 Installing Python packages manually
 -----------------------------------
 


### PR DESCRIPTION
## Scope and purpose

Ensures Playwright browsers are installed with system dependencies during devcontainer creation, so JavaScript tests can run out of the box.

### This pull request
* Adds `make setup-playwright` target with a configurable `PLAYWRIGHT_BROWSERS` variable (defaults to `chromium`)
* Hooks browser installation into the devcontainer `postCreateCommand`
* Documents the setup in the devcontainer guide

## Contributor Checklist

* [ ] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file