### PR TITLE
Fix report `$explain_` tooltips when `$name_` is also set

### DIFF
--- a/changelog.d/3876.fixed.md
+++ b/changelog.d/3876.fixed.md
@@ -1,0 +1,1 @@
+Fix report column tooltips (`$explain_`) not showing when the column also has a `$name_` override.

--- a/python/nav/report/report.py
+++ b/python/nav/report/report.py
@@ -186,9 +186,10 @@ class Report(object):
 
             uri = "?{0}".format(self.query_args.urlencode())
 
-            # change if the names exist in the overrider hash
-            title = names.get(title, title)
+            # look up explanation before overriding title with display name,
+            # since the explain dict is keyed by the original SQL field name
             explanation = explain.get(title, "")
+            title = names.get(title, title)
 
             field = Cell(title, uri, explanation)
             headers.append(field)


### PR DESCRIPTION
## Scope and purpose

Fixes #3876.

The `$explain_` directive in the report configuration is supposed to add a tooltip to column headers, but the tooltip never appears when the column also has a `$name_` override. The `explain` dict is keyed by the original SQL field name, but the lookup in `make_table_headers` happened after the field name had already been replaced by the display name from `$name_`. This caused the lookup to silently miss for any column that uses both directives (13 of 24 existing `$explain_` usages are affected).

The fix is to look up the explanation before overriding the title.

## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] ~~Added/amended tests for new/changed code~~
* [ ] ~~Added/changed documentation~~
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [X] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~