### PR TITLE
Strip whitespace from bulk import fields

### DIFF
--- a/changelog.d/3884.fixed.md
+++ b/changelog.d/3884.fixed.md
@@ -1,0 +1,1 @@
+Fixed a crash in SeedDB bulk import when IP addresses contain trailing whitespace.

--- a/python/nav/bulkparse.py
+++ b/python/nav/bulkparse.py
@@ -86,8 +86,23 @@ class BulkParser:
         # source file.
         self.line_num = self.reader.reader.line_num
 
+        self._strip_cell_whitespace(row)
         self.validate_row(row)
         return row
+
+    @staticmethod
+    def _strip_cell_whitespace(row):
+        """Strip leading/trailing whitespace from all cell values.
+
+        Stray whitespace (especially tabs) in CSV fields can cause
+        database errors, e.g. PostgreSQL's inet type rejects IPs with
+        trailing whitespace.
+        """
+        for key, value in row.items():
+            if isinstance(value, str):
+                row[key] = value.strip()
+            elif isinstance(value, list):
+                row[key] = [v.strip() if isinstance(v, str) else v for v in value]
 
     def validate_row(self, row):
         """Validate an entire row"""

--- a/tests/unittests/general/bulkparse_test.py
+++ b/tests/unittests/general/bulkparse_test.py
@@ -97,6 +97,12 @@ class TestNetboxBulkParser(object):
         with pytest.raises(bulkparse.InvalidFieldValue):
             next(b)
 
+    def test_when_ip_has_trailing_whitespace_it_should_be_stripped(self):
+        data = b"room1:10.0.0.186\t:myorg:OTHER:SNMP v1 read profile::\n"
+        b = bulkparse.NetboxBulkParser(data)
+        row = next(b)
+        assert row['ip'] == '10.0.0.186'
+
     def test_short_line_should_raise_error_with_correct_details(self):
         data = b"room1:10.0.0.8"
         b = bulkparse.NetboxBulkParser(data)


### PR DESCRIPTION
## Scope and purpose

Fixes #3884.

Stray whitespace (e.g. tab characters) in bulk import CSV fields would pass through the `BulkParser` unmodified. For IP address fields, this caused a `DataError` from PostgreSQL, since the `inet` type does not accept trailing whitespace — even though `IPy.IP()` silently strips it during validation.

This adds a `_strip_cell_whitespace()` step to `BulkParser.__next__()` that strips leading/trailing whitespace from all cell values before validation and further processing.

## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [X] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [X] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~