### PR TITLE
Support toml config and config social auth

### DIFF
--- a/changelog.d/3889.added.md
+++ b/changelog.d/3889.added.md
@@ -1,0 +1,4 @@
+Support configuration files in TOML format. Add a new optional TOML config file
+"/etc/webfront/authentication.toml" for authentication purposes which currently
+supports configuring multi-factor autehntication, OIDC and allauth's bundled
+providers.

--- a/doc/howto/allauth-and-oidc.rst
+++ b/doc/howto/allauth-and-oidc.rst
@@ -2,6 +2,13 @@
 Authenticating with OIDC/OAuth2 by using a local settings file
 ==============================================================
 
+.. info::
+   If the config described in the reference documentation :doc:`External web
+   authentication (OAuth2, OIDC) <../reference/social-account>`_ is
+   insufficient for your needs, you can *instead* use a local settings file.
+   Don't use both, and make an issue about your issue so that we can improve
+   the proper config file.
+
 It is possible to use a local settings-file to unlock every option available in
 `django-allauth <https://docs.allauth.org/en/latest/>`_'s arsenal but we will
 only show how to support bundled and OIDC providers here. Have a look at

--- a/doc/reference/authentication.rst
+++ b/doc/reference/authentication.rst
@@ -13,4 +13,5 @@ LDAP, and authenticating against the header REMOTE_USER, set by the web server.
 
    mfa
    ldap
+   social-account
    remote_user

--- a/doc/reference/mfa.rst
+++ b/doc/reference/mfa.rst
@@ -3,10 +3,9 @@ Multi-factor authentication
 ===========================
 
 Multi-factor authentication (aka. 2-factor authentication or "2FA") needs to be
-enabled site-wide before it is available. This includes support for passkeys
-aka. "webauthn". If disabled, the ``My account``-page will have a tab
-mentioning that it is disabled. After enabling, that tab will change to allow
-the logged in user to set up 2FA for themselves.
+enabled site-wide before it is available. If disabled, the ``My account``-page
+will have a tab mentioning that it is disabled. After enabling, that tab will
+change to allow the logged in user to set up 2FA for themselves.
 
 The configuration is stored in the ``[multi-factor-authentication]`` section of
 :file:`webfront/authentication.toml`.
@@ -16,16 +15,10 @@ The default settings are::
     [multi-factor-authentication]
     enabled = false
     support-recovery-codes = true
-    support-passkeys = false
-    support-passkey-signups = false
-    allow-insecure-origin = false
 
 Changing ``enabled`` to ``true`` will turn on TOTP support, including 10
 recovery keys per account. Turn off recovery keys support by toggling
 ``support-recovery-codes`` to ``false``.
-
-The three other settings control passkeys. ``allow-insecure-origin`` should
-stay ``false`` in production, it is meant primarily for development.
 
 There is no way to force the activation of second factor support on first
 login, or activate a second factor on behalf of someone else via sudo, as the

--- a/doc/reference/mfa.rst
+++ b/doc/reference/mfa.rst
@@ -4,28 +4,28 @@ Multi-factor authentication
 
 Multi-factor authentication (aka. 2-factor authentication or "2FA") needs to be
 enabled site-wide before it is available. This includes support for passkeys
-aka. "webauthn". If disabled, the `My account`-page will have a tab mentioning
-that it is disabled. After enabling, that tab will change to allow the logged
-in user to set up 2FA for themselves.
+aka. "webauthn". If disabled, the ``My account``-page will have a tab
+mentioning that it is disabled. After enabling, that tab will change to allow
+the logged in user to set up 2FA for themselves.
 
 The configuration is stored in the ``[multi-factor-authentication]`` section of
-:file:`webfront.conf`.
+:file:`webfront/authentication.toml`.
 
 The default settings are::
 
     [multi-factor-authentication]
-    enabled = no
-    support-recovery-codes = yes
-    support-passkeys = no
-    support-passkey-signups = no
-    allow-insecure-origin = no
+    enabled = false
+    support-recovery-codes = true
+    support-passkeys = false
+    support-passkey-signups = false
+    allow-insecure-origin = false
 
-Changing ``enabled`` to ``yes`` will turn on TOTP support, including 10
+Changing ``enabled`` to ``true`` will turn on TOTP support, including 10
 recovery keys per account. Turn off recovery keys support by toggling
-``support-recovery-codes`` to ``no``.
+``support-recovery-codes`` to ``false``.
 
 The three other settings control passkeys. ``allow-insecure-origin`` should
-stay ``no`` in production, it is meant primarily for development.
+stay ``false`` in production, it is meant primarily for development.
 
 There is no way to force the activation of second factor support on first
 login, or activate a second factor on behalf of someone else via sudo, as the

--- a/doc/reference/social-account.rst
+++ b/doc/reference/social-account.rst
@@ -1,0 +1,193 @@
+==========================================
+External web authentication (OAuth2, OIDC)
+==========================================
+
+It is possible to log in to the NAV web UI with an external identity provider
+like OAuth2 or OIDC with depending on the HTTP header ``REMOTE_USER``.
+
+NAV uses the 3rd party django app ``django-allauth`` for this.
+
+The configuration is stored in the file :file:`webfront/authentication.toml`.
+
+.. note::
+   See the howto :doc:`Authenticating with OIDC/OAuth2 by using a local
+   settings file <../howto/allauth-and-oidc>` for the full power of allauth,
+   but please do only one of the two: either ``webfront/authentication.toml``
+   or a local settings file.
+
+Support for SAML is planned.
+
+Using a provider bundled with django-allauth
+============================================
+
+Have a look at the list of providers at `django-allauth's provider list
+<https://docs.allauth.org/en/latest/socialaccount/providers/index.html>`_.
+
+You will need the name of the module (for instance
+``allauth.socialaccount.providers.github`` for GitHub), the provider id
+(``github`` for GitHub, this is always a valid python module name) and at
+minimum a ``client_id`` and a ``secret``.
+
+Note that the bundled "openid" provider needs extra tables, NAV does not ship
+with them by default.
+
+Example: Logging in with the bundled GitHub provider
+----------------------------------------------------
+
+Anyone can get an account at GitHub so we're using that as the most basic
+example.
+
+See `Authorizing OAuth apps
+<https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps,>`_
+for details.
+
+The app for this does not need any additional tables so the below configuration
+is all you need.
+
+.. code-block:: toml
+
+   [social.providers.github
+   module-path = "allauth.socialaccount.providers.github"
+   client_id = "your.service.id"
+   secret = "your.service.secret"
+
+You need to create an OAuth app at `GitHub: New OAuth Application
+<https://github.com/settings/applications/new>`_.
+
+The client id and regenerating the secret will be available on `GitHub:
+Authorized Oauth Apps <https://github.com/settings/applications>`_ and `GitHub:
+Developer applications <https://github.com/settings/developers>`_ after
+creation.
+
+You need to add the redirect url, it will look something like
+``https://YOURDOMAIN/accounts/github/login/callback/``.
+
+GitHub does *not* support having multiple redirect urls on file simultaneously.
+
+Example: Logging in with the bundled Feide OIDC (aka. dataporten) provider
+--------------------------------------------------------------------------
+
+Your organization needs to be paying for `Feide <https://www.feide.no/>`_.
+
+The app for this does not need any additional tables so the below configuration
+is all you need.
+
+.. code-block:: toml
+
+   [social.providers.dataporten]
+   module-path = "allauth.socialaccount.providers.dataporten"
+   client_id = "your.service.id"
+   secret =  "your.service.secret"
+
+You get the client id and secret from `Feide Kundeportal
+<https://kunde.feide.no>`_, and you need to add the redirect url there. The
+redirect url will look something like
+``https://YOURDOMAIN/accounts/dataporten/login/callback/``.
+
+.. tip::
+   If you attempt to log in without the url set you will get an error-page that
+   shows exactly what url you need to use.
+
+Dataporten supports having multiple redirect urls on file simultaneously.
+
+Using generic OIDC
+==================
+
+This may take *a lot more* configuration so check if there is a bundled
+provider first.
+
+Overview of settings:
+
+.. code-block:: toml
+
+   [oidc]
+   # module-path = "your.oidc.provider.module"  # default
+   #
+   # Optional PKCE defaults to False, but may be required by your provider
+   # Can be set globally, or per app (settings).
+   # "OAUTH_PKCE_ENABLED": False,
+   # oauth_pkce_enabled = false
+
+   [oidc.idps.some-unique-id]  # this id must be urlsafe
+   name = "Some Login System",  # Shown in the frontend
+   client_id = "your.service.id", # Get from idp
+   secret = "your.service.secret", # Get from idp
+   server_url = "https://my.server.example.com"
+
+   # [oidc.idps.some-unique-id.settings]  # optional settings
+   # Optional PKCE defaults False, but may be required by
+   # your provider
+   # oauth_pkce_enabled = false
+   #
+   # When enabled, an additional call to the userinfo
+   # endpoint takes place. The data returned is stored in
+   # `SocialAccount.extra_data`. When disabled, the (decoded) ID
+   # token payload is used instead.
+   # fetch_userinfo = true
+   #
+   # Optional token endpoint authentication method.
+   # May be one of "client_secret_basic", "client_secret_post"
+   # If omitted, a method from the the server's
+   # token auth methods list is used
+   # token_auth_method = client_secret_basic
+   #
+   # scope = [],
+   #
+   # The field to be used as the account ID. Might depend on scope
+   # uid_field = "sub"
+
+You need to come up with a unique provider id. Note that it will be used
+verbatim in the redirect url and that it must not conflict with any other
+``provider_id`` or ``provider`` in use.
+
+See `django-allauth: OpenID Connect
+<https://docs.allauth.org/en/latest/socialaccount/providers/openid_connect.html>`_
+for more details.
+
+You can override the module used for OIDC by setting module-path explicitly:
+
+.. code-block:: toml
+
+   [oidc]
+   module-path = "your.oidc.provider.module"
+
+The ``server_url`` is just the first part of an url that ends with
+``.well-known/openid-configuration`` used for OpenID Connect discovery.
+
+.. note::
+   Providers that come both bundled and have an OIDC endpoint are not
+   equivalent, the former might have provider specific code.
+
+
+Example: Logging in with Feide OIDC (dataporten) without using a provider app
+-----------------------------------------------------------------------------
+
+Using Feide OIDC (aka. dataporten) as an example
+
+.. code-block:: toml
+
+   [oidc.idps.dataporten-oidc]
+   name = "Feide OIDC",  # Shown in the frontend
+   client_id = "your.service.id",  # Get from your Feide admin
+   secret = "your.service.secret",  # Get from your Feide admin
+   server_url = "https://auth.dataporten.no/"
+
+   # optional settings but needed for Feide OIDC
+   [oidc.idps.dataporten-oidc.settings]
+   uid_field = "https://n.feide.no/claims/eduPersonPrincipalName"
+   scope = ["userid-feide"]
+
+Just like when using a provider app you get the client id and secret from
+`Feide Kundeportal <https://kunde.feide.no>`_, and you need to add the redirect
+url there. The redirect url will look something like
+``https://YOURDOMAIN/accounts/oidc/dataporten-oidc/login/callback/``.
+
+.. tip::
+   If you attempt to log in without the url set you will get an error-page that
+   shows exactly what url you need to use.
+
+.. note::
+   If you choose "Client type": "Public" you must set ``oauth_pkce_enabled`` to
+   True.
+
+Dataporten supports having multiple redirect urls on file simultaneously.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ dependencies = [
 
     "distro",
 
+    'tomli; python_version<"3.11"',
+
     # The following modules are really sub-requirements of Twisted, not of
     # NAV directly.  They may be optional from Twisted's point of view,
     # but they are required for parts of the Twisted library that NAV uses:

--- a/python/nav/config/__init__.py
+++ b/python/nav/config/__init__.py
@@ -70,18 +70,18 @@ def get_config_locations() -> Iterator[Path]:
         yield Path(location)
 
 
-def list_config_files_from_dir(dirname):
+def list_config_files_from_dir(dirname, suffix="conf"):
     return [
         os.path.join(dirname, f)
         for f in sorted(os.listdir(dirname))
         if os.path.isfile(os.path.join(dirname, f))
-        and f.endswith(".conf")
+        and f.endswith(f".{suffix}")
         and not f.startswith(".")
     ]
 
 
-def find_config_dir():
-    nav_conf = find_config_file('nav.conf')
+def find_config_dir(suffix="conf"):
+    nav_conf = find_config_file(f'nav.{suffix}')
     if nav_conf:
         return os.path.dirname(nav_conf)
 

--- a/python/nav/config/__init__.py
+++ b/python/nav/config/__init__.py
@@ -31,7 +31,7 @@ from typing import Iterator
 
 from nav.errors import GeneralException
 from nav.util import resource_files, resource_bytes
-from . import buildconf
+from nav import buildconf
 
 _logger = logging.getLogger(__name__)
 

--- a/python/nav/config/toml.py
+++ b/python/nav/config/toml.py
@@ -1,0 +1,112 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.  You should have received a copy of the GNU General Public
+# License along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Utility functions for NAV TOML configuration file discovery and parsing."""
+
+try:
+    import tomllib
+except ImportError:
+    # Before Python 3.11
+    import tomli as tomllib
+
+import logging
+from collections import UserDict
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Optional
+
+from . import find_config_file
+
+
+_logger = logging.getLogger(__name__)
+
+
+class TOMLConfigParser(UserDict):
+    """Parse a toml file or section of a toml file into a dict
+
+    The protocol is inspired by but does not blindly mimic NAVConfigParser.
+    Writing config files are as of yet not supported.
+
+    TOML as of 1.1 does not support null values so if null is needed define it
+    in the DEFAULT_CONFIG.
+    """
+
+    SECTION: str = ""  # optional, for parsers specialized for a single section
+    DEFAULT_CONFIG: dict = {}
+    DEFAULT_CONFIG_FILE: str = ""
+
+    def __init__(
+        self, default_config: Optional[dict] = None, default_config_file: str = ""
+    ):
+        super().__init__()
+        if default_config is not None:
+            self.DEFAULT_CONFIG = default_config
+        # NOTE: a single filename!
+        if default_config_file:
+            self.DEFAULT_CONFIG_FILE = default_config_file
+
+        ok = self._read(self.DEFAULT_CONFIG_FILE)
+        if not ok:
+            self.data = self.DEFAULT_CONFIG
+
+    def __getitem__(self, key):
+        data = self.data
+        if self.SECTION:
+            data = self.data.get(self.SECTION, {})
+        if key in data:
+            return data[key]
+        raise KeyError(key)
+
+    def read_file(self, fp):
+        config = tomllib.load(fp)
+        self._merge_with_default(config)
+        return self.data
+
+    def read_string(self, s: str, /, *, parse_float=float):
+        config = tomllib.loads(s, parse_float)
+        self._merge_with_default(config)
+        return self.data
+
+    def _merge_with_default(self, configdict):
+        self.data = merge_dict_with_defaults(configdict, self.DEFAULT_CONFIG)
+
+    def _read(self, filename):
+        fqfn = find_config_file(filename)
+        if not fqfn:
+            _logger.warning('Config file "%s" not found!', filename)
+            return None
+        try:
+            with open(fqfn, "rb") as F:
+                self.read_file(F)
+        except OSError:
+            return None
+        return filename
+
+
+def merge_dict_with_defaults(data, defaults):
+    """Merge the mappings data and defaults, the values in data always wins"""
+    if not (isinstance(data, Mapping) and isinstance(defaults, Mapping)):
+        return data
+    outdict = deepcopy(data)
+    for key, value in defaults.items():
+        if key not in outdict:
+            outdict[key] = value
+            continue
+        if outdict[key] == value:
+            continue
+        if not isinstance(value, Mapping):
+            continue
+        outdict[key] = merge_dict_with_defaults(outdict[key], value)
+    return outdict

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -31,7 +31,7 @@ from nav.db import get_connection_parameters
 import nav.buildconf
 from nav.jwtconf import JWTConf, LocalJWTConfig
 from nav.web.security import WebSecurityConfigParser
-from nav.web.auth.allauth import MFAConfigParser
+from nav.web.auth.allauth import MFAConfigParser, SocialConfigParser, OIDCConfigParser
 from nav.django.utils import get_os_version
 
 
@@ -370,9 +370,6 @@ ACCOUNT_USER_MODEL_USERNAME_FIELD = 'login'
 ACCOUNT_ALLOW_SIGNUPS = False
 ACCOUNT_MAX_EMAIL_ADDRESSES = 1
 
-# SOCIALACCOUNT_AUTO_SIGNUP = True
-# SOCIALACCOUNT_ADAPTER = 'nav.web.auth.allauth.adapter.NAVSocialAccountAdapter'
-
 MFA_ADAPTER = "nav.web.auth.allauth.adapter.NAVMFAAdapter"
 MFA_TOTP_ISSUER = 'NAV'
 MFA_TOTP_TOLERANCE = 1
@@ -386,3 +383,20 @@ MFA_PASSKEY_SIGNUP_ENABLED = (
 MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN = (
     _allauth_mfa_config.get_MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN_setting()
 )
+
+# SOCIALACCOUNT_AUTO_SIGNUP = True
+# SOCIALACCOUNT_ADAPTER = 'nav.web.auth.allauth.adapter.NAVSocialAccountAdapter'
+
+SOCIALACCOUNT_PROVIDERS = {}
+
+_allauth_social_config = SocialConfigParser()
+_social_providers = _allauth_social_config.generate_SOCIALACCOUNT_PROVIDERS()
+if _social_providers:
+    SOCIALACCOUNT_PROVIDERS.update(_social_providers)
+    INSTALLED_APPS += tuple(_allauth_social_config.get_provider_import_paths())
+
+_allauth_oidc_parser = OIDCConfigParser()
+_oidc_providers = _allauth_oidc_parser.generate_SOCIALACCOUNT_PROVIDERS()
+if _oidc_providers:
+    SOCIALACCOUNT_PROVIDERS.update(_oidc_providers)
+    INSTALLED_APPS += tuple(_allauth_oidc_parser.get_provider_import_paths())

--- a/python/nav/etc/webfront/authentication.toml
+++ b/python/nav/etc/webfront/authentication.toml
@@ -8,11 +8,6 @@ enabled = false
 #support-recovery-codes = true
 # The number of codes is hard-coded to 10
 
-# Whether passkeys (webauthn) is supported (Poorly supported on Linux!)
-#support-passkeys = false
-#support-passkey-signups = false
-#allow-insecure-origin = false
-
 
 # Configuration for "social" login providers bundled with django-allauth
 # See https://docs.allauth.org/en/latest/socialaccount/providers/index.html

--- a/python/nav/etc/webfront/authentication.toml
+++ b/python/nav/etc/webfront/authentication.toml
@@ -12,3 +12,32 @@ enabled = false
 #support-passkeys = false
 #support-passkey-signups = false
 #allow-insecure-origin = false
+
+
+# Configuration for "social" login providers bundled with django-allauth
+# See https://docs.allauth.org/en/latest/socialaccount/providers/index.html
+# for list. "oidc" and "SAML" have their own config sections
+# We have tested github and dataporten.
+
+# Example: github
+# [social.providers.github]
+# client_id = "not.optional"
+# secret = "not.optional"
+# scope = ["user:email"]  # optional, "user" scope is default and includes "user:email"
+
+
+# Configuration for OIDC login
+# [oidc]
+# module-path = "allauth.socialaccount.providers.openid_connect"
+#
+# Example: Feide OIDC (dataporten)
+# [oidc.idps.dataporten-oidc]  # The name after the dot is used in the URLs
+# name = "Feide OIDC"  # Shown in login screen
+# client_id = "not.optional"
+# secret = "not.optional"
+# server_url = "https://auth.dataporten.no/"  # NEVER optional
+# Feide OIDC does not support the standard OIDC scopes/claims
+# scope = ["userid-feide"]
+
+# [oidc.dataporten-oidc.settings]
+# uid_field = "https://n.feide.no/claims/eduPersonPrincipalName"

--- a/python/nav/etc/webfront/authentication.toml
+++ b/python/nav/etc/webfront/authentication.toml
@@ -1,0 +1,14 @@
+# Should NAV itself handle multi factor authentication (mfa)?
+[multi-factor-authentication]
+# Whether mfa should be enabled
+enabled = false
+
+# Whether mfa recovery codes can be generated and used. Default: yes
+## We recommend not changing this setting.
+#support-recovery-codes = true
+# The number of codes is hard-coded to 10
+
+# Whether passkeys (webauthn) is supported (Poorly supported on Linux!)
+#support-passkeys = false
+#support-passkey-signups = false
+#allow-insecure-origin = false

--- a/python/nav/etc/webfront/webfront.conf
+++ b/python/nav/etc/webfront/webfront.conf
@@ -131,21 +131,6 @@ enabled = no
 # out. The default/unset value is "/"
 #post-logout-redirect-url=/magic/logout?nexthop=/
 
-# Should NAV itself handle multi factor authentication (mfa)?
-[multi-factor-authentication]
-# Whether mfa should be enabled
-enabled = no
-
-# Whether mfa recovery codes can be generated and used. Default: yes
-## We recommend not changing this setting.
-#support-recovery-codes = yes
-# The number of codes is hard-coded to 10
-#
-## Whether passkeys (webauthn) is supported (Poorly supported on Linux!)
-#support-passkeys = no
-#support-passkey-signups = no
-#allow-insecure-origin = no
-
 [security]
 # Whether NAV must be run under TLS or not. Toggling this to `yes` toggles web
 # security features that are only available with TLS/SSL enabled. In

--- a/python/nav/web/auth/allauth/__init__.py
+++ b/python/nav/web/auth/allauth/__init__.py
@@ -3,7 +3,6 @@ import logging
 from nav.config.toml import TOMLConfigParser
 
 
-__all__ = []
 _logger = logging.getLogger(__name__)
 
 
@@ -84,3 +83,171 @@ class MFAConfigParser(TOMLConfigParser):
                 _logger.warn(f"{insecure_message}: yes, this is a security risk!")
             else:
                 _logger.info(f"{insecure_message}: no")
+
+
+class SocialProviderHelper:
+    """Helper class for social account configs
+
+    Social account configs have a section inside a section structure that is
+    a list of providers*, allowing for configs that hold for all providers on
+    the SECTION.
+
+    [*] Aka. idps for OIDC
+    """
+
+    _subkey: str
+
+    def get_providers(self) -> dict:
+        return self.get(self._subkey, {})
+
+    def get_provider_config(self, provider: str) -> dict:
+        providers = self.get_providers()
+        return providers.get(provider, {})
+
+    def _get_common_SOCIALACCOUNT_PROVIDERS_fields_for_provider(
+        self, provider_config: dict
+    ) -> dict:
+        # Do not alter the provider_config below
+        config = {}
+        settings = provider_config.get("settings", {})
+        config["client_id"] = provider_config["client_id"]
+        config["secret"] = provider_config["secret"]
+        if settings:
+            config["settings"] = settings
+        return config
+
+
+class SocialConfigParser(SocialProviderHelper, TOMLConfigParser):
+    """Parse the "social" section of authentication.toml
+
+    Example:
+
+    [social.providers.github]
+    module-path = allauth.socialaccount.providers.github
+    client_id = "not.optional"
+    secret = "not.optional"
+    scope = ["user:email"]  # optional, "user" scope is default for github
+                            # and includes "user:email"
+    """
+
+    _subkey = "providers"
+    SECTION = "social"
+    DEFAULT_CONFIG_FILE = "webfront/authentication.toml"
+    DEFAULT_CONFIG = {
+        SECTION: {},
+    }
+
+    def translate_entry_for_provider(self, provider: str):
+        provider_config = self.get_provider_config(provider)
+        if not provider_config:
+            return {}
+        # Do not alter the provider_config below
+        config = {}
+        SCOPE = provider_config.get("scope", [])
+        if SCOPE:
+            config["SCOPE"] = SCOPE
+
+        APP = self._get_common_SOCIALACCOUNT_PROVIDERS_fields_for_provider(
+            provider_config
+        )
+        config["APP"] = APP
+        return config
+
+    def translate_all_provider_configs(self):
+        configs = {}
+        for provider in self.get_providers().keys():
+            configs[provider] = self.translate_entry_for_provider(provider)
+        return configs
+
+    def generate_SOCIALACCOUNT_PROVIDERS(self):
+        configs = self.translate_all_provider_configs()
+        return configs
+
+    def get_provider_import_paths(self):
+        module_paths = []
+        missing_modules = []
+        for provider_id, provider_config in self.get_providers().values():
+            if "module-path" in provider_config:
+                module_paths.append(provider_config["module_path"])
+            else:
+                missing_modules.append(provider_id)
+        if missing_modules:
+            _logger.error(
+                "No module path configured for social account provider(s) %s",
+                ', '.join(missing_modules),
+            )
+        return module_paths
+
+
+class OIDCConfigParser(SocialProviderHelper, TOMLConfigParser):
+    """Parse the "oidc" section of authentication.toml
+
+    Example:
+
+    [oidc]
+    module-path = "allauth.socialccount.providers.openid_connect"  # optional
+
+    [oidc.idps.dataporten]
+    provider = dataporten-oidc"  # The name after the dot is used in the URLs
+    name = "Feide OIDC"  # Shown in login screen
+    client_id = "not.optional"
+    secret = "not.optional"
+    server_url = "https://auth.dataporten.no/"  # NEVER optional
+    Feide OIDC does not support the standard OIDC scopes/claims
+    scope = ["userid-feide"]  # Other idps have "profile" for this
+
+    [oidc.dataporten-oidc.settings]
+    uid_field = "https://n.feide.no/claims/eduPersonPrincipalName"
+    """
+
+    _subkey = "idps"
+    _module_path = "allauth.socialaccount.providers.openid_connect"
+    SECTION = "oidc"
+    DEFAULT_CONFIG_FILE = "webfront/authentication.toml"
+    DEFAULT_CONFIG = {
+        SECTION: {},
+    }
+
+    def translate_entry_for_provider(self, provider: str) -> dict:
+        provider_config = self.get_provider_config(provider)
+        if not provider_config:
+            return {}
+        APP = self._get_common_SOCIALACCOUNT_PROVIDERS_fields_for_provider(
+            provider_config
+        )
+        APP["provider_id"] = provider
+        APP["name"] = provider_config["name"]
+        APP.setdefault("settings", {})
+        try:
+            APP["settings"]["server_url"] = provider_config["server_url"]
+        except KeyError:
+            raise KeyError('"server_url" is a mandatory setting')
+        provider_settings = provider_config.get("settings", {})
+        APP["settings"]["uid_field"] = provider_settings.get(
+            "uid_field",
+            "sub",
+        )
+        return APP
+
+    def translate_all_provider_configs(self):
+        configs = []
+        for provider in self.get_providers().keys():
+            configs.append(self.translate_entry_for_provider(provider))
+        return configs
+
+    def get_OAUTH_PKCE_ENABLED(self):
+        return self.get("oauth_pkce_enabled", False)
+
+    def generate_SOCIALACCOUNT_PROVIDERS(self) -> dict:
+        configs = self.translate_all_provider_configs()
+        if configs:
+            return {
+                "openid_connect": {
+                    "OAUTH_PKCE_ENABLED": self.get_OAUTH_PKCE_ENABLED(),
+                    "APPS": configs,
+                },
+            }
+        return {}
+
+    def get_provider_import_paths(self):
+        return [self.get("module-path", self._module_path)]

--- a/python/nav/web/auth/allauth/__init__.py
+++ b/python/nav/web/auth/allauth/__init__.py
@@ -1,7 +1,6 @@
 import logging
-from os.path import join
 
-from nav.config import NAVConfigParser
+from nav.config.toml import TOMLConfigParser
 
 
 __all__ = []
@@ -9,33 +8,36 @@ _logger = logging.getLogger(__name__)
 
 
 # See https://docs.allauth.org/en/latest/mfa/index.html for more docs
-class MFAConfigParser(NAVConfigParser):
-    _KEY = "multi-factor-authentication"
-    DEFAULT_CONFIG_FILES = [join('webfront', 'webfront.conf')]
-    DEFAULT_CONFIG = f"""
-[{_KEY}]
-enabled=no
-support-recovery-codes=yes
-support_passkeys=no
-support-passkey-signups=no
-allow-insecure-origin=no
-"""
+class MFAConfigParser(TOMLConfigParser):
+    """Parse the "multi-factor-authentication" section of authentication.toml"""
+
+    SECTION = "multi-factor-authentication"
+    DEFAULT_CONFIG_FILE = "webfront/authentication.toml"
+    DEFAULT_CONFIG = {
+        SECTION: {
+            "enabled": False,
+            "support-recovery-codes": True,
+            "support-passkeys": False,
+            "support-passkey-signups": False,
+            "allow-insecure-origin": False,
+        }
+    }
 
     def is_mfa_enabled(self):
-        return self.getboolean(self._KEY, 'enabled', fallback=False)
+        return self["enabled"]
 
     def are_recovery_codes_enabled(self):
-        return self.getboolean(self._KEY, 'support-recovery-codes', fallback=True)
+        return self["support-recovery-codes"]
 
     def are_passkeys_enabled(self):
-        return self.getboolean(self._KEY, 'support-passkeys', fallback=False)
+        return self["support-passkeys"]
 
     def are_passkey_signups_enabled(self):
-        return self.getboolean(self._KEY, 'support-passkey-signups', fallback=False)
+        return self["support-passkey-signups"]
 
     def are_insecure_origins_allowed(self):
         # Set to True when developing
-        return self.getboolean(self._KEY, 'allow-insecure-origin', fallback=False)
+        return self["allow-insecure-origin"]
 
     def get_MFA_SUPPORTED_TYPES_setting(self):
         methods = []

--- a/tests/unittests/config_toml_test.py
+++ b/tests/unittests/config_toml_test.py
@@ -1,0 +1,127 @@
+from unittest import TestCase
+
+from nav.config.toml import TOMLConfigParser, merge_dict_with_defaults
+
+
+class TOMLConfigParserTest(TestCase):
+    def test_merge_with_default_returns_the_combined_output(self):
+        class TestConfig(TOMLConfigParser):
+            DEFAULT_CONFIG = {
+                "a": 1,
+                "b": True,
+            }
+
+        tc = TestConfig()
+        tc._merge_with_default({"b": False, "c": "foo"})
+        expected = {
+            "a": 1,
+            "b": False,
+            "c": "foo",
+        }
+        self.assertEqual(tc.data, expected)
+
+    def test_if_section_is_set_and_no_default_config_get_item_fetches_from_inputted_subdict(  # noqa: E501
+        self,
+    ):
+        class TestConfig(TOMLConfigParser):
+            SECTION = "bar"
+            DEFAULT_CONFIG = {}
+
+        tc = TestConfig({"bar": {"a": 3}})
+        self.assertEqual(tc["a"], 3)
+
+    def test_if_section_is_set_and_no_input_get_item_fetches_from_default_subdict(self):
+        class TestConfig(TOMLConfigParser):
+            SECTION = "bar"
+            DEFAULT_CONFIG = {
+                "a": 2,
+                SECTION: {
+                    "a": 1,
+                },
+            }
+
+        tc = TestConfig()
+        self.assertEqual(tc["a"], 1)
+
+
+class MergeDictWithDefaults(TestCase):
+    def test_golden_path(self):
+        data = {
+            1: 1,
+            2: {
+                3: 3,
+                6: {7: 7},
+                8: None,
+            },
+            4: 4,
+        }
+        defaults = {
+            0: 0,
+            2: {
+                3: 0,
+                5: 0,
+                6: None,
+                8: {9: 0},
+            },
+            4: 0,
+        }
+        expected = {
+            0: 0,
+            1: 1,
+            2: {
+                3: 3,
+                5: 0,
+                6: {7: 7},
+                8: None,
+            },
+            4: 4,
+        }
+        result = merge_dict_with_defaults(data, defaults)
+        self.assertEqual(result, expected)
+
+    def test_deeper_recursion(self):
+        # four levels is the maximum that allauth social auth config needs
+        data = {
+            1: 1,
+            0: {
+                2: 2,
+                1: {
+                    3: 3,
+                    2: {
+                        3: {
+                            4: {6: 6},
+                        },
+                    },
+                },
+            },
+        }
+        defaults = {
+            0: {
+                1: {
+                    2: {
+                        3: {
+                            4: {5: 0},
+                        },
+                    },
+                }
+            },
+        }
+        expected = {
+            1: 1,
+            0: {
+                2: 2,
+                1: {
+                    3: 3,
+                    2: {
+                        3: {
+                            4: {
+                                5: 0,
+                                6: 6,
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        result = merge_dict_with_defaults(data, defaults)
+        self.assertEqual(result, expected)

--- a/tests/unittests/web/auth/allauth_config_test.py
+++ b/tests/unittests/web/auth/allauth_config_test.py
@@ -20,7 +20,7 @@ class SocialProviderHelperTest(TestCase):
         SECTION = "foo"
         DEFAULT_CONFIG = {SECTION: {}}
 
-    def test_if_providers_exist_get_providers_returns_value_of_subkey(self):
+    def test_when_providers_exist_then_get_providers_should_return_subkey_value(self):  # noqa: E501
         config = {
             "foo": {
                 "bar": 1,
@@ -31,14 +31,16 @@ class SocialProviderHelperTest(TestCase):
         result = mc.get_providers()
         self.assertEqual(result, 1)
 
-    def test_if_providers_does_not_exist_return_empty_dict(self):
+    def test_when_no_providers_exist_then_get_providers_should_return_empty_dict(self):  # noqa: E501
         mc = self.MyConfig()
         result = mc.get_providers()
         self.assertEqual(result, {})
 
 
 class SocialConfigParserTests(TestCase):
-    def test_generate_SOCIALACCOUNT_PROVIDERS_golden_path(self):
+    def test_when_providers_configured_then_generate_SOCIALACCOUNT_PROVIDERS_should_return_translated_config(  # noqa: E501
+        self,
+    ):
         config_string = """
 [social.providers.testprovider1]
 client_id = "not.optional"
@@ -75,14 +77,18 @@ foo = 1  # This is not a valid setting, just for tests!
         result = sc.generate_SOCIALACCOUNT_PROVIDERS()
         self.assertEqual(result, expected)
 
-    def test_if_no_config_generate_SOCIALACCOUNT_PROVIDERS_returns_empty_dict(self):
+    def test_when_no_config_then_generate_SOCIALACCOUNT_PROVIDERS_should_return_empty_dict(  # noqa: E501
+        self,
+    ):
         sc = SocialConfigParser()
         result = sc.generate_SOCIALACCOUNT_PROVIDERS()
         self.assertEqual(result, {})
 
 
 class OIDCConfigParserTests(TestCase):
-    def test_generate_SOCIALACCOUNT_PROVIDERS_golden_path(self):
+    def test_when_idps_configured_then_generate_SOCIALACCOUNT_PROVIDERS_should_return_translated_config(  # noqa: E501
+        self,
+    ):
         config_string = """
 [oidc.idps.testprovider1]
 name="Provider 1"
@@ -118,12 +124,14 @@ foo = 1  # This is not a valid setting, just for tests!
         result = sc.generate_SOCIALACCOUNT_PROVIDERS()
         self.assertEqual(result, expected)
 
-    def test_if_no_config_generate_SOCIALACCOUNT_PROVIDERS_returns_empty_dict(self):
+    def test_when_no_config_then_generate_SOCIALACCOUNT_PROVIDERS_should_return_empty_dict(  # noqa: E501
+        self,
+    ):
         sc = OIDCConfigParser()
         result = sc.generate_SOCIALACCOUNT_PROVIDERS()
         self.assertEqual(result, {})
 
-    def test_if_nouid_field_set_fall_back_to_sub(self):
+    def test_when_no_uid_field_set_then_it_should_fall_back_to_sub(self):
         config_string = """
 [oidc.idps.testprovider1]
 name="Provider 1"

--- a/tests/unittests/web/auth/allauth_config_test.py
+++ b/tests/unittests/web/auth/allauth_config_test.py
@@ -1,0 +1,149 @@
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from nav.config.toml import TOMLConfigParser
+from nav.web.auth.allauth import (
+    SocialProviderHelper,
+    SocialConfigParser,
+    OIDCConfigParser,
+)
+
+
+class SocialProviderHelperTest(TestCase):
+    class MyConfig(SocialProviderHelper, TOMLConfigParser):
+        _subkey = "bar"
+        SECTION = "foo"
+        DEFAULT_CONFIG = {SECTION: {}}
+
+    def test_if_providers_exist_get_providers_returns_value_of_subkey(self):
+        config = {
+            "foo": {
+                "bar": 1,
+                "xux": 2,
+            },
+        }
+        mc = self.MyConfig(default_config=config)
+        result = mc.get_providers()
+        self.assertEqual(result, 1)
+
+    def test_if_providers_does_not_exist_return_empty_dict(self):
+        mc = self.MyConfig()
+        result = mc.get_providers()
+        self.assertEqual(result, {})
+
+
+class SocialConfigParserTests(TestCase):
+    def test_generate_SOCIALACCOUNT_PROVIDERS_golden_path(self):
+        config_string = """
+[social.providers.testprovider1]
+client_id = "not.optional"
+secret = "not.optional"
+scope = ["email"]
+
+[social.providers.testprovider2]
+client_id = "not.optional2"
+secret = "not.optional2"
+
+[social.providers.testprovider2.settings]
+foo = 1  # This is not a valid setting, just for tests!
+"""
+        config = tomllib.loads(config_string)
+        sc = SocialConfigParser(default_config=config)
+        expected = {
+            "testprovider1": {
+                "APP": {
+                    "client_id": "not.optional",
+                    "secret": "not.optional",
+                },
+                "SCOPE": ["email"],
+            },
+            "testprovider2": {
+                "APP": {
+                    "client_id": "not.optional2",
+                    "secret": "not.optional2",
+                    "settings": {
+                        "foo": 1,
+                    },
+                },
+            },
+        }
+        result = sc.generate_SOCIALACCOUNT_PROVIDERS()
+        self.assertEqual(result, expected)
+
+    def test_if_no_config_generate_SOCIALACCOUNT_PROVIDERS_returns_empty_dict(self):
+        sc = SocialConfigParser()
+        result = sc.generate_SOCIALACCOUNT_PROVIDERS()
+        self.assertEqual(result, {})
+
+
+class OIDCConfigParserTests(TestCase):
+    def test_generate_SOCIALACCOUNT_PROVIDERS_golden_path(self):
+        config_string = """
+[oidc.idps.testprovider1]
+name="Provider 1"
+client_id = "not.optional"
+secret = "not.optional"
+server_url = "https://server1.example.com"
+
+[oidc.idps.testprovider1.settings]
+foo = 1  # This is not a valid setting, just for tests!
+"""
+        config = tomllib.loads(config_string)
+        with patch.object(OIDCConfigParser, '_read', return_value=None):
+            sc = OIDCConfigParser(default_config=config)
+        sc._merge_with_default(config)
+        expected = {
+            "openid_connect": {
+                "OAUTH_PKCE_ENABLED": False,
+                "APPS": [
+                    {
+                        "provider_id": "testprovider1",
+                        "name": "Provider 1",
+                        "client_id": "not.optional",
+                        "secret": "not.optional",
+                        "settings": {
+                            "server_url": "https://server1.example.com",
+                            "uid_field": "sub",
+                            "foo": 1,
+                        },
+                    },
+                ],
+            },
+        }
+        result = sc.generate_SOCIALACCOUNT_PROVIDERS()
+        self.assertEqual(result, expected)
+
+    def test_if_no_config_generate_SOCIALACCOUNT_PROVIDERS_returns_empty_dict(self):
+        sc = OIDCConfigParser()
+        result = sc.generate_SOCIALACCOUNT_PROVIDERS()
+        self.assertEqual(result, {})
+
+    def test_if_nouid_field_set_fall_back_to_sub(self):
+        config_string = """
+[oidc.idps.testprovider1]
+name="Provider 1"
+client_id = "not.optional"
+secret = "not.optional"
+server_url = "https://server1.example.com"
+"""
+        config = tomllib.loads(config_string)
+        with patch.object(OIDCConfigParser, '_read', return_value=None):
+            sc = OIDCConfigParser(default_config=config)
+        sc._merge_with_default(config)
+        expected = {
+            "provider_id": "testprovider1",
+            "name": "Provider 1",
+            "client_id": "not.optional",
+            "secret": "not.optional",
+            "settings": {
+                "server_url": "https://server1.example.com",
+                "uid_field": "sub",
+            },
+        }
+        result = sc.translate_entry_for_provider("testprovider1")
+        self.assertEqual(result, expected)


### PR DESCRIPTION
## Scope and purpose

Fixes #3814

Depends on #3924

Setting up social providers (like saml, oidc, github, google, facebook..) with NAV-config isn't supported very well with today's nav config infrastructure, so here's an attempt at using toml instead.

The new TOMLConfigParser-class does not support everything the old class does. It does not support writing out toml-files, because we'd need an additional library for that if we don't want to roll our own.

It does not support multiple files per config section, as I couldn't find that this feature was used anywhere in the existing code.

It does support predefining a default-config section, and we need that for any None-value since toml does not support None as a value on principle. We can have 'em in default config anyway.


### This pull request
* adds/changes/removes a dependency
   tomli, so that tests pass on Python < 3.11

## How to test

This involves a new config file, "/etc/nav/webfront/authentication.toml". Make sure a copy is in the right location when testing. If using "docker compose" it might be easiest to copy the new file manually to the correct location, the container "config" should always be up and running.

It is necessary to have a client id and secret from "some" provider for a full manual test. 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
