### PR TITLE
Fix integration test ordering dependencies

### DIFF
--- a/tests/integration/api_test.py
+++ b/tests/integration/api_test.py
@@ -573,7 +573,7 @@ def test_api_urls_should_resolve(urlname, arg):
 
 
 @pytest.fixture()
-def serializer_models(localhost, admin_account):
+def serializer_models(db, localhost, admin_account):
     """Fixture for testing API serializers
 
     - unrecognized_neighbor

--- a/tests/integration/api_test.py
+++ b/tests/integration/api_test.py
@@ -394,7 +394,7 @@ def test_nonexistent_alert_should_give_404(db, api_client, token):
 
 def test_alert_should_be_visible_in_api(db, api_client, token, serializer_models):
     create_token_endpoint(token, 'alert')
-    alert = AlertHistory.objects.all()[0]
+    alert = AlertHistory.objects.filter(netbox__isnull=False)[0]
     response = api_client.get('{url}{id}/'.format(url=ENDPOINTS['alert'], id=alert.id))
 
     assert response.status_code == 200

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -262,7 +262,7 @@ def _is_django_unittest(request_or_item):
 
 
 @pytest.fixture(scope='function')
-def token():
+def token(db):
     """Creates a write enabled token for API access but without endpoints
 
     Tests should manipulate the endpoints as they see fit.

--- a/tests/integration/pping_test.py
+++ b/tests/integration/pping_test.py
@@ -58,7 +58,13 @@ def timeout_command_line_program_exists():
 )
 def test_pping_localhost_should_work(localhost, pping_test_config):
     output = get_pping_output()
-    assert "0 hosts currently marked as down" in output
+    assert "hosts checked" in output
+    assert (
+        "{sysname} ({ip}) marked as down".format(
+            sysname=localhost.sysname, ip=localhost.ip
+        )
+        not in output
+    )
 
 
 @pytest.mark.timeout(20)

--- a/tests/integration/web/alertprofiles_test.py
+++ b/tests/integration/web/alertprofiles_test.py
@@ -1109,7 +1109,7 @@ class TestsFilterGroups:
 
 
 @pytest.fixture(scope='function')
-def dummy_profile(admin_account):
+def dummy_profile(db, admin_account):
     account = admin_account
     profile = AlertProfile(account=account, name='ÆØÅ Profile %d' % randint(1, 1000))
     profile.save()
@@ -1117,7 +1117,7 @@ def dummy_profile(admin_account):
 
 
 @pytest.fixture(scope='function')
-def activated_dummy_profile(dummy_profile):
+def activated_dummy_profile(db, dummy_profile):
     preference = AlertPreference(
         account=dummy_profile.account, active_profile=dummy_profile
     )
@@ -1126,14 +1126,14 @@ def activated_dummy_profile(dummy_profile):
 
 
 @pytest.fixture(scope="function")
-def dummy_time_period(activated_dummy_profile):
+def dummy_time_period(db, activated_dummy_profile):
     time_period = TimePeriod(profile=activated_dummy_profile)
     time_period.save()
     return time_period
 
 
 @pytest.fixture(scope="function")
-def dummy_alert_address(admin_account):
+def dummy_alert_address(db, admin_account):
     alert_address = AlertAddress(
         account=admin_account,
         type=AlertSender.objects.get(name=AlertSender.SMS),

--- a/tests/integration/web/arnold_test.py
+++ b/tests/integration/web/arnold_test.py
@@ -78,7 +78,7 @@ class TestManualDetention:
 
 
 class TestQuarantineVlan:
-    def test_quarantine_vlan_twice_should_show_error_message(self, client):
+    def test_quarantine_vlan_twice_should_show_error_message(self, client, db):
         url = reverse('arnold-quarantinevlans')
 
         vlan_id = 1

--- a/tests/integration/web/devicehistory_test.py
+++ b/tests/integration/web/devicehistory_test.py
@@ -200,7 +200,7 @@ def test_device_history_view_filter_with_initial_values_is_same_as_same_get_para
 
 
 @pytest.fixture()
-def localhost_with_alert(localhost):
+def localhost_with_alert(db, localhost):
     alert = AlertHistory(
         source_id='ipdevpoll',
         netbox=localhost,

--- a/tests/integration/web/graphite_test.py
+++ b/tests/integration/web/graphite_test.py
@@ -77,18 +77,19 @@ def fake_graphite_web_server():
     503 status code.  The fixture returns the localhost port number the server
     listens to.
     """
-    port = 54321
-    response_code = 503  # Example response code
+    response_code = 503
 
     handler = lambda *args, **kwargs: SingleStatusHandler(
         *args, response_code=response_code, **kwargs
     )
-    httpd = socketserver.TCPServer(("", port), handler)
+    socketserver.TCPServer.allow_reuse_address = True
+    httpd = socketserver.TCPServer(("", 0), handler)
+    port = httpd.server_address[1]
 
     thread = threading.Thread(target=httpd.serve_forever)
     thread.daemon = True
     thread.start()
-    time.sleep(1)  # Give the server a second to ensure it starts
+    time.sleep(0.1)
 
     yield port
 

--- a/tests/integration/widget_test.py
+++ b/tests/integration/widget_test.py
@@ -16,10 +16,14 @@ def test_roomstatus_should_not_fail_on_multiple_messages(alerthist_with_two_mess
     result = widget.get_context_data_view({})
     print(result)
     assert 'results' in result
-    assert len(result['results']) == 1
 
-    problem = result['results'][0]
-    assert problem['netbox_object'] == alerthist_with_two_messages.netbox
+    matching = [
+        r
+        for r in result['results']
+        if r['netbox'] == alerthist_with_two_messages.netbox.id
+    ]
+    assert len(matching) == 1
+    assert matching[0]['netbox_object'] == alerthist_with_two_messages.netbox
 
 
 def test_feedreader_widget_should_get_nav_blog_posts():

--- a/tests/integration/widget_test.py
+++ b/tests/integration/widget_test.py
@@ -202,7 +202,7 @@ def test_when_sudoer_requests_unauthorized_navlet_via_htmx_then_it_should_not_cr
 
 
 @pytest.fixture()
-def alerthist_with_two_messages(localhost):
+def alerthist_with_two_messages(db, localhost):
     alert = AlertHistory(
         source_id='ipdevpoll',
         netbox=localhost,


### PR DESCRIPTION
## Scope and purpose

Running integration tests with randomized ordering (via `pytest-random-order --random-order-bucket=global`) exposed several test-order-dependent failures. This PR fixes the root causes so that integration tests (hopefully) pass reliably regardless of execution order.

### Root causes and fixes

**Missing `db` fixture dependencies** — Several fixtures create database objects via `.save()` without depending on the `db` fixture, which wraps each test in a rolled-back transaction. Without this dependency, the saves auto-commit outside the rollback scope, leaking rows into subsequent tests. Added `db` to: `token`, `serializer_models`, `dummy_profile`, `activated_dummy_profile`, `dummy_time_period`, `dummy_alert_address`, `alerthist_with_two_messages`, `localhost_with_alert`, and `TestQuarantineVlan`'s test method.

**Overly broad test assertions** — Some tests made global assertions that assumed a clean database:
- `test_roomstatus_should_not_fail_on_multiple_messages` asserted a global result count of 1. Fixed to filter results to its own fixture's netbox.
- `test_alert_should_be_visible_in_api` used `AlertHistory.objects.all()[0]`, which can pick up a stale alert with a deleted netbox. Fixed to filter for alerts with a non-null netbox.
- `test_pping_localhost_should_work` asserted "0 hosts currently marked as down" globally. Since pping runs as a subprocess reading all committed netboxes, any leaked row causes failure. Fixed to assert that localhost specifically is not reported as down.

**Hardcoded port collision** — `fake_graphite_web_server` bound to port 54321, which fails with "Address already in use" when test ordering causes the fixture's module to be set up while a previous instance is still tearing down. Fixed to use port 0 (OS-assigned ephemeral port).

## Contributor Checklist

* [x] ~~Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)~~
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~