### PR TITLE
Add libtidy to devcontainer image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -37,6 +37,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
        python3-dev \
        git \
        libsnmp40 \
+       libtidy5deb1 \
        cron \
        inotify-tools \
        vim \


### PR DESCRIPTION
## Scope and purpose

The devcontainer was missing `libtidy5deb1`, which meant the HTML validation crawler tests (`tests/integration/web/crawler_test.py`) were always skipped when running locally. CI already installs this library.

## Contributor Checklist

* [ ] ~~Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)~~
* [ ] ~~Added/amended tests for new/changed code~~
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~