### PR TITLE
Fix unlikely edgecase in nav.util.cachedfor

### DIFF
--- a/python/nav/util.py
+++ b/python/nav/util.py
@@ -373,7 +373,7 @@ class cachedfor(object):
         self.max_age = max_age
         self.value = None
         self.func = None
-        self.updated = datetime.datetime.min
+        self.updated = datetime.datetime.now() - max_age
 
     def __call__(self, func):
         self.func = func

--- a/tests/unittests/general/util_test.py
+++ b/tests/unittests/general/util_test.py
@@ -15,8 +15,11 @@
 import time
 import pytest
 
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
 from nav import util
-from nav.util import IPRange, first_true
+from nav.util import cachedfor, first_true, IPRange
 from IPy import IP
 
 
@@ -185,3 +188,77 @@ class TestTimer:
     def test_when_used_as_context_variable_it_should_return_self(self):
         with util.Timer() as t:
             assert isinstance(t, util.Timer)
+
+
+class TestCachedFor:
+    NOW = datetime.fromisoformat("2000-01-01T00:00:00.000000")
+
+    def test_cachedfor_should_hit_cache_when_age_less_than_validity_duration(self):
+        state = 0
+        validity_duration = timedelta(seconds=1)
+        age = validity_duration / 2
+
+        with patch("nav.util.datetime.datetime", self.frozen_datetime(self.NOW)):
+
+            @cachedfor(validity_duration)
+            def inc():
+                nonlocal state
+                state += 1
+                return state
+
+            first = inc()
+
+        with patch("nav.util.datetime.datetime", self.frozen_datetime(self.NOW + age)):
+            second = inc()
+
+        assert first == 1
+        assert second == 1
+
+    def test_cachedfor_should_miss_cache_when_age_greater_than_validity_duration(self):
+        state = 0
+        validity_duration = timedelta(seconds=1)
+        age = validity_duration * 2
+
+        with patch("nav.util.datetime.datetime", self.frozen_datetime(self.NOW)):
+
+            @cachedfor(validity_duration)
+            def inc():
+                nonlocal state
+                state += 1
+                return state
+
+            first = inc()
+
+        with patch("nav.util.datetime.datetime", self.frozen_datetime(self.NOW + age)):
+            second = inc()
+
+        assert first == 1
+        assert second == 2
+
+    def test_cachedfor_should_not_raise_when_validity_duration_is_not_too_big(self):
+        validity_duration = (self.NOW - datetime.min) - timedelta(seconds=1)
+
+        with patch("nav.util.datetime.datetime", self.frozen_datetime(self.NOW)):
+
+            @cachedfor(validity_duration)
+            def foo():
+                return
+
+    def test_cachedfor_should_raise_when_validity_duration_is_too_big(self):
+        validity_duration = (self.NOW - datetime.min) + timedelta(seconds=1)
+
+        with patch("nav.util.datetime.datetime", self.frozen_datetime(self.NOW)):
+            with pytest.raises(OverflowError):
+
+                @cachedfor(validity_duration)
+                def foo():
+                    return
+
+    @staticmethod
+    def frozen_datetime(start_time):
+        class _datetime(datetime):
+            @classmethod
+            def now(cls):
+                return start_time
+
+        return _datetime


### PR DESCRIPTION
## Scope and purpose

This fixes an edge case in nav.util.cachedfor, which occurs when the sole parameter `max_age` is greater than `datetime.now() - datetime.min` (739698 days as of today). In this case, it causes the function decorated with nav.util.cachedfor to return the default, uninitialized, cache value of None until `datetime.now() - datetime.min` is greater than or equal to `max_age`.

Without this PR:

```python
>>> from datetime import datetime, timedelta
>>> from nav.util import cachedfor
>>> @cachedfor(datetime.now() - datetime.min + timedelta(days=1))
... def f():
...     return 1
... 
>>> print(f())
None
```

With this PR:

```python
>>> from datetime import datetime, timedelta
>>> from nav.util import cachedfor
>>> @cachedfor(datetime.now() - datetime.min + timedelta(days=1))
... def f():
...     return 1
... 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    @cachedfor(datetime.now() - datetime.min + timedelta(days=1))
     ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "nav/python/nav/util.py", line 376, in __init__
    self.updated = datetime.datetime.now() - max_age
                   ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
OverflowError: date value out of range
```

I opted for just having nav.util.cachedfor bubble an `OverflowError`; it's trivial to make the cache work with any sizes of `max_age`, but I don't see a reason why that should be needed as a `max_age` that would have caused the original bug (because it had a value larger than 739698 days as of today) is probably a bug in itself.

<!-- remove things that do not apply -->
### This pull request
* fixes a very unlikely bug

## Contributor Checklist

* [x] Added/amended tests for new/changed code
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
