### PR TITLE
Fix race condition crash in asyncdns `_save_result`

### DIFF
--- a/changelog.d/3902.fixed.md
+++ b/changelog.d/3902.fixed.md
@@ -1,0 +1,1 @@
+Fixed a race condition crash in asyncdns `ForwardResolver` where a DNS error on one record type (A/AAAA) could cause an `AttributeError` when the other record type resolved successfully.

--- a/python/nav/asyncdns.py
+++ b/python/nav/asyncdns.py
@@ -141,8 +141,9 @@ class Resolver(object):
     def _save_result(self, result):
         name, response = result
         if isinstance(response, Exception):
-            self.results[name] = response
-        else:
+            if not self.results[name]:
+                self.results[name] = response
+        elif isinstance(self.results[name], list):
             self.results[name].extend(response)
 
     @staticmethod

--- a/tests/unittests/asyncdns_test.py
+++ b/tests/unittests/asyncdns_test.py
@@ -1,7 +1,10 @@
+from collections import defaultdict
+
 from mock import Mock
 from twisted.names import dns
+from twisted.names.error import DNSNameError
 
-from nav.asyncdns import ForwardResolver
+from nav.asyncdns import ForwardResolver, Resolver
 
 BUICK_NAME = "buick.lab.uninett.no"
 
@@ -40,3 +43,38 @@ def test_forward_lookup_should_work_with_different_case_name_results():
 
     assert result_name == BUICK_NAME
     assert address_list == ["158.38.152.162"]
+
+
+class TestSaveResult:
+    """Tests for Resolver._save_result"""
+
+    def _make_resolver(self):
+        """Returns a Resolver instance without triggering __init__'s side effects"""
+        resolver = object.__new__(Resolver)
+        resolver.results = defaultdict(list)
+        return resolver
+
+    def test_when_error_arrives_after_success_it_should_keep_addresses(self):
+        resolver = self._make_resolver()
+        resolver._save_result(("host", ["10.0.0.1"]))
+        resolver._save_result(("host", DNSNameError()))
+        assert resolver.results["host"] == ["10.0.0.1"]
+
+    def test_when_success_arrives_after_error_it_should_not_raise(self):
+        resolver = self._make_resolver()
+        resolver._save_result(("host", DNSNameError()))
+        resolver._save_result(("host", []))
+        assert isinstance(resolver.results["host"], DNSNameError)
+
+    def test_when_both_succeed_it_should_combine_results(self):
+        resolver = self._make_resolver()
+        resolver._save_result(("host", ["10.0.0.1"]))
+        resolver._save_result(("host", ["::1"]))
+        assert resolver.results["host"] == ["10.0.0.1", "::1"]
+
+    def test_when_both_fail_it_should_store_first_error(self):
+        resolver = self._make_resolver()
+        first_error = DNSNameError()
+        resolver._save_result(("host", first_error))
+        resolver._save_result(("host", DNSNameError()))
+        assert resolver.results["host"] is first_error


### PR DESCRIPTION
## Scope and purpose

Fixes #3902.

`ForwardResolver` issues parallel A and AAAA lookups per name, and both results are written to `self.results[name]` via `_save_result`. If the error callback ran first, it replaced the default list with an exception object, causing the subsequent success callback to crash with `AttributeError` on `.extend()`. The opposite ordering silently discarded valid addresses.

The fix ensures that a DNS error does not overwrite existing valid results, and that `.extend()` is only called when the stored value is still a list.

## Contributor Checklist

- [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
- [x] Added/amended tests for new/changed code
- [ ] ~~Added/changed documentation~~
- [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
- [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
- [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
- [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done — #4035
- [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
- [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~