### PR TITLE
Defer reverse() calls in breadcrumbs templatetag

### DIFF
--- a/python/nav/django/templatetags/breadcrumbs.py
+++ b/python/nav/django/templatetags/breadcrumbs.py
@@ -1,39 +1,45 @@
+from functools import cache
+
 from django import template
 from django.urls import reverse
 
 register = template.Library()
 
-BASE_CRUMB = ('Home', reverse('webfront-index'))
 
-# Account-related Breadcrumbs
-BASE_ACCOUNT_CRUMB = ('Account', reverse('webfront-preferences'))
-CURRENT_PATH = ''
-ACCOUNTS_BREADCRUMB_MAP = {
-    reverse('webfront-preferences'): [BASE_ACCOUNT_CRUMB],
-    reverse('account_change_password'): [
-        BASE_ACCOUNT_CRUMB,
-        ('Change Password', CURRENT_PATH),
-    ],
-    reverse('account_reauthenticate'): [
-        BASE_ACCOUNT_CRUMB,
-        ('Re-authenticate', CURRENT_PATH),
-    ],
-    reverse('socialaccount_connections'): [
-        BASE_ACCOUNT_CRUMB,
-        ('Account Connections', CURRENT_PATH),
-    ],
-}
+@cache
+def _get_breadcrumb_config():
+    """Build breadcrumb configuration on first use.
 
-# Combine all breadcrumb mappings
-BREADCRUMB_MAP = {
-    **ACCOUNTS_BREADCRUMB_MAP,
-}
+    Deferred to avoid calling reverse() at module import time, which forces
+    all URL configs and their views to be loaded eagerly.
+    """
+    base_crumb = ('Home', reverse('webfront-index'))
+    base_account_crumb = ('Account', reverse('webfront-preferences'))
 
-# 2FA Breadcrumbs
-TWO_FACTOR_AUTH_CRUMB = [
-    BASE_ACCOUNT_CRUMB,
-    ('Two-Factor Authentication', CURRENT_PATH),
-]
+    breadcrumb_map = {
+        reverse('webfront-preferences'): [base_account_crumb],
+        reverse('account_change_password'): [
+            base_account_crumb,
+            ('Change Password', ''),
+        ],
+        reverse('account_reauthenticate'): [
+            base_account_crumb,
+            ('Re-authenticate', ''),
+        ],
+        reverse('socialaccount_connections'): [
+            base_account_crumb,
+            ('Account Connections', ''),
+        ],
+    }
+
+    two_factor_auth_crumb = [
+        base_account_crumb,
+        ('Two-Factor Authentication', ''),
+    ]
+
+    mfa_prefix = reverse('mfa_index')
+
+    return base_crumb, breadcrumb_map, two_factor_auth_crumb, mfa_prefix
 
 
 @register.filter
@@ -47,16 +53,18 @@ def to_breadcrumbs(path):
         of each breadcrumb.
     :rtype: list
     """
-    # Remove leading and trailing slashes and split the path
+    base_crumb, breadcrumb_map, two_factor_auth_crumb, mfa_prefix = (
+        _get_breadcrumb_config()
+    )
+
     path = clean_path(path)
-    if path in BREADCRUMB_MAP:
-        crumbs = [BASE_CRUMB] + BREADCRUMB_MAP[path]
-        return crumbs
+    if path in breadcrumb_map:
+        return [base_crumb] + breadcrumb_map[path]
 
-    if path.startswith(reverse('mfa_index')):
-        return [BASE_CRUMB] + TWO_FACTOR_AUTH_CRUMB
+    if path.startswith(mfa_prefix):
+        return [base_crumb] + two_factor_auth_crumb
 
-    return [BASE_CRUMB]
+    return [base_crumb]
 
 
 def clean_path(path):


### PR DESCRIPTION
## Scope and purpose

Split from #3864.

Replace eager `reverse()` calls in the breadcrumbs templatetag with `lazy_reverse()`. This prevents `ImproperlyConfigured` errors when the templatetag module is imported before Django URL configuration is fully loaded, which happens when running NAV outside of the devcontainer (e.g. local dev with `django-admin runserver`).

### This pull request
* changes the breadcrumbs templatetag to use lazy URL resolution

## Contributor Checklist

* [ ] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file