### PR TITLE
Add local dev setup with lightweight Docker infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dummy clean distclean testclean docclean doc cssclean sassbuild sasswatch setup-playwright .FORCE
+.PHONY: dummy clean distclean testclean docclean doc cssclean sassbuild sasswatch setup-playwright local-setup local-up local-down .FORCE
 
 dummy:
 	@echo "'make' is no longer used for deployment. See 'doc/intro/install.rst'"
@@ -56,5 +56,14 @@ PLAYWRIGHT_BROWSERS ?= chromium
 
 setup-playwright:
 	uv run playwright install --with-deps $(PLAYWRIGHT_BROWSERS)
+
+local-setup:
+	tools/local-dev/setup.sh
+
+local-up:
+	docker compose -f tools/local-dev/docker-compose.yml up -d
+
+local-down:
+	docker compose -f tools/local-dev/docker-compose.yml down
 
 .FORCE:

--- a/tests/setup_test_config.py
+++ b/tests/setup_test_config.py
@@ -79,7 +79,7 @@ def _write_db_conf(config_dir: Path) -> None:
     host = os.environ.get("PGHOST", "localhost")
     port = os.environ.get("PGPORT", "5432")
     user = os.environ.get("PGUSER", "nav")
-    password = os.environ.get("PGPASSWORD", "")
+    password = os.environ.get("PGPASSWORD", "nav")
     dbname = _get_test_database_name()
 
     db_conf = config_dir / "db.conf"

--- a/tools/local-dev/configure.py
+++ b/tools/local-dev/configure.py
@@ -1,0 +1,98 @@
+"""Configure the virtualenv for local NAV development.
+
+Writes sitecustomize.py (env defaults), installs NAV config templates,
+and patches them for local Docker services.
+
+Run via: uv run python tools/local-dev/configure.py
+"""
+
+import getpass
+import os
+import site
+import subprocess
+import sys
+from pathlib import Path
+from string import Template
+
+SCRIPT_DIR = Path(__file__).parent
+VENV_DIR = Path(sys.prefix)
+SITE_PACKAGES = Path(site.getsitepackages()[0])
+NAV_CONFIG_DIR = VENV_DIR / "etc" / "nav"
+PG_PORT = os.environ.get("NAV_PG_PORT", "5434")
+
+DB_CONF = Template("""\
+dbhost=127.0.0.1
+dbport=$pg_port
+db_nav=nav
+script_default=nav
+userpw_nav=nav
+""")
+
+GRAPHITE_CONF = """\
+[carbon]
+host=localhost
+port=2003
+
+[graphiteweb]
+base=http://localhost:8088/
+"""
+
+
+def info(msg):
+    print(f"\033[0;32m==>\033[0m {msg}")
+
+
+def write_sitecustomize():
+    template = Template((SCRIPT_DIR / "sitecustomize.py.tmpl").read_text())
+    dest = SITE_PACKAGES / "sitecustomize.py"
+    info(f"Writing {dest}")
+    dest.write_text(template.substitute(pg_port=PG_PORT))
+
+
+def install_nav_config():
+    info(f"Installing NAV config templates to {NAV_CONFIG_DIR}")
+    subprocess.run(
+        ["nav", "config", "install", str(NAV_CONFIG_DIR)],
+        capture_output=True,
+    )
+
+
+def write_db_conf():
+    path = NAV_CONFIG_DIR / "db.conf"
+    info(f"Writing {path}")
+    path.write_text(DB_CONF.substitute(pg_port=PG_PORT))
+
+
+def write_nav_conf():
+    path = NAV_CONFIG_DIR / "nav.conf"
+    upload_dir = VENV_DIR / "var" / "nav" / "uploads"
+    upload_dir.mkdir(parents=True, exist_ok=True)
+
+    info(f"Configuring {path}")
+    # nav.conf is parsed by read_flat_config() which uses last-value-wins,
+    # so we can just append our overrides.
+    with path.open("a") as f:
+        f.write("\n# Local dev overrides\n")
+        f.write(f"NAV_USER={getpass.getuser()}\n")
+        f.write("DJANGO_DEBUG=True\n")
+        f.write(f"UPLOAD_DIR={upload_dir}\n")
+
+
+def write_graphite_conf():
+    path = NAV_CONFIG_DIR / "graphite.conf"
+    info(f"Writing {path}")
+    path.write_text(GRAPHITE_CONF)
+
+
+def main():
+    info(f"Virtualenv: {VENV_DIR}")
+    info(f"NAV config: {NAV_CONFIG_DIR}")
+    write_sitecustomize()
+    install_nav_config()
+    write_db_conf()
+    write_nav_conf()
+    write_graphite_conf()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/local-dev/docker-compose.yml
+++ b/tools/local-dev/docker-compose.yml
@@ -1,0 +1,32 @@
+# Lightweight infrastructure services for local NAV development.
+# Usage: make local-up / make local-down
+#
+# This runs only PostgreSQL and Graphite — NAV itself runs natively
+# on your machine. Run 'make local-setup' for first-time setup.
+
+services:
+  db:
+    image: postgres:17
+    restart: unless-stopped
+    ports:
+      - "${NAV_PG_PORT:-5434}:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: nav
+      POSTGRES_DB: nav
+      POSTGRES_PASSWORD: nav
+
+  graphite:
+    build: ../../tools/docker/graphite
+    restart: unless-stopped
+    ports:
+      - "2003:2003"
+      - "2003:2003/udp"
+      - "8088:8000"
+    volumes:
+      - ../../python/nav/etc/graphite/storage-schemas.conf:/etc/carbon/storage-schemas.conf
+      - ../../python/nav/etc/graphite/storage-aggregation.conf:/etc/carbon/storage-aggregation.conf
+
+volumes:
+  postgres-data:

--- a/tools/local-dev/setup.sh
+++ b/tools/local-dev/setup.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -euo pipefail
+
+# One-time setup for local NAV development (without devcontainers).
+#
+# Prerequisites:
+#   - uv, Node.js/npm, Docker, pg_dump (>= 17)
+#   - System libraries: libpq, net-snmp, libjpeg
+#
+# Usage:
+#   make local-setup
+
+cd "$(cd "$(dirname "$0")/../.." && pwd)"
+
+NAV_PG_PORT="${NAV_PG_PORT:-5434}"
+export NAV_PG_PORT
+
+info()  { echo -e "\033[0;32m==>\033[0m $*"; }
+error() { echo -e "\033[0;31m==> ERROR:\033[0m $*" >&2; }
+
+# --- Check prerequisites ---
+info "Checking prerequisites..."
+MISSING=0
+for cmd in uv node npm docker; do
+    command -v "$cmd" &>/dev/null || { error "$cmd is not installed."; MISSING=1; }
+done
+[ "$MISSING" -eq 1 ] && exit 1
+
+# --- Install dependencies ---
+info "Installing Python dependencies..."
+uv sync --python "${NAV_PYTHON:-3.11}" --all-extras --all-groups
+
+info "Installing npm dependencies and building CSS..."
+npm install
+npm run build:sass
+
+# --- Configure virtualenv for local development ---
+uv run python tools/local-dev/configure.py
+
+# --- Start infrastructure and sync database ---
+info "Starting PostgreSQL and Graphite containers..."
+docker compose -f tools/local-dev/docker-compose.yml up -d
+
+info "Waiting for PostgreSQL..."
+for _ in $(seq 1 30); do
+    PGPASSWORD=nav psql -h 127.0.0.1 -p "$NAV_PG_PORT" -U nav -d nav -c "SELECT 1" &>/dev/null && break
+    sleep 1
+done
+if ! PGPASSWORD=nav psql -h 127.0.0.1 -p "$NAV_PG_PORT" -U nav -d nav -c "SELECT 1" &>/dev/null; then
+    error "PostgreSQL did not become ready in time."
+    exit 1
+fi
+
+info "Syncing NAV database schema..."
+PGPASSWORD=nav PGUSER=nav uv run navsyncdb
+
+echo ""
+info "Local development environment is ready!"
+cat <<EOF
+
+  Start the web server:
+    uv run django-admin runserver
+
+  If the above does not work, check if your OS/distro has hijacked
+  the sitecustomize.py file. If it has you need to set the
+  environment variables by hand, see the sitecustomize.py you find
+  inside the .venv directory.
+
+  Watch SASS for changes (optional):
+    make sasswatch
+
+  Infrastructure services:
+    make local-up       # start
+    make local-down     # stop
+
+  Run tests:
+    uv run pytest tests/unittests/
+
+EOF

--- a/tools/local-dev/sitecustomize.py.tmpl
+++ b/tools/local-dev/sitecustomize.py.tmpl
@@ -1,0 +1,10 @@
+import os
+
+for key, value in {
+    "DJANGO_SETTINGS_MODULE": "nav.django.settings",
+    "PGHOST": "127.0.0.1",
+    "PGPORT": "$pg_port",
+    "PGUSER": "nav",
+    "PGPASSWORD": "nav",
+}.items():
+    os.environ.setdefault(key, value)


### PR DESCRIPTION
## Scope and purpose

Split from #3864. 

Adds a lightweight alternative to devcontainers for local NAV development. Uses a minimal `docker-compose.local.yml` (PostgreSQL + Graphite only) with a setup script that configures the virtualenv, installs dependencies, and syncs the database.

### Usage

```bash
make local-setup    # one-time setup
make local-up       # start infrastructure
make local-down     # stop infrastructure
uv run django-admin runserver  # run web server
```

Note: `make local-setup` cannot upgrade an existing .venv. If `uv run django-admin runserver` does not work, remove the `.venv` and rerun `make local-setup`. (A .venv may have been created by the heavy docker compose dev setup.)

The Python version defaults to 3.11 but can be overridden with `NAV_PYTHON=3.12 make local-setup`.

### Why `sitecustomize.py`
The setup installs a `sitecustomize.py` into the site-packages of the virtualenv. This enables us to set `DJANGO_SETTINGS_MODULE`, `PGHOST` and other required env variables automatically on every Python invocation. That means `uv run django-admin runserver`, `uv run pytest` etc. all work without having to source an `.env.` file or using shell helper scripts. It is also a good place to put the macOS patch in #3911.

### This pull request
* adds a dependency on Docker (PostgreSQL + Graphite containers)

## Contributor Checklist

* [ ] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [x] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file