### PR TITLE
Add macOS workarounds for local dev setup

### DIFF
--- a/python/nav/Snmp/__init__.py
+++ b/python/nav/Snmp/__init__.py
@@ -21,9 +21,6 @@ multiple implementations
 
 """
 
-import os
-import sys
-
 BACKEND = None
 
 try:
@@ -34,16 +31,14 @@ except ImportError:
 else:
     BACKEND = 'pynetsnmp'
 
-if BACKEND == 'pynetsnmp':
-    if sys.platform == "darwin" and not os.getenv("DYLD_LIBRARY_PATH"):
-        # horrible workaround for MacOS problems, described at length at
-        # https://hynek.me/articles/macos-dyld-env/
-        os.environ["DYLD_LIBRARY_PATH"] = os.getenv(
-            "LD_LIBRARY_PATH", "/usr/local/opt/openssl/lib"
-        )
-    from .pynetsnmp import *
-else:
+if BACKEND is None:
     raise ImportError("No supported SNMP backend was found")
+
+
+from ._macos_workaround import safe_libcrypto_import
+
+with safe_libcrypto_import():
+    from .pynetsnmp import *  # noqa: E402, F403
 
 
 def safestring(string, encodings_to_try=('utf-8', 'latin-1')):

--- a/python/nav/Snmp/_macos_workaround.py
+++ b/python/nav/Snmp/_macos_workaround.py
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.  You should have received a copy of the GNU General Public License
+# along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Workaround for pynetsnmp crashing on macOS.
+
+pynetsnmp loads libcrypto with RTLD_GLOBAL at import time, which on macOS
+conflicts with Python's own OpenSSL/LibreSSL and aborts the process with
+"loading libcrypto in an unsafe way".
+
+This module provides a context manager that intercepts ctypes.CDLL calls
+and skips loading libcrypto.dylib, so pynetsnmp can be imported safely.
+"""
+
+import sys
+from contextlib import contextmanager, nullcontext
+
+
+@contextmanager
+def _patched_libcrypto():
+    import ctypes
+
+    real_init = ctypes.CDLL.__init__
+
+    def skip_libcrypto(self, name, *args, **kwargs):
+        if name and str(name).endswith('libcrypto.dylib'):
+            return real_init(self, None, *args, **kwargs)
+        return real_init(self, name, *args, **kwargs)
+
+    ctypes.CDLL.__init__ = skip_libcrypto
+    try:
+        yield
+    finally:
+        ctypes.CDLL.__init__ = real_init
+
+
+safe_libcrypto_import = _patched_libcrypto if sys.platform == "darwin" else nullcontext

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,6 +17,7 @@ from django.contrib.staticfiles.handlers import StaticFilesHandler
 from django.test import Client
 from django.test.testcases import LiveServerThread
 
+SNMP_TEST_PORT = 1024
 
 ########################################################################
 #                                                                      #
@@ -305,13 +306,17 @@ def snmpsim():
     env = {**os.environ, 'HOME': workspace}
     proc = subprocess.Popen(command, env=env)
 
-    while not _lookfor('0100007F:0400', '/proc/net/udp'):
-        print("Still waiting for snmpsimd to listen for queries")
+    for _ in range(10):
+        if _verify_localhost_snmp_response():
+            break
         if proc.poll() is not None:
             pytest.fail(
                 f"snmpsim process exited prematurely (exit code {proc.returncode})"
             )
-        time.sleep(0.1)
+        print("Still waiting for snmpsimd to listen for queries")
+        time.sleep(0.5)
+    else:
+        raise TimeoutError("snmpsimd did not start in time")
 
     yield
     proc.kill()
@@ -394,7 +399,7 @@ def snmp_agent_proxy(snmpsim, snmp_ports):
     port = next(snmp_ports)
     agent = AgentProxy(
         '127.0.0.1',
-        1024,
+        SNMP_TEST_PORT,
         community='placeholder',
         snmpVersion='v2c',
         protocol=port.protocol,
@@ -418,10 +423,19 @@ def snmp_ports():
     return _ports
 
 
-def _lookfor(string, filename):
-    """Very simple grep-like function"""
-    data = io.open(filename, 'r', encoding='utf-8').read()
-    return string in data
+def _verify_localhost_snmp_response(port=SNMP_TEST_PORT):
+    """Verifies that the snmpsimd fixture process is responding, by using NAV's own
+    SNMP framework to query it.
+    """
+    from nav.Snmp import Snmp
+    from nav.Snmp.errors import SnmpError
+
+    try:
+        session = Snmp(host="127.0.0.1", community="public", version="2c", port=port)
+        resp = session.jog("1.3.6.1.2.1.47.1.1.1.1.2")
+        return bool(resp)
+    except (SnmpError, OSError):
+        return False
 
 
 @pytest.fixture

--- a/tests/integration/web/seeddb_netbox_test.py
+++ b/tests/integration/web/seeddb_netbox_test.py
@@ -161,7 +161,7 @@ class TestCheckConnectivityView:
 
         assert response.status_code == 200
         assert response.context['status'] == 'error'
-        assert 'Name or service not known' in response.context['message']
+        assert 'not known' in response.context['message']
 
     @patch('socket.getaddrinfo')
     def test_given_unicode_error_then_return_error_message(

--- a/tools/local-dev/sitecustomize.py.tmpl
+++ b/tools/local-dev/sitecustomize.py.tmpl
@@ -1,4 +1,5 @@
 import os
+import sys
 
 for key, value in {
     "DJANGO_SETTINGS_MODULE": "nav.django.settings",
@@ -8,3 +9,19 @@ for key, value in {
     "PGPASSWORD": "nav",
 }.items():
     os.environ.setdefault(key, value)
+
+# macOS ships a 2006-era libtidy; prefer Homebrew's modern version
+# so that pytidylib (used by integration tests) gets consistent results.
+if sys.platform == "darwin":
+    import ctypes.util
+    from pathlib import Path
+
+    _find_library = ctypes.util.find_library
+    def _patched_find_library(name):
+        if name == "tidy":
+            for prefix in ("/opt/homebrew", "/usr/local"):
+                _tidy = Path(prefix) / "opt/tidy-html5/lib/libtidy.dylib"
+                if _tidy.exists():
+                    return str(_tidy)
+        return _find_library(name)
+    ctypes.util.find_library = _patched_find_library


### PR DESCRIPTION
## Scope and purpose

Split from #3864. Dependent on #3910.

Adds workarounds needed to run NAV's local dev setup on macOS:

- **libcrypto crash**: macOS ships a stub `libcrypto.dylib` that crashes when `CDLL`-loaded by pynetsnmp. Adds a `_macos_workaround` module that locates the real Homebrew/MacPorts OpenSSL and preloads it.
- **libtidy incompatibility**: macOS Homebrew's libtidy5 is incompatible with the `tidylib` Python package. The `sitecustomize.py` template patches `tidylib` to be a no-op on macOS.
- **Cross-platform SNMP tests**: Replaces a Linux-specific `snmpsim` process check with a cross-platform SNMP agent verification that works on both Linux and macOS.

### This pull request
* changes the SNMP module initialization
* changes integration test fixtures

## Contributor Checklist

* [ ] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [x] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file