### PR TITLE
Add test name convention checker

### DIFF
--- a/.claude/hooks/check-test-names.sh
+++ b/.claude/hooks/check-test-names.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# PostToolUse hook: check test naming conventions after Edit/Write on test files.
+# Gives Claude feedback (exit 2) so it can fix the names before committing.
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# Only check test files under tests/
+if [[ ! "$FILE_PATH" =~ ^.*/tests/.*\.py$ ]] && [[ ! "$FILE_PATH" =~ ^tests/.*\.py$ ]]; then
+  exit 0
+fi
+
+# Find the project root (where checks/ lives)
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+CHECKER="$PROJECT_DIR/checks/check_test_names.py"
+
+if [[ ! -f "$CHECKER" ]]; then
+  exit 0
+fi
+
+# Make file_path relative to project root for the checker
+REL_PATH="${FILE_PATH#"$PROJECT_DIR"/}"
+
+output=$(python3 "$CHECKER" --files "$REL_PATH" 2>&1)
+exit_code=$?
+
+if [[ $exit_code -ne 0 ]]; then
+  echo "$output" >&2
+  exit 2
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-test-names.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/check-test-names.yml
+++ b/.github/workflows/check-test-names.yml
@@ -1,0 +1,60 @@
+name: Check test names
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check-test-names:
+    runs-on: ubuntu-latest
+    name: Check test naming convention
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Check new test names
+      id: check
+      run: |
+        base="origin/${{ github.event.pull_request.base.ref }}"
+        output=$(python3 checks/check_test_names.py --base "$base" --format markdown 2>&1) && has_violations=false || has_violations=true
+        echo "$output"
+        {
+          echo "body<<BODY_EOF"
+          echo "$output"
+          echo "BODY_EOF"
+        } >> "$GITHUB_OUTPUT"
+        echo "has_violations=$has_violations" >> "$GITHUB_OUTPUT"
+
+    - name: Find existing comment
+      uses: peter-evans/find-comment@v3
+      id: find-comment
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: '<!-- check-test-names -->'
+
+    - name: Post or update comment
+      if: steps.check.outputs.has_violations == 'true'
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        comment-id: ${{ steps.find-comment.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        edit-mode: replace
+        body: |
+          <!-- check-test-names -->
+          ${{ steps.check.outputs.body }}
+
+    - name: Change comment to mention resolved violations
+      if: steps.check.outputs.has_violations == 'false' && steps.find-comment.outputs.comment-id != ''
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        comment-id: ${{ steps.find-comment.outputs.comment-id }}
+        edit-mode: replace
+        body: |
+          <!-- check-test-names -->
+          ### Test naming convention
+
+          All new test names follow the convention. :thumbsup:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@
 !.pre-commit-config.yaml
 !.readthedocs.yaml
 !.sonarcloud.properties
+!.claude/
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
 
 *.orig
 *.rej

--- a/checks/check_test_names.py
+++ b/checks/check_test_names.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Check that new test method names follow the given/when/then/it_should convention.
+
+Scans git diff for newly added test methods and warns if they lack
+convention keywords (given, when, then, should).
+
+Usage:
+    # Check staged changes (pre-commit)
+    python checks/check_test_names.py
+
+    # Check branch diff against master
+    python checks/check_test_names.py --base master
+
+    # Check specific files
+    python checks/check_test_names.py --files tests/test_foo.py tests/test_bar.py
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+
+KEYWORDS = {"given", "when", "then"}
+PHRASE_KEYWORDS = {"it_should"}
+TEST_DEF_RE = re.compile(r"^\+\s*def (test_\w+)\(")
+TEST_FILE_RE = re.compile(r"^tests/.*\.py$")
+
+# Matches: +++ b/tests/some/path.py
+DIFF_FILE_RE = re.compile(r"^\+\+\+ b/(.+)$")
+
+
+def get_new_test_names_from_diff(diff: str) -> list[tuple[str, str]]:
+    """Extract (filename, test_name) pairs from added lines in a diff."""
+    results = []
+    current_file = None
+
+    for line in diff.splitlines():
+        file_match = DIFF_FILE_RE.match(line)
+        if file_match:
+            path = file_match.group(1)
+            current_file = path if TEST_FILE_RE.match(path) else None
+            continue
+
+        if current_file is None:
+            continue
+
+        test_match = TEST_DEF_RE.match(line)
+        if test_match:
+            results.append((current_file, test_match.group(1)))
+
+    return results
+
+
+def check_name(name: str) -> bool:
+    """Return True if the test name contains at least one convention keyword."""
+    lower = name.lower()
+    parts = set(lower.split("_"))
+    if parts & KEYWORDS:
+        return True
+    return any(phrase in lower for phrase in PHRASE_KEYWORDS)
+
+
+def get_diff_staged() -> str:
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--unified=0"],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def get_diff_base(base: str) -> str:
+    merge_base = subprocess.run(
+        ["git", "merge-base", base, "HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    base_ref = merge_base.stdout.strip()
+    if not base_ref:
+        print(f"Could not find merge base with {base}", file=sys.stderr)
+        sys.exit(2)
+
+    result = subprocess.run(
+        ["git", "diff", base_ref, "HEAD", "--unified=0"],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def get_diff_files(files: list[str]) -> str:
+    """Read files and pretend all test defs are new (for checking specific files)."""
+    lines = []
+    for path in files:
+        if not TEST_FILE_RE.match(path):
+            continue
+        lines.append(f"+++ b/{path}")
+        try:
+            with open(path) as f:
+                for line in f:
+                    stripped = line.rstrip()
+                    if re.match(r"\s*def test_\w+\(", stripped):
+                        lines.append(f"+{stripped}")
+        except FileNotFoundError:
+            print(f"File not found: {path}", file=sys.stderr)
+    return "\n".join(lines)
+
+
+def format_plain(violations, total):
+    lines = [
+        f"{len(violations)} of {total} new test name(s) missing"
+        " convention keywords (given/when/then/it_should):\n"
+    ]
+    for filepath, name in violations:
+        lines.append(f"  {filepath}: {name}")
+    lines.append(
+        "\nConsider rephrasing with given/when/then/it_should, e.g.:"
+        "\n  test_when_no_incidents_then_returns_empty_list"
+        "\n  test_it_should_create_incident_with_set_description"
+        "\n  test_given_expired_token_when_refreshing_then_raises_error"
+    )
+    return "\n".join(lines)
+
+
+def format_markdown(violations, total):
+    lines = [
+        "> [!WARNING]",
+        f"> **{len(violations)}** of **{total}** new test names are missing"
+        " convention keywords (`given`/`when`/`then`/`it_should`)",
+        "",
+        "| File | Test name |",
+        "|------|-----------|",
+    ]
+    for filepath, name in violations:
+        lines.append(f"| `{filepath}` | `{name}` |")
+    lines.extend(
+        [
+            "",
+            "<details>",
+            "<summary>Why am I seeing this?</summary>",
+            "",
+            "Test names should follow a loose **given/when/then** pattern with"
+            " keywords like `given`, `when`, `then`, or `it_should`."
+            " This is a suggestion, not a blocker."
+            " The check runs on new test methods added in this PR.",
+            "",
+            "Examples:",
+            "- `test_when_no_incidents_then_returns_empty_list`",
+            "- `test_it_should_create_incident_with_set_description`",
+            "- `test_given_expired_token_when_refreshing_then_raises_error`",
+            "</details>",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        help="Base branch to diff against (e.g. master)."
+        " If omitted, checks staged changes.",
+    )
+    parser.add_argument(
+        "--files",
+        nargs="+",
+        help="Check all test names in specific files (ignores git diff).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["plain", "markdown"],
+        default="plain",
+        dest="output_format",
+        help="Output format (default: plain).",
+    )
+    args = parser.parse_args()
+
+    if args.files:
+        diff = get_diff_files(args.files)
+    elif args.base:
+        diff = get_diff_base(args.base)
+    else:
+        diff = get_diff_staged()
+
+    new_tests = get_new_test_names_from_diff(diff)
+
+    if not new_tests:
+        return
+
+    violations = [(f, name) for f, name in new_tests if not check_name(name)]
+
+    if not violations:
+        print(f"All {len(new_tests)} new test name(s) follow the naming convention.")
+        return
+
+    formatter = format_markdown if args.output_format == "markdown" else format_plain
+    print(formatter(violations, len(new_tests)))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Scope and purpose

Ports the test name convention checker from Argus (Uninett/Argus#1814) to NAV. The code is essentially identical.

Adds tooling to enforce the `given`/`when`/`then`/`it_should` test naming convention:

1. **Claude hook** (`.claude/hooks/check-test-names.sh`). Gives immediate feedback when editing test files
2. **GitHub Action** (`.github/workflows/check-test-names.yml`). Posts/updates a PR comment listing violations (non-blocking)

Both use the same script (`checks/check_test_names.py`).

> [!NOTE]
> The second commit adds an intentionally bad test name to verify the GitHub workflow. Delete after verification.

## Contributor Checklist

* [ ] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.