### PR TITLE
Remove duplicates from location search

### DIFF
--- a/changelog.d/3914.fixed.md
+++ b/changelog.d/3914.fixed.md
@@ -1,0 +1,1 @@
+Remove duplicates from location search

--- a/python/nav/web/info/location/views.py
+++ b/python/nav/web/info/location/views.py
@@ -93,13 +93,17 @@ def process_searchform(form):
     if query is None:
         return Location.objects.all()
     else:
-        return Location.objects.filter(
-            Q(id__icontains=query)
-            | Q(aliases__icontains=query)
-            | Q(description__icontains=query)
-            | Q(child_locations__id__icontains=query)
-            | Q(child_locations__aliases__icontains=query)
-        ).order_by("id")
+        return (
+            Location.objects.filter(
+                Q(id__icontains=query)
+                | Q(aliases__icontains=query)
+                | Q(description__icontains=query)
+                | Q(child_locations__id__icontains=query)
+                | Q(child_locations__aliases__icontains=query)
+            )
+            .distinct()
+            .order_by("id")
+        )
 
 
 def locationinfo(request, locationid):

--- a/tests/integration/web/info/search_test.py
+++ b/tests/integration/web/info/search_test.py
@@ -269,6 +269,30 @@ class TestInfoSearchViews:
         assert response.status_code == 200
         assert parent_location.pk in response.content.decode('utf-8')
 
+    def test_when_location_has_multiple_matching_children_then_it_should_not_return_duplicates_in_location_search(  # noqa: E501
+        self, client, location_with_alias
+    ):
+        """
+        Turns out that the way child_locations are joined in the search for locations
+        if we have a locations with multiple child locations where both the id of the
+        parent and the ids of the children match the query without having a distinct()
+        added we get the same parent location returned multiple times
+        """
+        mylocation = Location.objects.get(id="mylocation")
+        mylocation.parent = location_with_alias
+        mylocation.save()
+
+        second_child = Location.objects.create(id='secondlocation')
+        second_child.parent = location_with_alias
+        second_child.save()
+
+        url = reverse('location-search') + '?query=location'
+        response = client.get(url)
+
+        assert response.status_code == 200
+        ids = response.context["locations"].values_list("id", flat=True)
+        assert len(ids) == len(set(ids))
+
 
 class TestIndexSearchPreviewView:
     """Tests for the search preview feature."""

--- a/tests/integration/web/info/search_test.py
+++ b/tests/integration/web/info/search_test.py
@@ -14,18 +14,6 @@ def test_search_for_ip_devices_should_not_crash(client):
     assert response.status_code == 200
 
 
-def test_search_for_rooms_should_not_crash(client):
-    url = reverse('room-search') + '?query=a'
-    response = client.get(url)
-    assert response.status_code == 200
-
-
-def test_search_for_locations_should_not_crash(client):
-    url = reverse('location-search') + '?query=a'
-    response = client.get(url)
-    assert response.status_code == 200
-
-
 def test_search_for_vlans_should_not_crash(client):
     url = reverse('vlan-index') + '?query=a'
     response = client.get(url)
@@ -229,7 +217,14 @@ class TestInfoSearchViews:
             'location-info', kwargs={'locationid': location_with_alias.pk}
         )
 
-    def test_given_alias_for_room_in_room_search_should_return_room(
+
+class TestRoomSearchView:
+    def test_given_standard_query_then_should_not_crash(self, client):
+        url = reverse('room-search') + '?query=a'
+        response = client.get(url)
+        assert response.status_code == 200
+
+    def test_given_alias_for_room_then_should_return_room(
         self, client, room_with_alias
     ):
         url = reverse('room-search') + f'?query={room_with_alias.aliases[0]}'
@@ -238,7 +233,7 @@ class TestInfoSearchViews:
         assert response.status_code == 200
         assert room_with_alias.pk in response.content.decode('utf-8')
 
-    def test_given_alias_for_location_in_room_search_should_return_room_in_location(
+    def test_given_alias_for_location_then_should_return_room_in_location(
         self, client, location_with_alias, room_with_alias
     ):
         url = reverse('room-search') + f'?query={location_with_alias.aliases[0]}'
@@ -247,7 +242,14 @@ class TestInfoSearchViews:
         assert response.status_code == 200
         assert room_with_alias.pk in response.content.decode('utf-8')
 
-    def test_given_alias_for_location_in_location_search_should_return_location(
+
+class TestLocationSearchView:
+    def test_given_standard_query_then_it_should_not_crash(self, client):
+        url = reverse('location-search') + '?query=a'
+        response = client.get(url)
+        assert response.status_code == 200
+
+    def test_given_alias_for_location_then_it_should_return_location(
         self, client, location_with_alias
     ):
         url = reverse('location-search') + f'?query={location_with_alias.aliases[0]}'
@@ -256,7 +258,7 @@ class TestInfoSearchViews:
         assert response.status_code == 200
         assert location_with_alias.pk in response.content.decode('utf-8')
 
-    def test_given_alias_for_location_in_location_search_should_return_parent_location(
+    def test_given_alias_for_location_then_it_should_return_parent_location(
         self, client, location_with_alias
     ):
         parent_location = Location.objects.create(id="parent_location")
@@ -269,7 +271,7 @@ class TestInfoSearchViews:
         assert response.status_code == 200
         assert parent_location.pk in response.content.decode('utf-8')
 
-    def test_when_location_has_multiple_matching_children_then_it_should_not_return_duplicates_in_location_search(  # noqa: E501
+    def test_when_location_has_multiple_matching_children_then_it_should_not_return_duplicates(  # noqa: E501
         self, client, location_with_alias
     ):
         """


### PR DESCRIPTION
## Scope and purpose

To replicate: Take a copy of the Sikt VK and go to `/search/room/?query=tr&submit=Search`

If a location has multiple child location and both the parent location id or alias and the child location id or alias are hit by the query, then the parent will be returned multiple times without the `distinct()`.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [X] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
    decided to base it again master since there are changes to that part of the code due to new alias feature, so to avoid merge conflicts this is easier
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [X] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
