### PR TITLE
Use `verbose_string` for rooms and locations in device history search

### DIFF
--- a/python/nav/web/devicehistory/utils/componentsearch.py
+++ b/python/nav/web/devicehistory/utils/componentsearch.py
@@ -134,6 +134,8 @@ def _get_option_label(component: Model):
     """
     if component._meta.db_table == 'netbox':
         return '%(sysname)s [%(ip)s - %(chassis_serial)s]' % component.__dict__
+    if component._meta.db_table in ('room', 'location'):
+        return component.verbose_string
     return str(component)
 
 


### PR DESCRIPTION
## Scope and purpose

One part of #3882. I think here it is good to have the aliases in addition, since you can also search for aliases and there is plenty of space, so it doesn't get too busy.

To see the change: `/devicehistory/` and search for a room/location with its alias. 

Screenshots:
Before:
<img width="384" height="119" alt="image" src="https://github.com/user-attachments/assets/64726abe-419b-4060-877e-fcef59ff0ea9" />

After:
<img width="384" height="119" alt="image" src="https://github.com/user-attachments/assets/2a0c448d-484e-437a-8a1d-a12d53c9f839" />

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [ ] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
  we have enough alias mentions in the changelog fragments already, this is just a polish
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [X] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [X] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
