### PR TITLE
Show matched alias in navbar search preview

### DIFF
--- a/changelog.d/3880.added.md
+++ b/changelog.d/3880.added.md
@@ -1,0 +1,1 @@
+Show matched alias in navbar search preview when a room or location is found via alias

--- a/python/nav/django/templatetags/info.py
+++ b/python/nav/django/templatetags/info.py
@@ -16,10 +16,13 @@
 #
 """Template tags used in info subsystem"""
 
+import re
 from datetime import datetime, timedelta
 import time
 
 from django import template
+from django.utils.html import escape
+from django.utils.safestring import mark_safe
 from django.utils.timesince import timesince
 
 register = template.Library()
@@ -180,6 +183,17 @@ def sortdict(dictionary, reverse=False):
 def is_list(value):
     """Returns True if the value is a list"""
     return isinstance(value, list)
+
+
+@register.filter
+def highlight(text, query):
+    """Wraps case-insensitive occurrences of query in <mark> tags"""
+    if not query:
+        return text
+    escaped_text = escape(text)
+    escaped_query = escape(query)
+    pattern = re.compile(re.escape(escaped_query), re.IGNORECASE)
+    return mark_safe(pattern.sub(lambda m: f"<mark>{m.group()}</mark>", escaped_text))
 
 
 @register.filter

--- a/python/nav/web/info/searchproviders.py
+++ b/python/nav/web/info/searchproviders.py
@@ -36,7 +36,9 @@ from nav.web.ipdevinfo.views import is_valid_hostname
 from nav.web.info.prefix.views import get_query_results as get_prefix_results
 
 
-SearchResult = namedtuple("SearchResult", ['href', 'inst'])
+SearchResult = namedtuple(
+    "SearchResult", ['href', 'inst', 'matched_aliases'], defaults=[None]
+)
 
 
 class SearchProvider(object):
@@ -87,7 +89,11 @@ class RoomSearchProvider(SearchProvider):
         results = Room.objects.aka_or_description(self.query).order_by("id")
         for result in results:
             self.results.append(
-                SearchResult(reverse('room-info', kwargs={'roomid': result.id}), result)
+                SearchResult(
+                    reverse('room-info', kwargs={'roomid': result.id}),
+                    result,
+                    _find_matching_aliases(result.aliases, self.query),
+                )
             )
 
 
@@ -103,7 +109,9 @@ class LocationSearchProvider(SearchProvider):
         for result in results:
             self.results.append(
                 SearchResult(
-                    reverse('location-info', kwargs={'locationid': result.id}), result
+                    reverse('location-info', kwargs={'locationid': result.id}),
+                    result,
+                    _find_matching_aliases(result.aliases, self.query),
                 )
             )
 
@@ -282,3 +290,9 @@ class DevicegroupSearchProvider(SearchProvider):
             .annotate(num_netboxes=Count('netboxes'))
         )
         self.results = [SearchResult(g.get_absolute_url(), g) for g in query_result]
+
+
+def _find_matching_aliases(aliases, query):
+    """Returns all aliases that contain the query (case-insensitive)."""
+    query_lower = query.lower()
+    return [alias for alias in aliases if query_lower in alias.lower()] or None

--- a/python/nav/web/templates/info/_navbar_search_results.html
+++ b/python/nav/web/templates/info/_navbar_search_results.html
@@ -1,3 +1,4 @@
+{% load info %}
 {% if show_results %}
     {% if not results %}
     <div class="alert-box secondary">No results for "{{ query }}"</div>
@@ -7,7 +8,12 @@
             <h5>{{ provider.name }} ({{ provider.count }})</h5>
             <div>
                 {% for item in provider.results %}
-                <a href="{{ item.href }}" class="result-item">{{ item.inst }}</a>
+                <a href="{{ item.href }}" class="result-item">
+                    {{ item.inst }}
+                    {% if item.matched_aliases %}
+                        aka {% for alias in item.matched_aliases %}"{{ alias|highlight:query }}"{% if not forloop.last %}, {% endif %}{% endfor %}
+                    {% endif %}
+                </a>
                 {% endfor %}
             </div>
             {% if provider.truncated %}

--- a/tests/unittests/django/templatetags/info_test.py
+++ b/tests/unittests/django/templatetags/info_test.py
@@ -7,6 +7,7 @@ from nav.django.templatetags.info import (
     is_max_timestamp,
     get_attr,
     find_attr,
+    highlight,
 )
 
 
@@ -90,3 +91,26 @@ class TemplateTagsTest(unittest.TestCase):
         """Test helper function for getting attributes from objects"""
 
         self.assertEqual(find_attr(self.dummy, ['dummyobjec', 'test', 'nothere']), "")
+
+
+class HighlightFilterTest(unittest.TestCase):
+    def test_when_query_matches_then_it_should_wrap_in_mark_tags(self):
+        assert str(highlight("Building A", "build")) == "<mark>Build</mark>ing A"
+
+    def test_when_match_is_case_insensitive_then_it_should_preserve_case(self):
+        assert str(highlight("FOOBAR", "foo")) == "<mark>FOO</mark>BAR"
+
+    def test_when_query_does_not_match_then_it_should_return_escaped_text(self):
+        assert str(highlight("Hello World", "xyz")) == "Hello World"
+
+    def test_when_text_contains_html_then_it_should_escape_it(self):
+        result = str(highlight("<script>alert(1)</script>", "alert"))
+        assert "&lt;script&gt;" in result
+        assert "<mark>alert</mark>" in result
+
+    def test_when_query_is_empty_then_it_should_return_text_unchanged(self):
+        assert highlight("Hello", "") == "Hello"
+
+    def test_when_query_has_multiple_matches_then_it_should_highlight_all(self):
+        result = str(highlight("foo bar foo", "foo"))
+        assert result == "<mark>foo</mark> bar <mark>foo</mark>"

--- a/tests/unittests/info/views_test.py
+++ b/tests/unittests/info/views_test.py
@@ -18,7 +18,11 @@
 
 import unittest
 
-from nav.web.info.searchproviders import SearchResult, SearchProvider
+from nav.web.info.searchproviders import (
+    SearchResult,
+    SearchProvider,
+    _find_matching_aliases,
+)
 from nav.web.info.views import has_results, has_only_one_result
 from nav.web.info.forms import SearchForm
 
@@ -72,3 +76,23 @@ class ViewsTest(unittest.TestCase):
         form = SearchForm({'query': 'Test '})
         form.is_valid()
         self.assertEqual(form.cleaned_data['query'], 'Test')
+
+
+class TestFindMatchingAliases:
+    def test_when_alias_matches_query_then_it_should_return_alias(self):
+        assert _find_matching_aliases(["Building A", "Bygg A"], "bygg") == ["Bygg A"]
+
+    def test_when_no_alias_matches_then_it_should_return_none(self):
+        assert _find_matching_aliases(["Building A"], "xyz") is None
+
+    def test_when_aliases_is_empty_then_it_should_return_none(self):
+        assert _find_matching_aliases([], "test") is None
+
+    def test_when_multiple_aliases_match_then_it_should_return_all(self):
+        assert _find_matching_aliases(["Alpha Foo", "Beta Foo"], "foo") == [
+            "Alpha Foo",
+            "Beta Foo",
+        ]
+
+    def test_when_query_matches_case_insensitively_then_it_should_return_alias(self):
+        assert _find_matching_aliases(["ROOM-101"], "room") == ["ROOM-101"]


### PR DESCRIPTION
## Scope and purpose

Fixes #3880.

When rooms/locations are found via alias search, the matched alias is now displayed (highlighted) in the navbar search preview, so users can see *why* a result appeared.

### This pull request
* adds a `highlight` template filter for wrapping query matches in `<mark>` tags
* extends `SearchResult` to carry an optional matched alias
* displays the matched alias in navbar search results

## Screenshots

| Location | Room |
| ---- | ---- |
| <img width="416" height="193" alt="image" src="https://github.com/user-attachments/assets/8989ebfd-df3d-472b-9466-879bda3b8218" /> | <img width="421" height="219" alt="image" src="https://github.com/user-attachments/assets/41e0099c-62e6-4fa5-867c-930171314800" /> |


## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file