### PR TITLE
Use room/location `verbose_string` in netmap node info

### DIFF
--- a/python/nav/netmap/metadata.py
+++ b/python/nav/netmap/metadata.py
@@ -105,7 +105,7 @@ class Node(object):
             try:
                 location = self.node.room.location
                 locationid = location.id
-                location_descr = location.description
+                location_descr = location.verbose_string
             except AttributeError:
                 locationid = ''
                 location_descr = ''
@@ -122,8 +122,8 @@ class Node(object):
                     'up_image': get_status_image_link(self.node.up),
                     'roomid': self.node.room.id,
                     'locationid': str(locationid),
-                    'location': str(location_descr),
-                    'room': str(self.node.room),
+                    'location': location_descr,
+                    'room': self.node.room.verbose_string,
                     'is_elink_node': False,
                 }
             )

--- a/tests/unittests/netmap/metadata_json_test.py
+++ b/tests/unittests/netmap/metadata_json_test.py
@@ -143,7 +143,7 @@ class SharedJsonMetadataTests:
     def test_json_location_is_included_in_metadata_from_node(self):
         foo = metadata.Node(self.a, self.nx_edge_metadata).to_json()['2']
         self.assertTrue('location' in foo)
-        self.assertEqual('In a galaxy far far away', foo['location'])
+        self.assertEqual('galaxy: In a galaxy far far away', foo['location'])
 
     def test_json_room_is_included_in_metadata_from_node(self):
         foo = metadata.Node(self.a, self.nx_edge_metadata).to_json()['2']


### PR DESCRIPTION
## Scope and purpose

Part of #3882.

To see: You might have to remove the `cache_topology` decorator from `https://github.com/Uninett/nav/blob/29828101539f23ef09cd8401a76a320fc030a66d/python/nav/web/netmap/graph.py#L56` to see the changes. 
Go to `/netmap/` and click on a node, see that the room and location are using the verbose description. 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [ ] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [X] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
