### PR TITLE
Downgrade missing alert subject log to debug

### DIFF
--- a/changelog.d/3927.changed.md
+++ b/changelog.d/3927.changed.md
@@ -1,0 +1,1 @@
+Downgraded spammy WARNING log about alerts referencing deleted objects to DEBUG level.

--- a/python/nav/models/event.py
+++ b/python/nav/models/event.py
@@ -269,10 +269,16 @@ class EventMixIn(object):
                 try:
                     return model.objects.get(pk=subid)
                 except model.DoesNotExist:
-                    _logger.warning(
-                        "alert subid %s points to non-existant %s",
+                    timestamp = getattr(self, "start_time", None) or getattr(
+                        self, "time", None
+                    )
+                    _logger.debug(
+                        "alert %r subid %s points to non-existent %s,"
+                        " maybe it was deleted after %s",
+                        self,
                         subid,
                         model,
+                        timestamp,
                     )
                     return UnknownEventSubject(self)
 


### PR DESCRIPTION
## Scope and purpose

When an alert's subject ID references a deleted database object (e.g. an interface removed during device re-discovery), `EventMixIn.get_subject()` logged a WARNING on every status widget reload. This is spammy and looks alarming to end users monitoring logs, but it's actually a normal operational state — the alert is just outdated and should be closed by an operator. Downgraded to DEBUG and added more context to the message.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] ~~Added/amended tests for new/changed code~~
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~