### PR TITLE
Fix test name hook to only check diff, not entire file

### DIFF
--- a/.claude/hooks/check-test-names.sh
+++ b/.claude/hooks/check-test-names.sh
@@ -21,7 +21,16 @@ fi
 # Make file_path relative to project root for the checker
 REL_PATH="${FILE_PATH#"$PROJECT_DIR"/}"
 
-output=$(python3 "$CHECKER" --files "$REL_PATH" 2>&1)
+# For untracked (new) files, check the entire file; for tracked files, only check the diff
+if ! git -C "$PROJECT_DIR" ls-files --error-unmatch "$REL_PATH" >/dev/null 2>&1; then
+  output=$(python3 "$CHECKER" --files "$REL_PATH" 2>&1)
+else
+  DIFF=$(git -C "$PROJECT_DIR" diff HEAD --unified=0 -- "$REL_PATH")
+  if [[ -z "$DIFF" ]]; then
+    exit 0
+  fi
+  output=$(echo "$DIFF" | python3 "$CHECKER" --stdin 2>&1)
+fi
 exit_code=$?
 
 if [[ $exit_code -ne 0 ]]; then

--- a/checks/check_test_names.py
+++ b/checks/check_test_names.py
@@ -167,6 +167,11 @@ def main():
         help="Check all test names in specific files (ignores git diff).",
     )
     parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read unified diff from stdin.",
+    )
+    parser.add_argument(
         "--format",
         choices=["plain", "markdown"],
         default="plain",
@@ -175,7 +180,9 @@ def main():
     )
     args = parser.parse_args()
 
-    if args.files:
+    if args.stdin:
+        diff = sys.stdin.read()
+    elif args.files:
         diff = get_diff_files(args.files)
     elif args.base:
         diff = get_diff_base(args.base)


### PR DESCRIPTION
## Scope and purpose

The Claude hook for test name checking (`check-test-names.sh`) was using `--files` which scans the entire file and flags all non-conforming test names, including pre-existing ones that weren't touched. This changes it to pipe `git diff HEAD` through a new `--stdin` flag, so only newly added/modified test names are checked. For untracked (new) files, it falls back to `--files` since there's no git history to diff against.

## Contributor Checklist

* [ ] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file