### PR TITLE
Validate that management profile names do not contain pipe character 

### DIFF
--- a/changelog.d/3946.added.md
+++ b/changelog.d/3946.added.md
@@ -1,0 +1,1 @@
+Validate that management profile names do not contain the pipe character

--- a/python/nav/bulkimport.py
+++ b/python/nav/bulkimport.py
@@ -20,7 +20,7 @@ import json
 
 from django.core.exceptions import ValidationError
 
-from nav.django.forms import validate_aliases
+from nav.django.validators import validate_aliases
 from nav.models.fields import PointField
 from nav.models.manage import Netbox, Room, Organization
 from nav.models.manage import Category, NetboxInfo, NetboxGroup

--- a/python/nav/django/forms.py
+++ b/python/nav/django/forms.py
@@ -19,13 +19,10 @@
 import json
 
 from django import forms
-from django.core.exceptions import ValidationError
 from django.forms import Field, Textarea
 
 from nav.util import is_valid_cidr
 from nav.django import validators, widgets
-
-MAX_ALIAS_LENGTH = 64
 
 
 class CIDRField(forms.CharField):
@@ -76,31 +73,6 @@ class HStoreField(Field):
         return validators.validate_hstore(value)
 
 
-def validate_aliases(aliases: list[str]) -> list[str]:
-    """
-    Validates a given list of aliases and raises a ValidationError if any of the
-    aliases contain the pipe character or are too long
-
-    Returns a deduplicated and stripped version of the given list
-    """
-    if not aliases:
-        return []
-    cleaned = []
-    for item in aliases:
-        if not isinstance(item, str):
-            raise ValidationError("All aliases must be strings.")
-        stripped = item.strip()
-        if "|" in stripped:
-            raise ValidationError("Aliases cannot contain the pipe character ('|')")
-        if len(stripped) > MAX_ALIAS_LENGTH:
-            raise ValidationError(
-                f"Alias must be {MAX_ALIAS_LENGTH} characters or fewer."
-            )
-        if stripped and stripped not in cleaned:
-            cleaned.append(stripped)
-    return cleaned
-
-
 class AliasListWidget(forms.Widget):
     """Widget that renders a dynamic list of alias text inputs"""
 
@@ -136,7 +108,7 @@ class AliasListField(forms.Field):
         return value or []
 
     def clean(self, value):
-        return validate_aliases(value)
+        return validators.validate_aliases(value)
 
 
 def _parse_json_list(value):

--- a/python/nav/django/validators.py
+++ b/python/nav/django/validators.py
@@ -22,6 +22,8 @@ from decimal import Decimal, InvalidOperation
 from django.utils.translation import gettext
 from django.core.exceptions import ValidationError
 
+MAX_ALIAS_LENGTH = 64
+
 
 def is_valid_point_string(point_string):
     if len(point_string.split(',')) == 2:
@@ -74,3 +76,28 @@ def validate_hstore(value):
     dictionary = json.loads(value)
 
     return dictionary
+
+
+def validate_aliases(aliases: list[str]) -> list[str]:
+    """
+    Validates a given list of aliases and raises a ValidationError if any of the
+    aliases contain the pipe character or are too long
+
+    Returns a deduplicated and stripped version of the given list
+    """
+    if not aliases:
+        return []
+    cleaned = []
+    for item in aliases:
+        if not isinstance(item, str):
+            raise ValidationError("All aliases must be strings.")
+        stripped = item.strip()
+        if "|" in stripped:
+            raise ValidationError("Aliases cannot contain the pipe character ('|')")
+        if len(stripped) > MAX_ALIAS_LENGTH:
+            raise ValidationError(
+                f"Alias must be {MAX_ALIAS_LENGTH} characters or fewer."
+            )
+        if stripped and stripped not in cleaned:
+            cleaned.append(stripped)
+    return cleaned

--- a/python/nav/django/validators.py
+++ b/python/nav/django/validators.py
@@ -78,6 +78,12 @@ def validate_hstore(value):
     return dictionary
 
 
+def validate_no_pipe(value: str) -> str:
+    """Validates that a string value does not contain the pipe character"""
+    if "|" in value:
+        raise ValidationError("Cannot contain the pipe character ('|')")
+
+
 def validate_aliases(aliases: list[str]) -> list[str]:
     """
     Validates a given list of aliases and raises a ValidationError if any of the
@@ -92,8 +98,7 @@ def validate_aliases(aliases: list[str]) -> list[str]:
         if not isinstance(item, str):
             raise ValidationError("All aliases must be strings.")
         stripped = item.strip()
-        if "|" in stripped:
-            raise ValidationError("Aliases cannot contain the pipe character ('|')")
+        validate_no_pipe(stripped)
         if len(stripped) > MAX_ALIAS_LENGTH:
             raise ValidationError(
                 f"Alias must be {MAX_ALIAS_LENGTH} characters or fewer."

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -40,6 +40,7 @@ from django.urls import reverse
 
 from nav import util
 from nav.bitvector import BitVector
+from nav.django.validators import validate_no_pipe
 from nav.metrics.data import get_netboxes_availability
 from nav.metrics.graphs import get_simple_graph_url, Graph
 from nav.metrics.names import get_all_leaves_below
@@ -125,7 +126,7 @@ class ManagementProfile(models.Model):
     """
 
     id = models.AutoField(db_column='management_profileid', primary_key=True)
-    name = VarcharField(unique=True)
+    name = VarcharField(unique=True, validators=[validate_no_pipe])
     description = VarcharField(blank=True, null=True)
 
     PROTOCOL_DEBUG = 0

--- a/python/nav/web/api/v1/serializers.py
+++ b/python/nav/web/api/v1/serializers.py
@@ -21,7 +21,7 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from nav.django.forms import validate_aliases
+from nav.django.validators import validate_aliases
 from nav.web.api.v1.fields import DisplayNameWritableField
 from nav.models import manage, cabling, rack, profiles
 from nav.web.seeddb.page.netbox.edit import get_sysname

--- a/tests/integration/api_test.py
+++ b/tests/integration/api_test.py
@@ -6,7 +6,7 @@ import json
 import pytest
 from django.urls import reverse
 
-from nav.django.forms import MAX_ALIAS_LENGTH
+from nav.django.validators import MAX_ALIAS_LENGTH
 from nav.models.event import AlertHistory
 from nav.models.fields import INFINITY
 from nav.web.api.v1.views import get_endpoints

--- a/tests/integration/bulkimport_test.py
+++ b/tests/integration/bulkimport_test.py
@@ -2,7 +2,7 @@
 
 from unittest import TestCase
 
-from nav.django.forms import MAX_ALIAS_LENGTH
+from nav.django.validators import MAX_ALIAS_LENGTH
 from nav.models import manage
 from nav.tests.cases import DjangoTransactionTestCase
 from nav import bulkimport, bulkparse

--- a/tests/integration/seeddb_test.py
+++ b/tests/integration/seeddb_test.py
@@ -91,6 +91,22 @@ def test_adding_netbox_with_invalid_profiles_should_fail(db, client):
     assert not Netbox.objects.filter(ip=ip).exists()
 
 
+def test_when_adding_management_profile_with_pipe_in_name_then_it_should_fail(
+    db, client
+):
+    url = reverse('seeddb-management-profile-edit')
+    name = "namewith|pipe"
+
+    response = client.post(
+        url,
+        follow=True,
+        data={"name": name},
+    )
+
+    assert response.status_code == 200
+    assert 'Cannot contain the pipe character' in smart_str(response.content)
+
+
 @pytest.fixture()
 def netbox(management_profile):
     box = Netbox(

--- a/tests/unittests/django/aliases_field_test.py
+++ b/tests/unittests/django/aliases_field_test.py
@@ -4,12 +4,8 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.http import QueryDict
 
-from nav.django.forms import (
-    MAX_ALIAS_LENGTH,
-    AliasListField,
-    AliasListWidget,
-    validate_aliases,
-)
+from nav.django.forms import AliasListField, AliasListWidget
+from nav.django.validators import MAX_ALIAS_LENGTH, validate_aliases
 
 
 class TestAliasListFieldClean:

--- a/tests/unittests/django/validators_test.py
+++ b/tests/unittests/django/validators_test.py
@@ -2,6 +2,7 @@ import pytest
 from nav.django.validators import (
     is_valid_point_string,
     validate_hstore,
+    validate_no_pipe,
     ValidationError,
 )
 
@@ -54,3 +55,15 @@ class TestValidHStoreField(object):
         input = '{"a": "b"}'
         result = validate_hstore(input)
         assert result == {'a': 'b'}
+
+
+class TestValidateNoPipe:
+    def test_given_string_without_pipe_charactor_then_do_nothing(self):
+        input = "stringwithoutpipecharacter123"
+        result = validate_no_pipe(input)
+        assert result is None
+
+    def test_given_string_with_pipe_character_then_raise_validation_error(self):
+        input = "stringwith|pipe"
+        with pytest.raises(ValidationError):
+            validate_no_pipe(input)

--- a/tests/unittests/django/validators_test.py
+++ b/tests/unittests/django/validators_test.py
@@ -58,7 +58,7 @@ class TestValidHStoreField(object):
 
 
 class TestValidateNoPipe:
-    def test_given_string_without_pipe_charactor_then_do_nothing(self):
+    def test_given_string_without_pipe_character_then_do_nothing(self):
         input = "stringwithoutpipecharacter123"
         result = validate_no_pipe(input)
         assert result is None


### PR DESCRIPTION
## Scope and purpose

Something I noticed when working on #3843 - management profile names of a netbox are separated when using `navdump` using the pipe character `|`, but it is possible to create management profiles with a name containing that character, which would break the bulk import of a netbox with that management profile.

Question: Should I add a migration that removes the pipe character for existing management profiles?

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
