### PR TITLE
Validate that management profile configuration does not contain pipe character

### DIFF
--- a/changelog.d/3948.added.md
+++ b/changelog.d/3948.added.md
@@ -1,0 +1,1 @@
+Validate that management profile configuration does not contain the pipe character

--- a/python/nav/web/seeddb/page/management_profile/forms.py
+++ b/python/nav/web/seeddb/page/management_profile/forms.py
@@ -15,6 +15,7 @@
 #
 from django import forms
 
+from nav.django.validators import validate_no_pipe
 from nav.models.manage import ManagementProfile
 from nav.web.seeddb.forms import get_single_layout
 
@@ -75,6 +76,7 @@ class HttpApiForm(ProtocolSpecificMixIn, forms.ModelForm):
         label="API key",
         help_text="Key/token to authenticate to the service",
         required=True,
+        validators=[validate_no_pipe],
     )
 
     service = forms.ChoiceField(
@@ -93,7 +95,7 @@ class DebugForm(ProtocolSpecificMixIn, forms.ModelForm):
         configuration_fields = ['foo']
         fields = []
 
-    foo = forms.CharField(required=True)
+    foo = forms.CharField(required=True, validators=[validate_no_pipe])
 
 
 class SnmpForm(ProtocolSpecificMixIn, forms.ModelForm):
@@ -111,7 +113,7 @@ class SnmpForm(ProtocolSpecificMixIn, forms.ModelForm):
             (1, '1'),
         )
     )
-    community = forms.CharField(required=True)
+    community = forms.CharField(required=True, validators=[validate_no_pipe])
     write = forms.BooleanField(
         required=False,
         help_text="Check if this community string enables write access",
@@ -164,6 +166,7 @@ class SnmpV3Form(ProtocolSpecificMixIn, forms.ModelForm):
             "The username to authenticate as.  This is required even if noAuthPriv "
             "security mode is selected."
         ),
+        validators=[validate_no_pipe],
     )
     auth_password = forms.CharField(
         widget=forms.PasswordInput(render_value=True, attrs={"autocomplete": "off"}),
@@ -173,6 +176,7 @@ class SnmpV3Form(ProtocolSpecificMixIn, forms.ModelForm):
             "authPriv security levels."
         ),
         required=False,
+        validators=[validate_no_pipe],
     )
     priv_protocol = forms.ChoiceField(
         label="Privacy protocol",
@@ -191,6 +195,7 @@ class SnmpV3Form(ProtocolSpecificMixIn, forms.ModelForm):
             "security level."
         ),
         required=False,
+        validators=[validate_no_pipe],
     )
     write = forms.BooleanField(
         initial=False,
@@ -240,16 +245,22 @@ class NapalmForm(ProtocolSpecificMixIn, forms.ModelForm):
         initial="JunOS",
         help_text="Which NAPALM driver to use",
     )
-    username = forms.CharField(required=True, help_text="User name to use for login")
+    username = forms.CharField(
+        required=True,
+        help_text="User name to use for login",
+        validators=[validate_no_pipe],
+    )
     password = forms.CharField(
         required=False,
         widget=forms.PasswordInput(render_value=True),
         help_text="Password to use for login",
+        validators=[validate_no_pipe],
     )
     private_key = forms.CharField(
         required=False,
         widget=forms.Textarea(),
         help_text="SSH private key to use for login",
+        validators=[validate_no_pipe],
     )
     use_keys = forms.BooleanField(
         required=False, help_text="Check to try the available keys in ~/.ssh/"

--- a/tests/integration/seeddb_test.py
+++ b/tests/integration/seeddb_test.py
@@ -7,7 +7,7 @@ from django.test.client import RequestFactory
 from mock import MagicMock
 
 from django.utils.encoding import smart_str
-from nav.models.manage import Interface, Netbox, NetboxInfo, Room
+from nav.models.manage import Interface, ManagementProfile, Netbox, NetboxInfo, Room
 from nav.models.cabling import Cabling, Patch
 from nav.web.auth.utils import set_account
 from nav.web.seeddb.page.netbox.edit import netbox_edit, log_netbox_change
@@ -101,6 +101,89 @@ def test_when_adding_management_profile_with_pipe_in_name_then_it_should_fail(
         url,
         follow=True,
         data={"name": name},
+    )
+
+    assert response.status_code == 200
+    assert 'Cannot contain the pipe character' in smart_str(response.content)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {
+            "name": "test",
+            "protocol": str(ManagementProfile.PROTOCOL_HTTP_API),
+            "api_key": "keywith|pipe",
+            "service": "Palo Alto ARP",
+        },
+        {
+            "name": "test",
+            "protocol": str(ManagementProfile.PROTOCOL_DEBUG),
+            "foo": "bar|pipe",
+        },
+        {
+            "name": "test",
+            "protocol": str(ManagementProfile.PROTOCOL_SNMP),
+            "version": "2",
+            "community": "communitywith|pipe",
+        },
+        {
+            "name": "test",
+            "protocol": str(ManagementProfile.PROTOCOL_SNMPV3),
+            "sec_level": "noAuthNoPriv",
+            "auth_protocol": "MD5",
+            "sec_name": "name|pipe",
+        },
+        {
+            "name": "test",
+            "protocol": str(ManagementProfile.PROTOCOL_SNMPV3),
+            "sec_level": "authNoPriv",
+            "auth_protocol": "MD5",
+            "sec_name": "namewithoutpipe",
+            "auth_password": "password|pipe",
+        },
+        {
+            "name": "test",
+            "protocol": str(ManagementProfile.PROTOCOL_SNMPV3),
+            "sec_level": "authPriv",
+            "auth_protocol": "MD5",
+            "sec_name": "namenopipe",
+            "auth_password": "passwordnopipe",
+            "priv_protocol": "DES",
+            "priv_password": "password|pipe",
+        },
+        {
+            "name": "test",
+            "protocol": str(ManagementProfile.PROTOCOL_NAPALM),
+            "driver": "JunOS",
+            "username": "username|pipe",
+        },
+        {
+            "name": "test",
+            "protocol": str(ManagementProfile.PROTOCOL_NAPALM),
+            "driver": "JunOS",
+            "username": "usernamenopipe",
+            "password": "password|pipe",
+        },
+        {
+            "name": "test",
+            "protocol": str(ManagementProfile.PROTOCOL_NAPALM),
+            "driver": "JunOS",
+            "username": "usernamenopipe",
+            "password": "passwordnopipe",
+            "private_key": "key|pipe",
+        },
+    ],
+)
+def test_when_adding_management_profile_with_pipe_in_attributes_then_it_should_fail(
+    db, client, data
+):
+    url = reverse('seeddb-management-profile-edit')
+
+    response = client.post(
+        url,
+        follow=True,
+        data=data,
     )
 
     assert response.status_code == 200


### PR DESCRIPTION
## Scope and purpose

Dependent on #3946.

Something I noticed when working on #3843 - management profile attributes (configuration) are separated when using navdump using the pipe character |, but it is possible to create management profiles with attributes containing that character, which would break the bulk import of that management profile.

Question: Should I add a migration that removes the pipe character from configuration for existing management profiles?

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [X] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
