### PR TITLE
Add validation for no pipe  in netbox data

### DIFF
--- a/changelog.d/3949.added.md
+++ b/changelog.d/3949.added.md
@@ -1,0 +1,1 @@
+Validate that IP device attributes do not contain the pipe character

--- a/python/nav/django/validators.py
+++ b/python/nav/django/validators.py
@@ -78,6 +78,16 @@ def validate_hstore(value):
     return dictionary
 
 
+def validate_hstore_no_pipe(value):
+    """
+    Validates that a hstore field does not have any keys or value containing the pipe
+    character
+    """
+    for k, v in value.items():
+        if "|" in k or "|" in v:
+            raise ValidationError("Cannot contain the pipe character ('|')")
+
+
 def validate_no_pipe(value: str) -> str:
     """Validates that a string value does not contain the pipe character"""
     if "|" in value:

--- a/python/nav/web/seeddb/page/netbox/forms.py
+++ b/python/nav/web/seeddb/page/netbox/forms.py
@@ -23,6 +23,7 @@ from django.db.models import Q
 from django.urls import reverse
 
 from nav.django.forms import HStoreField
+from nav.django.validators import validate_hstore_no_pipe
 from nav.web.crispyforms import (
     FlatFieldset,
     FormColumn,
@@ -73,7 +74,9 @@ class NetboxModelForm(forms.ModelForm):
 
     ip = forms.CharField()
     function = forms.CharField(required=False)
-    data = HStoreField(label='Attributes', required=False)
+    data = HStoreField(
+        label='Attributes', required=False, validators=[validate_hstore_no_pipe]
+    )
     sysname = forms.CharField(required=False)
     virtual_instance = MyModelMultipleChoiceField(
         queryset=Netbox.objects.none(),

--- a/tests/integration/seeddb_test.py
+++ b/tests/integration/seeddb_test.py
@@ -91,6 +91,34 @@ def test_adding_netbox_with_invalid_profiles_should_fail(db, client):
     assert not Netbox.objects.filter(ip=ip).exists()
 
 
+@pytest.mark.parametrize(
+    "data",
+    [
+        {
+            'ip': '10.254.254.253',
+            'room': 'myroom',
+            'category': 'GW',
+            'organization': 'myorg',
+            'data': ['{"a|b":"c|d"}'],
+        },
+    ],
+)
+def test_when_adding_netbox_with_pipe_in_attributes_then_it_should_fail(
+    db, client, data
+):
+    url = reverse('seeddb-netbox-edit')
+
+    response = client.post(
+        url,
+        follow=True,
+        data=data,
+    )
+
+    assert response.status_code == 200
+    assert 'Cannot contain the pipe character' in smart_str(response.content)
+    assert not Netbox.objects.filter(ip=data["ip"]).exists()
+
+
 def test_when_adding_management_profile_with_pipe_in_name_then_it_should_fail(
     db, client
 ):


### PR DESCRIPTION
## Scope and purpose

Dependent on #3946.

Something I noticed when working on #3843 - netbox attributes (data) are separated when using navdump using the pipe character `|`, but it is possible to create netboxes with attributes containing that character, which would break the bulk import of that netbox.

Note: `validate_hstore` is run first, since it is called by `HStoreField`'s `to_python` method, which is called before the validators set for the field (ref: https://docs.djangoproject.com/en/6.0/ref/forms/validation/#form-and-field-validation)

Question: Should I add a migration that removes the pipe character from data for existing netboxes?

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [X] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
