### PR TITLE
Fix login redirect by using `next` instead of `origin`

### DIFF
--- a/changelog.d/3954.fixed.md
+++ b/changelog.d/3954.fixed.md
@@ -1,0 +1,1 @@
+Fixed post-login redirect not returning users to the page they originally requested

--- a/python/nav/web/auth/__init__.py
+++ b/python/nav/web/auth/__init__.py
@@ -45,7 +45,7 @@ def get_login_url(request: HttpRequest, path=None) -> str:
     if path == "/":
         default_new_url = LOGIN_URL
     else:
-        default_new_url = '{0}?origin={1}&noaccess'.format(LOGIN_URL, path)
+        default_new_url = '{0}?next={1}&noaccess'.format(LOGIN_URL, path)
     remote_loginurl = remote_user.CONFIG.get_loginurl(request)
     return remote_loginurl if remote_loginurl else default_new_url
 

--- a/python/nav/web/templates/account/login.html
+++ b/python/nav/web/templates/account/login.html
@@ -7,7 +7,7 @@
             You need to log in to access this resource
         </div>
     {% endif %}
-    {% with redirect_url=request.GET.origin|default:redirect_field_value %}
+    {% with redirect_url=redirect_field_value %}
     {% if redirect_url %}
         <div class="alert-box secondary origin">
             After successfully logging in, you will be redirected to:<br/>

--- a/tests/integration/web/auth/login_redirect_test.py
+++ b/tests/integration/web/auth/login_redirect_test.py
@@ -1,0 +1,54 @@
+#
+# Copyright (C) 2026 Uninett AS
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License version 3 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+from urllib.parse import urlparse, parse_qs
+
+from django.test import Client
+from django.urls import reverse
+
+
+class TestLoginRedirect:
+    def test_when_unauthenticated_user_accesses_protected_page_then_login_should_redirect_back(  # noqa: E501
+        self, db, admin_username, admin_password
+    ):
+        client = Client()
+        protected_url = '/ipdevinfo/'
+
+        # Unauthenticated request to a protected page should redirect to login
+        response = client.get(protected_url)
+        assert response.status_code == 302
+        redirect_url = response['Location']
+
+        parsed = urlparse(redirect_url)
+        query = parse_qs(parsed.query)
+
+        # The redirect should use 'next', not 'origin'
+        assert 'next' in query, f"Expected 'next' in query params, got: {parsed.query}"
+        assert 'origin' not in query
+        assert query['next'][0] == protected_url
+
+        # Log in via the redirect URL
+        login_url = reverse('account_login')
+        response = client.post(
+            login_url,
+            {
+                'login': admin_username,
+                'password': admin_password,
+                'next': query['next'][0],
+            },
+        )
+        # allauth redirects to the 'next' URL after successful login
+        assert response.status_code == 302
+        assert response['Location'] == protected_url

--- a/tests/unittests/general/webfront_test.py
+++ b/tests/unittests/general/webfront_test.py
@@ -28,6 +28,13 @@ class TestGetStandardUrls(object):
         result = auth.get_login_url(request)
         assert result.startswith(raw_login_url)
 
+    def test_when_path_is_not_root_then_get_login_url_should_use_next_parameter(self):
+        r = RequestFactory()
+        request = r.get('/ipdevinfo/')
+        result = auth.get_login_url(request)
+        assert 'next=' in result
+        assert 'origin=' not in result
+
     def test_get_remote_login_url(self):
         r = RequestFactory()
         request = r.get('/')


### PR DESCRIPTION
## Scope and purpose

Fixes #3954.

The authorization middleware was appending `?origin=` to the login URL, but django-allauth expects `?next=`. This caused users to land on `/` after login instead of the page they originally requested.

The fix changes the query parameter in `get_login_url()` from `origin` to `next`, and removes a now-unnecessary workaround in the login template that manually read `origin` from the GET params.

### How to verify

1. Visit any protected page (e.g. `/ipdevinfo/`) while logged out
2. Observe the redirect goes to `/accounts/login/?next=/ipdevinfo/&noaccess`
3. Log in — you should be returned to `/ipdevinfo/`, not `/`

## Contributor Checklist

- [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
- [x] Added/amended tests for new/changed code
- [ ] ~~Added/changed documentation~~
- [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
- [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
- [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
- [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
- [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
- [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
- [x] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file