### PR TITLE
Guard MessageForm queryset against unsaved instance

### DIFF
--- a/changelog.d/3959.fixed.md
+++ b/changelog.d/3959.fixed.md
@@ -1,0 +1,1 @@
+Fix crash on `/messages/create/` when used with Django 5.0+.

--- a/python/nav/web/messages/forms.py
+++ b/python/nav/web/messages/forms.py
@@ -46,9 +46,10 @@ class MessageForm(ModelForm):
 
         # Since the m2m uses through, we need to fetch initial data manually
         initials = []
-        tasks = MessageToMaintenanceTask.objects.filter(message=self.instance)
-        for task in tasks.all():
-            initials.append(task.maintenance_task.pk)
+        if self.instance.pk:
+            tasks = MessageToMaintenanceTask.objects.filter(message=self.instance)
+            for task in tasks.all():
+                initials.append(task.maintenance_task.pk)
         self.initial['maintenance_tasks'] = initials
 
         # Classes for javascript plugin

--- a/tests/integration/web/messages_test.py
+++ b/tests/integration/web/messages_test.py
@@ -1,0 +1,55 @@
+"""Integration tests for the messages form"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from nav.models.msgmaint import (
+    MaintenanceTask,
+    Message,
+    MessageToMaintenanceTask,
+)
+from nav.web.messages.forms import MessageForm
+
+
+class TestMessageForm:
+    def test_when_instance_is_unsaved_then_it_should_not_raise(self, db):
+        form = MessageForm(instance=Message())
+        assert form.initial['maintenance_tasks'] == []
+
+    def test_when_instance_is_saved_then_it_should_fetch_maintenance_tasks(
+        self, message, maintenance_task
+    ):
+        MessageToMaintenanceTask(
+            message=message, maintenance_task=maintenance_task
+        ).save()
+
+        form = MessageForm(instance=message)
+        assert form.initial['maintenance_tasks'] == [maintenance_task.pk]
+
+
+@pytest.fixture
+def message(db):
+    message = Message(
+        title="Test message",
+        description="A test message",
+        publish_start=datetime.now(),
+        publish_end=datetime.now() + timedelta(days=7),
+        author="testuser",
+        last_changed=datetime.now(),
+    )
+    message.save()
+    return message
+
+
+@pytest.fixture
+def maintenance_task(db):
+    task = MaintenanceTask(
+        start_time=datetime.now(),
+        end_time=datetime.now() + timedelta(hours=1),
+        description="Test task",
+        author="testuser",
+        state=MaintenanceTask.STATE_SCHEDULED,
+    )
+    task.save()
+    return task


### PR DESCRIPTION
## Scope and purpose

Part of #3932.

Django 5.0 raises `ValueError` when passing unsaved model instances to queryset filters. `MessageForm.__init__` filters `MessageToMaintenanceTask` by `self.instance`, which is unsaved when creating a new message. On Django 4.2 this silently returned empty results; on 5.0+ it crashes `/messages/create/`.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file