### PR TITLE
Exclude JavaScript test files from installed package

### DIFF
--- a/changelog.d/3916.changed.md
+++ b/changelog.d/3916.changed.md
@@ -1,0 +1,1 @@
+Exclude JavaScript test files from installed package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,9 @@ platforms = ["any"]
 [tool.setuptools.package-data]
 "nav.web" = ["static/**"]
 
+[tool.setuptools.exclude-package-data]
+"nav.web" = ["static/js/test/**"]
+
 [tool.setuptools_scm]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Scope and purpose

Fixes #3916.

JavaScript test files under `static/js/test/` are unnecessarily bundled into the installed NAV package. This adds an exclude rule in `pyproject.toml` to keep them out.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file