### PR TITLE
Migrate gauge and linear_gauge from D3 v3 to D3 v7

### DIFF
--- a/changelog.d/3907.changed.md
+++ b/changelog.d/3907.changed.md
@@ -1,0 +1,1 @@
+Migrate gauge and linear_gauge from D3 v3 to D3 v7.

--- a/python/nav/web/static/js/src/plugins/gauge.js
+++ b/python/nav/web/static/js/src/plugins/gauge.js
@@ -1,6 +1,6 @@
 define(function (require, exports, module) {
 
-    var d3 = require('d3');
+    var d3 = require('d3v7');
 
     /*
      Gauge implementation in D3. Heavily inspired by JustGage - http://justgage.com/
@@ -32,21 +32,21 @@ define(function (require, exports, module) {
         var vis = d3.select(node).append('svg')
             .attr("width", width)
             .attr("height", radius)
-            .append("svg:g")
+            .append("g")
             .attr("transform", "translate(" + radius + "," + radius + ")");
         this.vis = vis;
 
         /* Create linear scale for start and end points */
-        this.myScale = d3.scale.linear().domain([min, max]).range([-90 * (pi/180), 90 * (pi/180)]);
+        this.myScale = d3.scaleLinear().domain([min, max]).range([-90 * (pi/180), 90 * (pi/180)]);
 
         /* Create linear scale for color transitions */
         this.color = this.createColorScale(min, max, thresholds, invertScale);
 
-        this.fontSizeScale = d3.scale.linear().domain([50, 150]).range([14, 30]);
-        this.smallfontSizeScale = d3.scale.linear().domain([50, 150]).range([8, 20]);
+        this.fontSizeScale = d3.scaleLinear().domain([50, 150]).range([14, 30]);
+        this.smallfontSizeScale = d3.scaleLinear().domain([50, 150]).range([8, 20]);
 
         /* Define arc */
-        this.arc = d3.svg.arc().outerRadius(radius).innerRadius(ir).startAngle(this.myScale(min));
+        this.arc = d3.arc().outerRadius(radius).innerRadius(ir).startAngle(this.myScale(min));
 
         /* Create background arc with gradient */
         var gradientId = this.createGradient(node);
@@ -84,7 +84,7 @@ define(function (require, exports, module) {
     JohnGauge.prototype = {
         loadData: function (url) {
             var self = this;
-            d3.json(url, function (error, json) {
+            d3.json(url).then(function (json) {
                 var datapoints = json[0].datapoints,
                     value = datapoints[datapoints.length - 1][0] ||
                             datapoints[datapoints.length - 2][0];
@@ -219,7 +219,7 @@ define(function (require, exports, module) {
                 config.colors.reverse();
             }
 
-            var scale = d3.scale.linear()
+            var scale = d3.scaleLinear()
                           .domain(domain)
                           .interpolate(d3.interpolateRgb)
                           .range(config.colors);

--- a/python/nav/web/static/js/src/plugins/gauge.js
+++ b/python/nav/web/static/js/src/plugins/gauge.js
@@ -89,6 +89,8 @@ define(function (require, exports, module) {
                     value = datapoints[datapoints.length - 1][0] ||
                             datapoints[datapoints.length - 2][0];
                 self.refresh(value);
+            }).catch(function (error) {
+                console.error("Failed to load gauge data:", error);
             });
         },
         refresh: function (inputValue) {

--- a/python/nav/web/static/js/src/plugins/linear_gauge.js
+++ b/python/nav/web/static/js/src/plugins/linear_gauge.js
@@ -1,6 +1,6 @@
 define(function (require, exports, module) {
 
-    var d3 = require('d3');
+    var d3 = require('d3v7');
 
     /* Need a random id for the gradient */
     function guid() {
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
         var self = this;
 
         // Specify scaling for y-axis
-        this.y = d3.scale.linear().domain([0, this.max]).range([this.height, 0]);
+        this.y = d3.scaleLinear().domain([0, this.max]).range([this.height, 0]);
 
         // Set data to zero, add group element
         var group = this.container.selectAll('g'),
@@ -85,17 +85,17 @@ define(function (require, exports, module) {
         createGradient: function () {
             /* Create gradient to indicate severity of value */
             var gradient = this.container
-                .append("svg:defs").append("svg:linearGradient")
+                .append("defs").append("linearGradient")
                 .attr("id", this.gradientId).attr("x1", "100%").attr("y1", "100%")
                 .attr("x2", "100%").attr("y2", "0%").attr('gradientUnits', 'userSpaceOnUse');
-            gradient.append("svg:stop").attr("offset", "0%").attr("stop-color", "lightgreen");
-            gradient.append("svg:stop").attr("offset", "50%").attr("stop-color", "yellow");
-            gradient.append("svg:stop").attr("offset", "100%").attr("stop-color", "red");
+            gradient.append("stop").attr("offset", "0%").attr("stop-color", "lightgreen");
+            gradient.append("stop").attr("offset", "50%").attr("stop-color", "yellow");
+            gradient.append("stop").attr("offset", "100%").attr("stop-color", "red");
         },
         loadData: function() {
 
             var self = this;
-            d3.json(this.url, function (json, error) {
+            d3.json(this.url).then(function (json) {
                 var datapoints = json[0].datapoints,
                     value = datapoints[datapoints.length - 1][0] || datapoints[datapoints.length - 2][0];
 

--- a/python/nav/web/static/js/src/plugins/linear_gauge.js
+++ b/python/nav/web/static/js/src/plugins/linear_gauge.js
@@ -103,6 +103,8 @@ define(function (require, exports, module) {
                     value = new Number(value).toFixed(self.precision);
                 }
                 self.update(value);
+            }).catch(function (error) {
+                console.error("Failed to load linear gauge data:", error);
             });
     /*
              var value = Math.floor(Math.random() * (this.max + 1));


### PR DESCRIPTION
## Scope and purpose

Partial fix for #3907.

Migrates `gauge.js` and `linear_gauge.js` from D3 v3 to D3 v7, updating the deprecated API calls to their v7 equivalents. This removes two of the remaining non-rickshaw consumers of D3 v3.

The D3 v3 alias in `require_config.js` is intentionally kept, as rickshaw and `ipam/viz.js` still depend on it.

### How to verify

- Check that gauges render and animate on `/styleguide/` (circular gauge with various threshold configs)
- `/info/room/.../` rack view for linear gauges (PDU)

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file