### PR TITLE
Collect Juniper dom threshold values

### DIFF
--- a/changelog.d/2340.added.md
+++ b/changelog.d/2340.added.md
@@ -1,0 +1,1 @@
+Collect juniper dom threshold values

--- a/python/nav/ipdevpoll/plugins/sensors.py
+++ b/python/nav/ipdevpoll/plugins/sensors.py
@@ -127,6 +127,9 @@ class Sensors(Plugin):
                 sensor.on_message_sys = row.get('on_message')
                 sensor.off_message_sys = row.get('off_message')
                 sensor.on_state_sys = row.get('on_state')
+                sensor.threshold_type = row.get('threshold_type')
+                sensor.threshold_alert_type = row.get('threshold_alert_type')
+                sensor.threshold_for_oid = row.get('threshold_for_oid')
                 if ifindex:
                     iface = self.containers.factory(ifindex, shadows.Interface)
                     iface.netbox = self.netbox

--- a/python/nav/ipdevpoll/plugins/sensors.py
+++ b/python/nav/ipdevpoll/plugins/sensors.py
@@ -129,12 +129,17 @@ class Sensors(Plugin):
                 sensor.on_state_sys = row.get('on_state')
                 sensor.threshold_type = row.get('threshold_type')
                 sensor.threshold_alert_type = row.get('threshold_alert_type')
-                sensor.threshold_for_oid = row.get('threshold_for_oid')
                 if ifindex:
                     iface = self.containers.factory(ifindex, shadows.Interface)
                     iface.netbox = self.netbox
                     iface.ifindex = ifindex
                     sensor.interface = iface
+                if threshold_for_oid := row.get('threshold_for_oid'):
+                    threshold_for_sensor = self.containers.factory(
+                        threshold_for_oid, shadows.Sensor
+                    )
+                    threshold_for_sensor.oid = threshold_for_oid
+                    sensor.threshold_for = threshold_for_sensor
                 sensors.append(sensors)
         return sensors
 

--- a/python/nav/ipdevpoll/plugins/sensors.py
+++ b/python/nav/ipdevpoll/plugins/sensors.py
@@ -104,7 +104,6 @@ class Sensors(Plugin):
         that they may be persisted to the database.
 
         """
-        sensors = []
         for row in result:
             oid = row.get('oid', None)
             internal_name = row.get('internal_name', None)
@@ -140,8 +139,6 @@ class Sensors(Plugin):
                     )
                     threshold_for_sensor.oid = threshold_for_oid
                     sensor.threshold_for = threshold_for_sensor
-                sensors.append(sensors)
-        return sensors
 
 
 ####################

--- a/python/nav/mibs/juniper_dom_mib.py
+++ b/python/nav/mibs/juniper_dom_mib.py
@@ -20,7 +20,7 @@ from nav.smidumps import get_mib
 from nav.mibs.mibretriever import MibRetriever
 from nav.models.manage import Sensor
 
-COLUMNS = {
+SENSOR_COLUMNS = {
     "jnxDomCurrentRxLaserPower": {
         "unit_of_measurement": Sensor.UNIT_DBM,
         "precision": 2,
@@ -48,6 +48,97 @@ COLUMNS = {
     },
 }
 
+THRESHOLD_COLUMNS = {
+    "jnxDomCurrentRxLaserPower": {
+        "jnxDomCurrentRxLaserPowerHighAlarmThreshold": {
+            "name": "{ifc} RX Laser Power High Alarm Threshold",
+            "threshold_type": Sensor.THRESHOLD_TYPE_HIGH,
+            "threshold_alert_type": Sensor.ALERT_TYPE_ALERT,
+        },
+        "jnxDomCurrentRxLaserPowerLowAlarmThreshold": {
+            "name": "{ifc} RX Laser Power Low Alarm Threshold",
+            "threshold_type": Sensor.THRESHOLD_TYPE_LOW,
+            "threshold_alert_type": Sensor.ALERT_TYPE_ALERT,
+        },
+        "jnxDomCurrentRxLaserPowerHighWarningThreshold": {
+            "name": "{ifc} RX Laser Power High Warning Threshold",
+            "threshold_type": Sensor.THRESHOLD_TYPE_HIGH,
+            "threshold_alert_type": Sensor.ALERT_TYPE_WARNING,
+        },
+        "jnxDomCurrentRxLaserPowerLowWarningThreshold": {
+            "name": "{ifc} RX Laser Power Low Warning Threshold",
+            "threshold_type": Sensor.THRESHOLD_TYPE_LOW,
+            "threshold_alert_type": Sensor.ALERT_TYPE_WARNING,
+        },
+    },
+    "jnxDomCurrentTxLaserBiasCurrent": {
+        "jnxDomCurrentTxLaserBiasCurrentHighAlarmThreshold": {
+            "name": "{ifc} TX Laser Bias Current High Alarm Threshold",
+            "threshold_type": Sensor.THRESHOLD_TYPE_HIGH,
+            "threshold_alert_type": Sensor.ALERT_TYPE_ALERT,
+        },
+        "jnxDomCurrentTxLaserBiasCurrentLowAlarmThreshold": {
+            "name": "{ifc} TX Laser Bias Current Low Alarm Threshold",
+            "threshold_type": Sensor.THRESHOLD_TYPE_LOW,
+            "threshold_alert_type": Sensor.ALERT_TYPE_ALERT,
+        },
+        "jnxDomCurrentTxLaserBiasCurrentHighWarningThreshold": {
+            "name": "{ifc} TX Laser Bias Current High Warning Threshold",
+            "threshold_type": Sensor.THRESHOLD_TYPE_HIGH,
+            "threshold_alert_type": Sensor.ALERT_TYPE_WARNING,
+        },
+        "jnxDomCurrentTxLaserBiasCurrentLowWarningThreshold": {
+            "name": "{ifc} TX Laser Bias Current Low Warning Threshold",
+            "threshold_type": Sensor.THRESHOLD_TYPE_LOW,
+            "threshold_alert_type": Sensor.ALERT_TYPE_WARNING,
+        },
+    },
+    "jnxDomCurrentTxLaserOutputPower": {
+        "jnxDomCurrentTxLaserOutputPowerHighAlarmThreshold": {
+            "name": "{ifc} TX Laser Output Power High Alarm Threshold",
+            "threshold_type": Sensor.THRESHOLD_TYPE_HIGH,
+            "threshold_alert_type": Sensor.ALERT_TYPE_ALERT,
+        },
+        "jnxDomCurrentTxLaserOutputPowerLowAlarmThreshold": {
+            "name": "{ifc} TX Laser Output Power Low Alarm Threshold",
+            "threshold_type": Sensor.THRESHOLD_TYPE_LOW,
+            "threshold_alert_type": Sensor.ALERT_TYPE_ALERT,
+        },
+        "jnxDomCurrentTxLaserOutputPowerHighWarningThreshold": {
+            "name": "{ifc} TX Laser Output Power High Warning Threshold",
+            "threshold_type": Sensor.THRESHOLD_TYPE_HIGH,
+            "threshold_alert_type": Sensor.ALERT_TYPE_WARNING,
+        },
+        "jnxDomCurrentTxLaserOutputPowerLowWarningThreshold": {
+            "name": "{ifc} TX Laser Output Power Low Warning Threshold",
+            "threshold_type": Sensor.THRESHOLD_TYPE_LOW,
+            "threshold_alert_type": Sensor.ALERT_TYPE_WARNING,
+        },
+    },
+    "jnxDomCurrentModuleTemperature": {
+        "jnxDomCurrentModuleTemperatureHighAlarmThreshold": {
+            "name": "{ifc} Module Temperature High Alarm Threshold",
+            "threshold_type": Sensor.THRESHOLD_TYPE_HIGH,
+            "threshold_alert_type": Sensor.ALERT_TYPE_ALERT,
+        },
+        "jnxDomCurrentModuleTemperatureLowAlarmThreshold": {
+            "name": "{ifc} Module Temperature Low Alarm Threshold",
+            "threshold_type": Sensor.THRESHOLD_TYPE_LOW,
+            "threshold_alert_type": Sensor.ALERT_TYPE_ALERT,
+        },
+        "jnxDomCurrentModuleTemperatureHighWarningThreshold": {
+            "name": "{ifc} Module Temperature High Warning Threshold",
+            "threshold_type": Sensor.THRESHOLD_TYPE_HIGH,
+            "threshold_alert_type": Sensor.ALERT_TYPE_WARNING,
+        },
+        "jnxDomCurrentModuleTemperatureLowWarningThreshold": {
+            "name": "{ifc} Module Temperature Low Warning Threshold",
+            "threshold_type": Sensor.THRESHOLD_TYPE_LOW,
+            "threshold_alert_type": Sensor.ALERT_TYPE_WARNING,
+        },
+    },
+}
+
 
 class JuniperDomMib(MibRetriever):
     """MibRetriever for Juniper DOM Sensors"""
@@ -60,12 +151,21 @@ class JuniperDomMib(MibRetriever):
         device.
         """
         sensors = []
-        for column, config in COLUMNS.items():
-            sensors += yield self.handle_column(column, config)
+        for sensor_column, sensor_config in SENSOR_COLUMNS.items():
+            sensors += yield self.handle_sensor_column(sensor_column, sensor_config)
+            for threshold_column, threshold_config in THRESHOLD_COLUMNS[
+                sensor_column
+            ].items():
+                sensors += yield self.handle_threshold_column(
+                    threshold_column,
+                    threshold_config,
+                    sensor_column,
+                    sensor_config,
+                )
         return sensors
 
     @defer.inlineCallbacks
-    def handle_column(self, column, config):
+    def handle_sensor_column(self, column, config):
         """Returns the sensors of the given type"""
         result = []
         value_oid = self.nodes[column].oid
@@ -80,4 +180,29 @@ class JuniperDomMib(MibRetriever):
             )
             sensor.update(config)
             result.append(sensor)
+        return result
+
+    @defer.inlineCallbacks
+    def handle_threshold_column(
+        self, column, config, related_sensor_column, related_sensor_config
+    ):
+        """Returns the sensor thresholds of the given type"""
+        result = []
+        value_oid = self.nodes[column].oid
+        related_sensor_oid = self.nodes[related_sensor_column].oid
+        rows = yield self.retrieve_column(column)
+        for row in rows:
+            threshold_sensor = dict(
+                oid=str(value_oid + row),
+                scale=None,
+                mib=self.get_module_name(),
+                description=config['name'],
+                internal_name="{ifc}." + column,
+                ifindex=row[-1],
+                unit_of_measurement=related_sensor_config['unit_of_measurement'],
+                precision=related_sensor_config['precision'],
+                threshold_for_oid=str(related_sensor_oid + row),
+            )
+            threshold_sensor.update(config)
+            result.append(threshold_sensor)
         return result

--- a/python/nav/mibs/juniper_dom_mib.py
+++ b/python/nav/mibs/juniper_dom_mib.py
@@ -48,95 +48,39 @@ SENSOR_COLUMNS = {
     },
 }
 
+THRESHOLD_LEVELS = {
+    "HighAlarm": {
+        "label": "High Alarm",
+        "threshold_type": Sensor.THRESHOLD_TYPE_HIGH,
+        "threshold_alert_type": Sensor.ALERT_TYPE_ALERT,
+    },
+    "LowAlarm": {
+        "label": "Low Alarm",
+        "threshold_type": Sensor.THRESHOLD_TYPE_LOW,
+        "threshold_alert_type": Sensor.ALERT_TYPE_ALERT,
+    },
+    "HighWarning": {
+        "label": "High Warning",
+        "threshold_type": Sensor.THRESHOLD_TYPE_HIGH,
+        "threshold_alert_type": Sensor.ALERT_TYPE_WARNING,
+    },
+    "LowWarning": {
+        "label": "Low Warning",
+        "threshold_type": Sensor.THRESHOLD_TYPE_LOW,
+        "threshold_alert_type": Sensor.ALERT_TYPE_WARNING,
+    },
+}
+
 THRESHOLD_COLUMNS = {
-    "jnxDomCurrentRxLaserPower": {
-        "jnxDomCurrentRxLaserPowerHighAlarmThreshold": {
-            "name": "{ifc} RX Laser Power High Alarm Threshold",
-            "threshold_type": Sensor.THRESHOLD_TYPE_HIGH,
-            "threshold_alert_type": Sensor.ALERT_TYPE_ALERT,
-        },
-        "jnxDomCurrentRxLaserPowerLowAlarmThreshold": {
-            "name": "{ifc} RX Laser Power Low Alarm Threshold",
-            "threshold_type": Sensor.THRESHOLD_TYPE_LOW,
-            "threshold_alert_type": Sensor.ALERT_TYPE_ALERT,
-        },
-        "jnxDomCurrentRxLaserPowerHighWarningThreshold": {
-            "name": "{ifc} RX Laser Power High Warning Threshold",
-            "threshold_type": Sensor.THRESHOLD_TYPE_HIGH,
-            "threshold_alert_type": Sensor.ALERT_TYPE_WARNING,
-        },
-        "jnxDomCurrentRxLaserPowerLowWarningThreshold": {
-            "name": "{ifc} RX Laser Power Low Warning Threshold",
-            "threshold_type": Sensor.THRESHOLD_TYPE_LOW,
-            "threshold_alert_type": Sensor.ALERT_TYPE_WARNING,
-        },
-    },
-    "jnxDomCurrentTxLaserBiasCurrent": {
-        "jnxDomCurrentTxLaserBiasCurrentHighAlarmThreshold": {
-            "name": "{ifc} TX Laser Bias Current High Alarm Threshold",
-            "threshold_type": Sensor.THRESHOLD_TYPE_HIGH,
-            "threshold_alert_type": Sensor.ALERT_TYPE_ALERT,
-        },
-        "jnxDomCurrentTxLaserBiasCurrentLowAlarmThreshold": {
-            "name": "{ifc} TX Laser Bias Current Low Alarm Threshold",
-            "threshold_type": Sensor.THRESHOLD_TYPE_LOW,
-            "threshold_alert_type": Sensor.ALERT_TYPE_ALERT,
-        },
-        "jnxDomCurrentTxLaserBiasCurrentHighWarningThreshold": {
-            "name": "{ifc} TX Laser Bias Current High Warning Threshold",
-            "threshold_type": Sensor.THRESHOLD_TYPE_HIGH,
-            "threshold_alert_type": Sensor.ALERT_TYPE_WARNING,
-        },
-        "jnxDomCurrentTxLaserBiasCurrentLowWarningThreshold": {
-            "name": "{ifc} TX Laser Bias Current Low Warning Threshold",
-            "threshold_type": Sensor.THRESHOLD_TYPE_LOW,
-            "threshold_alert_type": Sensor.ALERT_TYPE_WARNING,
-        },
-    },
-    "jnxDomCurrentTxLaserOutputPower": {
-        "jnxDomCurrentTxLaserOutputPowerHighAlarmThreshold": {
-            "name": "{ifc} TX Laser Output Power High Alarm Threshold",
-            "threshold_type": Sensor.THRESHOLD_TYPE_HIGH,
-            "threshold_alert_type": Sensor.ALERT_TYPE_ALERT,
-        },
-        "jnxDomCurrentTxLaserOutputPowerLowAlarmThreshold": {
-            "name": "{ifc} TX Laser Output Power Low Alarm Threshold",
-            "threshold_type": Sensor.THRESHOLD_TYPE_LOW,
-            "threshold_alert_type": Sensor.ALERT_TYPE_ALERT,
-        },
-        "jnxDomCurrentTxLaserOutputPowerHighWarningThreshold": {
-            "name": "{ifc} TX Laser Output Power High Warning Threshold",
-            "threshold_type": Sensor.THRESHOLD_TYPE_HIGH,
-            "threshold_alert_type": Sensor.ALERT_TYPE_WARNING,
-        },
-        "jnxDomCurrentTxLaserOutputPowerLowWarningThreshold": {
-            "name": "{ifc} TX Laser Output Power Low Warning Threshold",
-            "threshold_type": Sensor.THRESHOLD_TYPE_LOW,
-            "threshold_alert_type": Sensor.ALERT_TYPE_WARNING,
-        },
-    },
-    "jnxDomCurrentModuleTemperature": {
-        "jnxDomCurrentModuleTemperatureHighAlarmThreshold": {
-            "name": "{ifc} Module Temperature High Alarm Threshold",
-            "threshold_type": Sensor.THRESHOLD_TYPE_HIGH,
-            "threshold_alert_type": Sensor.ALERT_TYPE_ALERT,
-        },
-        "jnxDomCurrentModuleTemperatureLowAlarmThreshold": {
-            "name": "{ifc} Module Temperature Low Alarm Threshold",
-            "threshold_type": Sensor.THRESHOLD_TYPE_LOW,
-            "threshold_alert_type": Sensor.ALERT_TYPE_ALERT,
-        },
-        "jnxDomCurrentModuleTemperatureHighWarningThreshold": {
-            "name": "{ifc} Module Temperature High Warning Threshold",
-            "threshold_type": Sensor.THRESHOLD_TYPE_HIGH,
-            "threshold_alert_type": Sensor.ALERT_TYPE_WARNING,
-        },
-        "jnxDomCurrentModuleTemperatureLowWarningThreshold": {
-            "name": "{ifc} Module Temperature Low Warning Threshold",
-            "threshold_type": Sensor.THRESHOLD_TYPE_LOW,
-            "threshold_alert_type": Sensor.ALERT_TYPE_WARNING,
-        },
-    },
+    sensor_column: {
+        f"{sensor_column}{level}Threshold": {
+            "name": f"{config['name']} {attrs['label']} Threshold",
+            "threshold_type": attrs["threshold_type"],
+            "threshold_alert_type": attrs["threshold_alert_type"],
+        }
+        for level, attrs in THRESHOLD_LEVELS.items()
+    }
+    for sensor_column, config in SENSOR_COLUMNS.items()
 }
 
 

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -2739,6 +2739,21 @@ class Sensor(models.Model):
             }
         return {}
 
+    @property
+    def threshold_for(self):
+        """Returns the sensor this is a threshold for.
+        Returns None if no such sensor exists.
+        """
+        if not self.threshold_for_oid:
+            return None
+        try:
+            return self.__class__.objects.get(
+                netbox=self.netbox, oid=self.threshold_for_oid, mib=self.mib
+            )
+        except self.DoesNotExist:
+            _logger.error("Could not find sensor with oid %s", self.threshold_for_oid)
+            return None
+
 
 class PowerSupplyOrFan(models.Model):
     STATE_UP = 'y'

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -2563,6 +2563,13 @@ class Sensor(models.Model):
         (ALERT_TYPE_WARNING, 'An orange warning'),
     )
 
+    THRESHOLD_TYPE_HIGH = 1
+    THRESHOLD_TYPE_LOW = 2
+    THRESHOLD_TYPE_CHOICES = (
+        (THRESHOLD_TYPE_HIGH, 'Threshold for high values'),
+        (THRESHOLD_TYPE_LOW, 'Threshold for low values'),
+    )
+
     id = models.AutoField(db_column='sensorid', primary_key=True)
     netbox = models.ForeignKey(
         Netbox,
@@ -2605,6 +2612,12 @@ class Sensor(models.Model):
     on_state_sys = models.IntegerField(db_column='on_state_sys', null=True)
     alert_type = models.IntegerField(
         db_column='alert_type', choices=ALERT_TYPE_CHOICES, null=True
+    )
+    threshold_type = models.IntegerField(
+        db_column='threshold_type', choices=THRESHOLD_TYPE_CHOICES, null=True
+    )
+    threshold_alert_type = models.IntegerField(
+        db_column='threshold_alert_type', choices=ALERT_TYPE_CHOICES, null=True
     )
 
     class Meta(object):

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -2619,6 +2619,7 @@ class Sensor(models.Model):
     threshold_alert_type = models.IntegerField(
         db_column='threshold_alert_type', choices=ALERT_TYPE_CHOICES, null=True
     )
+    threshold_for_oid = VarcharField(db_column='threshold_for_oid', null=True)
 
     class Meta(object):
         db_table = 'sensor'

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -2754,6 +2754,14 @@ class Sensor(models.Model):
             _logger.error("Could not find sensor with oid %s", self.threshold_for_oid)
             return None
 
+    @property
+    def thresholds(self):
+        """Returns list of all threshold-sensors for this sensor"""
+        thresholds = self.__class__.objects.filter(
+            netbox=self.netbox, threshold_for_oid=self.oid, mib=self.mib
+        )
+        return list(thresholds)
+
 
 class PowerSupplyOrFan(models.Model):
     STATE_UP = 'y'

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -2565,6 +2565,13 @@ class Sensor(models.Model):
         (ALERT_TYPE_WARNING, 'An orange warning'),
     )
 
+    THRESHOLD_TYPE_HIGH = 1
+    THRESHOLD_TYPE_LOW = 2
+    THRESHOLD_TYPE_CHOICES = (
+        (THRESHOLD_TYPE_HIGH, 'Threshold for high values'),
+        (THRESHOLD_TYPE_LOW, 'Threshold for low values'),
+    )
+
     id = models.AutoField(db_column='sensorid', primary_key=True)
     netbox = models.ForeignKey(
         Netbox,
@@ -2607,6 +2614,12 @@ class Sensor(models.Model):
     on_state_sys = models.IntegerField(db_column='on_state_sys', null=True)
     alert_type = models.IntegerField(
         db_column='alert_type', choices=ALERT_TYPE_CHOICES, null=True
+    )
+    threshold_type = models.IntegerField(
+        db_column='threshold_type', choices=THRESHOLD_TYPE_CHOICES, null=True
+    )
+    threshold_alert_type = models.IntegerField(
+        db_column='threshold_alert_type', choices=ALERT_TYPE_CHOICES, null=True
     )
 
     class Meta(object):

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -2621,7 +2621,13 @@ class Sensor(models.Model):
     threshold_alert_type = models.IntegerField(
         db_column='threshold_alert_type', choices=ALERT_TYPE_CHOICES, null=True
     )
-    threshold_for_oid = VarcharField(db_column='threshold_for_oid', null=True)
+    threshold_for = models.ForeignKey(
+        'Sensor',
+        on_delete=models.CASCADE,
+        db_column='threshold_for_id',
+        null=True,
+        related_name="thresholds",
+    )
 
     class Meta(object):
         db_table = 'sensor'
@@ -2740,29 +2746,6 @@ class Sensor(models.Model):
                 'alert_type': self.alert_type_class,
             }
         return {}
-
-    @property
-    def threshold_for(self):
-        """Returns the sensor this is a threshold for.
-        Returns None if no such sensor exists.
-        """
-        if not self.threshold_for_oid:
-            return None
-        try:
-            return self.__class__.objects.get(
-                netbox=self.netbox, oid=self.threshold_for_oid, mib=self.mib
-            )
-        except self.DoesNotExist:
-            _logger.error("Could not find sensor with oid %s", self.threshold_for_oid)
-            return None
-
-    @property
-    def thresholds(self):
-        """Returns list of all threshold-sensors for this sensor"""
-        thresholds = self.__class__.objects.filter(
-            netbox=self.netbox, threshold_for_oid=self.oid, mib=self.mib
-        )
-        return list(thresholds)
 
 
 class PowerSupplyOrFan(models.Model):

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -2756,6 +2756,14 @@ class Sensor(models.Model):
             _logger.error("Could not find sensor with oid %s", self.threshold_for_oid)
             return None
 
+    @property
+    def thresholds(self):
+        """Returns list of all threshold-sensors for this sensor"""
+        thresholds = self.__class__.objects.filter(
+            netbox=self.netbox, threshold_for_oid=self.oid, mib=self.mib
+        )
+        return list(thresholds)
+
 
 class PowerSupplyOrFan(models.Model):
     STATE_UP = 'y'

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -2621,6 +2621,7 @@ class Sensor(models.Model):
     threshold_alert_type = models.IntegerField(
         db_column='threshold_alert_type', choices=ALERT_TYPE_CHOICES, null=True
     )
+    threshold_for_oid = VarcharField(db_column='threshold_for_oid', null=True)
 
     class Meta(object):
         db_table = 'sensor'

--- a/python/nav/models/manage.py
+++ b/python/nav/models/manage.py
@@ -2741,6 +2741,21 @@ class Sensor(models.Model):
             }
         return {}
 
+    @property
+    def threshold_for(self):
+        """Returns the sensor this is a threshold for.
+        Returns None if no such sensor exists.
+        """
+        if not self.threshold_for_oid:
+            return None
+        try:
+            return self.__class__.objects.get(
+                netbox=self.netbox, oid=self.threshold_for_oid, mib=self.mib
+            )
+        except self.DoesNotExist:
+            _logger.error("Could not find sensor with oid %s", self.threshold_for_oid)
+            return None
+
 
 class PowerSupplyOrFan(models.Model):
     STATE_UP = 'y'

--- a/python/nav/models/sql/changes/sc.05.19.0001.sql
+++ b/python/nav/models/sql/changes/sc.05.19.0001.sql
@@ -1,0 +1,5 @@
+ALTER TABLE sensor
+  ADD threshold_type INT,
+  ADD threshold_alert_type INT,
+  ADD threshold_for_oid VARCHAR
+;

--- a/python/nav/models/sql/changes/sc.05.19.0003.sql
+++ b/python/nav/models/sql/changes/sc.05.19.0003.sql
@@ -1,0 +1,5 @@
+ALTER TABLE sensor
+  ADD threshold_type INT,
+  ADD threshold_alert_type INT,
+  ADD threshold_for_oid VARCHAR
+;

--- a/python/nav/models/sql/changes/sc.05.19.0003.sql
+++ b/python/nav/models/sql/changes/sc.05.19.0003.sql
@@ -2,5 +2,6 @@ ALTER TABLE sensor
   ADD threshold_type INT,
   ADD threshold_alert_type INT,
   ADD threshold_for_id INT,
-  ADD CONSTRAINT sensor_threshold_for_id_fkey FOREIGN KEY(threshold_for_id) REFERENCES sensor(sensorid)
+  ADD CONSTRAINT sensor_threshold_for_id_fkey
+    FOREIGN KEY (threshold_for_id) REFERENCES sensor(sensorid) ON DELETE CASCADE
 ;

--- a/python/nav/models/sql/changes/sc.05.19.0003.sql
+++ b/python/nav/models/sql/changes/sc.05.19.0003.sql
@@ -5,3 +5,5 @@ ALTER TABLE sensor
   ADD CONSTRAINT sensor_threshold_for_id_fkey
     FOREIGN KEY (threshold_for_id) REFERENCES sensor(sensorid) ON DELETE CASCADE
 ;
+
+CREATE INDEX sensor_threshold_for_id_btree ON sensor USING btree (threshold_for_id);

--- a/python/nav/models/sql/changes/sc.05.19.0003.sql
+++ b/python/nav/models/sql/changes/sc.05.19.0003.sql
@@ -1,5 +1,6 @@
 ALTER TABLE sensor
   ADD threshold_type INT,
   ADD threshold_alert_type INT,
-  ADD threshold_for_oid VARCHAR
+  ADD threshold_for_id INT,
+  ADD CONSTRAINT sensor_threshold_for_id_fkey FOREIGN KEY(threshold_for_id) REFERENCES sensor(sensorid)
 ;

--- a/python/nav/web/templates/ipdevinfo/sensor-details.html
+++ b/python/nav/web/templates/ipdevinfo/sensor-details.html
@@ -88,6 +88,16 @@
             <td>{{sensor.display_maximum_sys}}</td>
           </tr>
         {% endif %}
+        {% if sensor.threshold_for %}
+        <tr>
+          <th>Threshold for</th>
+            <td>
+              <a href="{% url 'sensor-details' sensor.threshold_for.id %}">
+                {{sensor.threshold_for.name}}
+              </a>
+            </td>
+        </tr>
+        {% endif %}
       </table>
     </div>
     <div class="large-6 column">

--- a/tests/integration/models/sensor_test.py
+++ b/tests/integration/models/sensor_test.py
@@ -1,0 +1,78 @@
+from nav.models.manage import Sensor
+import pytest
+
+
+class TestSensor:
+    def test_threshold_for_property_returns_the_sensor_the_current_sensor_is_a_threshold_for(
+        self, db, sensor, threshold_sensor1
+    ):
+        threshold_for_sensor = threshold_sensor1.threshold_for
+        assert threshold_for_sensor == sensor
+
+    def test_thresholds_property_returns_all_sensors_that_are_thresholds_for_current_sensor(
+        self, db, sensor, threshold_sensor1, threshold_sensor2
+    ):
+        threshold_sensors = sensor.thresholds
+        expected_threshold_sensors = Sensor.objects.filter(
+            threshold_for_oid=sensor.oid
+        ).all()
+        assert set(threshold_sensors) == set(expected_threshold_sensors)
+
+
+@pytest.fixture
+def threshold_sensor1(db, localhost):
+    sensor = Sensor(
+        netbox=localhost,
+        oid="1.2.4",
+        unit_of_measurement=Sensor.UNIT_OTHER,
+        data_scale=Sensor.SCALE_MILLI,
+        precision=1,
+        human_readable="threshold_sensor1",
+        name="threshold_sensor1",
+        internal_name="threshold_sensor1",
+        mib="testmib",
+        threshold_for_oid="1.2.3",
+    )
+    sensor.save()
+    yield sensor
+    if sensor.pk:
+        sensor.delete()
+
+
+@pytest.fixture
+def threshold_sensor2(db, localhost):
+    sensor = Sensor(
+        netbox=localhost,
+        oid="1.2.5",
+        unit_of_measurement=Sensor.UNIT_OTHER,
+        data_scale=Sensor.SCALE_MILLI,
+        precision=1,
+        human_readable="threshold_sensor2",
+        name="threshold_sensor2",
+        internal_name="threshold_sensor2",
+        mib="testmib",
+        threshold_for_oid="1.2.3",
+    )
+    sensor.save()
+    yield sensor
+    if sensor.pk:
+        sensor.delete()
+
+
+@pytest.fixture
+def sensor(db, localhost):
+    sensor = Sensor(
+        netbox=localhost,
+        oid="1.2.3",
+        unit_of_measurement=Sensor.UNIT_OTHER,
+        data_scale=Sensor.SCALE_MILLI,
+        precision=1,
+        human_readable="value",
+        name="sensor",
+        internal_name="sensor",
+        mib="testmib",
+    )
+    sensor.save()
+    yield sensor
+    if sensor.pk:
+        sensor.delete()

--- a/tests/integration/models/sensor_test.py
+++ b/tests/integration/models/sensor_test.py
@@ -1,0 +1,78 @@
+from nav.models.manage import Sensor
+import pytest
+
+
+class TestSensor:
+    def test_threshold_for_returns_the_sensor_the_current_sensor_is_a_threshold_for(
+        self, db, sensor, threshold_sensor1
+    ):
+        threshold_for_sensor = threshold_sensor1.threshold_for
+        assert threshold_for_sensor == sensor
+
+    def test_thresholds_returns_all_sensors_that_are_thresholds_for_current_sensor(
+        self, db, sensor, threshold_sensor1, threshold_sensor2
+    ):
+        threshold_sensors = sensor.thresholds
+        expected_threshold_sensors = Sensor.objects.filter(
+            threshold_for_oid=sensor.oid
+        ).all()
+        assert set(threshold_sensors) == set(expected_threshold_sensors)
+
+
+@pytest.fixture
+def threshold_sensor1(db, localhost):
+    sensor = Sensor(
+        netbox=localhost,
+        oid="1.2.4",
+        unit_of_measurement=Sensor.UNIT_OTHER,
+        data_scale=Sensor.SCALE_MILLI,
+        precision=1,
+        human_readable="threshold_sensor1",
+        name="threshold_sensor1",
+        internal_name="threshold_sensor1",
+        mib="testmib",
+        threshold_for_oid="1.2.3",
+    )
+    sensor.save()
+    yield sensor
+    if sensor.pk:
+        sensor.delete()
+
+
+@pytest.fixture
+def threshold_sensor2(db, localhost):
+    sensor = Sensor(
+        netbox=localhost,
+        oid="1.2.5",
+        unit_of_measurement=Sensor.UNIT_OTHER,
+        data_scale=Sensor.SCALE_MILLI,
+        precision=1,
+        human_readable="threshold_sensor2",
+        name="threshold_sensor2",
+        internal_name="threshold_sensor2",
+        mib="testmib",
+        threshold_for_oid="1.2.3",
+    )
+    sensor.save()
+    yield sensor
+    if sensor.pk:
+        sensor.delete()
+
+
+@pytest.fixture
+def sensor(db, localhost):
+    sensor = Sensor(
+        netbox=localhost,
+        oid="1.2.3",
+        unit_of_measurement=Sensor.UNIT_OTHER,
+        data_scale=Sensor.SCALE_MILLI,
+        precision=1,
+        human_readable="value",
+        name="sensor",
+        internal_name="sensor",
+        mib="testmib",
+    )
+    sensor.save()
+    yield sensor
+    if sensor.pk:
+        sensor.delete()

--- a/tests/integration/models/sensor_test.py
+++ b/tests/integration/models/sensor_test.py
@@ -12,15 +12,13 @@ class TestSensor:
     def test_thresholds_returns_all_sensors_that_are_thresholds_for_current_sensor(
         self, db, sensor, threshold_sensor1, threshold_sensor2
     ):
-        threshold_sensors = sensor.thresholds
-        expected_threshold_sensors = Sensor.objects.filter(
-            threshold_for_oid=sensor.oid
-        ).all()
+        threshold_sensors = sensor.thresholds.all()
+        expected_threshold_sensors = Sensor.objects.filter(threshold_for=sensor).all()
         assert set(threshold_sensors) == set(expected_threshold_sensors)
 
 
 @pytest.fixture
-def threshold_sensor1(db, localhost):
+def threshold_sensor1(db, localhost, sensor):
     sensor = Sensor(
         netbox=localhost,
         oid="1.2.4",
@@ -31,7 +29,7 @@ def threshold_sensor1(db, localhost):
         name="threshold_sensor1",
         internal_name="threshold_sensor1",
         mib="testmib",
-        threshold_for_oid="1.2.3",
+        threshold_for=sensor,
     )
     sensor.save()
     yield sensor
@@ -40,7 +38,7 @@ def threshold_sensor1(db, localhost):
 
 
 @pytest.fixture
-def threshold_sensor2(db, localhost):
+def threshold_sensor2(db, localhost, sensor):
     sensor = Sensor(
         netbox=localhost,
         oid="1.2.5",
@@ -51,7 +49,7 @@ def threshold_sensor2(db, localhost):
         name="threshold_sensor2",
         internal_name="threshold_sensor2",
         mib="testmib",
-        threshold_for_oid="1.2.3",
+        threshold_for=sensor,
     )
     sensor.save()
     yield sensor

--- a/tests/integration/models/sensor_test.py
+++ b/tests/integration/models/sensor_test.py
@@ -1,76 +1,58 @@
-from nav.models.manage import Sensor
 import pytest
 
+from nav.models.manage import Sensor
 
-class TestSensor:
-    def test_threshold_for_returns_the_sensor_the_current_sensor_is_a_threshold_for(
+
+class TestThresholdFor:
+    def test_when_sensor_is_a_threshold_then_threshold_for_should_return_its_parent(
         self, db, sensor, threshold_sensor1
     ):
-        threshold_for_sensor = threshold_sensor1.threshold_for
-        assert threshold_for_sensor == sensor
+        assert threshold_sensor1.threshold_for == sensor
 
-    def test_thresholds_returns_all_sensors_that_are_thresholds_for_current_sensor(
+
+class TestThresholds:
+    def test_when_sensor_has_thresholds_then_thresholds_should_return_exactly_them(
         self, db, sensor, threshold_sensor1, threshold_sensor2
     ):
-        threshold_sensors = sensor.thresholds.all()
-        expected_threshold_sensors = Sensor.objects.filter(threshold_for=sensor).all()
-        assert set(threshold_sensors) == set(expected_threshold_sensors)
+        assert set(sensor.thresholds.all()) == {threshold_sensor1, threshold_sensor2}
 
-
-@pytest.fixture
-def threshold_sensor1(db, localhost, sensor):
-    sensor = Sensor(
-        netbox=localhost,
-        oid="1.2.4",
-        unit_of_measurement=Sensor.UNIT_OTHER,
-        data_scale=Sensor.SCALE_MILLI,
-        precision=1,
-        human_readable="threshold_sensor1",
-        name="threshold_sensor1",
-        internal_name="threshold_sensor1",
-        mib="testmib",
-        threshold_for=sensor,
-    )
-    sensor.save()
-    yield sensor
-    if sensor.pk:
-        sensor.delete()
-
-
-@pytest.fixture
-def threshold_sensor2(db, localhost, sensor):
-    sensor = Sensor(
-        netbox=localhost,
-        oid="1.2.5",
-        unit_of_measurement=Sensor.UNIT_OTHER,
-        data_scale=Sensor.SCALE_MILLI,
-        precision=1,
-        human_readable="threshold_sensor2",
-        name="threshold_sensor2",
-        internal_name="threshold_sensor2",
-        mib="testmib",
-        threshold_for=sensor,
-    )
-    sensor.save()
-    yield sensor
-    if sensor.pk:
-        sensor.delete()
+    def test_when_sensor_has_no_thresholds_then_thresholds_should_be_empty(
+        self, db, threshold_sensor1
+    ):
+        assert list(threshold_sensor1.thresholds.all()) == []
 
 
 @pytest.fixture
 def sensor(db, localhost):
+    return _make_sensor(localhost, oid="1.2.3", name="sensor")
+
+
+@pytest.fixture
+def threshold_sensor1(db, localhost, sensor):
+    return _make_sensor(
+        localhost, oid="1.2.4", name="threshold_sensor1", threshold_for=sensor
+    )
+
+
+@pytest.fixture
+def threshold_sensor2(db, localhost, sensor):
+    return _make_sensor(
+        localhost, oid="1.2.5", name="threshold_sensor2", threshold_for=sensor
+    )
+
+
+def _make_sensor(netbox, oid, name, threshold_for=None):
     sensor = Sensor(
-        netbox=localhost,
-        oid="1.2.3",
+        netbox=netbox,
+        oid=oid,
         unit_of_measurement=Sensor.UNIT_OTHER,
         data_scale=Sensor.SCALE_MILLI,
         precision=1,
-        human_readable="value",
-        name="sensor",
-        internal_name="sensor",
+        human_readable=name,
+        name=name,
+        internal_name=name,
         mib="testmib",
+        threshold_for=threshold_for,
     )
     sensor.save()
-    yield sensor
-    if sensor.pk:
-        sensor.delete()
+    return sensor

--- a/tests/unittests/mibs/juniper_dom_mib_test.py
+++ b/tests/unittests/mibs/juniper_dom_mib_test.py
@@ -1,0 +1,47 @@
+from unittest import TestCase
+from mock import patch, Mock
+
+from twisted.internet import defer
+from twisted.internet.defer import succeed
+
+from nav.mibs.juniper_dom_mib import JuniperDomMib, SENSOR_COLUMNS, THRESHOLD_COLUMNS
+
+
+class TestJuniperDomMIB(TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_handle_sensor_column_returns_correct_amount_of_sensor_dicts(self):
+        rows_for_column = {"0": "interface 0", "1": "interface 1"}
+
+        with patch(
+            'nav.mibs.juniper_dom_mib.JuniperDomMib.retrieve_column'
+        ) as retrieve:
+            retrieve.return_value = succeed(rows_for_column)
+            mib = JuniperDomMib(Mock())
+            column = "jnxDomCurrentRxLaserPower"
+            deferred_result = mib.handle_sensor_column(column, SENSOR_COLUMNS[column])
+            result = deferred_result.result
+        self.assertEqual(len(result), len(rows_for_column))
+
+    def test_handle_threshold_column_returns_correct_amount_of_sensor_dicts(self):
+        rows_for_column = {"0": "interface 0", "1": "interface 1"}
+
+        with patch(
+            'nav.mibs.juniper_dom_mib.JuniperDomMib.retrieve_column'
+        ) as retrieve:
+            retrieve.return_value = succeed(rows_for_column)
+            mib = JuniperDomMib(Mock())
+            threshold_column = "jnxDomCurrentRxLaserPowerHighAlarmThreshold"
+            sensor_column = "jnxDomCurrentRxLaserPower"
+            deferred_result = mib.handle_threshold_column(
+                threshold_column,
+                THRESHOLD_COLUMNS[sensor_column][threshold_column],
+                sensor_column,
+                SENSOR_COLUMNS[sensor_column],
+            )
+            result = deferred_result.result
+        self.assertEqual(len(result), len(rows_for_column), result)

--- a/tests/unittests/mibs/juniper_dom_mib_test.py
+++ b/tests/unittests/mibs/juniper_dom_mib_test.py
@@ -1,39 +1,112 @@
+import pytest
 from mock import patch, Mock
 
 from twisted.internet.defer import succeed
 
 from nav.mibs.juniper_dom_mib import JuniperDomMib, SENSOR_COLUMNS, THRESHOLD_COLUMNS
+from nav.models.manage import Sensor
 
 
-class TestJuniperDomMIB:
-    def test_handle_sensor_column_returns_correct_amount_of_sensor_dicts(self):
-        rows_for_column = {"0": "interface 0", "1": "interface 1"}
+class TestHandleSensorColumn:
+    def test_when_a_column_has_rows_then_each_row_should_yield_one_sensor(self):
+        column = "jnxDomCurrentRxLaserPower"
+        rows = {(1,): "interface 1", (2,): "interface 2"}
 
-        with patch(
-            'nav.mibs.juniper_dom_mib.JuniperDomMib.retrieve_column'
-        ) as retrieve:
-            retrieve.return_value = succeed(rows_for_column)
-            mib = JuniperDomMib(Mock())
-            column = "jnxDomCurrentRxLaserPower"
-            deferred_result = mib.handle_sensor_column(column, SENSOR_COLUMNS[column])
-            result = deferred_result.result
-        assert len(result) == len(rows_for_column)
+        sensors = _run_handle_sensor_column(column, rows)
 
-    def test_handle_threshold_column_returns_correct_amount_of_sensor_dicts(self):
-        rows_for_column = {"0": "interface 0", "1": "interface 1"}
+        assert len(sensors) == len(rows)
 
-        with patch(
-            'nav.mibs.juniper_dom_mib.JuniperDomMib.retrieve_column'
-        ) as retrieve:
-            retrieve.return_value = succeed(rows_for_column)
-            mib = JuniperDomMib(Mock())
-            threshold_column = "jnxDomCurrentRxLaserPowerHighAlarmThreshold"
-            sensor_column = "jnxDomCurrentRxLaserPower"
-            deferred_result = mib.handle_threshold_column(
-                threshold_column,
-                THRESHOLD_COLUMNS[sensor_column][threshold_column],
-                sensor_column,
-                SENSOR_COLUMNS[sensor_column],
+    def test_when_handling_a_column_then_oid_and_ifindex_should_derive_from_the_row(
+        self,
+    ):
+        column = "jnxDomCurrentRxLaserPower"
+        rows = {(1,): "interface 1", (2,): "interface 2"}
+
+        sensors = _run_handle_sensor_column(column, rows)
+
+        value_oid = JuniperDomMib(Mock()).nodes[column].oid
+        by_ifindex = {sensor["ifindex"]: sensor for sensor in sensors}
+        assert set(by_ifindex) == {1, 2}
+        for suffix in rows:
+            assert by_ifindex[suffix[-1]]["oid"] == str(value_oid + suffix)
+
+
+class TestHandleThresholdColumn:
+    @pytest.mark.parametrize(
+        "threshold_column, expected_threshold_type, expected_alert_type",
+        [
+            (
+                "jnxDomCurrentRxLaserPowerHighAlarmThreshold",
+                Sensor.THRESHOLD_TYPE_HIGH,
+                Sensor.ALERT_TYPE_ALERT,
+            ),
+            (
+                "jnxDomCurrentRxLaserPowerLowAlarmThreshold",
+                Sensor.THRESHOLD_TYPE_LOW,
+                Sensor.ALERT_TYPE_ALERT,
+            ),
+            (
+                "jnxDomCurrentRxLaserPowerHighWarningThreshold",
+                Sensor.THRESHOLD_TYPE_HIGH,
+                Sensor.ALERT_TYPE_WARNING,
+            ),
+            (
+                "jnxDomCurrentRxLaserPowerLowWarningThreshold",
+                Sensor.THRESHOLD_TYPE_LOW,
+                Sensor.ALERT_TYPE_WARNING,
+            ),
+        ],
+    )
+    def test_when_handling_a_threshold_column_then_each_sensor_should_carry_matching_metadata(  # noqa: E501
+        self, threshold_column, expected_threshold_type, expected_alert_type
+    ):
+        sensor_column = "jnxDomCurrentRxLaserPower"
+        rows = {(1,): "interface 1", (2,): "interface 2"}
+
+        thresholds = _run_handle_threshold_column(threshold_column, sensor_column, rows)
+
+        assert len(thresholds) == len(rows)
+        for threshold in thresholds:
+            assert threshold["threshold_type"] == expected_threshold_type
+            assert threshold["threshold_alert_type"] == expected_alert_type
+            # a threshold inherits unit/precision from the sensor it guards;
+            # jnxDomCurrentRxLaserPower is dBm with 2 decimals of precision
+            assert threshold["unit_of_measurement"] == Sensor.UNIT_DBM
+            assert threshold["precision"] == 2
+
+    def test_when_handling_a_threshold_column_then_threshold_for_oid_should_match_parent_oid(  # noqa: E501
+        self,
+    ):
+        sensor_column = "jnxDomCurrentRxLaserPower"
+        threshold_column = "jnxDomCurrentRxLaserPowerHighAlarmThreshold"
+        rows = {(1,): "interface 1", (2,): "interface 2"}
+
+        parent_sensors = _run_handle_sensor_column(sensor_column, rows)
+        thresholds = _run_handle_threshold_column(threshold_column, sensor_column, rows)
+
+        parent_oid_by_ifindex = {s["ifindex"]: s["oid"] for s in parent_sensors}
+        assert thresholds  # guard against a vacuous pass
+        for threshold in thresholds:
+            assert (
+                threshold["threshold_for_oid"]
+                == parent_oid_by_ifindex[threshold["ifindex"]]
             )
-            result = deferred_result.result
-        assert len(result) == len(rows_for_column), result
+
+
+def _run_handle_sensor_column(column, rows):
+    with patch('nav.mibs.juniper_dom_mib.JuniperDomMib.retrieve_column') as retrieve:
+        retrieve.return_value = succeed(rows)
+        mib = JuniperDomMib(Mock())
+        return mib.handle_sensor_column(column, SENSOR_COLUMNS[column]).result
+
+
+def _run_handle_threshold_column(threshold_column, sensor_column, rows):
+    with patch('nav.mibs.juniper_dom_mib.JuniperDomMib.retrieve_column') as retrieve:
+        retrieve.return_value = succeed(rows)
+        mib = JuniperDomMib(Mock())
+        return mib.handle_threshold_column(
+            threshold_column,
+            THRESHOLD_COLUMNS[sensor_column][threshold_column],
+            sensor_column,
+            SENSOR_COLUMNS[sensor_column],
+        ).result

--- a/tests/unittests/mibs/juniper_dom_mib_test.py
+++ b/tests/unittests/mibs/juniper_dom_mib_test.py
@@ -1,0 +1,39 @@
+from mock import patch, Mock
+
+from twisted.internet.defer import succeed
+
+from nav.mibs.juniper_dom_mib import JuniperDomMib, SENSOR_COLUMNS, THRESHOLD_COLUMNS
+
+
+class TestJuniperDomMIB:
+    def test_handle_sensor_column_returns_correct_amount_of_sensor_dicts(self):
+        rows_for_column = {"0": "interface 0", "1": "interface 1"}
+
+        with patch(
+            'nav.mibs.juniper_dom_mib.JuniperDomMib.retrieve_column'
+        ) as retrieve:
+            retrieve.return_value = succeed(rows_for_column)
+            mib = JuniperDomMib(Mock())
+            column = "jnxDomCurrentRxLaserPower"
+            deferred_result = mib.handle_sensor_column(column, SENSOR_COLUMNS[column])
+            result = deferred_result.result
+        assert len(result) == len(rows_for_column)
+
+    def test_handle_threshold_column_returns_correct_amount_of_sensor_dicts(self):
+        rows_for_column = {"0": "interface 0", "1": "interface 1"}
+
+        with patch(
+            'nav.mibs.juniper_dom_mib.JuniperDomMib.retrieve_column'
+        ) as retrieve:
+            retrieve.return_value = succeed(rows_for_column)
+            mib = JuniperDomMib(Mock())
+            threshold_column = "jnxDomCurrentRxLaserPowerHighAlarmThreshold"
+            sensor_column = "jnxDomCurrentRxLaserPower"
+            deferred_result = mib.handle_threshold_column(
+                threshold_column,
+                THRESHOLD_COLUMNS[sensor_column][threshold_column],
+                sensor_column,
+                SENSOR_COLUMNS[sensor_column],
+            )
+            result = deferred_result.result
+        assert len(result) == len(rows_for_column), result


### PR DESCRIPTION
## Scope and purpose

Fixes #2340.
Replaces #2513 

Collects threshold values as sensors. Adds new fields to the Sensor class used to define the properties of the threshold.
Adds fields for stating if the threshold should trigger for the value being higher or lower than the given threshold, and
if the severity of the alarm that should be made if the threshold is breached.
A Threshold Sensor will have a foreign key to the sensor it is a threshold for.

A row has been added to the Sensor details page showing which sensor a Threshold Sensor is a threshold for.

Before:
<img width="1167" height="627" alt="image" src="https://github.com/user-attachments/assets/1e3de6a5-2756-488c-9400-b2243f997183" />

After:
<img width="1167" height="627" alt="image" src="https://github.com/user-attachments/assets/19d203bd-3c78-4800-909f-17fac2c5b3cd" />


To test this an Inventory job must run to find and register the threshold sensors. 1min stats can then be run to actually collect data from the sensors.

`uninett-tor-sw1.uninett.no` from sikt-vk should be a decent candidate for testing, since it has the dom mib sensors registered. Some of these actually get real values from the switch (just for a few interfaces that are actually in use), and a succesful tests should show that the threshold sensors for these sensors also collect values that make sense

<!-- remove things that do not apply -->
### This pull request
* changes the database


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
