### PR TITLE
Use portable bash shebang in host-runnable scripts

### DIFF
--- a/.claude/hooks/check-test-names.sh
+++ b/.claude/hooks/check-test-names.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PostToolUse hook: check test naming conventions after Edit/Write on test files.
 # Gives Claude feedback (exit 2) so it can fix the names before committing.
 

--- a/python/nav/web/static/js/geomap/projdefs/fetch.sh
+++ b/python/nav/web/static/js/geomap/projdefs/fetch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for i in $(seq -w 1 60)
 do

--- a/tests/free-port.sh
+++ b/tests/free-port.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Helper script for Hudson CI setup
 # Prints a random port number > 9000 that appears to be unused.
 # Is only confirmed to work on a Debian system.

--- a/tests/javascript-test.sh
+++ b/tests/javascript-test.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 if [ ! -n "$1" ]; then
     echo "Need path to workspace"
     exit 1

--- a/tools/forward/snmp_forward.sh
+++ b/tools/forward/snmp_forward.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -----------------------------------------------------------------------
 # Shell script snmp_forward.sh
 # Create an SNMP tunnel to remote Agent through a hop host
@@ -42,4 +42,3 @@ trap "echo A tunnel subprocess died, stopping all forwarding; kill -HUP -$PGID" 
 remote_tunnel &
 local_tunnel &
 wait  # Just wait for all background processes to die
-

--- a/tools/restore-db.sh
+++ b/tools/restore-db.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 # This simple script is designed to run inside a devcontainer doing a full
 # database drop-and-restore cycle.  It expects the SQL schema to load to
 # be its input on stdin.


### PR DESCRIPTION
## Scope and purpose

Replace `#!/bin/bash` with `#!/usr/bin/env bash` in the shell scripts that may be executed on a developer's host machine. `/bin/bash` does not exist on NixOS, so those scripts currently fail to run there; the `env` form resolves bash through `PATH` and works on NixOS, macOS and standard Linux distros alike.

Scripts that only run inside the project's Docker images (`tools/docker/*.sh`) and the devcontainer init script are intentionally left alone — those environments are guaranteed to ship `/bin/bash`, and changing them would just be churn.

For the two scripts that previously used `#!/bin/bash -e`, the `-e` option is moved into a `set -e` line on the next line, since `/usr/bin/env` cannot portably accept additional arguments on a shebang line — most kernels pass everything after the interpreter path as a single argument.

## Contributor Checklist

* [ ] ~~Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)~~ — not a user-facing change
* [ ] ~~Added/amended tests for new/changed code~~ — no behavioral change
* [ ] ~~Added/changed documentation~~ — no user-visible behavior to document
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions) — verify with `grep -rn '^#!/bin/bash' .claude tools tests python` (should only list `tools/docker/*.sh`); run any of the changed scripts on a NixOS host
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~