### PR TITLE
Add allauth adapter for OIDC social login

### DIFF
--- a/changelog.d/4122.fixed.md
+++ b/changelog.d/4122.fixed.md
@@ -1,0 +1,1 @@
+Fixed a server error (crash) on first-time OIDC sign-in. Provisioning new NAV accounts from a social identity remains disabled by default; first-time sign-in is now cleanly refused instead of crashing. Provisioning can be enabled early through the provisional, unsupported `NAV_ALLOW_SIGNUPS` escape hatch in `local_settings`, but only with an IdP that controls who may reach NAV

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -403,8 +403,22 @@ MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN = (
     _auth_config.mfa.get_MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN_setting()
 )
 
-# SOCIALACCOUNT_AUTO_SIGNUP = True
-# SOCIALACCOUNT_ADAPTER = 'nav.web.auth.allauth.adapter.NAVSocialAccountAdapter'
+# Provisioning a brand-new NAV account from a social (OIDC) identity is disabled
+# by default; see NAVSocialAccountAdapter.is_open_for_signup. Enable
+# NAV_ALLOW_SIGNUPS to auto-provision accounts for first-time social logins
+# instead of pre-creating each account manually -- only sound when the IdP
+# itself restricts who may authenticate to NAV. It is a provisional, unsupported
+# power-user escape hatch (set in local_settings): a NAV-specific setting, not an
+# allauth one, expected to be replaced by a single authentication.toml option
+# once an authorization design (who may sign up, who becomes admin) lands.
+#
+# AUTO_SIGNUP is on so NAV_ALLOW_SIGNUPS is the single gate: while it is closed
+# (default) is_open_for_signup returns False and first-time sign-in is cleanly
+# refused; when opened, the account is provisioned directly. Without AUTO_SIGNUP,
+# opening the gate would instead route to allauth's stock signup form, which NAV
+# does not have.
+SOCIALACCOUNT_AUTO_SIGNUP = True
+SOCIALACCOUNT_ADAPTER = 'nav.web.auth.allauth.adapter.NAVSocialAccountAdapter'
 
 SOCIALACCOUNT_PROVIDERS = {}
 

--- a/python/nav/web/auth/allauth/adapter.py
+++ b/python/nav/web/auth/allauth/adapter.py
@@ -1,10 +1,10 @@
 from django.conf import settings
 
+from allauth.account import app_settings as account_settings
 from allauth.account.adapter import DefaultAccountAdapter
-from allauth.account.adapter import get_adapter as get_account_adapter
+from allauth.account.utils import user_username
 from allauth.mfa.adapter import DefaultMFAAdapter
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
-from allauth.socialaccount import app_settings as socialaccount_app_settings
 
 
 class NAVAccountAdapter(DefaultAccountAdapter):
@@ -16,15 +16,46 @@ class NAVAccountAdapter(DefaultAccountAdapter):
         # Override with setting, otherwise default to super.
         return getattr(settings, "ACCOUNT_ALLOW_SIGNUPS", allow_signups)
 
+    def populate_username(self, request, user):
+        # NAV's login field is a VarcharField (TextField subclass) with no
+        # max_length. allauth's default generate_unique_username crashes on a
+        # None max_length. populate_user already sets user.login from the
+        # social account uid, so just keep the existing username as-is.
+        if account_settings.USER_MODEL_USERNAME_FIELD:
+            username = user_username(user)
+            if username:
+                user_username(user, username)
+
 
 class NAVSocialAccountAdapter(DefaultSocialAccountAdapter):
     def is_open_for_signup(self, request, sociallogin):
+        """Whether to provision a brand-new NAV account from a social identity.
+
+        Disabled by default. Provisioning accounts from an external identity
+        needs an authorization design (who may sign up, who becomes admin, and
+        for which provider) that is not in place yet, so signup stays closed.
+
+        Enable ``NAV_ALLOW_SIGNUPS`` to auto-provision accounts for first-time
+        social logins instead of pre-creating each account manually -- only
+        sound when the IdP itself controls who may reach NAV. It is a
+        provisional, unsupported power-user escape hatch (set in
+        ``local_settings``): a NAV-specific setting, not an allauth one,
+        expected to be replaced by a single ``authentication.toml`` option once
+        the authorization design lands. Existing users who have already
+        connected a social account are unaffected; only first-time provisioning
+        is gated.
         """
-        Whether to allow sign ups via social account
-        """
-        if socialaccount_app_settings.AUTO_SIGNUP:
-            return True
-        return get_account_adapter(request).is_open_for_signup(request)
+        return getattr(settings, "NAV_ALLOW_SIGNUPS", False)
+
+    def populate_user(self, request, sociallogin, data):
+        user = super().populate_user(request, sociallogin, data)
+        # Ensure a username exists so populate_username does not fall through to
+        # allauth's generate_unique_username, which crashes on NAV's login field
+        # having no max_length. The uid is a minimal default identity; the
+        # eventual signup design may map identity from a specific claim instead.
+        if not getattr(user, "login", None):
+            user.login = sociallogin.account.uid
+        return user
 
 
 class NAVMFAAdapter(DefaultMFAAdapter):

--- a/tests/unittests/web/auth/allauth_adapter_test.py
+++ b/tests/unittests/web/auth/allauth_adapter_test.py
@@ -1,0 +1,66 @@
+"""Tests for the NAV allauth social account adapter."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+from django.test import override_settings
+
+from nav.web.auth.allauth.adapter import NAVAccountAdapter, NAVSocialAccountAdapter
+
+
+class TestSocialIsOpenForSignup:
+    def test_when_setting_unset_then_signup_should_be_closed(self):
+        adapter = NAVSocialAccountAdapter()
+        assert adapter.is_open_for_signup(Mock(), _sociallogin()) is False
+
+    @override_settings(NAV_ALLOW_SIGNUPS=True)
+    def test_when_setting_enabled_then_signup_should_be_open(self):
+        adapter = NAVSocialAccountAdapter()
+        assert adapter.is_open_for_signup(Mock(), _sociallogin()) is True
+
+    @override_settings(NAV_ALLOW_SIGNUPS=False)
+    def test_when_setting_disabled_then_signup_should_be_closed(self):
+        adapter = NAVSocialAccountAdapter()
+        assert adapter.is_open_for_signup(Mock(), _sociallogin()) is False
+
+
+class TestPopulateUser:
+    def test_when_user_has_no_login_then_it_should_set_login_from_uid(self):
+        adapter = NAVSocialAccountAdapter()
+        sociallogin = _sociallogin(uid="alice")
+        with patch.object(
+            DefaultSocialAccountAdapter,
+            "populate_user",
+            return_value=SimpleNamespace(),
+        ):
+            user = adapter.populate_user(Mock(), sociallogin, {})
+        assert user.login == "alice"
+
+    def test_when_user_already_has_login_then_it_should_keep_it(self):
+        adapter = NAVSocialAccountAdapter()
+        sociallogin = _sociallogin(uid="alice")
+        with patch.object(
+            DefaultSocialAccountAdapter,
+            "populate_user",
+            return_value=SimpleNamespace(login="bob"),
+        ):
+            user = adapter.populate_user(Mock(), sociallogin, {})
+        assert user.login == "bob"
+
+
+class TestPopulateUsername:
+    def test_when_username_present_then_it_should_keep_it_without_generating(self):
+        # NAV's login field has no max_length, so allauth's
+        # generate_unique_username would crash if it were invoked; the override
+        # must keep the already-populated username untouched instead.
+        adapter = NAVAccountAdapter()
+        user = SimpleNamespace(login="alice")
+        adapter.populate_username(Mock(), user)
+        assert user.login == "alice"
+
+
+def _sociallogin(uid="alice"):
+    sociallogin = Mock()
+    sociallogin.account.uid = uid
+    return sociallogin


### PR DESCRIPTION
Closes #4122

Wires `NAVSocialAccountAdapter` into allauth (`SOCIALACCOUNT_ADAPTER`, previously commented out so the adapter was never active) and overrides `populate_username` to avoid allauth's `generate_unique_username` crashing on NAV's `login` field having no `max_length` — the crash tracked in #4122, which made first-time OIDC sign-in fail with a server error.

Social account **signup is disabled by default**. Provisioning a new NAV account from an external identity needs an authorization design (who may sign up, who becomes admin, per provider, over both OIDC and SAML) that isn't in place yet, so `SOCIALACCOUNT_AUTO_SIGNUP` is `False` and `is_open_for_signup` returns `False` unless a deployment opts in with `SOCIALACCOUNT_ALLOW_SIGNUPS`. Existing users who have already connected a social account are unaffected — only first-time provisioning is gated.

### Scope notes
- Scoped down to the **crash fix + adapter wiring** per review discussion. The signup *behaviour* (account linking, `ext_sync` stamping, opening provisioning to any authenticated identity) is removed here and deferred to a follow-up design that generalises NAV's LDAP authorization model (allow/admin criteria) to social identities, provider-neutrally.
- **Re-targeted from #3975 to #4122.** #3975 described a bug in the legacy `TOMLConfigParser` path, which `settings.py` no longer uses (Pydantic `read_authentication_config`); obsolete, superseded by #4025 and the cleanup in #4124.
- The shipped `authentication.toml` OIDC example fix is handled separately in #4123 (#4121).
- Once a fixed allauth release (codeberg #4751, fixed upstream 2026-06-08) can be pinned, the `populate_username` override becomes a no-op and can be removed.

### Checklist
- [x] Changelog fragment `changelog.d/4122.fixed.md`
- [x] Unit tests (`allauth_adapter_test.py`)
- [x] `ruff format` / `ruff check`
- [x] Commit messages follow the seven rules (cbea.ms/git-commit)
- [x] Based on `master`