### PR TITLE
Pin ipaddr in constraints to fix dev env build

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,2 @@
 snowballstemmer<3.0.0  # incompatible with Sphinx 7.4.7?
+ipaddr>=2.2.0  # older versions fail to install on Py3 (legacy 0L literal)


### PR DESCRIPTION
## Scope and purpose

The Docker dev environment build on master and 5.18.x has been failing because `pip-compile` backtracks across old `ipaddr` releases when resolving requirements. `pynetsnmp-2` declares `Requires-Dist: ipaddr` with no version, and the only Python-3-compatible release is 2.2.0 — every earlier release uses the Python 2 `0L` literal syntax. Since none of the releases ship a wheel, the resolver has to execute `setup.py` on each candidate, and the older sdists fail at parse time.

This adds an `ipaddr>=2.2.0` line to `constraints.txt` so the resolver skips the broken candidates. Constraints are not declarations, so this does not add `ipaddr` to NAV's direct dependencies — it only kicks in when something else (currently `pynetsnmp-2`) pulls it in.

This is a stop-gap. The plan is to migrate the docker-compose dev environment from pip-compile to uv (which handles these legacy sdists correctly via PEP 517) and eventually drop the `requirements/*.txt` files in favour of `pyproject.toml`. That migration is tracked in #3990.

### This pull request
* changes a build-time dependency constraint


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

* [ ] ~~Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)~~ — tooling/CI-only change, not user-facing
* [ ] ~~Added/amended tests for new/changed code~~ — change is a single constraint line; CI's "Build docker compose dev environment" job is the regression test
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done — follow-up #3990
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions) — run `docker compose build nav`
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~