### PR TITLE
Bump pynetsnmp-2 minimum to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 
     "iso8601",
 
-    "pynetsnmp-2>=0.1.10",
+    "pynetsnmp-2>=0.2.0",
 
     "napalm>=5.1.0,<5.2.0",
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,7 @@ django-htmx
 # REST framework
 iso8601
 
-pynetsnmp-2>=0.1.10
+pynetsnmp-2>=0.2.0
 
 napalm>=5.1.0,<5.2.0
 


### PR DESCRIPTION
## Scope and purpose

`pynetsnmp-2` 0.2.0 drops the `ipaddr` runtime requirement that was breaking `pip-compile` in the Docker dev environment. Bumping the minimum requirement past that release removes the need for the `ipaddr` constraint stop-gap proposed in #3991 and unblocks the dev environment without further workarounds. The longer-term migration from `pip-compile` to `uv` is still tracked in #3990.

### This pull request
* changes a dependency


## Contributor Checklist

* [ ] ~~Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)~~ — build/dev-env-only dependency bump, not user-facing
* [ ] ~~Added/amended tests for new/changed code~~ — CI's docker-compose build job is the regression test
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the boilerplate header to that file~~