### PR TITLE
Speed up pip-compile by pinning paramiko/pyjwt

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,4 @@
 snowballstemmer<3.0.0  # incompatible with Sphinx 7.4.7?
+# Bound the transitive paramiko range so pip-compile's backtracking resolver
+# doesn't enumerate versions across napalm/junos-eznc/ncclient/netmiko.
+paramiko>=4,<5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
 
     "requests",
 
-    "pyjwt>=2.6.0",
+    "pyjwt>=2.12,<3",
 
     "distro",
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -46,7 +46,7 @@ service-identity==21.1.0
 
 requests
 
-pyjwt>=2.6.0
+pyjwt>=2.12,<3
 distro
 
 django-allauth[mfa,socialaccount]


### PR DESCRIPTION
## Scope and purpose

`pip-compile` in the Docker dev environment has been spending hours resolving NAV's dependencies. Verbose logs showed pip's backtracking resolver enumerating ~30 candidates of `paramiko` (which `napalm`, `junos-eznc`, `ncclient` and `netmiko` all transitively depend on with overlapping but unbounded ranges) and ~13 candidates of `PyJWT` (pulled in by `drf-jwt-multi-auth`, `django-allauth[socialaccount]`, etc.) before converging — multiplied by sdist metadata fetches per candidate.

Pinning `paramiko>=4,<5` in `constraints.txt` (it's purely transitive, so it doesn't belong in `pyproject.toml`) and tightening the direct `pyjwt` requirement to `>=2.12,<3` short-circuits both backtracking branches.

Measured in a faithful replica of the Dockerfile setup:

| State | pip-compile time |
| --- | --- |
| Before | 2.5+ hours |
| After | ~2m45s |

The longer-term fix for this class of resolver explosion is the `uv` migration tracked in #3990.

This PR is based on #3998 — merge that first.

### This pull request
* changes a dependency


## Contributor Checklist

* [ ] ~~Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)~~ — build/dev-env-only resolver fix, not user-facing
* [ ] ~~Added/amended tests for new/changed code~~ — CI's docker-compose build job is the regression test
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the boilerplate header to that file~~