### PR TITLE
Fix alias removal not being saved in SeedDB

### DIFF
--- a/changelog.d/4002.fixed.md
+++ b/changelog.d/4002.fixed.md
@@ -1,0 +1,1 @@
+Fixed removal of all aliases from rooms/locations in SeedDB not being persisted on save.

--- a/python/nav/django/forms.py
+++ b/python/nav/django/forms.py
@@ -116,6 +116,9 @@ class AliasListWidget(forms.Widget):
     def value_from_datadict(self, data, files, name):
         return _parse_json_list(data.get(f'{name}_json', '[]'))
 
+    def value_omitted_from_data(self, data, files, name):
+        return f'{name}_json' not in data
+
 
 class AliasListField(forms.Field):
     """Form field for editing a list of alias strings"""

--- a/tests/unittests/django/aliases_field_test.py
+++ b/tests/unittests/django/aliases_field_test.py
@@ -79,6 +79,19 @@ class TestAliasListWidgetValueFromDatadict:
         assert widget.value_from_datadict(data, {}, 'aliases') == []
 
 
+class TestAliasListWidgetValueOmittedFromData:
+    def test_when_json_key_present_it_should_return_false(self):
+        widget = AliasListWidget()
+        data = QueryDict(mutable=True)
+        data['aliases_json'] = '[]'
+        assert widget.value_omitted_from_data(data, {}, 'aliases') is False
+
+    def test_when_json_key_absent_it_should_return_true(self):
+        widget = AliasListWidget()
+        data = QueryDict(mutable=True)
+        assert widget.value_omitted_from_data(data, {}, 'aliases') is True
+
+
 class TestAliasListFieldPrepareValue:
     def test_when_value_is_list_then_it_should_return_it(self):
         field = AliasListField(required=False)


### PR DESCRIPTION
## Scope and purpose

Removing all aliases from a room or location in SeedDB appears to succeed in the UI, but the aliases reappear after saving the form.

The root cause is that `AliasListWidget` stores its value in a hidden input named `{field}_json`, but Django's default [`Widget.value_omitted_from_data()`](https://docs.djangoproject.com/en/4.2/ref/forms/widgets/#django.forms.Widget.value_omitted_from_data) checks for `{field}` in the POST data. Since the `aliases` model field has `default=list`, Django's `construct_instance` sees three conditions met simultaneously: the field has a default, the value appears omitted from POST data, and the cleaned value (`[]`) is in `empty_values`. It therefore skips saving the field, leaving the original aliases on the instance.

Adding aliases works because a non-empty list is not in `empty_values`, so the skip logic doesn't trigger. The bug only manifests when removing *all* aliases.

The fix overrides `value_omitted_from_data()` in `AliasListWidget` to check for `{name}_json` instead.

### This pull request
* ~~adds/changes/removes a dependency~~
* ~~changes the database~~
* ~~changes the API~~

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~