### PR TITLE
Fix LDAP session invalidation on every login

### DIFF
--- a/changelog.d/4003.fixed.md
+++ b/changelog.d/4003.fixed.md
@@ -1,0 +1,1 @@
+Fixed LDAP authentication unconditionally rehashing the password on every login, which invalidated the Django session auth hash and broke MFA/TOTP setup for LDAP users.

--- a/python/nav/web/auth/ldap_auth_backend.py
+++ b/python/nav/web/auth/ldap_auth_backend.py
@@ -126,8 +126,9 @@ class LdapBackend(ModelBackend):
         """Ensures the necessary local account details are synced from LDAP user
         details.
         """
-        nav_user.set_password(password)
-        nav_user.save()
+        if not nav_user.check_password(password):
+            nav_user.set_password(password)
+            nav_user.save()
         cls._sync_nav_account_admin_privileges_from_ldap(ldap_user, nav_user)
 
     @staticmethod

--- a/tests/unittests/web/auth/backends_test.py
+++ b/tests/unittests/web/auth/backends_test.py
@@ -1,6 +1,7 @@
 from mock import Mock, patch
 
 from nav.web.auth.backends import NAVRemoteUserBackend
+from nav.web.auth.ldap_auth_backend import LdapBackend
 from nav.models.profiles import Account
 
 
@@ -75,3 +76,54 @@ class TestNAVRemoteUserBackend:
             result = backend.user_can_authenticate(account)
             assert result == account.is_active == False  # noqa: E712
             auditlog.assert_called_once()
+
+
+@patch(
+    'nav.web.auth.ldap_auth_backend.LdapBackend._sync_nav_account_admin_privileges_from_ldap'
+)
+class TestLdapBackendSyncNavAccount:
+    def test_when_password_is_unchanged_then_sync_nav_account_should_not_rehash(
+        self, mock_sync_privs
+    ):
+        account = Account(login="testuser")
+        account.set_password("secret")
+        account.save = Mock()
+
+        LdapBackend._sync_nav_account(Mock(), account, "secret")
+
+        account.save.assert_not_called()
+
+    def test_when_password_is_changed_then_sync_nav_account_should_rehash_and_save(
+        self, mock_sync_privs
+    ):
+        account = Account(login="testuser")
+        account.set_password("old_secret")
+        account.save = Mock()
+
+        LdapBackend._sync_nav_account(Mock(), account, "new_secret")
+
+        account.save.assert_called_once()
+        assert account.check_password("new_secret")
+
+    def test_when_password_is_unchanged_then_sync_nav_account_should_preserve_session_auth_hash(  # noqa: E501
+        self, mock_sync_privs
+    ):
+        account = Account(login="testuser")
+        account.set_password("secret")
+        hash_before = account.get_session_auth_hash()
+
+        LdapBackend._sync_nav_account(Mock(), account, "secret")
+
+        assert account.get_session_auth_hash() == hash_before
+
+    def test_when_password_is_changed_then_sync_nav_account_should_change_session_auth_hash(  # noqa: E501
+        self, mock_sync_privs
+    ):
+        account = Account(login="testuser")
+        account.set_password("old_secret")
+        account.save = Mock()
+        hash_before = account.get_session_auth_hash()
+
+        LdapBackend._sync_nav_account(Mock(), account, "new_secret")
+
+        assert account.get_session_auth_hash() != hash_before


### PR DESCRIPTION
## Scope and purpose

Fixes #4003.

`LdapBackend._sync_nav_account()` unconditionally called `set_password()` on every LDAP authentication, rehashing the password with a new salt. This invalidated Django's `_auth_user_hash` session key, causing session loss after allauth reauthentication — which broke MFA/TOTP setup for LDAP users.

The fix guards `set_password()` with `check_password()` so the hash is only updated when the password has actually changed.

## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [X] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~