### PR TITLE
Remove invalid escape sequence in Navlet docstring

### DIFF
--- a/python/nav/web/navlets/__init__.py
+++ b/python/nav/web/navlets/__init__.py
@@ -124,7 +124,7 @@ class Navlet(TemplateView):
         """
         Get template name based on navlet mode.
 
-        :param override_mode: Optional\; if provided, overrides the mode (VIEW or EDIT)
+        :param override_mode: Optional; if provided, overrides the mode (VIEW or EDIT)
             sent in the request. If None, uses self.mode. Used to enable the navlet to
             return the correct template in error situations.
         :return: The template name for the specified mode.


### PR DESCRIPTION
## Scope and purpose

The backslash-escaped semicolon (`\;`) in `Navlet.get_template_name`'s docstring is not a valid Python escape sequence, causing a `SyntaxWarning` on Python 3.13 when running the test suite.

## Contributor Checklist

- [ ] ~~Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)~~
- [ ] ~~Added/amended tests for new/changed code~~
- [ ] ~~Added/changed documentation~~
- [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
- [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
- [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
- [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
- [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
- [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
- [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~