### PR TITLE
Replace fixed-timeout integration tests with polling

### DIFF
--- a/python/nav/eventengine/__init__.py
+++ b/python/nav/eventengine/__init__.py
@@ -15,25 +15,61 @@
 #
 """NAV eventengine"""
 
-from subprocess import STDOUT, check_output, TimeoutExpired, CalledProcessError
+import threading
+import time
+from subprocess import PIPE, STDOUT, Popen
+
+
+class EventEngineProcess:
+    """Runs eventengine as a background subprocess with output capture.
+
+    Use as a context manager.  Poll a condition to detect when the desired
+    state has been reached, then exit the context to kill the process.
+    """
+
+    def __init__(self):
+        self._process = None
+        self._output_lines = []
+        self._reader_thread = None
+
+    def __enter__(self):
+        self._process = Popen(["eventengine", "-f"], stdout=PIPE, stderr=STDOUT)
+        self._reader_thread = threading.Thread(target=self._read_output, daemon=True)
+        self._reader_thread.start()
+        return self
+
+    def __exit__(self, *exc_info):
+        self._process.kill()
+        self._process.wait()
+        self._reader_thread.join(timeout=5)
+        output = self.get_output()
+        print(output)
+
+    def _read_output(self):
+        for line in self._process.stdout:
+            self._output_lines.append(line.decode("utf-8", errors="replace"))
+
+    def get_output(self):
+        return "".join(self._output_lines)
+
+    def wait_for_condition(self, condition, timeout=30, interval=0.5):
+        """Poll *condition()* until it returns True or *timeout* is reached."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            retcode = self._process.poll()
+            if retcode is not None:
+                raise AssertionError(
+                    f"eventengine exited unexpectedly (code {retcode}):\n"
+                    f"{self.get_output()}"
+                )
+            if condition():
+                return True
+            time.sleep(interval)
+        return False
 
 
 def get_eventengine_output(timeout=10):
-    """
-    Runs eventengine in foreground mode, kills it after timeout seconds and
-    returns the combined stdout+stderr output from the process.
-    Also asserts that pping shouldn't unexpectedly exit with a zero exitcode.
-    """
-    cmd = ["eventengine", "-f"]
-    try:
-        output = check_output(cmd, stderr=STDOUT, timeout=timeout)
-    except TimeoutExpired as error:
-        # this is the normal case, since we need to kill eventengine after the timeout
-        print(error.output.decode("utf-8"))
-        return error.output.decode("utf-8")
-    except CalledProcessError as error:
-        print(error.output.decode("utf-8"))
-        raise
-    else:
-        print(output)
-        assert False, "eventengine exited with non-zero status"
+    """Deprecated wrapper — prefer :class:`EventEngineProcess`."""
+    with EventEngineProcess() as engine:
+        time.sleep(timeout)
+    return engine.get_output()

--- a/tests/integration/eventengine/boxdown_test.py
+++ b/tests/integration/eventengine/boxdown_test.py
@@ -5,16 +5,18 @@ import os
 import pytest
 
 from nav.config import find_config_file
-from nav.eventengine import get_eventengine_output
+from nav.eventengine import EventEngineProcess
 from nav.models.manage import Netbox
 from nav.models.event import EventQueue as Event
 
 
 def test_eventengine_should_declare_box_down(host_going_down, eventengine_test_config):
     post_fake_boxdown(host_going_down)
-    get_eventengine_output(6)
-    states = host_going_down.get_unresolved_alerts("boxState")
-    assert states.count() > 0, "netbox has not been marked as down"
+    with EventEngineProcess() as engine:
+        marked_down = engine.wait_for_condition(
+            lambda: host_going_down.get_unresolved_alerts("boxState").count() > 0
+        )
+    assert marked_down, "netbox has not been marked as down"
 
 
 ########################

--- a/tests/integration/eventengine/juniper_alert_count_test.py
+++ b/tests/integration/eventengine/juniper_alert_count_test.py
@@ -7,7 +7,7 @@ import logging
 import pytest
 
 
-from nav.eventengine import unresolved, get_eventengine_output
+from nav.eventengine import EventEngineProcess, unresolved
 from nav.eventengine.engine import EventEngine
 from nav.eventengine.plugins.juniperalertcount import JuniperAlertCountHandler
 from nav.models.fields import INFINITY
@@ -24,7 +24,16 @@ class TestBlackBox:
     ):
         count = 2
         post_fake_yellow_alarm_start_event(netbox_having_new_alarm_count, count)
-        get_eventengine_output(6)
+        with EventEngineProcess() as engine:
+            engine.wait_for_condition(
+                lambda: (
+                    netbox_having_new_alarm_count.get_unresolved_alerts(
+                        "juniperYellowAlarmState"
+                    )
+                    .filter(variables__isnull=False)
+                    .exists()
+                )
+            )
         alert = (
             netbox_having_new_alarm_count.get_unresolved_alerts(
                 "juniperYellowAlarmState"
@@ -44,7 +53,16 @@ class TestBlackBox:
         new_count = 3
         post_fake_yellow_alarm_start_event(netbox_having_new_alarm_count, old_count)
         post_fake_yellow_alarm_start_event(netbox_having_new_alarm_count, new_count)
-        get_eventengine_output(6)
+        with EventEngineProcess() as engine:
+            engine.wait_for_condition(
+                lambda: (
+                    netbox_having_new_alarm_count.get_unresolved_alerts(
+                        "juniperYellowAlarmState"
+                    )
+                    .filter(variables__isnull=False)
+                    .exists()
+                )
+            )
         alerts = netbox_having_new_alarm_count.get_unresolved_alerts(
             "juniperYellowAlarmState"
         ).filter(variables__isnull=False)
@@ -61,10 +79,15 @@ class TestBlackBox:
     ):
         post_fake_yellow_alarm_start_event(netbox_having_new_alarm_count)
         post_fake_yellow_alarm_end_event(netbox_having_new_alarm_count)
-        get_eventengine_output(6)
-        assert not netbox_having_new_alarm_count.get_unresolved_alerts(
-            "juniperYellowAlarmState"
-        ).exists(), "an unresolved alert exists after posting end event"
+        with EventEngineProcess() as engine:
+            resolved = engine.wait_for_condition(
+                lambda: (
+                    not netbox_having_new_alarm_count.get_unresolved_alerts(
+                        "juniperYellowAlarmState"
+                    ).exists()
+                )
+            )
+        assert resolved, "an unresolved alert exists after posting end event"
 
     def test_eventengine_should_copy_alert_count_to_alert_history_on_red_start_event(
         self,
@@ -72,7 +95,16 @@ class TestBlackBox:
     ):
         count = 2
         post_fake_red_alarm_start_event(netbox_having_new_alarm_count, count)
-        get_eventengine_output(6)
+        with EventEngineProcess() as engine:
+            engine.wait_for_condition(
+                lambda: (
+                    netbox_having_new_alarm_count.get_unresolved_alerts(
+                        "juniperRedAlarmState"
+                    )
+                    .filter(variables__isnull=False)
+                    .exists()
+                )
+            )
         alert = (
             netbox_having_new_alarm_count.get_unresolved_alerts("juniperRedAlarmState")
             .filter(variables__isnull=False)
@@ -90,7 +122,16 @@ class TestBlackBox:
         new_count = 3
         post_fake_red_alarm_start_event(netbox_having_new_alarm_count, old_count)
         post_fake_red_alarm_start_event(netbox_having_new_alarm_count, new_count)
-        get_eventengine_output(6)
+        with EventEngineProcess() as engine:
+            engine.wait_for_condition(
+                lambda: (
+                    netbox_having_new_alarm_count.get_unresolved_alerts(
+                        "juniperRedAlarmState"
+                    )
+                    .filter(variables__isnull=False)
+                    .exists()
+                )
+            )
         alerts = netbox_having_new_alarm_count.get_unresolved_alerts(
             "juniperRedAlarmState"
         ).filter(variables__isnull=False)
@@ -107,10 +148,15 @@ class TestBlackBox:
     ):
         post_fake_red_alarm_start_event(netbox_having_new_alarm_count)
         post_fake_red_alarm_end_event(netbox_having_new_alarm_count)
-        get_eventengine_output(6)
-        assert not netbox_having_new_alarm_count.get_unresolved_alerts(
-            "juniperRedAlarmState"
-        ), "an unresolved alert exists after posting end event"
+        with EventEngineProcess() as engine:
+            resolved = engine.wait_for_condition(
+                lambda: (
+                    not netbox_having_new_alarm_count.get_unresolved_alerts(
+                        "juniperRedAlarmState"
+                    ).exists()
+                )
+            )
+        assert resolved, "an unresolved alert exists after posting end event"
 
 
 class TestStatelessEvent:

--- a/tests/integration/pping_test.py
+++ b/tests/integration/pping_test.py
@@ -4,19 +4,16 @@ various pping integration tests
 
 import os
 import getpass
+import threading
+import time
 from shutil import which
-from subprocess import STDOUT, check_output, CalledProcessError
+from subprocess import PIPE, STDOUT, Popen, TimeoutExpired
 
 import pytest
 
 from nav.models.manage import Netbox, NetboxProfile
 from nav.models.event import EventQueue
 from nav.config import find_config_file
-
-TIMEOUT_COMMAND_LINE = "/usr/bin/timeout"
-
-
-BINDIR = './python/nav/bin'
 
 
 #
@@ -41,98 +38,103 @@ def get_root_method():
         assert False, "cannot become root"
 
 
-def timeout_command_line_program_exists():
-    return os.access(TIMEOUT_COMMAND_LINE, os.X_OK)
+class PpingProcess:
+    """Runs pping as a background subprocess with output capture."""
+
+    def __init__(self):
+        self._process = None
+        self._output_lines = []
+        self._reader_thread = None
+
+    def __enter__(self):
+        pping = which("pping")
+        assert pping, "Cannot find pping in PATH"
+        cmd = get_root_method() + [pping, "-f"]
+        self._process = Popen(cmd, stdout=PIPE, stderr=STDOUT)
+        self._reader_thread = threading.Thread(target=self._read_output, daemon=True)
+        self._reader_thread.start()
+        return self
+
+    def __exit__(self, *exc_info):
+        self._process.terminate()
+        try:
+            self._process.wait(timeout=5)
+        except TimeoutExpired:
+            self._process.kill()
+            self._process.wait()
+        self._reader_thread.join(timeout=5)
+        print(self.get_output())
+
+    def _read_output(self):
+        for line in self._process.stdout:
+            self._output_lines.append(line.decode("utf-8", errors="replace"))
+
+    def get_output(self):
+        return "".join(self._output_lines)
+
+    def wait_for_condition(self, condition, timeout=30, interval=0.5):
+        """Poll *condition()* until it returns True or *timeout* is reached."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self._process.poll() is not None:
+                break
+            if condition():
+                return True
+            time.sleep(interval)
+        return False
 
 
 #
 # Actual tests begin here
 #
-@pytest.mark.timeout(20)
-@pytest.mark.skipif(
-    not timeout_command_line_program_exists(),
-    reason="{} is not available".format(TIMEOUT_COMMAND_LINE),
-)
+@pytest.mark.timeout(60)
 @pytest.mark.skipif(
     not can_be_root(), reason="pping can only be tested with root privileges"
 )
 def test_pping_localhost_should_work(localhost, pping_test_config):
-    output = get_pping_output()
-    assert "hosts checked" in output
-    assert (
-        "{sysname} ({ip}) marked as down".format(
-            sysname=localhost.sysname, ip=localhost.ip
+    with PpingProcess() as pping:
+        checked = pping.wait_for_condition(
+            lambda: "hosts checked" in pping.get_output()
         )
-        not in output
-    )
+    output = pping.get_output()
+    assert checked, "pping did not report 'hosts checked'"
+    assert f"{localhost.sysname} ({localhost.ip}) marked as down" not in output
 
 
-@pytest.mark.timeout(20)
-@pytest.mark.skipif(
-    not timeout_command_line_program_exists(),
-    reason="{} is not available".format(TIMEOUT_COMMAND_LINE),
-)
+@pytest.mark.timeout(60)
 @pytest.mark.skipif(
     not can_be_root(), reason="pping can only be tested with root privileges"
 )
 def test_pping_nonavailable_host_should_fail(
     host_expected_to_be_down, pping_test_config
 ):
-    expected = "{sysname} ({ip}) marked as down".format(
-        sysname=host_expected_to_be_down.sysname, ip=host_expected_to_be_down.ip
+    expected = (
+        f"{host_expected_to_be_down.sysname}"
+        f" ({host_expected_to_be_down.ip}) marked as down"
     )
-    output = get_pping_output()
-    assert expected in output
+    with PpingProcess() as pping:
+        marked_down = pping.wait_for_condition(lambda: expected in pping.get_output())
+    assert marked_down, f"pping did not mark host as down: {expected!r} missing"
 
 
-@pytest.mark.timeout(20)
-@pytest.mark.skipif(
-    not timeout_command_line_program_exists(),
-    reason="{} is not available".format(TIMEOUT_COMMAND_LINE),
-)
+@pytest.mark.timeout(60)
 @pytest.mark.skipif(
     not can_be_root(), reason="pping can only be tested with root privileges"
 )
 def test_pping_should_post_event_when_host_is_unreachable(
     host_expected_to_be_down, pping_test_config
 ):
-    get_pping_output()
-    assert EventQueue.objects.filter(
-        netbox=host_expected_to_be_down,
-        event_type_id='boxState',
-        state=EventQueue.STATE_START,
-    ), "The expected boxState start event was not found on the event queue"
-
-
-########################
-#                      #
-# fixtures and helpers #
-#                      #
-########################
-
-
-def get_pping_output(timeout=5):
-    """
-    Runs pping in foreground mode, kills it after timeout seconds and
-    returns the combined stdout+stderr output from the process.
-
-    Also asserts that pping shouldn't unexpectedly exit with a zero exitcode.
-    """
-    pping = which("pping")
-    assert pping, "Cannot find pping in PATH"
-    cmd = get_root_method() + [TIMEOUT_COMMAND_LINE, str(timeout), pping, "-f"]
-    try:
-        output = check_output(cmd, stderr=STDOUT)
-    except CalledProcessError as error:
-        if error.returncode == 124:  # timeout
-            # this is the normal case, since we need to kill pping after the timeout
-            print(error.output.decode('utf-8'))
-            return error.output.decode('utf-8')
-        print(error.output.decode('utf-8'))
-        raise
-    else:
-        print(output)
-        assert False, "pping exited unexpectedly"
+    with PpingProcess() as pping:
+        event_posted = pping.wait_for_condition(
+            lambda: EventQueue.objects.filter(
+                netbox=host_expected_to_be_down,
+                event_type_id='boxState',
+                state=EventQueue.STATE_START,
+            ).exists()
+        )
+    assert event_posted, (
+        "The expected boxState start event was not found on the event queue"
+    )
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Scope and purpose

Replace fixed-timeout integration tests with condition polling to eliminate timing sensitivity and reduce test wall-clock time.

The eventengine and pping integration tests launched daemon subprocesses, waited a fixed duration, then checked results. On Python 3.13 (which has slightly slower startup), the fixed timeouts left insufficient margin — the boxdown and pping tests failed locally even though they passed on GitHub Actions. The tests were also wasteful: the six juniper blackbox tests each waited 6s for events that process in under 1s. The polling approach returns as soon as the expected state is reached, with a generous 30s ceiling to prevent hangs.

### This pull request

* Adds `EventEngineProcess` and `PpingProcess` context managers that run daemons in the background, capture output, and provide a `wait_for_condition()` polling method
* Converts eventengine and pping integration tests from fixed-timeout sleeps to condition polling
* Removes the `/usr/bin/timeout` dependency from pping tests

## Contributor Checklist

* ~~[ ] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)~~
* [x] Added/amended tests for new/changed code
* ~~[ ] Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* ~~[ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* ~~[ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* ~~[ ] If this results in changes in the UI: Added screenshots of the before and after~~
* ~~[ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~