### PR TITLE
Add CI gate for vendored JS library sync

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,9 +8,116 @@ on:
   schedule: # Run daily at 08:00 CEST (06:00 UST)
     - cron: '0 6 * * *'
 
+permissions:
+  pull-requests: write
+
 jobs:
+  vendor-check:
+    name: Check vendored JS libraries
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
+    outputs:
+      result: ${{ steps.gate.outputs.result }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check if package.json changed
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            changed=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
+              --paginate -q '.[].filename' | grep -c '^package\.json$' || true)
+          else
+            changed=$(gh api repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.sha }} \
+              --paginate -q '.files[].filename' | grep -c '^package\.json$' || true)
+          fi
+          if [ "$changed" -gt 0 ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-node@v6
+        if: steps.filter.outputs.changed == 'true'
+        with:
+          node-version: 18
+
+      - uses: actions/setup-python@v6
+        if: steps.filter.outputs.changed == 'true'
+        with:
+          python-version: "3.11"
+
+      - name: Install npm dependencies
+        if: steps.filter.outputs.changed == 'true'
+        run: npm install --legacy-peer-deps
+
+      - name: Check vendored libraries are in sync
+        id: check
+        if: steps.filter.outputs.changed == 'true'
+        run: python3 tools/vendor.py check --no-untracked
+
+      - name: Show what needs updating
+        if: failure()
+        run: |
+          python3 tools/vendor.py sync
+          echo "### Changed files" >> "$GITHUB_STEP_SUMMARY"
+          git diff --stat python/nav/web/static/js/libs/ >> "$GITHUB_STEP_SUMMARY"
+          git diff --stat python/nav/web/static/js/require_config.js >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post PR comment on failure
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = [
+              '## Vendored JS libraries are out of sync',
+              '',
+              'This PR updates `package.json` but the vendored library files',
+              'in `python/nav/web/static/js/libs/` have not been updated to',
+              'match.',
+              '',
+              '**The test suite has been skipped because its results would not',
+              'be meaningful until the vendored libraries are synced.**',
+              '',
+              'To fix this, run:',
+              '```',
+              'npm install --legacy-peer-deps',
+              'python tools/vendor.py sync',
+              'git add python/nav/web/static/js/libs/ python/nav/web/static/js/require_config.js',
+              'git commit -m "Sync vendored JS libraries"',
+              '```',
+              '',
+              'See `tools/vendor.py --help` for more options.',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+
+      - name: Set gate result
+        id: gate
+        if: always()
+        run: |
+          if [ "${{ steps.filter.outputs.changed }}" != "true" ]; then
+            echo "result=skipped" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.check.outcome }}" = "success" ]; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+          fi
+
   build-and-test:
     name: "Test on Python ${{ matrix.python-version}}"
+    needs: vendor-check
+    if: >-
+      always() && (
+        needs.vendor-check.outputs.result != 'failure'
+        || github.event_name == 'schedule'
+      )
     runs-on: ubuntu-latest
 
     strategy:
@@ -107,6 +214,12 @@ jobs:
 
   javascript:
     name: "Test Javascript code"
+    needs: vendor-check
+    if: >-
+      always() && (
+        needs.vendor-check.outputs.result != 'failure'
+        || github.event_name == 'schedule'
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/tools/vendor.py
+++ b/tools/vendor.py
@@ -168,7 +168,7 @@ def cmd_list():
         print(f"  {name:<{w0}}  {version:<{w1}}  {local}")
 
 
-def cmd_check():
+def cmd_check(no_untracked=False):
     """Check for version mismatches, missing files, and untracked vendors."""
     _check_node_modules()
     problems = []
@@ -189,9 +189,10 @@ def cmd_check():
         elif actual != expected:
             problems.append(f"  {npm_name}: version mismatch ({actual} != {expected})")
 
-    for f in sorted(LIBS.glob("*.js")):
-        if f.name not in managed_files and VERSION_RE.search(f.name):
-            problems.append(f"  {f.name}: untracked")
+    if not no_untracked:
+        for f in sorted(LIBS.glob("*.js")):
+            if f.name not in managed_files and VERSION_RE.search(f.name):
+                problems.append(f"  {f.name}: untracked")
 
     if problems:
         print("Problems found:")
@@ -283,7 +284,14 @@ def build_parser():
     sub = parser.add_subparsers(dest="command", required=True)
 
     sub.add_parser("list", help="List vendored libraries and their status")
-    sub.add_parser("check", help="Check for version mismatches and untracked files")
+    check = sub.add_parser(
+        "check", help="Check for version mismatches and untracked files"
+    )
+    check.add_argument(
+        "--no-untracked",
+        action="store_true",
+        help="Skip checking for untracked files in libs/",
+    )
     sub.add_parser("sync", help="Sync all vendored libraries from node_modules")
 
     update = sub.add_parser("update", help="Update a vendored package")
@@ -307,7 +315,7 @@ if __name__ == "__main__":
     if args.command == "list":
         cmd_list()
     elif args.command == "check":
-        cmd_check()
+        cmd_check(no_untracked=args.no_untracked)
     elif args.command == "sync":
         cmd_sync()
     elif args.command == "update":


### PR DESCRIPTION
## Scope and purpose

Dependabot bumps `package.json` but doesn't run `tools/vendor.py sync`, so vendored files in `python/nav/web/static/js/libs/` and `require_config.js` remain stale. The test suite then runs against old library versions, producing a misleading green result.

This PR adds two things:

1. A `--no-untracked` flag to `vendor.py check`, so that legacy vendored JS files not managed via `package.json` (e.g. d3, openlayers, require) don't cause false positives.
2. A `vendor-check` gate job in the CI workflow that only runs when `package.json` actually changes. When vendored files are out of sync, the test jobs are skipped and a PR comment explains how to fix it. When `package.json` is unchanged, the check is skipped entirely and tests proceed normally. On scheduled (cron) runs the check is also skipped.

## Contributor Checklist

* [ ] ~~Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)~~
* [ ] ~~Added/amended tests for new/changed code~~
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~