### PR TITLE
Add hybrid port support to cam plugin

### DIFF
--- a/NOTES.rst
+++ b/NOTES.rst
@@ -22,6 +22,27 @@ Python modules with changed version requirements:
 
 * :mod:`Django` (``>=5.2,<5.3``)
 
+CAM logging for hybrid switch ports
+-----------------------------------
+
+Switch ports whose only neighbor is an unmanaged device (one registered in NAV
+but with no SNMP or other management profiles) can now optionally log CAM
+records.  Previously, once the topology detector discovered such a neighbor, the
+cam plugin would classify the port as a link port and stop logging forwarding
+table entries — making it invisible to Machine Tracker.
+
+To enable this, add the following to :file:`ipdevpoll.conf`::
+
+    [cam]
+    log_unmanaged_neighbor_macs = yes
+
+When enabled, these ports are treated as *hybrid* ports: their MAC addresses are
+logged for Machine Tracker while adjacency candidates are still created for the
+topology system.  This is useful for locating both the unmanaged device itself
+and any end hosts behind it.
+
+See the ``[cam]`` section in :doc:`/reference/ipdevpoll` for full details.
+
 NAV 5.18
 ========
 

--- a/changelog.d/2915.added.md
+++ b/changelog.d/2915.added.md
@@ -1,0 +1,1 @@
+The cam plugin can now optionally log CAM records for switch ports connected to unmanaged neighbors, so that Machine Tracker can locate both the unmanaged device itself and any end hosts behind it. See the `[cam]` section in the ipdevpoll reference docs for details.

--- a/doc/reference/ipdevpoll.rst
+++ b/doc/reference/ipdevpoll.rst
@@ -94,6 +94,20 @@ Section [netbox_filters]
   Allows you to specify the devices that WON'T be handled by this instance of
   ipdevpoll using a space separated list of group ids.
 
+Section [cam]
+-------------
+
+``log_unmanaged_neighbor_macs``
+  When set to ``yes``, switch ports whose only detected neighbor is an
+  unmanaged device (i.e. a device with no management profiles) will be treated
+  as *hybrid* ports: their CAM records are logged for Machine Tracker, and
+  adjacency candidates are still created for topology discovery.
+
+  The default value is ``no``.  See `GitHub issue #14
+  <https://github.com/Uninett/nav/issues/14>`_ for background on why this is
+  off by default.  The default may change to ``yes`` in a future release once
+  the feature has been validated in production environments.
+
 Section [linkstate]
 -------------------
 

--- a/python/nav/etc/ipdevpoll.conf
+++ b/python/nav/etc/ipdevpoll.conf
@@ -235,6 +235,20 @@ filter = topology
 #hostname = secret-API-key
 #ip = another-secret-API-key
 
+[cam]
+# When NAV detects a monitored MAC address on a switch port, it classifies the
+# port as a "link port" and only creates adjacency candidates — no CAM records
+# are logged for that port.  If the neighbor device has no management profiles,
+# however, it cannot be polled, so Machine Tracker has no way to locate end
+# hosts behind it.
+#
+# Enabling this option makes NAV treat such ports as hybrid: CAM records are
+# logged (so Machine Tracker works) AND adjacency candidates are still created
+# (so the topology remains correct).
+#
+# This option is off by default due to regression history (see GitHub #14).
+#log_unmanaged_neighbor_macs = no
+
 [sensors]
 # A space-separated list of Python modules to load into ipdevpoll as the
 # sensors plugin is loaded. An asterisk suffix will cause all modules in that

--- a/python/nav/ipdevpoll/plugins/cam.py
+++ b/python/nav/ipdevpoll/plugins/cam.py
@@ -20,6 +20,8 @@ from collections import defaultdict
 
 from twisted.internet import defer
 
+from django.db.models import Count
+
 from nav.models import manage
 from nav.util import splitby
 from nav.mibs.bridge_mib import MultiBridgeMib
@@ -52,6 +54,16 @@ class Cam(Plugin):
     accessports = None
     blocking = None
     my_macs = None
+
+    _log_unmanaged_neighbor_macs = False
+
+    @classmethod
+    def on_plugin_load(cls):
+        from nav.ipdevpoll.config import ipdevpoll_conf
+
+        cls._log_unmanaged_neighbor_macs = ipdevpoll_conf.getboolean(
+            'cam', 'log_unmanaged_neighbor_macs', fallback=False
+        )
 
     @classmethod
     @defer.inlineCallbacks
@@ -86,6 +98,8 @@ class Cam(Plugin):
             if netboxid == self.netbox.id
         )
         self._classify_ports()
+        if self._log_unmanaged_neighbor_macs:
+            yield self._promote_hybrid_ports()
         self._store_cam_records()
         self._store_adjacency_candidates()
 
@@ -158,6 +172,31 @@ class Cam(Plugin):
 
         self._logger.debug("up/downlinks: %r", sorted(self.linkports.keys()))
         self._logger.debug("access ports: %r", sorted(self.accessports.keys()))
+
+    async def _promote_hybrid_ports(self):
+        """Copies link ports with unmanaged neighbors into accessports.
+
+        This ensures CAM records are logged for ports whose only neighbor is an
+        unmanaged device (no management profiles), while still keeping them in
+        linkports so adjacency candidates are created as well.
+        """
+        hybrid = await db.run_in_thread(self._get_unmanaged_neighbor_linkports)
+        if hybrid:
+            self._logger.debug("hybrid ports (unmanaged neighbors): %r", sorted(hybrid))
+            for ifindex in hybrid:
+                self.accessports[ifindex] = self.linkports[ifindex]
+
+    def _get_unmanaged_neighbor_linkports(self):
+        return set(
+            manage.Interface.objects.filter(
+                netbox__id=self.netbox.id,
+                ifindex__in=self.linkports.keys(),
+                to_netbox__isnull=False,
+            )
+            .annotate(profile_count=Count('to_netbox__profiles'))
+            .filter(profile_count=0)
+            .values_list('ifindex', flat=True)
+        )
 
     def _store_cam_records(self):
         for port in self.accessports:

--- a/tests/unittests/ipdevpoll/cam_test.py
+++ b/tests/unittests/ipdevpoll/cam_test.py
@@ -1,0 +1,150 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License version 3 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Unit tests for the cam ipdevpoll plugin."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from twisted.internet import defer
+
+from nav.ipdevpoll.plugins.cam import Cam
+
+
+class TestPromoteHybridPorts:
+    """Tests for the hybrid port promotion logic in the cam plugin."""
+
+    @pytest.mark.twisted
+    async def test_when_no_unmanaged_neighbors_then_it_should_not_modify_accessports(
+        self, cam_plugin
+    ):
+        cam_plugin.linkports = {1: {'aa:bb:cc:dd:ee:01'}}
+        cam_plugin.accessports = {2: {'aa:bb:cc:dd:ee:02'}}
+
+        with patch(
+            'nav.ipdevpoll.plugins.cam.db.run_in_thread',
+            side_effect=lambda func: defer.succeed(func()),
+        ):
+            with patch.object(
+                cam_plugin,
+                '_get_unmanaged_neighbor_linkports',
+                return_value=set(),
+            ):
+                await cam_plugin._promote_hybrid_ports()
+
+        assert cam_plugin.accessports == {2: {'aa:bb:cc:dd:ee:02'}}
+        assert 1 not in cam_plugin.accessports
+
+    @pytest.mark.twisted
+    async def test_when_hybrid_port_exists_then_port_should_appear_in_both_dicts(
+        self, cam_plugin
+    ):
+        cam_plugin.linkports = {1: {'aa:bb:cc:dd:ee:01'}}
+        cam_plugin.accessports = {2: {'aa:bb:cc:dd:ee:02'}}
+
+        with patch(
+            'nav.ipdevpoll.plugins.cam.db.run_in_thread',
+            side_effect=lambda func: defer.succeed(func()),
+        ):
+            with patch.object(
+                cam_plugin,
+                '_get_unmanaged_neighbor_linkports',
+                return_value={1},
+            ):
+                await cam_plugin._promote_hybrid_ports()
+
+        assert 1 in cam_plugin.accessports
+        assert 1 in cam_plugin.linkports
+        assert cam_plugin.accessports[1] == {'aa:bb:cc:dd:ee:01'}
+
+    @pytest.mark.twisted
+    async def test_when_flag_is_enabled_then_handle_should_call_promote_hybrid_ports(
+        self, cam_plugin
+    ):
+        cam_plugin.fdb = {1: {'aa:bb:cc:dd:ee:01'}}
+        cam_plugin.monitored = {}
+        cam_plugin.my_macs = set()
+
+        with (
+            patch.object(Cam, '_log_unmanaged_neighbor_macs', True),
+            patch.object(
+                cam_plugin,
+                '_get_dot1q_mac_port_mapping',
+                return_value=defer.succeed({1: {'aa:bb:cc:dd:ee:01'}}),
+            ),
+            patch.object(
+                cam_plugin,
+                '_get_dot1d_stp_blocking',
+                return_value=defer.succeed({}),
+            ),
+            patch(
+                'nav.ipdevpoll.plugins.cam.db.run_in_thread',
+                side_effect=lambda func, *a, **kw: defer.succeed(func(*a, **kw)),
+            ),
+            patch(
+                'nav.ipdevpoll.plugins.cam.get_netbox_macs',
+                return_value={},
+            ),
+            patch.object(
+                cam_plugin,
+                '_promote_hybrid_ports',
+                return_value=defer.succeed(None),
+            ) as mock_promote,
+            patch.object(cam_plugin, '_store_cam_records'),
+            patch.object(cam_plugin, '_store_adjacency_candidates'),
+        ):
+            await cam_plugin.handle()
+
+        mock_promote.assert_called_once()
+
+    @pytest.mark.twisted
+    async def test_when_orm_returns_ifindexes_then_promote_should_use_them(
+        self, cam_plugin
+    ):
+        cam_plugin.linkports = {1: {'aa:bb:cc:dd:ee:01'}, 2: {'aa:bb:cc:dd:ee:02'}}
+        cam_plugin.accessports = {}
+
+        mock_qs = Mock()
+        mock_qs.filter.return_value = mock_qs
+        mock_qs.annotate.return_value = mock_qs
+        mock_qs.values_list.return_value = [1]
+
+        with (
+            patch(
+                'nav.ipdevpoll.plugins.cam.db.run_in_thread',
+                side_effect=lambda func: defer.succeed(func()),
+            ),
+            patch(
+                'nav.ipdevpoll.plugins.cam.manage.Interface.objects.filter',
+                return_value=mock_qs,
+            ),
+        ):
+            await cam_plugin._promote_hybrid_ports()
+
+        assert 1 in cam_plugin.accessports
+        assert 2 not in cam_plugin.accessports
+
+
+@pytest.fixture()
+def cam_plugin():
+    """Returns a Cam plugin instance with mocked dependencies."""
+    netbox = Mock(name='netbox')
+    netbox.id = 1
+    agent = Mock(name='agent')
+    containers = Mock(name='containers')
+    # containers.setdefault is used by CamManager.add_sentinel
+    containers.setdefault = Mock(return_value={})
+    plugin = Cam(netbox, agent, containers)
+    return plugin


### PR DESCRIPTION
## Scope and purpose

Fixes #2915.

The cam plugin classifies ports with monitored MAC addresses as "link ports" and skips CAM logging for them. When the known neighbor is an unmanaged device (no management profiles), this means Machine Tracker cannot locate the device or any end hosts hidden behind it (if the unmanaged device acts as a "hidden switch").

This adds an opt-in `log_unmanaged_neighbor_macs` setting in the `[cam]` section of `ipdevpoll.conf` that treats such ports as hybrid: CAM records are logged AND adjacency candidates are still created. The default is `no` due to regression history (#14), with the intent to flip to `yes` once validated in production.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [x] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file