### PR TITLE
 Escape pipe characters when dumping netbox

### DIFF
--- a/changelog.d/3960.fixed.md
+++ b/changelog.d/3960.fixed.md
@@ -1,0 +1,1 @@
+Fixed pipe characters in management profile names or netbox data breaking bulk dump/import

--- a/python/nav/bin/navdump.py
+++ b/python/nav/bin/navdump.py
@@ -27,6 +27,7 @@ from nav.bootstrap import bootstrap_django
 
 bootstrap_django(__file__)
 
+from nav.bulkparse import escape_pipe
 from nav.models import manage
 import nav.models.service
 
@@ -150,8 +151,13 @@ class Handlers(object):
             "devicegroup1:devicegroup2..]"
         )
         for box in manage.Netbox.objects.all():
-            profiles = '|'.join(box.profiles.values_list('name', flat=True))
-            data = '|'.join("%s=%s" % (k, v) for k, v in box.data.items())
+            profiles = '|'.join(
+                escape_pipe(name)
+                for name in box.profiles.values_list('name', flat=True)
+            )
+            data = '|'.join(
+                "%s=%s" % (escape_pipe(k), escape_pipe(v)) for k, v in box.data.items()
+            )
             line = [
                 box.room_id,
                 box.ip,

--- a/python/nav/bulkimport.py
+++ b/python/nav/bulkimport.py
@@ -33,7 +33,7 @@ from nav.models.service import Service, ServiceProperty
 from nav.util import is_valid_ip
 from nav.web.servicecheckers import get_description
 
-from nav.bulkparse import BulkParseError
+from nav.bulkparse import BulkParseError, split_on_pipe
 
 
 def _get_aliases(aliases: str) -> list[str]:
@@ -135,7 +135,7 @@ class NetboxImporter(BulkImporter):
         if not profile_names:
             return
 
-        profiles = profile_names.split('|')
+        profiles = split_on_pipe(profile_names)
         profiles = [
             get_object_or_fail(ManagementProfile, name=name)
             for name in profiles
@@ -164,7 +164,7 @@ class NetboxImporter(BulkImporter):
     @staticmethod
     def _parse_data(datastring):
         if datastring:
-            items = (item.split('=', 1) for item in datastring.split('|'))
+            items = (item.split('=', 1) for item in split_on_pipe(datastring))
         else:
             items = []
         return dict(items) if items else dict()

--- a/python/nav/bulkparse.py
+++ b/python/nav/bulkparse.py
@@ -35,6 +35,31 @@ from nav.models.manage import (
 )
 
 
+def escape_pipe(val: str):
+    """
+    Add escape characters to any backslashes and
+    pipe symbols in the provided string
+    """
+    return str(val).replace('\\', '\\\\').replace('|', '\\|')
+
+
+def split_on_pipe(val: str):
+    """Split provided string on all unescaped pipe characters"""
+    parts = []
+    current = []
+    it = iter(val)
+    for c in it:
+        if c == '\\':
+            current.append(next(it, c))
+        elif c == '|':
+            parts.append(''.join(current))
+            current = []
+        else:
+            current.append(c)
+    parts.append(''.join(current))
+    return parts
+
+
 class BulkParser:
     """Abstract base class for bulk parsers"""
 
@@ -210,7 +235,7 @@ class NetboxBulkParser(BulkParser):
     def _validate_data(datastring):
         try:
             if datastring:
-                items = (item.split('=', 1) for item in datastring.split('|'))
+                items = (item.split('=', 1) for item in split_on_pipe(datastring))
                 if items:
                     dict(items)
         except ValueError:

--- a/tests/unittests/general/bulkparse_test.py
+++ b/tests/unittests/general/bulkparse_test.py
@@ -3,6 +3,40 @@
 import pytest
 
 from nav import bulkparse
+from nav.bulkparse import escape_pipe, split_on_pipe
+
+
+class TestEscapePipe:
+    def test_when_pipe_in_string_then_it_should_be_escaped(self):
+        assert escape_pipe('a|b') == 'a\\|b'
+
+    def test_given_plain_string_then_it_should_be_unchanged(self):
+        assert escape_pipe('hello') == 'hello'
+
+    def test_given_backslash_in_string_then_it_should_be_escaped(self):
+        assert escape_pipe('a\\b') == 'a\\\\b'
+
+    def test_given_backslash_before_pipe_then_both_should_be_escaped(self):
+        assert escape_pipe('a\\|b') == 'a\\\\\\|b'
+
+
+class TestSplitOnPipe:
+    def test_given_no_pipe_then_it_should_return_single_element_list(self):
+        assert split_on_pipe('hello') == ['hello']
+
+    def test_given_unescaped_pipes_then_it_should_split_on_them(self):
+        assert split_on_pipe('a|b|c') == ['a', 'b', 'c']
+
+    def test_when_pipe_is_escaped_then_it_should_not_be_a_split_point(self):
+        assert split_on_pipe('a\\|b|c') == ['a|b', 'c']
+
+    def test_given_empty_string_then_it_should_return_list_with_empty_string(self):
+        assert split_on_pipe('') == ['']
+
+    def test_given_escaped_values_should_restore_originals(self):
+        values = ['foo|bar', 'testing', 'a\\b', 'a\\|b', 'a\\\\|b']
+        joined = '|'.join(escape_pipe(v) for v in values)
+        assert split_on_pipe(joined) == values
 
 
 class TestBulkParser(object):


### PR DESCRIPTION
## Scope and purpose

Fixes #3960

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
