### PR TITLE
fix: add is_active flag to Account model for proper lock handling

### DIFF
--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -115,6 +115,7 @@ class Account(AbstractBaseUser):
     email = models.EmailField(null=True, blank=True)  # Not currently used by NAV
     password = VarcharField()
     ext_sync = VarcharField(blank=True)
+    is_active = models.BooleanField(default=True)
     preferences = HStoreField(default=dict)
 
     organizations = models.ManyToManyField(
@@ -350,19 +351,11 @@ class Account(AbstractBaseUser):
 
     @property
     def locked(self):
-        return not self.password or self.password.startswith('!')
-
-    @property
-    def is_active(self):
-        """Returns True if this account is active (i.e. not locked)"""
-        return not self.locked
+        return not self.is_active
 
     @locked.setter
     def locked(self, value):
-        if not value:
-            self.password = self.password.removeprefix("!")
-        elif not self.password.startswith('!'):
-            self.password = '!' + self.password
+        self.is_active = not value
 
     @property
     def password_hash(self):
@@ -373,11 +366,8 @@ class Account(AbstractBaseUser):
 
     @property
     def unlocked_password(self):
-        """Returns the raw password value, but with any lock status stripped"""
-        if not self.locked:
-            return self.password or ''
-        else:
-            return self.password[1:] if self.password else ''
+        """Returns the raw password value"""
+        return self.password or ''
 
     def get_email_addresses(self):
         return self.alert_addresses.filter(type__name=AlertSender.EMAIL)

--- a/python/nav/models/sql/baseline/navprofiles.sql
+++ b/python/nav/models/sql/baseline/navprofiles.sql
@@ -57,6 +57,7 @@ CREATE TABLE Account (
     name varchar DEFAULT 'Noname',
     password varchar,
     ext_sync varchar,
+    is_active boolean NOT NULL DEFAULT true,
     preferences manage.hstore DEFAULT manage.hstore(''),
 
     CONSTRAINT account_pkey PRIMARY KEY(id),

--- a/python/nav/models/sql/changes/sc.05.18.0507.sql
+++ b/python/nav/models/sql/changes/sc.05.18.0507.sql
@@ -1,0 +1,9 @@
+ALTER TABLE profiles.account ADD COLUMN is_active boolean NOT NULL DEFAULT true;
+
+UPDATE profiles.account
+SET is_active = false
+WHERE password IS NULL OR password LIKE '!%';
+
+UPDATE profiles.account
+SET password = substring(password FROM 2)
+WHERE password LIKE '!%';


### PR DESCRIPTION
Replace password-prefix-based locking ("!<hash>") with an independent is_active boolean field, as recommended by Django's AbstractBaseUser design. This allows accounts to exist without a guessable password while remaining active — required for social/OIDC login accounts.

- Add is_active BooleanField (default True) to Account
- locked property now returns not self.is_active
- locked setter now only sets is_active, no password manipulation
- unlocked_password simplified; ! prefix stripped from existing passwords
- Schema change sc.05.18.0507 migrates existing locked accounts
