### PR TITLE
Add `is_active` flag to `Account` model

### DIFF
--- a/python/nav/bin/navuser.py
+++ b/python/nav/bin/navuser.py
@@ -50,7 +50,7 @@ def listusers(args):
         attrs = []
         if account.ext_sync:
             attrs.append(account.ext_sync)
-        if account.locked:
+        if not account.is_active:
             attrs.append('locked')
         attrs = '[%s]' % ','.join(attrs) if attrs else ''
         print(msg.format(login=account.login, name=account.name, attrs=attrs).strip())
@@ -147,23 +147,23 @@ def verify(args):
 
 
 def lock(args):
-    args.login.locked = True
-    if args.login.locked:
-        args.login.save()
-        print("User %s locked" % args.login.login, file=sys.stderr)
-    else:
-        print("Cannot lock %s" % args.login.login, file=sys.stderr)
+    if not args.login.is_active:
+        print("Cannot lock %s, already locked" % args.login.login, file=sys.stderr)
         sys.exit(1)
+
+    args.login.is_active = False
+    args.login.save()
+    print("User %s locked" % args.login.login, file=sys.stderr)
 
 
 def unlock(args):
-    args.login.locked = False
-    if args.login.locked:
-        print("Cannot unlock %s" % args.login.login, file=sys.stderr)
+    if args.login.is_active:
+        print("Cannot unlock %s, already unlocked" % args.login.login, file=sys.stderr)
         sys.exit(1)
-    else:
-        args.login.save()
-        print("User %s unlocked" % args.login.login, file=sys.stderr)
+
+    args.login.is_active = True
+    args.login.save()
+    print("User %s unlocked" % args.login.login, file=sys.stderr)
 
 
 ##########################

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -285,7 +285,7 @@ class Account(AbstractBaseUser):
 
         Copied from nav.db.navprofiles
         """
-        if not self.locked:
+        if self.is_active:
             try:
                 stored_hash = self.password_hash
             except nav.pwhash.InvalidHashStringError:
@@ -350,17 +350,6 @@ class Account(AbstractBaseUser):
         return verified
 
     @property
-    def locked(self):
-        return not self.password or self.password.startswith('!')
-
-    @locked.setter
-    def locked(self, value):
-        if not value:
-            self.password = self.password.removeprefix("!")
-        elif not self.password.startswith('!'):
-            self.password = '!' + self.password
-
-    @property
     def password_hash(self):
         """Returns the Account's password as a Hash object"""
         stored_hash = nav.pwhash.Hash()
@@ -369,11 +358,8 @@ class Account(AbstractBaseUser):
 
     @property
     def unlocked_password(self):
-        """Returns the raw password value, but with any lock status stripped"""
-        if not self.locked:
-            return self.password or ''
-        else:
-            return self.password[1:] if self.password else ''
+        """Returns the raw password value"""
+        return self.password or ''
 
     def get_email_addresses(self):
         return self.alert_addresses.filter(type__name=AlertSender.EMAIL)

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -116,6 +116,7 @@ class Account(AbstractBaseUser):
     password = VarcharField()
     ext_sync = VarcharField(blank=True)
     preferences = HStoreField(default=dict)
+    is_active = models.BooleanField(default=True)
 
     organizations = models.ManyToManyField(
         Organization,
@@ -351,11 +352,6 @@ class Account(AbstractBaseUser):
     @property
     def locked(self):
         return not self.password or self.password.startswith('!')
-
-    @property
-    def is_active(self):
-        """Returns True if this account is active (i.e. not locked)"""
-        return not self.locked
 
     @locked.setter
     def locked(self, value):

--- a/python/nav/models/sql/changes/sc.05.19.0001.sql
+++ b/python/nav/models/sql/changes/sc.05.19.0001.sql
@@ -1,0 +1,14 @@
+ALTER TABLE profiles.account ADD COLUMN is_active BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Set is_active true for all accounts that have a password set and that does not start with !
+UPDATE profiles.account
+SET is_active = TRUE
+WHERE password <> '' AND password NOT LIKE '!%' AND id <> 0;
+
+-- Remove locked indicator (!) from passwords
+UPDATE profiles.account
+SET password = SUBSTRING(password FROM 2)
+WHERE password LIKE '!%';
+
+-- Set default for is_active to true
+ALTER TABLE profiles.account ALTER COLUMN is_active SET DEFAULT TRUE;

--- a/python/nav/web/auth/backends.py
+++ b/python/nav/web/auth/backends.py
@@ -27,8 +27,6 @@ class NAVRemoteUserBackend(RemoteUserBackend):
 
     def configure_user(self, request, user, created=True):
         if created:
-            # for the sake of Account.locked
-            user.set_password(remote_user.fake_password(32))
             user.ext_sync = 'REMOTE_USER'
             user.save()
 

--- a/python/nav/web/auth/utils.py
+++ b/python/nav/web/auth/utils.py
@@ -110,7 +110,7 @@ def ensure_account(request):
 
     Translates Django's AnonymousUser to NAV's default_account
     """
-    if hasattr(request, "user") and request.user.id and not request.user.locked:
+    if hasattr(request, "user") and request.user.id and request.user.is_active:
         set_account(request, request.user, cycle_session_id=False)
         return
 
@@ -119,7 +119,7 @@ def ensure_account(request):
     )
     account = Account.objects.get(id=account_id)
 
-    if account.locked and not account.is_default_account():
+    if not account.is_active and not account.is_default_account():
         # logout of locked account
         clear_session(request)
 

--- a/python/nav/web/templates/useradmin/account_list.html
+++ b/python/nav/web/templates/useradmin/account_list.html
@@ -41,7 +41,7 @@
               <td>
                   {% if account.ext_sync %}<span class="label info" title="This account is managed externally via {{ account.ext_sync }}">{{ account.ext_sync }}</span>{% endif %}
 
-                  {% if account.locked %}
+                  {% if not account.is_active %}
                       <i class="fa fa-lock warning" title="This account is locked: It cannot be used to log in."></i>
                   {% elif account.has_plaintext_password %}
                       <i class="fa fa-warning warning" title="This account uses an insecure plaintext password. It should be reset."></i>

--- a/python/nav/web/useradmin/forms.py
+++ b/python/nav/web/useradmin/forms.py
@@ -139,7 +139,7 @@ class AccountForm(forms.ModelForm):
 
     class Meta(object):
         model = Account
-        exclude = ('password', 'ext_sync', 'organizations', 'preferences')
+        exclude = ('password', 'ext_sync', 'organizations', 'preferences', 'is_active')
 
 
 class ExternalAccountForm(AccountForm):

--- a/python/nav/web/useradmin/views.py
+++ b/python/nav/web/useradmin/views.py
@@ -126,7 +126,7 @@ def add_warnings_for_account(account, request):
     :type request: HttpRequest
     """
     if account.id == Account.DEFAULT_ACCOUNT:
-        if account.locked:
+        if not account.is_active:
             messages.warning(
                 request,
                 "This account represents all non-logged in users. Be wary of making "
@@ -139,10 +139,10 @@ def add_warnings_for_account(account, request):
                 " so it can be used to log in. Please LOCK this account immediately",
             )
     else:
-        if account.locked:
+        if not account.is_active:
             messages.warning(request, "This account is locked and cannot log in.")
 
-    if not account.locked and account.has_plaintext_password():
+    if account.is_active and account.has_plaintext_password():
         messages.warning(
             request,
             "This account's password is stored in plain text. Its password should be "

--- a/tests/integration/web/auth/conftest.py
+++ b/tests/integration/web/auth/conftest.py
@@ -21,7 +21,7 @@ def session_request(db):
 def locked_account(db):
     from nav.models.profiles import Account
 
-    account = Account(login="locked_user")
+    account = Account(login="locked_user", is_active=False)
     account.save()
     yield account
     account.delete()

--- a/tests/integration/web/auth/ldap_auth_backend_test.py
+++ b/tests/integration/web/auth/ldap_auth_backend_test.py
@@ -76,7 +76,7 @@ class TestAuthenticate:
         self, mock_authenticate, db, ldap_synced_account, non_admin_ldap_user
     ):
         mock_authenticate.return_value = non_admin_ldap_user
-        ldap_synced_account.locked = True
+        ldap_synced_account.is_active = False
         ldap_synced_account.save()
 
         with pytest.raises(PermissionDenied):

--- a/tests/integration/web/useradmin_test.py
+++ b/tests/integration/web/useradmin_test.py
@@ -3,6 +3,8 @@ from django.urls import reverse
 import pytest
 from allauth.mfa.models import Authenticator
 
+from nav.models.profiles import Account
+
 
 def test_given_no_authenticator_then_activated_2fa_is_false(
     db, client, non_admin_account, mfa_globally_enabled
@@ -57,6 +59,24 @@ def test_when_operating_as_user_then_it_should_not_crash(db, client, admin_accou
         },
     )
     assert response.status_code == 200
+
+
+def test_when_creating_new_user_then_user_should_be_active(db, client, admin_account):
+    response = client.post(
+        reverse('useradmin-account_new'),
+        follow=True,
+        data={
+            "login": "abc",
+            "name": "abc",
+            "password1": "@e!B>zm5f!}q;5%",
+            "password2": "@e!B>zm5f!}q;5%",
+            "submit_account": "Create account",
+        },
+    )
+
+    assert response.status_code == 200
+    account = Account.objects.get(login="abc")
+    assert account.is_active
 
 
 @pytest.fixture

--- a/tests/unittests/general/modpython_test.py
+++ b/tests/unittests/general/modpython_test.py
@@ -6,7 +6,7 @@ from nav.models import profiles
 from nav.web.modpython import ModPythonAuthorizationMiddleware
 
 
-PLAIN_ACCOUNT = profiles.Account(id=101, login='tim', password='wizard', locked=False)
+PLAIN_ACCOUNT = profiles.Account(id=101, login='tim', password='wizard', is_active=True)
 
 
 class TestModPythonAuthorizationMiddleware:

--- a/tests/unittests/general/web_middleware_test.py
+++ b/tests/unittests/general/web_middleware_test.py
@@ -21,16 +21,21 @@ from nav.web.webfront.views import _logout_helper
 from nav.models import profiles
 
 
-PLAIN_ACCOUNT = profiles.Account(id=101, login='tim', password='wizard', locked=False)
+PLAIN_ACCOUNT = profiles.Account(id=101, login='tim', password='wizard', is_active=True)
 ANOTHER_PLAIN_ACCOUNT = profiles.Account(
-    id=102, login='tom', password='pa$$w0rd', locked=False
+    id=102, login='tom', password='pa$$w0rd', is_active=True
 )
 SUDO_ACCOUNT = profiles.Account(
-    id=1337, login='bofh', password='alakazam', locked=False
+    id=1337, login='bofh', password='alakazam', is_active=True
 )
-LOCKED_ACCOUNT = profiles.Account(id=42, login='evil', password='haxxor', locked=True)
+LOCKED_ACCOUNT = profiles.Account(
+    id=42, login='evil', password='haxxor', is_active=False
+)
 DEFAULT_ACCOUNT = profiles.Account(
-    id=profiles.Account.DEFAULT_ACCOUNT, login='anonymous', password='bah', locked=False
+    id=profiles.Account.DEFAULT_ACCOUNT,
+    login='anonymous',
+    password='bah',
+    is_active=True,
 )
 
 
@@ -113,7 +118,9 @@ class TestAuthorizationMiddleware(object):
         self,
     ):
         # Golden path!
-        viewfunc = lambda request: None
+        def viewfunc(request):
+            return None
+
         r = RequestFactory()
         fake_request = r.get('/')
         fake_request.htmx = Mock()
@@ -132,7 +139,9 @@ class TestAuthorizationMiddleware(object):
     def test_when_explicit_login_required_and_not_authorized_then_it_should_call_redirect_to_login(  # noqa: E501
         self,
     ):
-        viewfunc = lambda request: None
+        def viewfunc(request):
+            return None
+
         r = RequestFactory()
         fake_request = r.get('/')
         fake_request.htmx = Mock()
@@ -147,7 +156,9 @@ class TestAuthorizationMiddleware(object):
                 rtl.assert_called_once()
 
     def test_when_explicit_login_is_not_required_then_it_should_return_none(self):
-        viewfunc = lambda request: None
+        def viewfunc(request):
+            return None
+
         viewfunc.login_required = False
         r = RequestFactory()
         fake_request = r.get('/')

--- a/tests/unittests/web/auth/backends_test.py
+++ b/tests/unittests/web/auth/backends_test.py
@@ -70,7 +70,7 @@ class TestNAVRemoteUserBackend:
     def test_user_can_authenticate_if_user_is_not_active_returns_False_and_adds_auditlog(  # noqa: E501
         self,
     ):
-        account = Account(login="blbl", password="!")
+        account = Account(login="blbl", is_active=False)
         backend = NAVRemoteUserBackend()
         with patch('nav.web.auth.backends.LogEntry.add_log_entry') as auditlog:
             result = backend.user_can_authenticate(account)


### PR DESCRIPTION
## Scope and purpose

Replaces #4022. Part of fixing #3964. 

Added the "discussion" label to discuss points brought up by @hmpf in #4022: 
1. Should the default be `True` or `False`?: In the migration first set it to `False`, then set all accounts with passwords that do not start with `!` to `True` and then change default to `True`.  
2. Should we remove the `!` at the beginning of passwords in the migration? - No 

Adds an `is_active` flag to the `Account` model, just like Django does it: https://docs.djangoproject.com/en/6.0/ref/contrib/auth/#django.contrib.auth.models.User.is_active.

This brings us once more closer to how Django does authentication and removes our previous locking mechanism by adding `!` to the start of a password. 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [ ] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
  should not lead to any changes for the users
* [X] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
