### PR TITLE
Replace TOML config parser with Pydantic models for auth config

### DIFF
--- a/changelog.d/4025.changed.md
+++ b/changelog.d/4025.changed.md
@@ -1,0 +1,1 @@
+Replaced TOML config parser with Pydantic models for authentication config.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ dependencies = [
 
     "pyjwt>=2.12,<3",
 
+    "pydantic>=2.0",
+
     "distro",
 
     # The following modules are really sub-requirements of Twisted, not of

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -46,7 +46,7 @@ from nav.db import get_connection_parameters
 import nav.buildconf
 from nav.jwtconf import JWTConf, LocalJWTConfig
 from nav.web.security import WebSecurityConfigParser
-from nav.web.auth.allauth import MFAConfigParser, SocialConfigParser, OIDCConfigParser
+from nav.web.auth.allauth.models import read_authentication_config
 from nav.django.utils import get_os_version
 
 
@@ -394,14 +394,13 @@ MFA_ADAPTER = "nav.web.auth.allauth.adapter.NAVMFAAdapter"
 MFA_TOTP_ISSUER = 'NAV'
 MFA_TOTP_TOLERANCE = 1
 
-_allauth_mfa_config = MFAConfigParser()
-MFA_SUPPORTED_TYPES = _allauth_mfa_config.get_MFA_SUPPORTED_TYPES_setting()
-MFA_PASSKEY_LOGIN_ENABLED = _allauth_mfa_config.get_MFA_PASSKEY_LOGIN_ENABLED_setting()
-MFA_PASSKEY_SIGNUP_ENABLED = (
-    _allauth_mfa_config.get_MFA_PASSKEY_SIGNUP_ENABLED_setting()
-)
+_auth_config = read_authentication_config()
+
+MFA_SUPPORTED_TYPES = _auth_config.mfa.get_MFA_SUPPORTED_TYPES_setting()
+MFA_PASSKEY_LOGIN_ENABLED = _auth_config.mfa.get_MFA_PASSKEY_LOGIN_ENABLED_setting()
+MFA_PASSKEY_SIGNUP_ENABLED = _auth_config.mfa.get_MFA_PASSKEY_SIGNUP_ENABLED_setting()
 MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN = (
-    _allauth_mfa_config.get_MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN_setting()
+    _auth_config.mfa.get_MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN_setting()
 )
 
 # SOCIALACCOUNT_AUTO_SIGNUP = True
@@ -409,14 +408,12 @@ MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN = (
 
 SOCIALACCOUNT_PROVIDERS = {}
 
-_allauth_social_config = SocialConfigParser()
-_social_providers = _allauth_social_config.generate_SOCIALACCOUNT_PROVIDERS()
+_social_providers = _auth_config.social.generate_SOCIALACCOUNT_PROVIDERS()
 if _social_providers:
     SOCIALACCOUNT_PROVIDERS.update(_social_providers)
-    INSTALLED_APPS += tuple(_allauth_social_config.get_provider_import_paths())
+    INSTALLED_APPS += tuple(_auth_config.social.get_provider_import_paths())
 
-_allauth_oidc_parser = OIDCConfigParser()
-_oidc_providers = _allauth_oidc_parser.generate_SOCIALACCOUNT_PROVIDERS()
+_oidc_providers = _auth_config.oidc.generate_SOCIALACCOUNT_PROVIDERS()
 if _oidc_providers:
     SOCIALACCOUNT_PROVIDERS.update(_oidc_providers)
-    INSTALLED_APPS += tuple(_allauth_oidc_parser.get_provider_import_paths())
+    INSTALLED_APPS += tuple(_auth_config.oidc.get_provider_import_paths())

--- a/python/nav/web/auth/allauth/models.py
+++ b/python/nav/web/auth/allauth/models.py
@@ -1,0 +1,267 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License version 3 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Pydantic models for authentication configuration.
+
+Replaces the TOMLConfigParser-based parsers for reading
+``webfront/authentication.toml``.
+"""
+
+import logging
+import tomllib
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from nav.config import find_config_file
+
+_logger = logging.getLogger(__name__)
+
+
+# --- Shared alias helpers ---------------------------------------------------
+
+
+def _to_hyphen(name: str) -> str:
+    """Convert underscored Python names to hyphenated TOML keys."""
+    return name.replace("_", "-")
+
+
+HYPHENATED = ConfigDict(
+    extra="forbid",
+    alias_generator=_to_hyphen,
+    populate_by_name=True,
+)
+
+
+# --- MFA -------------------------------------------------------------------
+
+
+class MFAConfig(BaseModel):
+    """Multi-factor authentication settings from ``[multi-factor-authentication]``."""
+
+    model_config = HYPHENATED
+
+    enabled: bool = False
+    support_recovery_codes: bool = True
+    support_passkeys: bool = False
+    support_passkey_signups: bool = False
+    allow_insecure_origin: bool = False
+
+    def get_MFA_SUPPORTED_TYPES_setting(self) -> list[str]:
+        """Return the value for Django's ``MFA_SUPPORTED_TYPES`` setting."""
+        methods = []
+        if self.enabled:
+            methods.append("totp")
+            if self.support_recovery_codes:
+                methods.append("recovery_codes")
+            if self.support_passkeys:
+                methods.append("passkeys")
+        return methods
+
+    def get_MFA_PASSKEY_LOGIN_ENABLED_setting(self) -> bool:
+        """Return the value for Django's ``MFA_PASSKEY_LOGIN_ENABLED`` setting."""
+        return self.enabled and self.support_passkeys
+
+    def get_MFA_PASSKEY_SIGNUP_ENABLED_setting(self) -> bool:
+        """Return the value for Django's ``MFA_PASSKEY_SIGNUP_ENABLED`` setting."""
+        return (
+            self.get_MFA_PASSKEY_LOGIN_ENABLED_setting()
+            and self.support_passkey_signups
+        )
+
+    def get_MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN_setting(self) -> bool:
+        """Return the value for the ``MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN`` setting."""
+        return (
+            self.get_MFA_PASSKEY_LOGIN_ENABLED_setting() and self.allow_insecure_origin
+        )
+
+
+# --- Social providers -------------------------------------------------------
+
+
+class SocialProviderEntry(BaseModel):
+    """A single social-login provider entry from ``[social.providers.<id>]``."""
+
+    model_config = HYPHENATED
+
+    client_id: str
+    secret: str
+    scope: list[str] = []
+    module_path: str
+    settings: dict[str, Any] = {}
+
+
+class SocialConfig(BaseModel):
+    """Social-login provider settings from ``[social]``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    providers: dict[str, SocialProviderEntry] = {}
+
+    def generate_SOCIALACCOUNT_PROVIDERS(self) -> dict:
+        """Translate configured providers into a ``SOCIALACCOUNT_PROVIDERS`` dict."""
+        configs: dict[str, Any] = {}
+        for provider_id, entry in self.providers.items():
+            config: dict[str, Any] = {}
+            if entry.scope:
+                config["SCOPE"] = entry.scope
+
+            app: dict[str, Any] = {
+                "client_id": entry.client_id,
+                "secret": entry.secret,
+            }
+            if entry.settings:
+                app["settings"] = entry.settings
+            config["APP"] = app
+            configs[provider_id] = config
+        return configs
+
+    def get_provider_import_paths(self) -> list[str]:
+        """Return dotted import paths for each configured provider."""
+        return [entry.module_path for entry in self.providers.values()]
+
+
+# --- OIDC providers ---------------------------------------------------------
+
+
+class OIDCProviderSettings(BaseModel):
+    """Provider-specific OIDC settings from ``[oidc.idps.<id>.settings]``.
+
+    Uses ``extra="allow"`` because OIDC settings carry arbitrary
+    provider-specific keys through to allauth.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    uid_field: str = "sub"
+
+
+class OIDCProviderEntry(BaseModel):
+    """A single OIDC identity provider entry from ``[oidc.idps.<id>]``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    client_id: str
+    secret: str
+    server_url: str
+    settings: OIDCProviderSettings = OIDCProviderSettings()
+
+
+class OIDCConfig(BaseModel):
+    """OpenID Connect provider settings from ``[oidc]``."""
+
+    model_config = HYPHENATED
+
+    module_path: str = "allauth.socialaccount.providers.openid_connect"
+    oauth_pkce_enabled: bool = False
+    idps: dict[str, OIDCProviderEntry] = {}
+
+    def generate_SOCIALACCOUNT_PROVIDERS(self) -> dict:
+        """Translate configured IDPs into a ``SOCIALACCOUNT_PROVIDERS`` dict."""
+        apps = []
+        for provider_id, entry in self.idps.items():
+            settings: dict[str, Any] = {
+                "server_url": entry.server_url,
+                "uid_field": entry.settings.uid_field,
+            }
+            # Pass through any extra provider-specific settings
+            settings.update(entry.settings.model_extra)
+
+            app: dict[str, Any] = {
+                "provider_id": provider_id,
+                "name": entry.name,
+                "client_id": entry.client_id,
+                "secret": entry.secret,
+                "settings": settings,
+            }
+            apps.append(app)
+
+        if apps:
+            return {
+                "openid_connect": {
+                    "OAUTH_PKCE_ENABLED": self.oauth_pkce_enabled,
+                    "APPS": apps,
+                },
+            }
+        return {}
+
+    def get_provider_import_paths(self) -> list[str]:
+        """Return the OIDC provider module path, or empty if no IDPs configured."""
+        if self.idps:
+            return [self.module_path]
+        return []
+
+
+# --- Root model + file reader -----------------------------------------------
+
+
+class AuthenticationConfig(BaseModel):
+    """Root model for ``webfront/authentication.toml``."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    mfa: MFAConfig = Field(
+        default_factory=MFAConfig, alias="multi-factor-authentication"
+    )
+    social: SocialConfig = Field(default_factory=SocialConfig)
+    oidc: OIDCConfig = Field(default_factory=OIDCConfig)
+
+
+def read_authentication_config(
+    config_file: str = "webfront/authentication.toml",
+) -> AuthenticationConfig:
+    """Read and validate the authentication TOML config file.
+
+    :param config_file: Path relative to the NAV config directory.
+    :returns: Parsed configuration, or all defaults if the file is not found.
+    :raises pydantic.ValidationError: If the file contains invalid keys or
+        values (a friendly message is logged before re-raising).
+    """
+    path = find_config_file(config_file)
+    if not path:
+        _logger.info(
+            "Authentication config file %s not found, using defaults",
+            config_file,
+        )
+        return AuthenticationConfig()
+
+    with open(path, "rb") as fh:
+        raw = tomllib.load(fh)
+
+    try:
+        return AuthenticationConfig.model_validate(raw)
+    except ValidationError as exc:
+        _logger.error(
+            "Validation errors in %s:\n%s",
+            path,
+            format_validation_error(exc),
+        )
+        raise
+
+
+def format_validation_error(exc: ValidationError) -> str:
+    """Return operator-friendly error lines from a ``ValidationError``.
+
+    Each Pydantic error is rendered as ``section.key: message``.
+
+    :param exc: The caught validation error.
+    :returns: A newline-separated string of error descriptions.
+    """
+    lines = []
+    for error in exc.errors():
+        location = ".".join(str(part) for part in error["loc"])
+        lines.append(f"  {location}: {error['msg']}")
+    return "\n".join(lines)

--- a/tests/unittests/web/auth/allauth_models_test.py
+++ b/tests/unittests/web/auth/allauth_models_test.py
@@ -1,0 +1,346 @@
+"""Tests for Pydantic-based authentication config models."""
+
+import tomllib
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from nav.web.auth.allauth.models import (
+    AuthenticationConfig,
+    MFAConfig,
+    OIDCConfig,
+    OIDCProviderEntry,
+    OIDCProviderSettings,
+    SocialConfig,
+    SocialProviderEntry,
+    format_validation_error,
+    read_authentication_config,
+)
+
+
+class TestMFAConfig:
+    def test_when_defaults_then_all_flags_should_match_expected(self):
+        mfa = MFAConfig()
+        assert mfa.enabled is False
+        assert mfa.support_recovery_codes is True
+        assert mfa.support_passkeys is False
+        assert mfa.support_passkey_signups is False
+        assert mfa.allow_insecure_origin is False
+
+    def test_when_disabled_then_supported_types_should_be_empty(self):
+        mfa = MFAConfig()
+        assert mfa.get_MFA_SUPPORTED_TYPES_setting() == []
+
+    def test_when_enabled_then_supported_types_should_include_totp_and_recovery(self):
+        mfa = MFAConfig(enabled=True)
+        assert mfa.get_MFA_SUPPORTED_TYPES_setting() == ["totp", "recovery_codes"]
+
+    def test_when_enabled_with_passkeys_then_supported_types_should_include_passkeys(  # noqa: E501
+        self,
+    ):
+        mfa = MFAConfig(enabled=True, support_passkeys=True)
+        assert mfa.get_MFA_SUPPORTED_TYPES_setting() == [
+            "totp",
+            "recovery_codes",
+            "passkeys",
+        ]
+
+    def test_when_enabled_without_recovery_codes_then_supported_types_should_exclude_them(  # noqa: E501
+        self,
+    ):
+        mfa = MFAConfig(enabled=True, support_recovery_codes=False)
+        assert mfa.get_MFA_SUPPORTED_TYPES_setting() == ["totp"]
+
+    def test_when_disabled_then_passkey_login_should_be_false(self):
+        mfa = MFAConfig(support_passkeys=True)
+        assert mfa.get_MFA_PASSKEY_LOGIN_ENABLED_setting() is False
+
+    def test_when_enabled_with_passkeys_then_passkey_login_should_be_true(self):
+        mfa = MFAConfig(enabled=True, support_passkeys=True)
+        assert mfa.get_MFA_PASSKEY_LOGIN_ENABLED_setting() is True
+
+    def test_when_passkey_login_disabled_then_passkey_signup_should_be_false(self):
+        mfa = MFAConfig(support_passkey_signups=True)
+        assert mfa.get_MFA_PASSKEY_SIGNUP_ENABLED_setting() is False
+
+    def test_when_passkey_login_enabled_then_passkey_signup_should_follow_flag(self):
+        mfa = MFAConfig(
+            enabled=True, support_passkeys=True, support_passkey_signups=True
+        )
+        assert mfa.get_MFA_PASSKEY_SIGNUP_ENABLED_setting() is True
+
+    def test_when_passkey_login_disabled_then_insecure_origin_should_be_false(self):
+        mfa = MFAConfig(allow_insecure_origin=True)
+        assert mfa.get_MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN_setting() is False
+
+    def test_when_passkey_login_enabled_then_insecure_origin_should_follow_flag(self):
+        mfa = MFAConfig(enabled=True, support_passkeys=True, allow_insecure_origin=True)
+        assert mfa.get_MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN_setting() is True
+
+    def test_when_hyphenated_keys_then_it_should_parse_correctly(self):
+        mfa = MFAConfig.model_validate(
+            {
+                "enabled": True,
+                "support-passkeys": True,
+                "support-recovery-codes": False,
+            }
+        )
+        assert mfa.enabled is True
+        assert mfa.support_passkeys is True
+        assert mfa.support_recovery_codes is False
+
+
+class TestSocialConfig:
+    def test_when_empty_then_generate_should_return_empty_dict(self):
+        sc = SocialConfig()
+        assert sc.generate_SOCIALACCOUNT_PROVIDERS() == {}
+
+    def test_when_providers_configured_then_generate_should_return_translated_config(
+        self,
+    ):
+        config_string = """
+[providers.testprovider1]
+client_id = "not.optional"
+secret = "not.optional"
+scope = ["email"]
+module-path = "allauth.socialaccount.providers.test1"
+
+[providers.testprovider2]
+client_id = "not.optional2"
+secret = "not.optional2"
+module-path = "allauth.socialaccount.providers.test2"
+
+[providers.testprovider2.settings]
+foo = 1
+"""
+        raw = tomllib.loads(config_string)
+        sc = SocialConfig.model_validate(raw)
+        expected = {
+            "testprovider1": {
+                "APP": {
+                    "client_id": "not.optional",
+                    "secret": "not.optional",
+                },
+                "SCOPE": ["email"],
+            },
+            "testprovider2": {
+                "APP": {
+                    "client_id": "not.optional2",
+                    "secret": "not.optional2",
+                    "settings": {
+                        "foo": 1,
+                    },
+                },
+            },
+        }
+        assert sc.generate_SOCIALACCOUNT_PROVIDERS() == expected
+
+    def test_when_module_path_present_then_import_paths_should_include_it(self):
+        sc = SocialConfig(
+            providers={
+                "github": SocialProviderEntry(
+                    client_id="id",
+                    secret="sec",
+                    module_path="allauth.socialaccount.providers.github",
+                ),
+            }
+        )
+        assert sc.get_provider_import_paths() == [
+            "allauth.socialaccount.providers.github"
+        ]
+
+    def test_when_module_path_missing_then_it_should_raise_validation_error(self):
+        with pytest.raises(ValidationError):
+            SocialProviderEntry(client_id="id", secret="sec")
+
+
+class TestOIDCConfig:
+    def test_when_empty_then_generate_should_return_empty_dict(self):
+        oc = OIDCConfig()
+        assert oc.generate_SOCIALACCOUNT_PROVIDERS() == {}
+
+    def test_when_idps_configured_then_generate_should_return_translated_config(self):
+        config_string = """
+[idps.testprovider1]
+name = "Provider 1"
+client_id = "not.optional"
+secret = "not.optional"
+server_url = "https://server1.example.com"
+
+[idps.testprovider1.settings]
+foo = 1
+"""
+        raw = tomllib.loads(config_string)
+        oc = OIDCConfig.model_validate(raw)
+        expected = {
+            "openid_connect": {
+                "OAUTH_PKCE_ENABLED": False,
+                "APPS": [
+                    {
+                        "provider_id": "testprovider1",
+                        "name": "Provider 1",
+                        "client_id": "not.optional",
+                        "secret": "not.optional",
+                        "settings": {
+                            "server_url": "https://server1.example.com",
+                            "uid_field": "sub",
+                            "foo": 1,
+                        },
+                    },
+                ],
+            },
+        }
+        assert oc.generate_SOCIALACCOUNT_PROVIDERS() == expected
+
+    def test_when_no_uid_field_set_then_it_should_fall_back_to_sub(self):
+        oc = OIDCConfig(
+            idps={
+                "testprovider1": OIDCProviderEntry(
+                    name="Provider 1",
+                    client_id="not.optional",
+                    secret="not.optional",
+                    server_url="https://server1.example.com",
+                ),
+            }
+        )
+        result = oc.generate_SOCIALACCOUNT_PROVIDERS()
+        settings = result["openid_connect"]["APPS"][0]["settings"]
+        assert settings["uid_field"] == "sub"
+
+    def test_when_pkce_enabled_then_generate_should_reflect_it(self):
+        oc = OIDCConfig(
+            oauth_pkce_enabled=True,
+            idps={
+                "test": OIDCProviderEntry(
+                    name="Test",
+                    client_id="id",
+                    secret="sec",
+                    server_url="https://example.com",
+                ),
+            },
+        )
+        result = oc.generate_SOCIALACCOUNT_PROVIDERS()
+        assert result["openid_connect"]["OAUTH_PKCE_ENABLED"] is True
+
+    def test_when_no_idps_then_import_paths_should_return_empty_list(self):
+        oc = OIDCConfig()
+        assert oc.get_provider_import_paths() == []
+
+    def test_when_idps_present_then_import_paths_should_return_default_module(self):
+        oc = OIDCConfig(
+            idps={
+                "test": OIDCProviderEntry(
+                    name="Test",
+                    client_id="id",
+                    secret="sec",
+                    server_url="https://example.com",
+                ),
+            }
+        )
+        assert oc.get_provider_import_paths() == [
+            "allauth.socialaccount.providers.openid_connect"
+        ]
+
+    def test_when_custom_module_with_idps_then_import_paths_should_return_it(self):
+        oc = OIDCConfig(
+            module_path="custom.module",
+            idps={
+                "test": OIDCProviderEntry(
+                    name="Test",
+                    client_id="id",
+                    secret="sec",
+                    server_url="https://example.com",
+                ),
+            },
+        )
+        assert oc.get_provider_import_paths() == ["custom.module"]
+
+    def test_when_scope_in_settings_then_generate_should_pass_it_through(self):
+        oc = OIDCConfig(
+            idps={
+                "test": OIDCProviderEntry(
+                    name="Test",
+                    client_id="id",
+                    secret="sec",
+                    server_url="https://example.com",
+                    settings=OIDCProviderSettings(scope=["openid", "email"]),
+                ),
+            },
+        )
+        result = oc.generate_SOCIALACCOUNT_PROVIDERS()
+        settings = result["openid_connect"]["APPS"][0]["settings"]
+        assert settings["scope"] == ["openid", "email"]
+
+
+class TestAuthenticationConfig:
+    def test_when_defaults_then_all_sections_should_have_defaults(self):
+        config = AuthenticationConfig()
+        assert config.mfa.enabled is False
+        assert config.social.providers == {}
+        assert config.oidc.idps == {}
+
+    def test_when_extra_key_then_it_should_raise_validation_error(self):
+        with pytest.raises(ValidationError):
+            AuthenticationConfig.model_validate({"unknown_section": {}})
+
+    def test_when_hyphenated_mfa_alias_then_it_should_parse_correctly(self):
+        raw = {
+            "multi-factor-authentication": {
+                "enabled": True,
+                "support-passkeys": True,
+            }
+        }
+        config = AuthenticationConfig.model_validate(raw)
+        assert config.mfa.enabled is True
+        assert config.mfa.support_passkeys is True
+
+
+class TestFormatValidationError:
+    def test_when_validation_error_then_it_should_include_location_and_message(self):
+        raw = {"multi-factor-authentication": {"bogus": True}}
+        try:
+            AuthenticationConfig.model_validate(raw)
+        except ValidationError as exc:
+            result = format_validation_error(exc)
+        assert "multi-factor-authentication.bogus" in result
+        assert "Extra inputs are not permitted" in result
+
+
+class TestReadAuthenticationConfig:
+    def test_when_file_not_found_then_it_should_return_defaults(self):
+        with patch("nav.web.auth.allauth.models.find_config_file", return_value=None):
+            config = read_authentication_config()
+        assert config.mfa.enabled is False
+        assert config.social.providers == {}
+        assert config.oidc.idps == {}
+
+    def test_when_valid_file_then_it_should_parse_correctly(self, tmp_path):
+        toml_content = b"""
+[multi-factor-authentication]
+enabled = true
+"""
+        config_file = tmp_path / "authentication.toml"
+        config_file.write_bytes(toml_content)
+
+        with patch(
+            "nav.web.auth.allauth.models.find_config_file",
+            return_value=str(config_file),
+        ):
+            config = read_authentication_config()
+        assert config.mfa.enabled is True
+
+    def test_when_invalid_keys_then_it_should_raise_validation_error(self, tmp_path):
+        toml_content = b"""
+[multi-factor-authentication]
+bogus-key = true
+"""
+        config_file = tmp_path / "authentication.toml"
+        config_file.write_bytes(toml_content)
+
+        with patch(
+            "nav.web.auth.allauth.models.find_config_file",
+            return_value=str(config_file),
+        ):
+            with pytest.raises(ValidationError):
+                read_authentication_config()


### PR DESCRIPTION
## Scope and purpose

Ref #4025.

This is a proof-of-concept for replacing the `TOMLConfigParser`-based authentication config parsers with Pydantic `BaseModel` classes, borrowing the approach we've been happy with in Zino 2.

The current `TOMLConfigParser` (a `UserDict` subclass) works — other PRs in flight have patched around its quirks — but it's slightly wonky to reason about: the section-collapsing, the `_merge_with_default` dance, and the `UserDict` heritage all make the config logic harder to follow than it needs to be. The Pydantic models serve as fairly legible documentation of the config format and its validation rules — you can read `MFAConfig` or `OIDCProviderEntry` and immediately see what keys are expected, what their types and defaults are, and what happens with unknown keys (`extra="forbid"`).

The new code is built in parallel: old parsers in `__init__.py` and `toml.py` are untouched, and the only consumer (`settings.py`) is rewired as the final step. Deletion of the old code is left for a follow-up PR once we're confident this holds up.

As a side effect, this also fixes two bugs in the old `SocialConfigParser.get_provider_import_paths()` (`.values()` destructuring and a `module_path` vs `module-path` key mismatch), though those code paths were unlikely to be hit in practice.

### This pull request
* adds a dependency (`pydantic>=2.0`)

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [x] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file