### PR TITLE
Add postgres rule to prevent active default user

### DIFF
--- a/changelog.d/4027.changed.md
+++ b/changelog.d/4027.changed.md
@@ -1,0 +1,1 @@
+Added postgres rule to never allow the default user to be active

--- a/python/nav/models/sql/changes/sc.05.19.0002.sql
+++ b/python/nav/models/sql/changes/sc.05.19.0002.sql
@@ -1,0 +1,4 @@
+-- Prevent the default account (id=0) from ever having is_active set to TRUE
+ALTER TABLE profiles.account
+    ADD CONSTRAINT default_account_never_active
+    CHECK (NOT (id = 0 AND is_active));

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -440,3 +440,10 @@ def non_admin_account(db):
     account.save()
     yield account
     account.delete()
+
+
+@pytest.fixture()
+def default_account(db):
+    from nav.models.profiles import Account
+
+    return Account.objects.get(id=Account.DEFAULT_ACCOUNT)

--- a/tests/integration/models/account_test.py
+++ b/tests/integration/models/account_test.py
@@ -1,14 +1,18 @@
-import unittest
-from nav.models.profiles import Account
+import pytest
+from django.db.utils import IntegrityError
 
 
-class AccountTest(unittest.TestCase):
-    def setUp(self):
-        self.admin_user = Account.objects.get(pk=Account.ADMIN_ACCOUNT)
-        self.default_user = Account.objects.get(pk=Account.DEFAULT_ACCOUNT)
+def test_is_admin_should_return_true_when_user_is_admin(db, admin_account):
+    assert admin_account.is_admin()
 
-    def test_is_admin_returns_true_if_administrator(self):
-        self.assertTrue(self.admin_user.is_admin())
 
-    def test_is_admin_returns_false_if_default_account(self):
-        self.assertFalse(self.default_user.is_admin())
+def test_is_admin_should_return_false_when_user_is_default_user(db, default_account):
+    assert not default_account.is_admin()
+
+
+def test_when_setting_is_active_true_for_default_account_then_it_should_fail(
+    db, default_account
+):
+    default_account.is_active = True
+    with pytest.raises(IntegrityError):
+        default_account.save()

--- a/tests/integration/web/auth/conftest.py
+++ b/tests/integration/web/auth/conftest.py
@@ -25,10 +25,3 @@ def locked_account(db):
     account.save()
     yield account
     account.delete()
-
-
-@pytest.fixture()
-def default_account(db):
-    from nav.models.profiles import Account
-
-    return Account.objects.get(id=Account.DEFAULT_ACCOUNT)


### PR DESCRIPTION
## Scope and purpose

Fixes #4027. Dependent on #4023.

Also reworks account_test tests to pure pytest tests.


<!-- remove things that do not apply -->
### This pull request
* changes the database


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
