### PR TITLE
Convert Sensor Details page from custom JS to htmx

### DIFF
--- a/changelog.d/4056.changed.md
+++ b/changelog.d/4056.changed.md
@@ -1,0 +1,1 @@
+Refactored the sensor-details page to fetch its current on/off state via htmx instead of a custom RequireJS/jQuery module.

--- a/python/nav/web/ipdevinfo/urls.py
+++ b/python/nav/web/ipdevinfo/urls.py
@@ -106,6 +106,11 @@ urlpatterns = [
         name="ipdevinfo-hostinfo",
     ),
     # Sensors
+    path(
+        'sensor/<int:identifier>/state/',
+        views.sensor_on_off_state,
+        name="sensor-on-off-state",
+    ),
     re_path(r'sensor/(?P<identifier>.+)', views.sensor_details, name="sensor-details"),
     re_path(
         r'^(?P<netboxid>\d+)/unrecognized_neighbors',

--- a/python/nav/web/ipdevinfo/views.py
+++ b/python/nav/web/ipdevinfo/views.py
@@ -23,6 +23,7 @@ from django.conf import settings
 from django.http import HttpResponseRedirect, Http404, HttpResponse
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django_htmx.http import (
     HttpResponseClientRedirect,
@@ -31,8 +32,8 @@ from django_htmx.http import (
 
 from nav.django.templatetags.thresholds import find_rules
 from nav.event2 import EventFactory
+from nav.metrics.data import get_metric_data
 from nav.metrics.errors import GraphiteUnreachableError
-from nav.metrics.graphs import get_simple_graph_url
 from nav.web.auth.utils import get_account
 from nav.web.modals import render_modal
 
@@ -918,9 +919,6 @@ def sensor_details(request, identifier):
         request,
         'ipdevinfo/sensor-details.html',
         {
-            'data_url': get_simple_graph_url(
-                sensor.get_metric_name(), time_frame='10minutes', format='json'
-            ),
             'sensor': sensor,
             'navpath': navpath,
             'heading': heading,
@@ -930,8 +928,56 @@ def sensor_details(request, identifier):
             'graphite_data_url': Graph(
                 magic_targets=[sensor.get_metric_name()], format='json'
             ),
+            'fetch_error_html': render_to_string('ipdevinfo/_fetch_error.html'),
         },
     )
+
+
+def sensor_on_off_state(request, identifier):
+    """Renders an htmx fragment with the current on/off state of a sensor.
+
+    Fetches the most recent non-null Graphite datapoint for the sensor's
+    metric within the last 10 minutes and compares it to the sensor's
+    configured `on_state`.  Renders the appropriate alert-box, or a
+    "no recent data" message if Graphite has nothing fresh for this
+    sensor.
+
+    Lets `GraphiteUnreachableError` propagate; htmx swaps the placeholder
+    to "Error fetching data" via `hx-on::response-error` on a 5xx, which
+    is the truthful UX when Graphite is genuinely down (as opposed to a
+    sensor that exists but has no recent readings).
+    """
+    sensor = get_object_or_404(Sensor, pk=identifier)
+    value = _latest_metric_value(sensor.get_metric_name())
+    if value is None:
+        state = None
+    elif value == sensor.on_state:
+        state = "on"
+    else:
+        state = "off"
+    return render(
+        request,
+        "ipdevinfo/frag_sensor_on_off.html",
+        {"sensor": sensor, "state": state},
+    )
+
+
+def _latest_metric_value(metric_name):
+    """Returns the most recent non-null value for a metric, or None.
+
+    Returns None when Graphite has no data for the metric within the
+    queried window, or when every datapoint in the window is null.
+    Does not catch `GraphiteUnreachableError` — that condition is
+    handled by the client's `hx-on::response-error` swap.
+    """
+    data = get_metric_data(metric_name, start="-10min")
+    if not data:
+        return None
+    datapoints = data[0].get("datapoints", [])
+    for value, _timestamp in reversed(datapoints):
+        if value is not None:
+            return value
+    return None
 
 
 def save_port_layout_pref(request):

--- a/python/nav/web/navlets/__init__.py
+++ b/python/nav/web/navlets/__init__.py
@@ -579,7 +579,7 @@ def add_user_navlet_sensor(request):
             preferences = {'sensor_id': sensor.pk, 'title': sensor.netbox.sysname}
         account = get_account(request)
         add_navlet(account, navlet, preferences)
-        return HttpResponse(status=200)
+        return render(request, 'ipdevinfo/frag_added_to_dashboard.html')
 
     return HttpResponse(status=400)
 

--- a/python/nav/web/sass/nav/ipdevinfo.scss
+++ b/python/nav/web/sass/nav/ipdevinfo.scss
@@ -235,3 +235,16 @@ table.module td div.portcell span.oplayer {
     height: 100%;
     width: 100%;
 }
+
+.add-to-dashboard-button {
+    // toggle between the button's resting label and the in-flight spinner
+    // based on htmx's auto-added .htmx-request class.
+    .htmx-indicator {
+        display: none;
+        opacity: 1; // override htmx's default opacity-based indicator
+    }
+    &.htmx-request {
+        .button-text { display: none; }
+        .htmx-indicator { display: inline; }
+    }
+}

--- a/python/nav/web/static/js/src/sensor_details.js
+++ b/python/nav/web/static/js/src/sensor_details.js
@@ -16,17 +16,5 @@ require([
                 thresholds: thresholds
             });
         }
-
-        $('#add-to-dashboard-button').on('click', function (event) {
-            event.preventDefault();
-            var $button = $(this);
-            var request = $.post($button.data('dashboardUrl'));
-            request.done(function() {
-                $button.removeClass('secondary').addClass('success');
-            });
-            request.fail(function() {
-                $button.removeClass('secondary').addClass('failure');
-            });
-        });
     });
 });

--- a/python/nav/web/static/js/src/sensor_details.js
+++ b/python/nav/web/static/js/src/sensor_details.js
@@ -15,33 +15,6 @@ require([
                 unit: $gauge.data('unit'),
                 thresholds: thresholds
             });
-        } else {
-            var $sensor = $('.sensor');
-            var request = $.get($sensor.data('url'));
-
-            request.done(function(data) {
-                if (data.length === 0) {
-                    return;
-                }
-
-                var datapoints = data[0].datapoints.reverse();
-
-                for (var i=0; i<datapoints.length; i++) {
-                    var value = datapoints[i][0];
-                    var epoch = datapoints[i][1];
-                    if (value !== null) {
-                        var on_state = $sensor.data('on-state');
-                        if (value === on_state ) {
-                            $(".off").addClass('hidden');
-                            $(".on").removeClass('hidden');
-                        } else {
-                            $(".on").addClass('hidden');
-                            $(".off").removeClass('hidden');
-                        }
-                        break;
-                    }
-                }
-            });
         }
 
         $('#add-to-dashboard-button').on('click', function (event) {

--- a/python/nav/web/templates/ipdevinfo/_add_to_dashboard_button.html
+++ b/python/nav/web/templates/ipdevinfo/_add_to_dashboard_button.html
@@ -1,0 +1,7 @@
+<button class="tiny secondary"
+        hx-post="{% url 'add-user-navlet-sensor' %}?sensor_id={{ sensor.pk }}"
+        hx-swap="outerHTML"
+        hx-on::response-error="this.classList.remove('secondary'); this.classList.add('failure')"
+        hx-on::send-error="this.classList.remove('secondary'); this.classList.add('failure')">
+  Add to dashboard
+</button>

--- a/python/nav/web/templates/ipdevinfo/_add_to_dashboard_button.html
+++ b/python/nav/web/templates/ipdevinfo/_add_to_dashboard_button.html
@@ -1,7 +1,11 @@
-<button class="tiny secondary"
+<button class="tiny secondary add-to-dashboard-button"
         hx-post="{% url 'add-user-navlet-sensor' %}?sensor_id={{ sensor.pk }}"
         hx-swap="outerHTML"
-        hx-on::response-error="this.classList.remove('secondary'); this.classList.add('failure')"
-        hx-on::send-error="this.classList.remove('secondary'); this.classList.add('failure')">
-  Add to dashboard
+        hx-disabled-elt="this"
+        hx-request='{"timeout": 10000}'
+        hx-on::response-error="this.classList.remove('secondary'); this.classList.add('alert')"
+        hx-on::send-error="this.classList.remove('secondary'); this.classList.add('alert')"
+        hx-on::timeout="this.classList.remove('secondary'); this.classList.add('alert')">
+  <span class="button-text">Add to dashboard</span>
+  <span class="htmx-indicator"><i class="fa fa-spinner fa-spin"></i> Adding...</span>
 </button>

--- a/python/nav/web/templates/ipdevinfo/_fetch_error.html
+++ b/python/nav/web/templates/ipdevinfo/_fetch_error.html
@@ -1,0 +1,1 @@
+<div class="alert-box alert"><i class="fa fa-exclamation-triangle"></i> Error fetching data</div>

--- a/python/nav/web/templates/ipdevinfo/frag_added_to_dashboard.html
+++ b/python/nav/web/templates/ipdevinfo/frag_added_to_dashboard.html
@@ -1,0 +1,3 @@
+<button class="tiny success" disabled>
+  <i class="fa fa-check"></i> Added to dashboard
+</button>

--- a/python/nav/web/templates/ipdevinfo/frag_sensor_on_off.html
+++ b/python/nav/web/templates/ipdevinfo/frag_sensor_on_off.html
@@ -1,0 +1,7 @@
+{% if state == 'on' %}
+  <div class="on alert-box with-icon {{ sensor.alert_type_class }}">{{ sensor.on_message }}</div>
+{% elif state == 'off' %}
+  <div class="off alert-box with-icon success">{{ sensor.off_message }}</div>
+{% else %}
+  <div class="alert-box secondary"><i class="fa fa-info-circle"></i> No recent data</div>
+{% endif %}

--- a/python/nav/web/templates/ipdevinfo/sensor-details.html
+++ b/python/nav/web/templates/ipdevinfo/sensor-details.html
@@ -99,13 +99,7 @@
                 hx-on::send-error="this.outerHTML='{{ fetch_error_html|escapejs }}'"
                 hx-on::response-error="this.outerHTML='{{ fetch_error_html|escapejs }}'"
           ><i class="fa fa-spinner fa-spin"></i> Fetching...</span>
-          <button class="tiny secondary"
-                  hx-post="{% url 'add-user-navlet-sensor' %}?sensor_id={{ sensor.pk }}"
-                  hx-swap="outerHTML"
-                  hx-on::response-error="this.classList.remove('secondary'); this.classList.add('failure')"
-                  hx-on::send-error="this.classList.remove('secondary'); this.classList.add('failure')">
-            Add to dashboard
-          </button>
+          {% include 'ipdevinfo/_add_to_dashboard_button.html' %}
           {% include 'custom_crispy_templates/flat_form.html' %}
         {% else %}
           <h4>Gauge display ranges</h4>
@@ -120,13 +114,7 @@
                  data-min="{{sensor.get_display_range.0}}"
                  data-max="{{sensor.get_display_range.1}}"
             ></div>
-            <button class="tiny secondary"
-                    hx-post="{% url 'add-user-navlet-sensor' %}?sensor_id={{ sensor.pk }}"
-                    hx-swap="outerHTML"
-                    hx-on::response-error="this.classList.remove('secondary'); this.classList.add('failure')"
-                    hx-on::send-error="this.classList.remove('secondary'); this.classList.add('failure')">
-              Add to dashboard
-            </button>
+            {% include 'ipdevinfo/_add_to_dashboard_button.html' %}
           </div>
           {% include 'custom_crispy_templates/flat_form.html' %}
         {% endif %}

--- a/python/nav/web/templates/ipdevinfo/sensor-details.html
+++ b/python/nav/web/templates/ipdevinfo/sensor-details.html
@@ -99,9 +99,11 @@
                 hx-on::send-error="this.outerHTML='{{ fetch_error_html|escapejs }}'"
                 hx-on::response-error="this.outerHTML='{{ fetch_error_html|escapejs }}'"
           ><i class="fa fa-spinner fa-spin"></i> Fetching...</span>
-          <button id="add-to-dashboard-button"
-                  class="tiny secondary"
-                  data-dashboard-url="{% url 'add-user-navlet-sensor' %}?sensor_id={{ sensor.pk }}">
+          <button class="tiny secondary"
+                  hx-post="{% url 'add-user-navlet-sensor' %}?sensor_id={{ sensor.pk }}"
+                  hx-swap="outerHTML"
+                  hx-on::response-error="this.classList.remove('secondary'); this.classList.add('failure')"
+                  hx-on::send-error="this.classList.remove('secondary'); this.classList.add('failure')">
             Add to dashboard
           </button>
           {% include 'custom_crispy_templates/flat_form.html' %}
@@ -118,9 +120,11 @@
                  data-min="{{sensor.get_display_range.0}}"
                  data-max="{{sensor.get_display_range.1}}"
             ></div>
-            <button id="add-to-dashboard-button"
-                    class="tiny secondary"
-                    data-dashboard-url="{% url 'add-user-navlet-sensor' %}?sensor_id={{ sensor.pk }}">
+            <button class="tiny secondary"
+                    hx-post="{% url 'add-user-navlet-sensor' %}?sensor_id={{ sensor.pk }}"
+                    hx-swap="outerHTML"
+                    hx-on::response-error="this.classList.remove('secondary'); this.classList.add('failure')"
+                    hx-on::send-error="this.classList.remove('secondary'); this.classList.add('failure')">
               Add to dashboard
             </button>
           </div>

--- a/python/nav/web/templates/ipdevinfo/sensor-details.html
+++ b/python/nav/web/templates/ipdevinfo/sensor-details.html
@@ -93,11 +93,12 @@
     <div class="large-6 column">
         {% if sensor.unit_of_measurement == 'boolean' %}
           <h4>Display values</h4>
-          <div class="sensor"
-               data-url="{{ data_url }}"
-               data-on-state="{{ sensor.on_state }}"/>
-          <div class="on alert-box with-icon {{ sensor.alert_type_class }} hidden">{{ sensor.on_message }}</div>
-          <div class="off alert-box with-icon success hidden">{{ sensor.off_message }}</div>
+          <span hx-get="{% url 'sensor-on-off-state' sensor.pk %}"
+                hx-trigger="load"
+                hx-swap="outerHTML"
+                hx-on::send-error="this.outerHTML='{{ fetch_error_html|escapejs }}'"
+                hx-on::response-error="this.outerHTML='{{ fetch_error_html|escapejs }}'"
+          ><i class="fa fa-spinner fa-spin"></i> Fetching...</span>
           <button id="add-to-dashboard-button"
                   class="tiny secondary"
                   data-dashboard-url="{% url 'add-user-navlet-sensor' %}?sensor_id={{ sensor.pk }}">

--- a/tests/integration/web/ipdevinfo_test.py
+++ b/tests/integration/web/ipdevinfo_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 from django.urls import reverse
 from django.utils.encoding import smart_str
@@ -14,6 +15,7 @@ from nav.models.manage import (
     Device,
     NetboxProfile,
     IpdevpollJobLog,
+    Sensor,
 )
 from nav.web.ipdevinfo.utils import get_module_view
 
@@ -271,11 +273,67 @@ class TestPoeHintModals:
         assert 'id="poe-classification-hint"' in smart_str(response.content)
 
 
+class TestSensorDetailsViews:
+    """200-check coverage for the htmx-driven sensor-details endpoints.
+
+    Previously the sensor-details web layer had no test coverage at all,
+    which would let a URL-pattern or import regression slip through CI
+    unnoticed (cf. the trailing-slash bug that hid in the watchdog views
+    for several releases).
+    """
+
+    def test_when_logged_in_then_sensor_details_should_respond_with_200(
+        self, client, boolean_sensor
+    ):
+        url = reverse('sensor-details', args=[boolean_sensor.pk])
+        response = client.get(url)
+        assert response.status_code == 200
+
+    def test_when_logged_in_then_sensor_on_off_state_should_respond_with_200(
+        self, client, boolean_sensor
+    ):
+        url = reverse('sensor-on-off-state', args=[boolean_sensor.pk])
+        with patch('nav.web.ipdevinfo.views.get_metric_data', return_value=[]):
+            response = client.get(url)
+        assert response.status_code == 200
+
+    def test_when_posting_with_sensor_id_then_add_user_navlet_sensor_should_respond_with_200(  # noqa: E501
+        self, client, boolean_sensor
+    ):
+        url = reverse('add-user-navlet-sensor')
+        response = client.post(f"{url}?sensor_id={boolean_sensor.pk}")
+        assert response.status_code == 200
+
+    def test_when_getting_then_add_user_navlet_sensor_should_respond_with_400(
+        self, client
+    ):
+        url = reverse('add-user-navlet-sensor')
+        response = client.get(url)
+        assert response.status_code == 400
+
+
 ###
 #
 # Fixtures
 #
 ###
+
+
+@pytest.fixture()
+def boolean_sensor(db, netbox):
+    """A minimal boolean sensor attached to the test netbox."""
+    return Sensor.objects.create(
+        netbox=netbox,
+        oid='.1.3.6.1.4.1.1.1',
+        unit_of_measurement=Sensor.UNIT_TRUTHVALUE,
+        data_scale=Sensor.SCALE_UNITS,
+        precision=0,
+        human_readable='Example boolean sensor',
+        name='example-boolean',
+        internal_name='example-boolean',
+        mib='EXAMPLE-MIB',
+        on_state_sys=1,
+    )
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Scope and purpose

Closes #4056.

This refactor replaces two of the three jobs `python/nav/web/static/js/src/sensor_details.js` (59 LOC) was doing with server-rendered htmx fragments: the boolean-sensor on/off display, and the "Add to dashboard" button.  The D3 gauge widget for numeric sensors stays in JS (it's reused elsewhere in NAV).  `sensor_details.js` shrinks from 59 LOC to 20 LOC after the conversion.

Along the way this PR quietly fixes two pre-existing latent UX bugs in `sensor_details.js`:

1. The `.failure` class added to the "Add to dashboard" button on POST failure had no matching CSS in NAV, so failure was visually indistinguishable from the resting state.  The button now flips to `.alert` (red), which has the canonical danger styling in NAV's bundled CSS.
2. When Graphite was unreachable, the boolean-display code left both `.on` and `.off` alert-boxes hidden with no error indication.  The new server-side view distinguishes "no recent data" (Graphite reachable, no value within the 10-minute window — gray informational alert) from a transport/5xx failure (Graphite unreachable — red "Error fetching data" alert via the client's `hx-on::response-error` handler).

The shared `add-user-navlet-sensor` endpoint now returns a small fragment instead of a bare HTTP 200; the room-info page's jQuery consumer (`sensor_controller.js`) is unaffected because it only checks the response status.

Also closes the pre-existing zero-coverage gap on the sensor-details web layer with parametrized 200-check integration tests for all three named URL endpoints (`sensor-details`, `sensor-on-off-state`, `add-user-navlet-sensor`).  Same shape as the test additions in #4055.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code — parametrized integration tests covering all named sensor-details URLs.
* [ ] ~~Added/changed documentation~~ — no user-facing docs reference the sensor-details page.
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long.  See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`).  For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~ — not applicable.
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~ — the only user-visible delta is the failure-state styling (now a red `.alert` button / red "Error fetching data" message), which is straightforward to observe by stopping the Graphite container or the dev server while loading a sensor-details page.
* [ ] ~~If this adds a new Python source code file: Added the boilerplate header to that file~~ — no new Python files.
