### PR TITLE
Log per-run summary for navtopology --l2

### DIFF
--- a/changelog.d/4067.added.md
+++ b/changelog.d/4067.added.md
@@ -1,0 +1,1 @@
+`navtopology --l2` now logs a per-run summary line to `navtopology.log` with phase timings, per-source resolved-link counts, and database write counts. Per-edge DEBUG lines from the reducer are also tagged with the heuristic that produced each resolution.

--- a/python/nav/topology/analyze.py
+++ b/python/nav/topology/analyze.py
@@ -44,6 +44,7 @@ import logging
 
 import networkx as nx
 from nav.models.manage import AdjacencyCandidate, InterfaceAggregate, InterfaceStack
+from nav.topology.stats import NullStats
 
 _logger = logging.getLogger(__name__)
 
@@ -77,9 +78,10 @@ class Port(tuple):
 class AdjacencyAnalyzer(object):
     """Adjacency candidate graph analyzer and manipulator"""
 
-    def __init__(self, graph, aggregates=None):
+    def __init__(self, graph, aggregates=None, stats=None):
         self.graph = graph
         self.aggregates = aggregates or {}
+        self.stats = stats if stats is not None else NullStats()
 
     def get_max_out_degree(self):
         """Returns the port node with the highest outgoing degree"""
@@ -164,10 +166,14 @@ class AdjacencyReducer(AdjacencyAnalyzer):
 
         """
         self.result = nx.DiGraph(name="network adjacency candidates")
-        self._reduce_discovery_protocol(LLDP)
-        self._reduce_discovery_protocol(CDP)
-        self._remove_aggregates()
-        self._reduce_cam()
+        with self.stats.time_phase("reduce.lldp"):
+            self._reduce_discovery_protocol(LLDP)
+        with self.stats.time_phase("reduce.cdp"):
+            self._reduce_discovery_protocol(CDP)
+        with self.stats.time_phase("reduce.aggregates"):
+            self._remove_aggregates()
+        with self.stats.time_phase("reduce.cam"):
+            self._reduce_cam()
         self.graph = self.result
 
     def _reduce_cam(self):
@@ -186,6 +192,13 @@ class AdjacencyReducer(AdjacencyAnalyzer):
         """
         max_degree = self.get_max_out_degree()
         _logger.debug("Analyzing graph with max degree %d", max_degree)
+
+        for port_degree, _port in self.get_ports_and_degree():
+            if port_degree < 1:
+                continue
+            bucket = self.stats.cam_degree_bucket(port_degree)
+            self.stats.cam_by_degree[bucket] += 1
+
         degree = 1
 
         while degree <= max_degree:
@@ -199,6 +212,9 @@ class AdjacencyReducer(AdjacencyAnalyzer):
             if not self._visit_unvisited(unvisited):
                 degree += 1
                 continue
+        self.stats.cam["unresolved_remaining"] += sum(
+            1 for n in self.graph.nodes() if isinstance(n, Port)
+        )
         self.result.add_edges_from(self.get_single_edges_from_ports())
 
     def _remove_aggregates(self):
@@ -219,8 +235,10 @@ class AdjacencyReducer(AdjacencyAnalyzer):
                     ', '.join(str(s) for s in self.aggregates[port]),
                 )
             self.graph.remove_nodes_from(removeable)
+            self.stats.aggregates["removed"] += len(removeable)
 
     def _reduce_discovery_protocol(self, sourcetype):
+        bucket = getattr(self.stats, sourcetype)
         done = False
         while not done:
             done = True
@@ -231,12 +249,14 @@ class AdjacencyReducer(AdjacencyAnalyzer):
                     or proto != sourcetype
                 ):
                     continue
+                bucket["edges_seen"] += 1
                 if source == dest:
                     _logger.info("Ignoring apparent %s self-loop on %s", proto, source)
+                    bucket["self_loops"] += 1
                     self.graph.remove_edge(source, dest, proto)
                     continue
                 if self.graph.has_edge(dest, source, proto):
-                    _logger.debug("Found connection from %s to %s", source, dest)
+                    self.stats.record_resolution(sourcetype, source, dest)
                     self.result.add_edge(source, dest)
                     self.result.add_edge(dest, source)
                     self.graph.remove_node(source)
@@ -247,6 +267,7 @@ class AdjacencyReducer(AdjacencyAnalyzer):
                     _logger.debug(
                         "Removing unmatched %s connection %s -> %s", proto, source, dest
                     )
+                    bucket["unmatched_dropped"] += 1
                     self.graph.remove_edge(source, dest, proto)
 
     def _visit_unvisited(self, unvisited):
@@ -257,21 +278,17 @@ class AdjacencyReducer(AdjacencyAnalyzer):
                     _logger.warning(
                         "A possible self-loop was found: %r", (source, dest)
                     )
+                    self.stats.cam["self_loops"] += 1
                     self.graph.remove_edge(source, dest)
                     continue
 
                 if self._is_single_dataless_destination(source, dest):
-                    self.connect_ports(source, dest)
+                    self.connect_ports(source, dest, source_tag='cam-dataless')
                     return True
 
                 remote_port = self.find_return_port(source, dest)
                 if remote_port:
-                    _logger.debug(
-                        "Found connection %s -> %s because of good return path",
-                        source,
-                        remote_port,
-                    )
-                    self.connect_ports(source, remote_port)
+                    self.connect_ports(source, remote_port, source_tag='cam-return')
                     return True
             _logger.debug("Found no connection for %s", port)
         return False
@@ -284,22 +301,18 @@ class AdjacencyReducer(AdjacencyAnalyzer):
             return False
         distinct_edges = set(self.graph.edges(source))
         if len(distinct_edges) == 1:
-            _logger.debug(
-                "No data from %s, trusting single distinct candidate from %s",
-                dest,
-                source,
-            )
             return True
         else:
             return False
 
-    def connect_ports(self, i, j):
+    def connect_ports(self, i, j, *, source_tag):
         """Add connection between a and b to result.
 
         If a or b are of type Port they are removed from the input
         graph, as they are now completely processed
 
         """
+        self.stats.record_resolution(source_tag, i, j)
         if isinstance(i, Port):
             self.graph.remove_node(i)
         if isinstance(j, Port):
@@ -312,20 +325,25 @@ class AdjacencyReducer(AdjacencyAnalyzer):
 # Graph builder functions
 
 
-def build_candidate_graph_from_db():
+def build_candidate_graph_from_db(stats=None):
     """Builds and returns a DiGraph conforming to the requirements of an
     AdjacencyAnalyzer, based on data found in the adjacency_candidate database
     table.
 
     """
+    stats = stats or NullStats()
     acs = AdjacencyCandidate.objects.select_related(
         'netbox', 'interface', 'to_netbox', 'to_interface'
     )
 
     graph = nx.MultiDiGraph(name="network adjacency candidates")
+    netboxes_seen = set()
+    ports_seen = set()
 
     for cand in acs:
+        stats.load["candidates"] += 1
         if not cand.interface.is_admin_up():
+            stats.load["filtered_admin_down"] += 1
             continue  # ignore data from disabled interfaces
         if cand.to_interface:
             dest_node = interface_to_port(cand.to_interface)
@@ -337,8 +355,14 @@ def build_candidate_graph_from_db():
         netbox = Box(cand.netbox.id)
         netbox.name = cand.netbox.sysname
 
+        netboxes_seen.add(int(netbox))
+        ports_seen.add(tuple(port))
+
         graph.add_edge(port, dest_node, cand.source)
         graph.add_edge(netbox, port)
+
+    stats.load["netboxes"] = len(netboxes_seen)
+    stats.load["ports"] = len(ports_seen)
 
     return graph
 

--- a/python/nav/topology/analyze.py
+++ b/python/nav/topology/analyze.py
@@ -306,11 +306,10 @@ class AdjacencyReducer(AdjacencyAnalyzer):
             return False
 
     def connect_ports(self, i, j, *, source_tag):
-        """Add connection between a and b to result.
+        """Add connection between i and j to result.
 
-        If a or b are of type Port they are removed from the input
-        graph, as they are now completely processed
-
+        If i or j are of type Port they are removed from the input
+        graph, as they are now completely processed.
         """
         self.stats.record_resolution(source_tag, i, j)
         if isinstance(i, Port):

--- a/python/nav/topology/detector.py
+++ b/python/nav/topology/detector.py
@@ -35,6 +35,7 @@ from nav.topology.analyze import (
     build_candidate_graph_from_db,
     get_aggregate_mapping,
 )
+from nav.topology.stats import ReducerStats
 from nav.topology.vlan import VlanGraphAnalyzer, VlanTopologyUpdater
 
 from nav.models.manage import Vlan, Prefix
@@ -118,12 +119,15 @@ def with_exception_logging(func):
 @with_exception_logging
 def do_layer2_detection():
     """Detect and update layer 2 topology"""
-    candidates = build_candidate_graph_from_db()
+    stats = ReducerStats()
+    with stats.time_phase("load"):
+        candidates = build_candidate_graph_from_db(stats=stats)
     aggregates = get_aggregate_mapping(include_stacks=True)
-    reducer = AdjacencyReducer(candidates, aggregates)
+    reducer = AdjacencyReducer(candidates, aggregates, stats=stats)
     reducer.reduce()
     links = reducer.get_single_edges_from_ports()
-    update_layer2_topology(links)
+    update_layer2_topology(links, stats=stats)
+    _logger.info("%s", stats.summary_line())
 
 
 @with_exception_logging

--- a/python/nav/topology/layer2.py
+++ b/python/nav/topology/layer2.py
@@ -21,6 +21,7 @@ from django.db import transaction
 from django.db.models import Q
 
 from nav.topology.analyze import Port
+from nav.topology.stats import NullStats
 
 from nav.models.manage import Interface, Netbox
 
@@ -29,21 +30,29 @@ _logger = logging.getLogger(__name__)
 
 
 @transaction.atomic()
-def update_layer2_topology(links):
+def update_layer2_topology(links, stats=None):
     """Updates the layer 2 topology in the NAV database.
 
     :param links: a list of edges from an adjacency graph
+    :param stats: optional `ReducerStats` collector for per-run instrumentation.
 
     """
-    for source, dest in links:
-        _update_interface_topology(source, dest)
+    stats = stats or NullStats()
+
+    stats.save["links_proposed"] = len(links)
+
+    with stats.time_phase("save.update"):
+        for source, dest in links:
+            _update_interface_topology(source, dest, stats=stats)
 
     touched_ifc_ids = [source[1] for source, _dest in links]
-    _clear_topology_for_nontouched(touched_ifc_ids)
-    _clear_topology_for_mismatched_state_links()
+    with stats.time_phase("save.clear_nontouched"):
+        _clear_topology_for_nontouched(touched_ifc_ids, stats=stats)
+    with stats.time_phase("save.clear_mismatched_state"):
+        _clear_topology_for_mismatched_state_links(stats=stats)
 
 
-def _update_interface_topology(source_node, dest_node):
+def _update_interface_topology(source_node, dest_node, stats=None):
     """Updates topology information for the source_node Interface.
 
     The interface's topology will _only_ be updated if its netbox is up, it is
@@ -51,6 +60,8 @@ def _update_interface_topology(source_node, dest_node):
     differs from what we want to set it to.
 
     """
+    stats = stats or NullStats()
+
     _netboxid, interfaceid = source_node
     ifc = Interface.objects.filter(
         id=interfaceid,
@@ -65,15 +76,18 @@ def _update_interface_topology(source_node, dest_node):
         kwargs = {'to_netbox': int(dest_node), 'to_interface': None}
 
     ifc = ifc.exclude(**kwargs)
-    ifc.update(**kwargs)
+    updated = ifc.update(**kwargs)
+    stats.save["rows_actually_updated"] += updated
 
 
-def _clear_topology_for_nontouched(touched_ifc_ids):
+def _clear_topology_for_nontouched(touched_ifc_ids, stats=None):
     """Clears topology information for all interfaces that are administratively
     up, except for those in the touched_ifc_ids list and those who currently
     have no associated topology information.
 
     """
+    stats = stats or NullStats()
+
     up_or_disabled = Q(ifoperstatus=Interface.OPER_UP) | Q(
         ifadminstatus=Interface.ADM_DOWN
     )
@@ -82,10 +96,11 @@ def _clear_topology_for_nontouched(touched_ifc_ids):
     )
     nontouched_ifcs = up_or_disabled_ifcs.exclude(id__in=touched_ifc_ids)
     clearable_ifcs = nontouched_ifcs.exclude(to_netbox__isnull=True)
-    clearable_ifcs.update(to_netbox=None, to_interface=None)
+    cleared = clearable_ifcs.update(to_netbox=None, to_interface=None)
+    stats.save["cleared_nontouched"] += cleared
 
 
-def _clear_topology_for_mismatched_state_links():
+def _clear_topology_for_mismatched_state_links(stats=None):
     """
     Clears topology for all interfaces that are down, but where the link
     partner is still up.
@@ -93,6 +108,8 @@ def _clear_topology_for_mismatched_state_links():
     This is a clear indication that the topology for an Interface has gone
     stale.
     """
+    stats = stats or NullStats()
+
     mismatched = Interface.objects.filter(
         ifoperstatus=Interface.OPER_DOWN,
         to_interface__ifoperstatus=Interface.OPER_UP,
@@ -101,3 +118,4 @@ def _clear_topology_for_mismatched_state_links():
     if count > 0:
         _logger.debug("deleting stale topology for %d operDown interfaces", count)
     mismatched.update(to_netbox=None, to_interface=None)
+    stats.save["cleared_mismatched_state"] += count

--- a/python/nav/topology/stats.py
+++ b/python/nav/topology/stats.py
@@ -1,0 +1,232 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License version 3 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Per-run statistics collector for the L2 topology detector.
+
+`ReducerStats` is owned by `do_layer2_detection` and threaded through
+`build_candidate_graph_from_db`, `AdjacencyReducer`, and
+`update_layer2_topology` so each phase can record counters and timings.
+
+The collector produces a single INFO-level summary log line at end of run.
+Per-resolution DEBUG log lines are emitted via `record_resolution`, tagging
+the source heuristic ('lldp', 'cdp', 'cam-dataless', 'cam-return').
+
+`NullStats` is a drop-in no-op used by callers that don't care (e.g. unit
+tests that exercise the reducer in isolation).
+
+Reading the summary line
+========================
+
+The end-of-run summary line looks like this::
+
+    navtopology --l2 finished in 1.84s: 4127 candidates (312 admin-down)
+    → 712 links (582 lldp, 47 cdp, 83 cam); 14 updated, 3 cleared
+    (nontouched), 0 cleared (mismatched-state); cam_by_degree: 1=75 2=8
+    3=0 4+=2; phases: load=0.31s reduce.lldp=0.04s ...
+
+Fields, in order:
+
+* ``finished in <T>s`` — wall-clock duration of the whole L2 detection run.
+* ``<N> candidates`` — rows read from ``adjacency_candidate``. The input
+  size for the entire reduction.
+* ``(<N> admin-down)`` — candidate rows skipped because the source
+  interface is administratively down (filtered in Python, not SQL).
+* ``<N> links`` — total resolved physical links written to the result
+  graph. Sum of the three sources that follow.
+* ``(<N> lldp, <N> cdp, <N> cam)`` — how many of those links were resolved
+  by each source. LLDP and CDP each count mutual-pair matches; "cam" sums
+  the two CAM heuristics (single-dataless-destination and return-path).
+* ``<N> updated`` — rows in the ``interface`` table whose topology
+  columns actually changed value. The Django ORM update returns this
+  count; rows whose proposed value matched the existing value are
+  excluded earlier in the chain. This is the load-bearing number for
+  judging how much database churn the detector causes.
+* ``<N> cleared (nontouched)`` — rows zeroed because no candidate
+  pointed at them this run.
+* ``<N> cleared (mismatched-state)`` — rows zeroed because the local
+  interface is operDown but the remote claims to still be operUp (stale
+  topology indicator).
+* ``cam_by_degree: 1=A 2=B 3=C 4+=D`` — **starting distribution** of
+  per-port CAM ambiguity, snapshotted just before ``_reduce_cam`` enters
+  its main loop. A port with out-degree N has CAM evidence pointing to N
+  distinct remote candidates. High ``4+`` counts mean the input data is
+  noisy (e.g. uplinks observing MAC addresses bleeding through from
+  downstream switches) — useful run-over-run to spot upstream issues.
+  *Not* a measure of what was left unresolved; see ``cam.unresolved_remaining``
+  (collected but not currently in the summary line) for that.
+* ``phases: ...`` — wall-clock seconds per phase. ``load`` is candidate
+  graph construction; ``reduce.{lldp,cdp,aggregates,cam}`` are the four
+  reduction phases; ``save.{update,clear_nontouched,clear_mismatched_state}``
+  are the three database write phases.
+
+Operators reading ``navtopology.log`` mostly care about the wall-clock,
+the resolved-links breakdown, and the ``updated`` count. Developers
+debugging "why does NAV think A connects to B?" should also enable
+``nav.topology = DEBUG`` to get one ``resolved: <src> -> <dst> [<tag>]``
+line per resolution.
+"""
+
+import logging
+import time
+from collections import defaultdict
+from contextlib import contextmanager
+
+_logger = logging.getLogger(__name__)
+
+_SOURCE_TAG_COUNTER = {
+    "lldp": ("lldp", "pairs_matched"),
+    "cdp": ("cdp", "pairs_matched"),
+    "cam-dataless": ("cam", "resolved_single_dataless"),
+    "cam-return": ("cam", "resolved_return_path"),
+}
+
+
+class ReducerStats:
+    """Accumulates counters and phase timings for one navtopology --l2 run.
+
+    See the module docstring for a field-by-field interpretation of the
+    summary line `summary_line()` produces.
+    """
+
+    def __init__(self):
+        self._wall_start = time.monotonic()
+        self.phase_timings = {}
+        self.load = defaultdict(int)
+        self.lldp = defaultdict(int)
+        self.cdp = defaultdict(int)
+        self.aggregates = defaultdict(int)
+        self.cam = defaultdict(int)
+        self.cam_by_degree = defaultdict(int)
+        self.save = defaultdict(int)
+
+    @contextmanager
+    def time_phase(self, name):
+        start = time.monotonic()
+        try:
+            yield
+        finally:
+            self.phase_timings[name] = time.monotonic() - start
+
+    def record_resolution(self, source_tag, src, dst):
+        """Bump the source-specific counter and emit a DEBUG line.
+
+        `source_tag` is one of 'lldp', 'cdp', 'cam-dataless', 'cam-return'.
+        """
+        bucket, counter = _SOURCE_TAG_COUNTER[source_tag]
+        getattr(self, bucket)[counter] += 1
+        _logger.debug("resolved: %s -> %s [%s]", src, dst, source_tag)
+
+    def cam_degree_bucket(self, degree):
+        """Map a raw out-degree into the {1, 2, 3, 4+} histogram bucket."""
+        return min(max(degree, 1), 4)
+
+    def total_duration(self):
+        return time.monotonic() - self._wall_start
+
+    def summary_line(self):
+        """Single human-readable line summarizing the run."""
+        candidates = self.load["candidates"]
+        admin_down = self.load["filtered_admin_down"]
+        lldp_links = self.lldp["pairs_matched"]
+        cdp_links = self.cdp["pairs_matched"]
+        cam_links = (
+            self.cam["resolved_single_dataless"] + self.cam["resolved_return_path"]
+        )
+        total_links = lldp_links + cdp_links + cam_links
+        updated = self.save["rows_actually_updated"]
+        cleared_nt = self.save["cleared_nontouched"]
+        cleared_ms = self.save["cleared_mismatched_state"]
+
+        phases = " ".join(
+            f"{name}={dur:.2f}s" for name, dur in self.phase_timings.items()
+        )
+        degree_buckets = " ".join(
+            f"{'4+' if b == 4 else b}={self.cam_by_degree[b]}" for b in (1, 2, 3, 4)
+        )
+
+        return (
+            f"navtopology --l2 finished in {self.total_duration():.2f}s: "
+            f"{candidates} candidates ({admin_down} admin-down) → "
+            f"{total_links} links "
+            f"({lldp_links} lldp, {cdp_links} cdp, {cam_links} cam); "
+            f"{updated} updated, "
+            f"{cleared_nt} cleared (nontouched), "
+            f"{cleared_ms} cleared (mismatched-state); "
+            f"cam_by_degree: {degree_buckets}; "
+            f"phases: {phases}"
+        )
+
+
+class _NullDict:
+    """Dict-like that swallows all writes and returns 0 for any read.
+
+    `__getitem__` returning 0 and `__setitem__` discarding are both required
+    for `null_dict[k] += 1` (an augmented assignment) to no-op without
+    accumulating state — a bare `defaultdict(int)` would leak memory on long
+    runs.
+    """
+
+    def __getitem__(self, key):
+        return 0
+
+    def __setitem__(self, key, value):
+        pass
+
+    def __contains__(self, key):
+        return False
+
+    def __iter__(self):
+        return iter(())
+
+    def items(self):
+        return ()
+
+
+_NULL_DICT = _NullDict()
+
+
+class NullStats:
+    """No-op drop-in for `ReducerStats`.
+
+    All counter attributes (`load`, `lldp`, `cdp`, `aggregates`, `cam`,
+    `cam_by_degree`, `save`, `phase_timings`) yield a `_NullDict` that
+    swallows writes. Methods are real but do nothing observable.
+
+    Pinned truthy so that the `stats = stats or NullStats()` sentinel
+    pattern keeps a caller-supplied instance intact even if a future
+    refactor adds `__len__` or other implicitly-falsy hooks.
+    """
+
+    def __bool__(self):
+        return True
+
+    def __getattr__(self, name):
+        return _NULL_DICT
+
+    @contextmanager
+    def time_phase(self, name):
+        yield
+
+    def record_resolution(self, source_tag, src, dst):
+        pass
+
+    def cam_degree_bucket(self, degree):
+        return min(max(degree, 1), 4)
+
+    def total_duration(self):
+        return 0.0
+
+    def summary_line(self):
+        return ""

--- a/tests/unittests/topology/analyze_test.py
+++ b/tests/unittests/topology/analyze_test.py
@@ -16,6 +16,7 @@
 import networkx as nx
 
 from nav.topology.analyze import AdjacencyReducer, Box, Port
+from nav.topology.stats import ReducerStats
 
 
 class TestAdjecencyReducer(object):
@@ -220,3 +221,70 @@ class TestAdjecencyReducer(object):
         assert not result.has_edge(self.switch_port_b, self.switch_port_a)
         assert result.out_degree(self.switch_port_a) == 1
         assert self.switch_port_b not in result
+
+    def test_when_lldp_pair_matches_then_stats_should_count_one_pair_matched(self):  # noqa: E501
+        graph = nx.MultiDiGraph()
+        graph.add_edge(self.switch_a, self.switch_port_a)
+        graph.add_edge(self.switch_b, self.switch_port_b)
+        graph.add_edge(self.switch_port_a, self.switch_port_b, "lldp")
+        graph.add_edge(self.switch_port_b, self.switch_port_a, "lldp")
+        stats = ReducerStats()
+        reducer = AdjacencyReducer(graph, stats=stats)
+        reducer.reduce()
+        assert stats.lldp["pairs_matched"] == 1
+        assert stats.lldp["unmatched_dropped"] == 0
+
+    def test_when_lldp_edge_is_unmatched_then_stats_should_count_one_dropped(self):
+        graph = nx.MultiDiGraph()
+        graph.add_edge(self.switch_a, self.switch_port_a)
+        graph.add_edge(self.switch_b, self.switch_port_b)
+        graph.add_edge(self.switch_port_a, self.switch_port_b, "lldp")
+        stats = ReducerStats()
+        reducer = AdjacencyReducer(graph, stats=stats)
+        reducer.reduce()
+        assert stats.lldp["unmatched_dropped"] == 1
+        assert stats.lldp["pairs_matched"] == 0
+
+    def test_when_lldp_edge_is_self_loop_then_stats_should_count_one_self_loop(self):
+        graph = nx.MultiDiGraph()
+        graph.add_edge(self.switch_a, self.switch_port_a)
+        graph.add_edge(self.switch_port_a, self.switch_port_a, "lldp")
+        stats = ReducerStats()
+        reducer = AdjacencyReducer(graph, stats=stats)
+        reducer.reduce()
+        assert stats.lldp["self_loops"] == 1
+
+    def test_when_cam_resolves_via_single_dataless_then_stats_should_count_it(self):  # noqa: E501
+        graph = nx.MultiDiGraph()
+        graph.add_edge(self.switch_a, self.switch_port_a)
+        graph.add_edge(self.switch_port_a, self.switch_b, "cam")
+        stats = ReducerStats()
+        reducer = AdjacencyReducer(graph, stats=stats)
+        reducer.reduce()
+        assert stats.cam["resolved_single_dataless"] == 1
+
+    def test_when_cam_resolves_via_return_path_then_stats_should_count_it(self):
+        graph = nx.MultiDiGraph(name="simple case cam")
+        graph.add_edge(self.switch_a, self.switch_port_a)
+        graph.add_edge(self.switch_b, self.switch_port_b)
+        graph.add_edge(self.switch_port_a, self.switch_b, "cam")
+        graph.add_edge(self.switch_port_b, self.switch_a, "cam")
+        stats = ReducerStats()
+        reducer = AdjacencyReducer(graph, stats=stats)
+        reducer.reduce()
+        assert stats.cam["resolved_return_path"] == 1
+
+    def test_when_aggregate_is_removed_then_stats_should_count_one_removed(self):
+        aggregator = Port((self.switch_a_id, 99))
+        aggregator.name = "agg"
+        graph = nx.MultiDiGraph()
+        graph.add_edge(self.switch_a, aggregator)
+        graph.add_edge(self.switch_a, self.switch_port_a)
+        graph.add_edge(self.switch_b, self.switch_port_b)
+        graph.add_edge(self.switch_port_a, self.switch_port_b, "lldp")
+        graph.add_edge(self.switch_port_b, self.switch_port_a, "lldp")
+        aggregates = {aggregator: {self.switch_port_a}}
+        stats = ReducerStats()
+        reducer = AdjacencyReducer(graph, aggregates=aggregates, stats=stats)
+        reducer.reduce()
+        assert stats.aggregates["removed"] == 1

--- a/tests/unittests/topology/reducer_stats_test.py
+++ b/tests/unittests/topology/reducer_stats_test.py
@@ -1,0 +1,153 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License version 3 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+
+import pytest
+
+from nav.topology.stats import NullStats, ReducerStats
+
+
+class TestReducerStatsCounters:
+    def test_when_counter_is_incremented_then_it_should_accumulate(self):
+        stats = ReducerStats()
+        stats.lldp["pairs_matched"] += 1
+        stats.lldp["pairs_matched"] += 1
+        assert stats.lldp["pairs_matched"] == 2
+
+    def test_when_counter_is_not_touched_then_it_should_default_to_zero(self):
+        stats = ReducerStats()
+        assert stats.cam["resolved_return_path"] == 0
+
+
+class TestReducerStatsTimePhase:
+    def test_when_phase_completes_then_duration_should_be_recorded(self):
+        stats = ReducerStats()
+        with stats.time_phase("load"):
+            pass
+        assert "load" in stats.phase_timings
+        assert stats.phase_timings["load"] >= 0
+
+    def test_when_phase_raises_then_duration_should_still_be_recorded(self):
+        stats = ReducerStats()
+        with pytest.raises(RuntimeError):
+            with stats.time_phase("broken"):
+                raise RuntimeError("boom")
+        assert "broken" in stats.phase_timings
+        assert stats.phase_timings["broken"] >= 0
+
+
+class TestRecordResolution:
+    @pytest.mark.parametrize(
+        "tag,bucket,counter",
+        [
+            ("lldp", "lldp", "pairs_matched"),
+            ("cdp", "cdp", "pairs_matched"),
+            ("cam-dataless", "cam", "resolved_single_dataless"),
+            ("cam-return", "cam", "resolved_return_path"),
+        ],
+    )
+    def test_when_tag_is_known_then_record_resolution_should_bump_counter(
+        self, tag, bucket, counter
+    ):
+        stats = ReducerStats()
+        stats.record_resolution(tag, "src", "dst")
+        assert getattr(stats, bucket)[counter] == 1
+
+    def test_when_tag_is_unknown_then_record_resolution_should_raise(self):
+        stats = ReducerStats()
+        with pytest.raises(KeyError):
+            stats.record_resolution("bogus", "src", "dst")
+
+
+class TestCamDegreeBucket:
+    @pytest.mark.parametrize(
+        "degree,expected",
+        [(1, 1), (2, 2), (3, 3), (4, 4), (5, 4), (99, 4)],
+    )
+    def test_when_degree_is_given_then_bucket_should_clamp_at_four(
+        self, degree, expected
+    ):
+        assert ReducerStats().cam_degree_bucket(degree) == expected
+
+
+class TestSummaryLine:
+    def test_when_run_has_no_data_then_summary_should_still_render(self):
+        line = ReducerStats().summary_line()
+        assert "navtopology --l2 finished" in line
+        assert "candidates" in line
+        assert "links" in line
+        assert "phases" in line
+
+    def test_when_counters_are_set_then_summary_should_include_their_values(self):
+        stats = ReducerStats()
+        stats.load["candidates"] = 4127
+        stats.load["filtered_admin_down"] = 312
+        stats.lldp["pairs_matched"] = 582
+        stats.cdp["pairs_matched"] = 47
+        stats.cam["resolved_single_dataless"] = 12
+        stats.cam["resolved_return_path"] = 71
+        stats.save["rows_actually_updated"] = 14
+        stats.save["cleared_nontouched"] = 3
+        stats.save["cleared_mismatched_state"] = 0
+        stats.phase_timings["load"] = 0.31
+        stats.cam_by_degree[1] = 75
+        stats.cam_by_degree[2] = 8
+        stats.cam_by_degree[4] = 2
+
+        line = stats.summary_line()
+
+        assert "4127 candidates" in line
+        assert "312 admin-down" in line
+        assert "582 lldp" in line
+        assert "47 cdp" in line
+        assert "83 cam" in line  # 12 + 71 resolved via cam
+        assert "14 updated" in line
+        assert "3 cleared (nontouched)" in line
+        assert "0 cleared (mismatched-state)" in line
+        assert "load=0.31s" in line
+        assert "1=75" in line
+        assert "2=8" in line
+        assert "4+=2" in line
+
+
+class TestNullStats:
+    def test_when_counter_is_incremented_on_nullstats_then_it_should_not_raise(self):
+        null = NullStats()
+        null.lldp["pairs_matched"] += 1
+        null.cam["resolved_return_path"] += 5
+        null.cam_by_degree[null.cam_degree_bucket(7)] += 1
+
+    def test_when_time_phase_is_used_on_nullstats_then_it_should_be_a_no_op(self):
+        null = NullStats()
+        with null.time_phase("anything"):
+            pass
+
+    def test_when_record_resolution_is_called_on_nullstats_then_it_should_not_raise(
+        self,
+    ):
+        NullStats().record_resolution("lldp", "src", "dst")
+
+    def test_when_summary_line_is_called_on_nullstats_then_it_should_return_empty(self):
+        assert NullStats().summary_line() == ""
+
+    def test_when_total_duration_is_called_on_nullstats_then_it_should_return_zero(
+        self,
+    ):
+        assert NullStats().total_duration() == 0.0
+
+    def test_when_phase_timings_is_iterated_on_nullstats_then_it_should_be_empty(self):
+        null = NullStats()
+        assert list(null.phase_timings) == []
+        assert list(null.phase_timings.items()) == []


### PR DESCRIPTION
## Scope and purpose

Topology problems in NAV are notoriously hard to debug. The existing how-to at [doc/howto/debugging-topology.rst](https://github.com/Uninett/nav/blob/24f6a8d28/doc/howto/debugging-topology.rst) helps an operator inspect inputs (CAM, LLDP/CDP, candidate tables) but says nothing about what the L2 reducer actually did during any given run — how many candidates it loaded, how each source (LLDP/CDP/CAM) contributed to the resolved set, how many `interface` rows it actually updated, or how long the phases took. Today an operator can't even tell from `navtopology.log` whether the detector did meaningful work on the last run, let alone diagnose drift over time.

This pull request adds a per-run summary line at INFO level to `navtopology.log`. Example:

    navtopology --l2 finished in 1.84s: 4127 candidates (312 admin-down) → 712 links (582 lldp, 47 cdp, 83 cam); 14 updated, 3 cleared (nontouched), 0 cleared (mismatched-state); cam_by_degree: 1=75 2=8 3=0 4+=2; phases: load=0.31s reduce.lldp=0.04s reduce.cdp=0.02s reduce.aggregates=0.01s reduce.cam=0.18s save.update=1.20s save.clear_nontouched=0.07s save.clear_mismatched_state=0.01s

The new module docstring on [\`python/nav/topology/stats.py\`](https://github.com/Uninett/nav/blob/24f6a8d28/python/nav/topology/stats.py) documents the summary line field-by-field, including non-obvious counters like \`cam_by_degree\` (a starting-state CAM-ambiguity histogram).

A secondary effect of this work: the existing per-edge DEBUG resolutions are now funnelled through a single helper that tags each line with the heuristic that produced it (\`lldp\`, \`cdp\`, \`cam-dataless\`, \`cam-return\`). With \`nav.topology = DEBUG\` in \`logging.conf\`, the question "why does NAV think A connects to B?" becomes answerable from the log alone — a useful complement to the existing debugging how-to.

The reducer algorithm itself is untouched. There are no schema changes, no new CLI flags, no JSON or external metrics output. The risk profile is observability-only.

The \`rows_actually_updated\` counter is the load-bearing number for downstream discussions about reducing topology-related database churn — previously unobservable without ad-hoc patches.

### This pull request
* adds a per-run summary log line to \`navtopology --l2\`
* adds uniform per-edge DEBUG provenance for resolved topology links

### Verifying

1. Run \`navtopology --l2\` and tail \`navtopology.log\`. The last line should match the example above (numbers will vary).
2. Set \`nav.topology = DEBUG\` in \`logging.conf\`, run again, and grep for \`resolved:\` — each resolved link gets one line with its source tag in brackets.
3. Run a second \`navtopology --l2\` immediately. On a stable network \`updated\` should be close to zero — most rows already match what the reducer wants to write.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~ (the new module docstring on \`stats.py\` interprets the summary line for developers; no operator-facing doc tree updates beyond that)
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [x] If this adds a new Python source code file: Added the boilerplate header to that file