### PR TITLE
Make devcontainer init script reusable from the host

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,8 @@
   "containerEnv": {
     "DJANGO_SETTINGS_MODULE": "nav.django.settings",
     "DISPLAY": "dummy",
-    "CLAUDE_CONFIG_DIR": "/home/vscode/.claude"
+    "CLAUDE_CONFIG_DIR": "/home/vscode/.claude",
+    "DEVCONTAINER": "true"
   },
 
   // Configure tool-specific properties.

--- a/.devcontainer/scripts/init-nav-config.sh
+++ b/.devcontainer/scripts/init-nav-config.sh
@@ -27,14 +27,17 @@ update_nav_conf() {
 
 update_graphite_conf() {
   GRAPHITE_CONF="${NAV_CONFIG_DIR}/graphite.conf"
+  CARBON_HOST="${CARBON_HOST:-graphite}"
+  CARBON_PORT="${CARBON_PORT:-2003}"
+  GRAPHITEWEB_BASE="${GRAPHITEWEB_BASE:-http://graphite:8000/}"
   echo "Updating $GRAPHITE_CONF"
   cat > "$GRAPHITE_CONF" <<EOF
 [carbon]
-host=graphite
-port=2003
+host=${CARBON_HOST}
+port=${CARBON_PORT}
 
 [graphiteweb]
-base=http://graphite:8000/
+base=${GRAPHITEWEB_BASE}
 EOF
 }
 

--- a/.devcontainer/scripts/init-nav-config.sh
+++ b/.devcontainer/scripts/init-nav-config.sh
@@ -46,7 +46,13 @@ update_nav_conf
 update_nav_db_conf
 update_graphite_conf
 
-# Ensure the default virtualenv is in the secure_path when running sudo
-echo "Defaults        secure_path=\"${UV_PROJECT_ENVIRONMENT}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"" | sudo tee /etc/sudoers.d/secure_path_virtualenv
-# Install an empty crontab to avoid the error "no crontab for vscode"
-echo -n | crontab
+# Devcontainer-only: sudoers secure_path + empty crontab.  Skipped on the host
+# (e.g. when invoked from nix-shell).  Gated on $DEVCONTAINER, which we set
+# ourselves in devcontainer.json's `containerEnv` so the signal is independent
+# of which IDE (VS Code, JetBrains, ...) brought the container up.
+if [ -n "$DEVCONTAINER" ]; then
+    # Ensure the default virtualenv is in the secure_path when running sudo
+    echo "Defaults        secure_path=\"${UV_PROJECT_ENVIRONMENT}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"" | sudo tee /etc/sudoers.d/secure_path_virtualenv
+    # Install an empty crontab to avoid the error "no crontab for vscode"
+    echo -n | crontab
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ ldap = ["python-ldap==3.4.5"]  # optional for LDAP authentication, requires libl
 [dependency-groups]
 dev = [
     "isort",
+    "pip",  # PyCharm's package inspector needs `pip` in the venv to detect deps
     "ruff",
     "towncrier",
     "pre-commit",


### PR DESCRIPTION
## Scope and purpose

I'm setting up a local NAV development environment on my own machine, running NAV directly on the host while still reusing the Postgres and Graphite container definitions from `.devcontainer/docker-compose.yml`. I'd like to reuse the existing `init-nav-config.sh` for the NAV config bootstrap rather than duplicate its logic, but two small things in it currently assume it's being run inside the devcontainer. This PR makes those non-breaking, plus one unrelated dev-ergonomics fix.

The host-side glue (shell environment, override compose file with the published ports, etc.) lives in my personal working tree and isn't part of this PR — I'm currently the only one developing this way, and it doesn't need to be in the repo until/unless more developers adopt the same workflow.

**Parameterize the graphite settings in `init-nav-config.sh`.** The script previously hardcoded the carbon host/port (`graphite:2003`) and the graphiteweb base URL (`http://graphite:8000/`), which are correct inside the devcontainer's Docker network but wrong when NAV runs on the host and reaches the same containers via published loopback ports. The script now honors `CARBON_HOST` / `CARBON_PORT` / `GRAPHITEWEB_BASE` env vars, falling back to the original devcontainer defaults when unset. Existing behavior is unchanged.

**Gate the devcontainer-only steps.** The script's final two actions — writing `/etc/sudoers.d/secure_path_virtualenv` and clearing the user's crontab — only make sense inside the devcontainer image. They now run only when `$DEVCONTAINER` is set. We set `DEVCONTAINER=true` ourselves in `devcontainer.json`'s `containerEnv` so the signal is IDE-agnostic — VS Code Dev Containers and JetBrains Dev Containers both honor `containerEnv`, but neither auto-sets a cross-tool "I'm in a devcontainer" marker of its own. Host invocations of the script (e.g. from a host shell when developing against the Postgres/Graphite containers directly) no longer trample the developer's sudoers configuration or crontab.

**Add `pip` to the `dev` dependency group.** Unrelated to the above but bundled here since it's a tiny tooling-only change: PyCharm's package inspector shells out to `pip list` / `pip show` and degrades when `pip` isn't present in the venv. `uv` deliberately doesn't install `pip` by default, so adding it to the `dev` group keeps the inspector happy for anyone using PyCharm together with `uv sync`.

### This pull request
* ~~adds/changes/removes a dependency~~ (only adds `pip` to the `dev` group — not a runtime dep)
* ~~changes the database~~
* ~~changes the API~~

## Contributor Checklist

* [ ] ~~Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)~~ — tooling-only, not user-facing; PR will be labeled `nonews`
* [ ] ~~Added/amended tests for new/changed code~~ — shell glue, no reasonable unit test surface
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the boilerplate header to that file~~
