### PR TITLE
Allow pping to run without root on Linux

### DIFF
--- a/NOTES.rst
+++ b/NOTES.rst
@@ -22,6 +22,34 @@ Python modules with changed version requirements:
 
 * :mod:`Django` (``>=5.2,<5.3``)
 
+
+Unprivileged ``pping``
+----------------------
+
+NAV's parallel pinger (``pping``) no longer needs to start as ``root`` on
+Linux. The shipped :file:`daemons.yml` now sets ``privileged: false`` for
+``pping``, which means ``nav start pping`` will launch the daemon directly
+as the configured ``NAV_USER`` instead of as ``root``. (Previously ``pping``
+started as ``root``, opened raw ICMP sockets, then dropped privileges to
+``NAV_USER`` — the end state is the same, only the startup path has
+changed.)
+
+For this to work, the kernel's ``net.ipv4.ping_group_range`` sysctl must
+cover the ``NAV_USER``'s gid (Linux 2.6.39+ for IPv4, 3.11+ for IPv6).
+Alternatively, the ``pping`` process must run with the ``CAP_NET_RAW``
+Linux capability granted by some other mechanism on your system.
+
+On non-Linux systems (FreeBSD, macOS), or on Linux installations where
+neither of the above is in place, ``pping`` will fail at startup with a
+descriptive error. To restore the previous behavior, edit
+:file:`daemons.yml` and set ``privileged: true`` for ``pping`` — the
+daemon will then start as ``root`` and drop privileges as before.
+
+Operators upgrading from earlier versions whose :file:`daemons.yml` is
+customized in place will not see this change automatically; only fresh
+installations or those that adopt the shipped default will be affected.
+
+
 NAV 5.18
 ========
 

--- a/NOTES.rst
+++ b/NOTES.rst
@@ -79,6 +79,34 @@ New navdashboard CLI tool
 A new :program:`navdashboard` command line tool is available for listing,
 exporting and importing dashboards.
 
+
+Unprivileged ``pping``
+----------------------
+
+NAV's parallel pinger (``pping``) no longer needs to start as ``root`` on
+Linux. The shipped :file:`daemons.yml` now sets ``privileged: false`` for
+``pping``, which means ``nav start pping`` will launch the daemon directly
+as the configured ``NAV_USER`` instead of as ``root``. (Previously ``pping``
+started as ``root``, opened raw ICMP sockets, then dropped privileges to
+``NAV_USER`` — the end state is the same, only the startup path has
+changed.)
+
+For this to work, the kernel's ``net.ipv4.ping_group_range`` sysctl must
+cover the ``NAV_USER``'s gid (Linux 2.6.39+ for IPv4, 3.11+ for IPv6).
+Alternatively, the ``pping`` process must run with the ``CAP_NET_RAW``
+Linux capability granted by some other mechanism on your system.
+
+On non-Linux systems (FreeBSD, macOS), or on Linux installations where
+neither of the above is in place, ``pping`` will fail at startup with a
+descriptive error. To restore the previous behavior, edit
+:file:`daemons.yml` and set ``privileged: true`` for ``pping`` — the
+daemon will then start as ``root`` and drop privileges as before.
+
+Operators upgrading from earlier versions whose :file:`daemons.yml` is
+customized in place will not see this change automatically; only fresh
+installations or those that adopt the shipped default will be affected.
+
+
 NAV 5.18
 ========
 

--- a/changelog.d/4059.changed.md
+++ b/changelog.d/4059.changed.md
@@ -1,0 +1,1 @@
+Run pping as the configured NAV user from startup instead of starting as root and dropping privileges. On Linux, this requires the NAV user's gid to be within `net.ipv4.ping_group_range`; on non-Linux systems, set `privileged: true` for pping in `daemons.yml` to restore the previous behavior.

--- a/doc/howto/generic-install-from-source.rst
+++ b/doc/howto/generic-install-from-source.rst
@@ -208,16 +208,26 @@ directory.
 Users and privileges
 --------------------
 
-Apart from the ``pping`` and ``snmptrapd`` daemons, no NAV processes should
-ever be run as ``root``. You should create a non-privileged system user and
-group, and ensure the ``NAV_USER`` option in :file:`nav.conf` is set
-accordingly. Also make sure this user has permissions to write to the directories
-configured in ``PID_DIR``, ``LOG_DIR`` and ``UPLOAD_DIR``.
+No NAV processes should ordinarily run as ``root``. You should create a
+non-privileged system user and group, and ensure the ``NAV_USER`` option in
+:file:`nav.conf` is set accordingly. Also make sure this user has permissions
+to write to the directories configured in ``PID_DIR``, ``LOG_DIR`` and
+``UPLOAD_DIR``.
 
-.. note:: The ``pping`` and ``snmptrapd`` daemons must be started as ``root``
-          to be able to create privileged communication sockets. Both daemons
-          will drop privileges and run as the configured non-privileged user as
-          soon as the sockets have been acquired.
+.. note:: The ``snmptrapd`` daemon must be started as ``root`` to be able to
+          bind UDP port 162 for incoming SNMP traps; it drops privileges as
+          soon as the socket is bound. In :file:`daemons.yml`, ``snmptrapd``
+          is marked ``privileged: true`` for this reason.
+
+.. note:: The ``pping`` daemon needs to open ICMP sockets, which historically
+          also required ``root``. On Linux, ``pping`` can run unprivileged if
+          the ``NAV_USER``'s gid is within the kernel's
+          ``net.ipv4.ping_group_range`` sysctl, or if ``CAP_NET_RAW`` is
+          granted to the Python binary. The shipped :file:`daemons.yml` sets
+          ``privileged: false`` for ``pping``; if you run NAV on a non-Linux
+          system (FreeBSD, macOS) or your kernel does not expose unprivileged
+          ICMP sockets, change it back to ``privileged: true`` so the daemon
+          starts as ``root`` and drops privileges after opening the sockets.
 
 Building the documentation
 --------------------------

--- a/python/nav/bin/pping.py
+++ b/python/nav/bin/pping.py
@@ -46,13 +46,15 @@ _logger = logging.getLogger('nav.pping')
 def main():
     args = make_argparser().parse_args()
 
-    if os.getuid() != 0:
-        print("Must be started as root")
+    try:
+        sockets = megaping.make_sockets()
+    except PermissionError as error:
+        print(f"Cannot open ICMP sockets: {error}", file=sys.stderr)
         sys.exit(1)
 
-    socket = megaping.make_sockets()  # make raw sockets while we have root
-    nav.daemon.switchuser(NAV_CONFIG['NAV_USER'])
-    start(args.foreground, socket)
+    if os.geteuid() == 0:
+        nav.daemon.switchuser(NAV_CONFIG['NAV_USER'])
+    start(args.foreground, sockets)
 
 
 def make_argparser():

--- a/python/nav/etc/daemons.yml
+++ b/python/nav/etc/daemons.yml
@@ -16,7 +16,12 @@ daemons:
     pping:
         description: Pings all IP devices for status monitoring.
         command: pping
-        privileged: true
+        # Linux exposes unprivileged ICMP datagram sockets via the
+        # net.ipv4.ping_group_range sysctl; if the NAV user's gid is in range,
+        # pping can run without root. On non-Linux systems (FreeBSD, macOS),
+        # pping still needs root to open ICMP sockets — set this to `true`
+        # there. See doc/howto/generic-install-from-source.rst.
+        privileged: false
 
     servicemon:
         description: Monitors configured services.

--- a/python/nav/statemon/icmppacket.py
+++ b/python/nav/statemon/icmppacket.py
@@ -119,10 +119,6 @@ class PacketV4(Packet):
     ICMP_ECHO = 8
     ICMP_TIME_EXCEEDED = 11
 
-    # IPv4 RAW sockets include the IP header in the received datagram.  This
-    # packet slice chops of the first 20 octets to get at the ICMP datagram
-    packet_slice = slice(20, None)
-
 
 class PacketV6(Packet):
     """An ICMPv6 packet.

--- a/python/nav/statemon/megaping.py
+++ b/python/nav/statemon/megaping.py
@@ -41,16 +41,14 @@ def make_sockets():
     """
     try:
         socketv6 = socket.socket(
-            socket.AF_INET6, socket.SOCK_RAW, socket.getprotobyname('ipv6-icmp')
+            socket.AF_INET6, socket.SOCK_RAW, socket.IPPROTO_ICMPV6
         )
     except Exception:  # noqa: BLE001
         _logger.error("Could not create v6 socket")
         raise
 
     try:
-        socketv4 = socket.socket(
-            socket.AF_INET, socket.SOCK_RAW, socket.getprotobyname('icmp')
-        )
+        socketv4 = socket.socket(socket.AF_INET, socket.SOCK_RAW, socket.IPPROTO_ICMP)
     except Exception:  # noqa: BLE001
         _logger.error("Could not create v4 socket")
         raise

--- a/python/nav/statemon/megaping.py
+++ b/python/nav/statemon/megaping.py
@@ -34,26 +34,45 @@ _logger = logging.getLogger(__name__)
 
 
 def make_sockets():
-    """Makes and returns the raw IPv6 and IPv4 ICMP sockets.
+    """Open ICMP sockets for IPv6 and IPv4.
 
-    This needs to run as root before dropping privileges.
-
+    Tries unprivileged SOCK_DGRAM/IPPROTO_ICMP first (works on Linux when
+    the caller's gid is within net.ipv4.ping_group_range, no CAP_NET_RAW
+    required), then falls back to SOCK_RAW which needs either root or
+    CAP_NET_RAW.
     """
-    try:
-        socketv6 = socket.socket(
-            socket.AF_INET6, socket.SOCK_RAW, socket.IPPROTO_ICMPV6
-        )
-    except Exception:  # noqa: BLE001
-        _logger.error("Could not create v6 socket")
-        raise
+    return [
+        _open_icmp_socket(socket.AF_INET6, socket.IPPROTO_ICMPV6),
+        _open_icmp_socket(socket.AF_INET, socket.IPPROTO_ICMP),
+    ]
 
-    try:
-        socketv4 = socket.socket(socket.AF_INET, socket.SOCK_RAW, socket.IPPROTO_ICMP)
-    except Exception:  # noqa: BLE001
-        _logger.error("Could not create v4 socket")
-        raise
 
-    return [socketv6, socketv4]
+def _open_icmp_socket(family, proto):
+    """Open an ICMP socket, trying SOCK_DGRAM before SOCK_RAW.
+
+    Raises PermissionError if neither kind opens. The error message names
+    all three Linux options so an operator troubleshooting an unexpected
+    failure knows which knob fits their constraints.
+    """
+    last_error = None
+    for kind in (socket.SOCK_DGRAM, socket.SOCK_RAW):
+        try:
+            return socket.socket(family, kind, proto)
+        except OSError as error:
+            last_error = error
+            _logger.debug(
+                "could not open socket(family=%s, kind=%s, proto=%s): %s",
+                family,
+                kind,
+                proto,
+                error,
+            )
+    raise PermissionError(
+        f"could not open ICMP socket (family={family}, proto={proto}). "
+        "On Linux, either add this user's gid to net.ipv4.ping_group_range, "
+        "grant CAP_NET_RAW to the python binary, or run as root. "
+        f"Last OS error: {last_error}"
+    )
 
 
 class Host(object):
@@ -186,18 +205,14 @@ class MegaPing(object):
         self._elapsedtime = 0
 
         # Initialize the sockets
-        if sockets is not None:
-            self._sock6 = sockets[0]
-            self._sock4 = sockets[1]
-        else:
-            try:
-                sockets = make_sockets()
-            except Exception:  # noqa: BLE001
-                _logger.error("Tried to create sockets without being root!")
-
-            self._sock6 = sockets[0]
-            self._sock4 = sockets[1]
-            _logger.info("No sockets passed as argument, creating own")
+        if sockets is None:
+            sockets = make_sockets()
+        self._sock6 = sockets[0]
+        self._sock4 = sockets[1]
+        # IPv4 SOCK_RAW delivers the 20-byte IP header along with the ICMP
+        # datagram; SOCK_DGRAM/IPPROTO_ICMP delivers only the ICMP payload.
+        # IPv6 never includes the IPv6 header in either kind of socket.
+        self._sock4_header_len = 20 if self._sock4.type == socket.SOCK_RAW else 0
 
     def set_hosts(self, ips):
         """
@@ -307,7 +322,10 @@ class MegaPing(object):
 
     def _process_response(self, raw_pong, sender, is_ipv6, arrival):
         # Extract header info and payload
+        sock = self._sock6 if is_ipv6 else self._sock4
         packet_class = PacketV6 if is_ipv6 else PacketV4
+        if not is_ipv6:
+            raw_pong = raw_pong[self._sock4_header_len :]
         try:
             pong = packet_class(raw_pong)
         except Exception as error:  # noqa: BLE001
@@ -319,7 +337,14 @@ class MegaPing(object):
             _logger.debug("Packet from %s was not an echo reply, but %s", sender, pong)
             return
 
-        if not pong.id == self._pid:
+        # SOCK_DGRAM/IPPROTO_ICMP sockets are demultiplexed by the kernel: it
+        # rewrites the icmp_id field of outgoing packets to the socket's local
+        # port and only delivers incoming replies whose id matches. The
+        # delivered pong.id therefore equals that port, not our pid — so we
+        # skip the check entirely and let the cookie comparison below confirm
+        # the reply belongs to a request we sent. SOCK_RAW receives every
+        # ICMP packet on the host and still needs explicit id-based filtering.
+        if sock.type == socket.SOCK_RAW and pong.id != self._pid:
             _logger.debug(
                 "packet from %r doesn't match our id (%s): %r (raw packet: %r)",
                 sender,

--- a/tests/unittests/statemon/icmp_test.py
+++ b/tests/unittests/statemon/icmp_test.py
@@ -37,11 +37,6 @@ class TestICMPPacket:
         packet.sequence = 3
         packet = packet.assemble()
 
-        # Mocking the IP header and prepending it to the packet so disassembling of
-        # packet works
-        IP_header = b'\x00' * 20
-        packet = IP_header + packet
-
         # Make Packet object which disassembles the raw packet
         v4_packet = PacketV4(packet, False)
 

--- a/tests/unittests/statemon/megaping_test.py
+++ b/tests/unittests/statemon/megaping_test.py
@@ -1,0 +1,33 @@
+import socket
+from unittest.mock import Mock, patch
+
+from nav.statemon.megaping import MegaPing
+
+
+class TestMegaPingHeaderStripping:
+    """Verifies that MegaPing records the right IPv4 header offset.
+
+    With SOCK_RAW the kernel hands us the 20-byte IP header before the ICMP
+    datagram. With SOCK_DGRAM/IPPROTO_ICMP the kernel strips it for us. The
+    receive loop slices ``raw_pong`` by this offset before parsing.
+    """
+
+    def test_when_v4_socket_is_raw_then_header_len_should_be_20(self):
+        mp = _make_megaping(v4_kind=socket.SOCK_RAW)
+        assert mp._sock4_header_len == 20
+
+    def test_when_v4_socket_is_dgram_then_header_len_should_be_0(self):
+        mp = _make_megaping(v4_kind=socket.SOCK_DGRAM)
+        assert mp._sock4_header_len == 0
+
+
+def _make_megaping(v4_kind):
+    sockets = [_make_socket_mock(socket.SOCK_RAW), _make_socket_mock(v4_kind)]
+    with patch("nav.statemon.megaping.config.pingconf", return_value={}):
+        return MegaPing(sockets=sockets)
+
+
+def _make_socket_mock(kind):
+    sock = Mock(spec=socket.socket)
+    sock.type = kind
+    return sock

--- a/tests/unittests/statemon/megaping_test.py
+++ b/tests/unittests/statemon/megaping_test.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock
+import socket
+from unittest.mock import MagicMock, Mock, patch
 
 from nav.statemon.megaping import Host, MegaPing
 
@@ -19,6 +20,23 @@ class TestMegaPingResults:
         assert megaping.results() == [("127.0.0.1", 0.001)]
 
 
+class TestMegaPingHeaderStripping:
+    """Verifies that MegaPing records the right IPv4 header offset.
+
+    With SOCK_RAW the kernel hands us the 20-byte IP header before the ICMP
+    datagram. With SOCK_DGRAM/IPPROTO_ICMP the kernel strips it for us. The
+    receive loop slices ``raw_pong`` by this offset before parsing.
+    """
+
+    def test_when_v4_socket_is_raw_then_header_len_should_be_20(self):
+        mp = _make_megaping(v4_kind=socket.SOCK_RAW)
+        assert mp._sock4_header_len == 20
+
+    def test_when_v4_socket_is_dgram_then_header_len_should_be_0(self):
+        mp = _make_megaping(v4_kind=socket.SOCK_DGRAM)
+        assert mp._sock4_header_len == 0
+
+
 def _megaping_with_host_reply(reply):
     sockets = (MagicMock(), MagicMock())
     megaping = MegaPing(sockets=sockets, conf={})
@@ -26,3 +44,15 @@ def _megaping_with_host_reply(reply):
     host.reply = reply
     megaping._hosts = {host.ip: host}
     return megaping
+
+
+def _make_megaping(v4_kind):
+    sockets = [_make_socket_mock(socket.SOCK_RAW), _make_socket_mock(v4_kind)]
+    with patch("nav.statemon.megaping.config.pingconf", return_value={}):
+        return MegaPing(sockets=sockets)
+
+
+def _make_socket_mock(kind):
+    sock = Mock(spec=socket.socket)
+    sock.type = kind
+    return sock


### PR DESCRIPTION
## Scope and purpose

Fixes #4059.

The user-visible change for operators: the shipped `daemons.yml` now sets `privileged: false` for pping, so `nav start pping` launches the daemon directly as `NAV_USER` instead of starting as `root` and dropping privileges. On Linux this requires the user's gid to be within `net.ipv4.ping_group_range`. On non-Linux systems, or Linux with the default empty range, set `privileged: true` for pping in `daemons.yml` to restore the previous behavior. The new "Unprivileged `pping`" section in `NOTES.rst` and the updated installation docs spell this out.

Drive-by: `make_sockets()` now uses `socket.IPPROTO_ICMP[V6]` constants instead of `socket.getprotobyname()`, which depends on `/etc/protocols`. This fixes a startup crash on minimal systems that don't ship `/etc/protocols` (NixOS without `iana-etc`, slim container images).

## Testing

Set `nav.statemon = DEBUG` in `logging.conf`. Run `pping -f` as a user whose gid is in `net.ipv4.ping_group_range` (Debian/Ubuntu typically include all users; Fedora/RHEL/NixOS may need `sysctl net.ipv4.ping_group_range="0 2147483647"` or similar). Confirm:

* pping starts without the "Must be started as root" abort;
* echoes go out, replies come back, "marked as up/down" log lines reflect actual reachability;
* the "doesn't match our id" debug line does *not* spam the output.

To exercise the legacy `SOCK_RAW` fallback (the code path used on non-Linux and on Linux with no ping group configured), temporarily empty the sysctl: `sysctl net.ipv4.ping_group_range="1 0"`. The unprivileged attempt will then fail with `EACCES` for non-root callers, and `make_sockets()` falls through to `SOCK_RAW`. Set `privileged: true` for pping in `daemons.yml` and start as root to confirm that path still works. Restore the sysctl afterwards.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [x] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file