### PR TITLE
Drop crontab -u when self-targeting

### DIFF
--- a/python/nav/startstop.py
+++ b/python/nav/startstop.py
@@ -17,6 +17,7 @@
 """NAV Service start/stop library."""
 
 import errno
+import getpass
 import os
 import shlex
 import signal
@@ -329,7 +330,7 @@ class Crontab(object):
     def load(self):
         """Loads the currently active crontab"""
         try:
-            output = subprocess.check_output(["crontab", "-u", self.user, "-l"])
+            output = subprocess.check_output(self._crontab_command("-l"))
             self.content = output.decode('utf-8').splitlines()
         except subprocess.CalledProcessError:
             # crontab doesn't have very helpful exit codes. if we get here, it
@@ -360,9 +361,7 @@ class Crontab(object):
     def save(self):
         """Saves the current state to the crontab"""
         self.update_init()
-        proc = subprocess.Popen(
-            ["crontab", "-u", self.user, "-"], stdin=subprocess.PIPE
-        )
+        proc = subprocess.Popen(self._crontab_command("-"), stdin=subprocess.PIPE)
         proc.stdin.write(str(self).encode('utf-8'))
         proc.stdin.close()
 
@@ -446,6 +445,19 @@ class Crontab(object):
 
     def __str__(self):
         return '\n'.join(self.content)
+
+    def _crontab_command(self, *extra):
+        """Build a `crontab` command, omitting `-u` when self-targeting.
+
+        Vixie cron rejects `-u` outright for non-root callers, even when the
+        named user is the current user.  Cronie permits the self-targeting
+        case.  Avoid the flag whenever we don't need it so NAV works against
+        either implementation.
+        """
+        cmd = ["crontab"]
+        if self.user != getpass.getuser():
+            cmd += ["-u", self.user]
+        return cmd + list(extra)
 
 
 class ServiceRegistry(dict):


### PR DESCRIPTION
## Scope and purpose

The `nav` CLI prints `must be privileged to use -u` to stderr on every invocation when running on a Vixie-cron system (NixOS, *BSD, minimal distros). `ServiceRegistry()` instantiates at import time and reads the current crontab via `crontab -u <NAV_USER> -l`. Vixie cron rejects `-u` for non-root callers even when the requested user is the current user; cronie (Debian-derived, including the devcontainer) permits the self-targeting case, which is why this hasn't surfaced before. NAV functionality is unaffected (the `CalledProcessError` is caught), but the stderr leak makes `nav` unusable in scripts/CI on non-cronie systems and is generally noisy on host dev environments.

The fix omits `-u` whenever `Crontab.user` matches the current user — both Vixie and cronie accept the bare `crontab -l` / `crontab -` form for the current user. No behavior change on cronie systems; one fewer stderr line on Vixie systems.

## Testing

On a Vixie-cron system, before this change: `nav --help` (or any other `nav` subcommand) emits `must be privileged to use -u` to stderr. After this change: no stderr noise. On a cronie system, behavior is unchanged.

## Contributor Checklist

* [ ] ~~Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)~~ — `nonews` label, behavior change is invisible on the platforms most users run.
* [ ] No unit test added — `_crontab_command` is a one-line behavior switch exercised implicitly by every `nav` CLI invocation. Happy to add one if a reviewer prefers.
* [x] Added/changed documentation — not needed, this is an invisible-on-cronie internal fix.
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~