### PR TITLE
Fix pping misclassifying hosts with 0.0 s RTT

### DIFF
--- a/changelog.d/4071.fixed.md
+++ b/changelog.d/4071.fixed.md
@@ -1,0 +1,1 @@
+pping no longer misclassifies hosts whose ICMP echo reply round-trip time measures as exactly 0 s.

--- a/python/nav/statemon/megaping.py
+++ b/python/nav/statemon/megaping.py
@@ -360,5 +360,6 @@ class MegaPing(object):
         Unreachable hosts will have roundtriptime = -1
         """
         return [
-            (host.ip, host.reply if host.reply else -1) for host in self._hosts.values()
+            (host.ip, host.reply if host.reply is not None else -1)
+            for host in self._hosts.values()
         ]

--- a/tests/unittests/statemon/megaping_test.py
+++ b/tests/unittests/statemon/megaping_test.py
@@ -1,0 +1,28 @@
+from unittest.mock import MagicMock
+
+from nav.statemon.megaping import Host, MegaPing
+
+
+class TestMegaPingResults:
+    """Tests for MegaPing.results()"""
+
+    def test_when_host_reply_is_none_then_results_should_return_minus_one(self):
+        megaping = _megaping_with_host_reply(None)
+        assert megaping.results() == [("127.0.0.1", -1)]
+
+    def test_when_host_reply_is_zero_then_results_should_return_zero(self):
+        megaping = _megaping_with_host_reply(0.0)
+        assert megaping.results() == [("127.0.0.1", 0.0)]
+
+    def test_when_host_reply_is_positive_then_results_should_return_that_value(self):
+        megaping = _megaping_with_host_reply(0.001)
+        assert megaping.results() == [("127.0.0.1", 0.001)]
+
+
+def _megaping_with_host_reply(reply):
+    sockets = (MagicMock(), MagicMock())
+    megaping = MegaPing(sockets=sockets, conf={})
+    host = Host("127.0.0.1")
+    host.reply = reply
+    megaping._hosts = {host.ip: host}
+    return megaping


### PR DESCRIPTION
## Scope and purpose

Fixes #4071.

`MegaPing.results()` used a Python truthiness check to distinguish "reply received" from "no reply received", which conflated `None` (timeout) with `0.0` (reply received with measured zero RTT) and resulted in spurious `boxDown` events. Replaced the truthiness check with an explicit `is not None` comparison. See the linked issue for the full failure analysis and the 2015 customer incident that motivated the report.


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~