### PR TITLE
Fix runaway sleep on loop overrun in pping and servicemon

### DIFF
--- a/changelog.d/4072.fixed.md
+++ b/changelog.d/4072.fixed.md
@@ -1,0 +1,1 @@
+pping and servicemon no longer schedule excessively long sleeps when a checking round overruns the configured `checkinterval`.

--- a/python/nav/bin/pping.py
+++ b/python/nav/bin/pping.py
@@ -197,15 +197,16 @@ class Pinger(object):
                 len(self.down),
             )
             wait = self._looptime - elapsedtime
-            if wait > 0:
-                _logger.debug("Sleeping %03.3f secs", wait)
-            else:
-                wait = abs(self._looptime + wait)
+            if wait <= 0:
                 _logger.warning(
-                    "Check lasted longer than looptime. "
-                    "Delaying next check for %03.3f secs",
-                    wait,
+                    "Check lasted %0.3fs, longer than looptime %0.3fs; "
+                    "starting next round immediately",
+                    elapsedtime,
+                    self._looptime,
                 )
+                wait = 0.0
+            else:
+                _logger.debug("Sleeping %03.3f secs", wait)
             sleep(wait)
 
     def signalhandler(self, signum, _frame):

--- a/python/nav/bin/servicemon.py
+++ b/python/nav/bin/servicemon.py
@@ -108,17 +108,19 @@ class Controller:
                 self._runqueue.enq(checker)
                 sleep(pause)
 
-            wait = self._looptime - (time.time() - start)
-            _logger.debug("Waiting %i seconds.", wait)
+            elapsed = time.time() - start
+            wait = self._looptime - elapsed
             if wait <= 0:
-                _logger.critical(
-                    "Only superman can do this. Humans cannot wait for %i seconds.",
-                    wait,
+                _logger.warning(
+                    "Checker enqueueing took %0.3fs, longer than looptime %0.3fs; "
+                    "starting next round immediately",
+                    elapsed,
+                    self._looptime,
                 )
-                wait %= self._looptime
-                sleep(wait)
+                wait = 0.0
             else:
-                sleep(wait)
+                _logger.debug("Waiting %0.3f seconds.", wait)
+            sleep(wait)
 
     def signalhandler(self, signum, _):
         if signum == signal.SIGTERM:

--- a/tests/unittests/bin/pping_test.py
+++ b/tests/unittests/bin/pping_test.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock, patch
+
+from nav.bin.pping import Pinger
+
+
+class TestPingerMainOverrun:
+    """Tests for Pinger.main()'s post-iteration sleep computation."""
+
+    def test_when_check_overruns_then_main_should_sleep_zero(self):
+        pinger = _make_pinger(looptime=20, elapsedtime=24179.267)
+        with patch("nav.bin.pping.sleep") as mock_sleep:
+            pinger.main()
+        mock_sleep.assert_called_once_with(0.0)
+
+    def test_when_check_finishes_quickly_then_main_should_sleep_remaining_time(self):
+        pinger = _make_pinger(looptime=20, elapsedtime=5.0)
+        with patch("nav.bin.pping.sleep") as mock_sleep:
+            pinger.main()
+        mock_sleep.assert_called_once_with(15.0)
+
+
+def _make_pinger(looptime, elapsedtime):
+    """Build a Pinger with just enough attributes to run main() for one
+    iteration. Skips the real __init__ (which opens a DB, parses config and
+    installs signal handlers) by going through __new__.
+    """
+    pinger = Pinger.__new__(Pinger)
+    pinger._isrunning = 1
+    pinger._looptime = looptime
+    pinger.netboxmap = {}
+    pinger.down = []
+    pinger.db = MagicMock()
+    pinger.update_host_list = MagicMock()
+    pinger.generate_events = MagicMock()
+
+    def fake_ping():
+        pinger._isrunning = 0
+        return elapsedtime
+
+    pinger.pinger = MagicMock()
+    pinger.pinger.ping.side_effect = fake_ping
+    return pinger

--- a/tests/unittests/bin/servicemon_test.py
+++ b/tests/unittests/bin/servicemon_test.py
@@ -1,0 +1,57 @@
+import itertools
+from unittest.mock import MagicMock, patch
+
+from nav.bin.servicemon import Controller
+
+
+class TestControllerMainSleep:
+    """Tests for Controller.main()'s post-enqueue sleep computation."""
+
+    def test_when_enqueue_overruns_then_main_should_sleep_zero(self):
+        controller = _make_controller(looptime=60)
+        # Three calls of interest in main(): loop start, first-overrun check,
+        # second-overrun check. Logging incidentally also calls time.time(),
+        # so keep yielding the last value afterwards.
+        # 24179 is chosen so that the buggy `wait %= looptime` would compute
+        # 1.0 (since -24119 % 60 == 1) and not coincidentally agree with the
+        # clamp-to-zero fix.
+        fake_clock = itertools.chain([0.0, 10.0, 24179.0], itertools.repeat(24179.0))
+        with (
+            patch("nav.bin.servicemon.sleep") as mock_sleep,
+            patch("nav.bin.servicemon.time.time", side_effect=fake_clock) as mock_time,
+        ):
+            mock_sleep.side_effect = lambda *_: setattr(controller, "_isrunning", 0)
+            controller.main()
+        mock_sleep.assert_called_once_with(0.0)
+        # Guard against a future refactor silently changing the time.time()
+        # call ordering: we expect at least the three calls listed above.
+        assert mock_time.call_count >= 3
+
+    def test_when_enqueue_finishes_quickly_then_main_should_sleep_remaining_time(self):
+        controller = _make_controller(looptime=60)
+        # Loop start at t=0, first-overrun check at t=5 (wait=55, positive),
+        # second-overrun check at t=10 (wait=50, positive) -> sleep(50).
+        fake_clock = itertools.chain([0.0, 5.0, 10.0], itertools.repeat(10.0))
+        with (
+            patch("nav.bin.servicemon.sleep") as mock_sleep,
+            patch("nav.bin.servicemon.time.time", side_effect=fake_clock) as mock_time,
+        ):
+            mock_sleep.side_effect = lambda *_: setattr(controller, "_isrunning", 0)
+            controller.main()
+        mock_sleep.assert_called_once_with(50.0)
+        assert mock_time.call_count >= 3
+
+
+def _make_controller(looptime):
+    """Build a Controller with just enough attributes to run main() for one
+    iteration. Skips the real __init__ by going through __new__ so we don't
+    open a DB, parse config, or install signal handlers.
+    """
+    controller = Controller.__new__(Controller)
+    controller._isrunning = 1
+    controller._looptime = looptime
+    controller._checkers = []
+    controller.db = MagicMock()
+    controller._runqueue = MagicMock()
+    controller.get_checkers = MagicMock()
+    return controller


### PR DESCRIPTION
## Scope and purpose

Fixes #4072.

Both `pping` and `servicemon` computed their post-iteration sleep with arithmetic that misbehaved on severe overruns. `pping`'s overrun branch used `wait = abs(self._looptime + wait)`, which resolves to `abs(2*looptime − elapsed)` — sensible only while the overrun is less than one looptime, and unbounded in the other direction. A laptop-suspend mid-loop with `checkinterval=20` is what motivated the issue: `elapsed=24179s` produced a scheduled sleep of `24139s` (~6h45m). `servicemon`'s analogous branch used `wait %= self._looptime`, with the opposite failure mode (loops back-to-back instead of waiting) and a misleading `"Only superman can do this"` critical log. Replaced both with a clamp-to-zero: log a warning naming the actual overrun magnitude, and start the next round immediately. See the linked issue for the 2002-vintage code archaeology that traces how each formula got there.

While in the area, also normalised the `_logger.debug("Waiting %i seconds.", wait)` line in servicemon to `%0.3f` so the two daemons' debug output is consistent (pping already uses `%03.3f` for the same value).


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~