### PR TITLE
Fix SeedDB IP Device add form crashing on Django 5.2

### DIFF
--- a/changelog.d/4077.fixed.md
+++ b/changelog.d/4077.fixed.md
@@ -1,0 +1,1 @@
+Fixed SeedDB IP Device "add" form crashing with `ValueError: Model instances passed to related filters must be saved.` after the Django 5.2 upgrade.

--- a/python/nav/web/seeddb/page/netbox/edit.py
+++ b/python/nav/web/seeddb/page/netbox/edit.py
@@ -393,6 +393,7 @@ def netbox_do_save(form):
 
     netbox = form.save(commit=False)  # Prevents saving m2m relationships
     netbox.save()
+    form.save_virtual_instances(netbox)
 
     # Save the function field
     function = form.cleaned_data['function']

--- a/python/nav/web/seeddb/page/netbox/forms.py
+++ b/python/nav/web/seeddb/page/netbox/forms.py
@@ -215,21 +215,19 @@ class NetboxModelForm(forms.ModelForm):
         if msg:
             raise IPExistsException(msg)
 
-    def save(self, commit=True):
-        netbox = super(NetboxModelForm, self).save(commit)
-        instances = self.cleaned_data.get('virtual_instance')
+    def save_virtual_instances(self, netbox):
+        """Reconcile the netbox's virtual instances against the form selection.
 
-        # Clean up instances
+        Must be called on a saved netbox: Django 5.2 refuses related-field
+        lookups against unsaved model instances.
+        """
+        instances = self.cleaned_data.get('virtual_instance') or []
         Netbox.objects.filter(master=netbox).exclude(pk__in=instances).update(
             master=None
         )
-
-        # Add new instances
         for instance in instances:
             instance.master = netbox
             instance.save()
-
-        return netbox
 
 
 class NetboxFilterForm(forms.Form):

--- a/tests/integration/web/seeddb_netbox_test.py
+++ b/tests/integration/web/seeddb_netbox_test.py
@@ -6,12 +6,14 @@ from django.urls import reverse
 from django.utils.encoding import smart_str
 from mock import Mock, patch
 
-from nav.models.manage import ManagementProfile, NetboxType, Vendor
+from nav.models.manage import ManagementProfile, Netbox, NetboxType, Vendor
 from nav.Snmp.errors import SnmpError
 from nav.web.seeddb.page.netbox.edit import (
     get_snmp_read_only_variables,
+    netbox_do_save,
     snmp_write_test,
 )
+from nav.web.seeddb.page.netbox.forms import NetboxModelForm
 
 
 class TestCheckConnectivityView:
@@ -501,6 +503,64 @@ class TestSnmpWriteTest:
         assert result['status'] is False
         assert result['custom_error'] == 'UnicodeDecodeError'
         assert result['error_message'] == "Could not decode SNMP response"
+
+
+class TestNetboxModelFormSave:
+    """Regression tests for `NetboxModelForm` save behaviour."""
+
+    def test_when_adding_a_new_netbox_then_save_should_not_raise(self, db):
+        """Regression for the Django 5.2 crash where `save()` filtered on the
+        unsaved netbox instance: "Model instances passed to related filters
+        must be saved."
+        """
+        form = NetboxModelForm(self._post_data())
+        assert form.is_valid(), form.errors
+        netbox = netbox_do_save(form)
+        assert netbox.pk is not None
+        assert not Netbox.objects.filter(master=netbox).exists()
+
+    def test_when_adding_with_virtual_instances_then_they_should_be_saved(
+        self, db, existing_orphan_netbox
+    ):
+        """A new master netbox should have its selected virtual instances
+        re-pointed at it during creation.
+        """
+        form = NetboxModelForm(
+            self._post_data(
+                ip='127.0.0.43',
+                sysname='regression-master-netbox.example.org',
+                virtual_instance=[existing_orphan_netbox.pk],
+            )
+        )
+        assert form.is_valid(), form.errors
+        master = netbox_do_save(form)
+        existing_orphan_netbox.refresh_from_db()
+        assert existing_orphan_netbox.master_id == master.pk
+
+    @staticmethod
+    def _post_data(**overrides):
+        data = {
+            'ip': '127.0.0.42',
+            'room': 'myroom',
+            'category': 'SRV',
+            'organization': 'myorg',
+            'sysname': 'regression-test-netbox.example.org',
+        }
+        data.update(overrides)
+        return data
+
+
+@pytest.fixture
+def existing_orphan_netbox(db):
+    netbox = Netbox(
+        ip='127.0.0.50',
+        sysname='regression-orphan-netbox.example.org',
+        room_id='myroom',
+        category_id='SRV',
+        organization_id='myorg',
+    )
+    netbox.save()
+    return netbox
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Scope and purpose

Adding a new IP Device in SeedDB on `master` crashes with `ValueError at /seeddb/netbox/add/`: *Model instances passed to related filters must be saved.* The bug was introduced by the Django 5.2 upgrade (#3958) and has not reached a stable release.

[`NetboxModelForm.save()`](https://github.com/Uninett/nav/blob/995153b2533f47d3213612c8f7ac7150082acb7a/python/nav/web/seeddb/page/netbox/forms.py#L218-L237) ran `Netbox.objects.filter(master=netbox)` against the instance returned by `super().save(commit=False)`. On the add path that instance has no `pk`, and [Django 5.2 now refuses](https://github.com/django/django/blob/5.2/django/db/models/fields/related_lookups.py#L15-L20) to silently substitute `None`. Pre-5.2 the call "worked" only because it silently became `WHERE master_id IS NULL` — which, for any non-empty selection of virtual instances, would also have updated rows that had nothing to do with the netbox being created.

The fix extracts the virtual-instance reconciliation into a new `NetboxModelForm.save_virtual_instances()` method, called explicitly from [`netbox_do_save()`](https://github.com/Uninett/nav/blob/995153b2533f47d3213612c8f7ac7150082acb7a/python/nav/web/seeddb/page/netbox/edit.py#L386-L426) *after* `netbox.save()`. This mirrors how groups, profiles, and the function field are already handled in that helper, and ensures the reconciliation runs against a saved netbox on both the add and the edit path.

### Alternatives considered

* **Short-circuit `save()` when `netbox.pk is None`**: simplest patch, but silently dropped any virtual instances the user had selected on the add form — caught during review.
* **Wrap `form.save_m2m()` from inside the overridden `save()`**: more idiomatic Django (the documented `commit=False` hook), but `netbox_do_save` doesn't call `save_m2m()` today — it handles `groups` and `profiles` manually via the through-tables. Switching to that pattern would either require an extra `save_m2m()` call alongside the existing manual handling, or a wider refactor dropping the manual handling. The explicit method keeps the multi-step save shape `netbox_do_save` already uses for everything else.

### Reproduction

1. SeedDB → IP Devices → *Add new IP Device*.
2. Fill in IP, room, category, organization, sysname. Virtual instances may be left empty.
3. Submit. Without this PR: 500 with the ValueError. With this PR: redirects to the edit view as expected.

A regression test covering both the empty and the non-empty virtual-instance case has been added in `tests/integration/web/seeddb_netbox_test.py::TestNetboxModelFormSave`.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~