### PR TITLE
Fix unclickable links in My stuff dropdown

### DIFF
--- a/python/nav/web/sass/_overrides.scss
+++ b/python/nav/web/sass/_overrides.scss
@@ -192,3 +192,15 @@ $driver-popover-progress-fg: $driver-popover-secondary-fg;
   border-bottom-style: solid;
   border-top-style: none;
 }
+
+/*
+  Reveal the 'My stuff' dropdown when megadrop.js toggles the .open class.
+  Foundation hides the dropdown with the "clip" technique (1px box, overflow
+  hidden) rather than display:none, so un-clip it here.
+*/
+.top-bar-section .has-dropdown.open > .dropdown {
+  height: auto;
+  width: auto;
+  overflow: visible;
+  clip: auto;
+}

--- a/python/nav/web/static/js/src/plugins/megadrop.js
+++ b/python/nav/web/static/js/src/plugins/megadrop.js
@@ -8,7 +8,6 @@ require([], function () {
             $megadroptoggler = $(document.getElementById(megadropTogglerSelector)),
             $mystufftoggler = $(document.getElementById(mystuffTogglerSelector)),
             $mystuffItem = $mystufftoggler.closest('li'),
-            $mystuffDropdown = $mystuffItem.find('.dropdown'),
             $caret = $megadroptoggler.find('i'),
             caretDownClass = 'fa-caret-down',
             caretUpClass = 'fa-caret-up',
@@ -27,12 +26,10 @@ require([], function () {
         }
 
         function hideMystuff() {
-            $mystuffDropdown.hide();
             $mystuffItem.removeClass('open');
         }
 
         function showMystuff() {
-            $mystuffDropdown.show();
             $mystuffItem.addClass('open');
         }
 
@@ -45,7 +42,7 @@ require([], function () {
         });
 
         $mystufftoggler.click(function (e) {
-            if ($mystuffDropdown.is(':visible')) {
+            if ($mystuffItem.hasClass('open')) {
                 hideMystuff();
             } else {
                 hideMegaDrop();
@@ -68,7 +65,7 @@ require([], function () {
                     hideMegaDrop();
                 }
             }
-            if ($mystuffDropdown.is(':visible')) {
+            if ($mystuffItem.hasClass('open')) {
                 const clickIsOutsideMystuff = $target.closest('#' + mystuffTogglerSelector).length === 0
                         && $target.closest('.has-dropdown').length === 0;
                 if (clickIsOutsideMystuff) {

--- a/python/nav/web/static/js/src/plugins/megadrop.js
+++ b/python/nav/web/static/js/src/plugins/megadrop.js
@@ -11,7 +11,8 @@ require([], function () {
             $caret = $megadroptoggler.find('i'),
             caretDownClass = 'fa-caret-down',
             caretUpClass = 'fa-caret-up',
-            slidespeed = 300;
+            slidespeed = 300,
+            mystuffIsOpen = false;
 
         function hideMegaDrop() {
             $megadrop.slideUp(slidespeed, function () {
@@ -27,13 +28,16 @@ require([], function () {
 
         function hideMystuff() {
             $mystuffItem.removeClass('open');
+            $mystufftoggler[0].blur();
+            mystuffIsOpen = false;
         }
 
         function showMystuff() {
             $mystuffItem.addClass('open');
+            mystuffIsOpen = true;
         }
 
-        $megadroptoggler.click(function () {
+        $megadroptoggler.on('click', function () {
             if ($megadrop.is(':visible')) {
                 hideMegaDrop();
             } else {
@@ -41,8 +45,8 @@ require([], function () {
             }
         });
 
-        $mystufftoggler.click(function (e) {
-            if ($mystuffItem.hasClass('open')) {
+        $mystufftoggler.on('click', function (e) {
+            if (mystuffIsOpen) {
                 hideMystuff();
             } else {
                 hideMegaDrop();
@@ -55,7 +59,7 @@ require([], function () {
             Hide megadrop when clicking outside it. See special case for
             top-bar dropdowns below
         */
-        $(document).click(function (event) {
+        $(document).on('click', function (event) {
             const $target = $(event.target);
             if ($megadrop.is(":visible")) {
                 const clickIsOutsideMegadrop = $target.parents('#' + megadropSelector).length <= 0,
@@ -65,7 +69,7 @@ require([], function () {
                     hideMegaDrop();
                 }
             }
-            if ($mystuffItem.hasClass('open')) {
+            if (mystuffIsOpen) {
                 const clickIsOutsideMystuff = $target.closest('#' + mystuffTogglerSelector).length === 0
                         && $target.closest('.has-dropdown').length === 0;
                 if (clickIsOutsideMystuff) {
@@ -75,7 +79,7 @@ require([], function () {
         });
 
         /* Special case for top bar dropdown menus (event does not propagate to document) */
-        $('.top-bar .has-dropdown').click(function () {
+        $('.top-bar .has-dropdown').on('click', function () {
             if ($megadrop.is(":visible")) {
                 hideMegaDrop();
             }


### PR DESCRIPTION
## Scope and purpose

Fixes a regression introduced by #4014.

The "My stuff" navbar dropdown already worked fine — the one problem #4014 set out to fix was that the caret indicator next to it didn't flip to reflect whether the menu was open. To track that open/closed state, #4014 started managing the dropdown with jQuery `.show()`/`.hide()` plus an `.open` class. Because the dropdown still appeared to function, nobody noticed this had broken clicking the links inside it.

Foundation's top-bar does not hide dropdowns with `display:none` — it uses the "clip" technique (a 1px box with `overflow:hidden` and `clip:rect()`, keeping `display:block`). So `.show()` only flipped `display` while the menu's contents stayed clipped and unclickable, and `.hide()` left an inline `display:none` behind that suppressed the reveal. This PR reveals the dropdown in CSS via the `.open` class the JS already toggles — un-clipping it the way Foundation's own reveal rules do — and drops the `.show()`/`.hide()` calls so nothing fights the stylesheet. The caret indicator still flips, since it keys off the same `.open` class.

To observe: log in, click **My stuff** in the navbar, then click any link in the dropdown — it now navigates instead of doing nothing. The caret still toggles up/down as the menu opens and closes.

## Manual test

Remember `make sassbuild` if there seems to be no change.

## Contributor Checklist

* [ ] ~~Added a changelog fragment for towncrier~~ — #4014 is unreleased, so this regression never shipped; nothing user-visible to note (labeling `nonews`).
* [ ] ~~Added/amended tests for new/changed code~~ — no JS/CSS test harness exists for the navbar.
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff (pre-commit; no Python touched)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ..."
* [x] Based this pull request on the correct upstream branch (`master`)
* [ ] ~~Created new issues if this PR does not fix the issue completely~~
* [x] Described how to interact with NAV to observe the effects (above)
* [ ] ~~Added screenshots of the before and after~~ — the dropdown looks identical; the fix is purely behavioral (links become clickable). The caret behavior is unchanged from #4014.
* [ ] ~~Added the boilerplate header to a new Python source file~~
