### PR TITLE
Fix wrong neighbour for aggregate interfaces over stacked members

### DIFF
--- a/changelog.d/4029.fixed.md
+++ b/changelog.d/4029.fixed.md
@@ -1,0 +1,1 @@
+Fixed topology detector assigning the wrong neighbor to aggregate (LAG) interfaces, such as Juniper `ae` interfaces, whose members are discovered through one or more layers of stacked interfaces.

--- a/python/nav/topology/analyze.py
+++ b/python/nav/topology/analyze.py
@@ -218,24 +218,69 @@ class AdjacencyReducer(AdjacencyAnalyzer):
         self.result.add_edges_from(self.get_single_edges_from_ports())
 
     def _remove_aggregates(self):
-        """Removes from the graph LAG ports whose aggregated (physical) ports
-        have already had their topology discovered.
-        """
-        removeable = []
-        for aggregator, aggregated in self.aggregates.items():
-            if aggregator in self.graph:
-                if any(port in self.result for port in aggregated):
-                    removeable.append(aggregator)
+        """Removes from the graph aggregate ports whose member interfaces have
+        already had their topology discovered.
 
-        if removeable:
-            for port in sorted(removeable, key=str):
+        An aggregate can sit several layers above the interfaces that actually
+        carry the discovery data: an aggregator over logical units, each unit
+        stacked above a physical port. Which layer exposes the resolving
+        LLDP/CDP data varies between vendors — it may be the physical port, an
+        intermediate logical interface, or (not handled here) the aggregate
+        itself. Because the mapping from `get_aggregate_mapping` is flat (one
+        entry per layer), membership is resolved by walking it transitively, so
+        the aggregate is suppressed as soon as *any* interface beneath it has
+        resolved, whatever layer that happens to be on. Checking only the
+        direct members would miss a member resolved further down the stack and
+        leave the aggregate for the CAM phase to resolve in isolation — the
+        #4029 failure, where Juniper exposes the data on the physical ports two
+        layers below the ``ae`` interface.
+        """
+        removable = {}
+        for aggregator in self.aggregates:
+            if aggregator not in self.graph:
+                continue
+            resolved = [
+                port
+                for port in self._aggregate_members(aggregator)
+                if port in self.result
+            ]
+            if resolved:
+                removable[aggregator] = resolved
+
+        if removable:
+            for port in sorted(removable, key=str):
                 _logger.debug(
-                    "Ignoring aggregate %s [%s]",
+                    "Ignoring aggregate %s (resolved via %s)",
                     port,
-                    ', '.join(str(s) for s in self.aggregates[port]),
+                    ', '.join(str(s) for s in sorted(removable[port], key=str)),
                 )
-            self.graph.remove_nodes_from(removeable)
-            self.stats.aggregates["removed"] += len(removeable)
+            self.graph.remove_nodes_from(removable)
+            self.stats.aggregates["removed"] += len(removable)
+
+    def _aggregate_members(self, aggregator):
+        """Returns the transitive set of interfaces aggregated under aggregator.
+
+        Follows the flat aggregate/stack mapping to arbitrary depth, so an
+        interface reached through several layers — a physical port beneath a
+        logical unit beneath the aggregate, and so on — counts as a member. The
+        accumulated set of members doubles as the visited set, keeping the walk
+        safe against cycles, which the database schema does not prevent in
+        device-reported data.
+
+        Both intermediate and leaf interfaces are returned, and the caller
+        treats them alike: a resolution at any layer of the stack establishes
+        the aggregate's topology, so it should suppress the aggregate without
+        caring which layer the vendor happened to expose the data on.
+        """
+        members = set()
+        queue = list(self.aggregates.get(aggregator, ()))
+        while queue:
+            member = queue.pop()
+            if member in members:
+                continue
+            members.add(member)
+            queue.extend(self.aggregates.get(member, ()))
+        return members
 
     def _reduce_discovery_protocol(self, sourcetype):
         bucket = getattr(self.stats, sourcetype)

--- a/python/nav/topology/stats.py
+++ b/python/nav/topology/stats.py
@@ -48,6 +48,11 @@ Fields, in order:
 * ``(<N> lldp, <N> cdp, <N> cam)`` — how many of those links were resolved
   by each source. LLDP and CDP each count mutual-pair matches; "cam" sums
   the two CAM heuristics (single-dataless-destination and return-path).
+* ``<N> aggregates suppressed`` — LAG/aggregate ports dropped from the
+  candidate graph because a member interface had already resolved, so the
+  aggregate was not resolved from its own candidates. Membership is walked
+  transitively through the aggregate/stack hierarchy, so this counts
+  members resolved at any layer below the aggregate (see issue #4029).
 * ``<N> updated`` — rows in the ``interface`` table whose topology
   columns actually changed value. The Django ORM update returns this
   count; rows whose proposed value matched the existing value are
@@ -145,6 +150,7 @@ class ReducerStats:
             self.cam["resolved_single_dataless"] + self.cam["resolved_return_path"]
         )
         total_links = lldp_links + cdp_links + cam_links
+        suppressed = self.aggregates["removed"]
         updated = self.save["rows_actually_updated"]
         cleared_nt = self.save["cleared_nontouched"]
         cleared_ms = self.save["cleared_mismatched_state"]
@@ -161,6 +167,7 @@ class ReducerStats:
             f"{candidates} candidates ({admin_down} admin-down) → "
             f"{total_links} links "
             f"({lldp_links} lldp, {cdp_links} cdp, {cam_links} cam); "
+            f"{suppressed} aggregates suppressed; "
             f"{updated} updated, "
             f"{cleared_nt} cleared (nontouched), "
             f"{cleared_ms} cleared (mismatched-state); "

--- a/tests/unittests/topology/analyze_test.py
+++ b/tests/unittests/topology/analyze_test.py
@@ -13,7 +13,10 @@
 # License along with NAV. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from types import SimpleNamespace
+
 import networkx as nx
+import pytest
 
 from nav.topology.analyze import AdjacencyReducer, Box, Port
 from nav.topology.stats import ReducerStats
@@ -288,3 +291,178 @@ class TestAdjecencyReducer(object):
         reducer = AdjacencyReducer(graph, aggregates=aggregates, stats=stats)
         reducer.reduce()
         assert stats.aggregates["removed"] == 1
+
+
+class TestJuniperAggregateStackTransitivity:
+    """Reproduces issue #4029: a Juniper aggregate (ae0) layered over
+    logical units, which are in turn stacked above physical ports, must be
+    suppressed once its physical members resolve via LLDP — even though the
+    aggregate-to-physical relationship spans two hops through the stack.
+
+    Topology modelled (all on the Juniper, netbox id 2):
+
+        ae0                          aggregate (CAM-only, candidate is WRONG)
+       /   \\
+      u1    u2                       logical units (no candidate data)
+      |      |
+      p1    p2                       physical ports (LLDP to the real neighbor)
+
+    p1/p2 resolve to the neighbor by LLDP. ae0's only candidate is a CAM
+    entry pointing at an unrelated box. Before the fix, the one-hop member
+    check in `_remove_aggregates` only sees {u1, u2} — neither of which is
+    ever resolved — so ae0 survives into the CAM phase and is wrongly
+    connected to the bystander.
+    """
+
+    def test_when_members_resolve_then_aggregate_should_not_inherit_cam_neighbor(
+        self, reduced
+    ):
+        assert not reduced.result.has_edge(reduced.ae0, reduced.bystander)
+        assert reduced.ae0 not in reduced.result
+
+    def test_when_members_resolve_by_lldp_then_member_topology_should_stand(
+        self, reduced
+    ):
+        assert reduced.result.has_edge(reduced.phys1, reduced.nbr_port1)
+        assert reduced.result.has_edge(reduced.phys2, reduced.nbr_port2)
+
+    def test_when_aggregate_suppressed_via_stack_then_stats_should_count_removed(
+        self, reduced
+    ):
+        assert reduced.stats.aggregates["removed"] == 1
+
+    def test_when_aggregate_is_three_layers_above_physical_then_it_should_be_suppressed(
+        self,
+    ):
+        ae0 = _port(2, 100, "juniper (ae0)")
+        unit = _port(2, 11, "juniper (xe-0/0/1.0)")
+        mid = _port(2, 21, "juniper (xe-0/0/1 midstack)")
+        phys = _port(2, 1, "juniper (xe-0/0/1)")
+        aggregates = {ae0: {unit}, unit: {mid}, mid: {phys}}
+        reduced = _reduce_single_member_scenario(aggregates)
+        assert reduced.stats.aggregates["removed"] == 1
+        assert reduced.ae0 not in reduced.result
+        assert not reduced.result.has_edge(reduced.ae0, reduced.bystander)
+
+    @pytest.mark.timeout(5)
+    def test_when_aggregate_mapping_contains_cycle_then_suppression_terminates(self):
+        ae0 = _port(2, 100, "juniper (ae0)")
+        unit = _port(2, 11, "juniper (xe-0/0/1.0)")
+        phys = _port(2, 1, "juniper (xe-0/0/1)")
+        # The unit points back up to the aggregate, forming a cycle that the
+        # member walk must not follow forever.
+        aggregates = {ae0: {unit}, unit: {phys, ae0}}
+        reduced = _reduce_single_member_scenario(aggregates)
+        assert reduced.stats.aggregates["removed"] == 1
+        assert reduced.ae0 not in reduced.result
+
+
+@pytest.fixture
+def reduced(juniper_aggregate_scenario):
+    """Run the reducer over the scenario, exposing result graph, stats, and
+    every scenario node as one namespace for terse assertions.
+    """
+    scenario = juniper_aggregate_scenario
+    stats = ReducerStats()
+    reducer = AdjacencyReducer(
+        scenario.graph, aggregates=scenario.aggregates, stats=stats
+    )
+    reducer.reduce()
+    return SimpleNamespace(result=reducer.graph, stats=stats, **vars(scenario))
+
+
+@pytest.fixture
+def juniper_aggregate_scenario():
+    """Build the #4029 candidate graph plus its flat aggregate mapping.
+
+    The mapping mirrors get_aggregate_mapping(include_stacks=True): the
+    aggregate maps to its logical units, and each unit maps to its physical
+    port — two hops from aggregate to physical member.
+    """
+    juniper = _box(2, "juniper")
+    neighbor = _box(3, "neighbor")
+    bystander = _box(1, "bystander")
+
+    ae0 = _port(2, 100, "juniper (ae0)")
+    unit1 = _port(2, 11, "juniper (xe-0/0/1.0)")
+    unit2 = _port(2, 12, "juniper (xe-0/0/2.0)")
+    phys1 = _port(2, 1, "juniper (xe-0/0/1)")
+    phys2 = _port(2, 2, "juniper (xe-0/0/2)")
+    nbr_port1 = _port(3, 1, "neighbor (xe-0/0/1)")
+    nbr_port2 = _port(3, 2, "neighbor (xe-0/0/2)")
+
+    aggregates = {
+        ae0: {unit1, unit2},
+        unit1: {phys1},
+        unit2: {phys2},
+    }
+
+    graph = nx.MultiDiGraph(name="juniper aggregate stack")
+    graph.add_edge(juniper, phys1)
+    graph.add_edge(juniper, phys2)
+    graph.add_edge(juniper, ae0)
+    graph.add_edge(neighbor, nbr_port1)
+    graph.add_edge(neighbor, nbr_port2)
+    # Physical members have mutual LLDP with the real neighbor.
+    graph.add_edge(phys1, nbr_port1, "lldp")
+    graph.add_edge(nbr_port1, phys1, "lldp")
+    graph.add_edge(phys2, nbr_port2, "lldp")
+    graph.add_edge(nbr_port2, phys2, "lldp")
+    # The aggregate's only evidence is a CAM entry to an unrelated box.
+    graph.add_edge(ae0, bystander, "cam")
+
+    return SimpleNamespace(
+        graph=graph,
+        aggregates=aggregates,
+        ae0=ae0,
+        bystander=bystander,
+        phys1=phys1,
+        phys2=phys2,
+        nbr_port1=nbr_port1,
+        nbr_port2=nbr_port2,
+    )
+
+
+def _reduce_single_member_scenario(aggregates):
+    """Reduce the #4029 graph reduced to a single physical member.
+
+    The graph is fixed — one aggregate (ae0) whose only candidate is a CAM
+    entry to an unrelated box, and one physical port (xe-0/0/1) with mutual
+    LLDP to a neighbor. The aggregate mapping is supplied by the caller so a
+    test can vary its depth or introduce a cycle; any intermediate ports the
+    mapping references but the graph omits stand in for the data-less logical
+    units of a real stack.
+    """
+    juniper = _box(2, "juniper")
+    neighbor = _box(3, "neighbor")
+    bystander = _box(1, "bystander")
+    ae0 = _port(2, 100, "juniper (ae0)")
+    phys = _port(2, 1, "juniper (xe-0/0/1)")
+    nbr_port = _port(3, 1, "neighbor (xe-0/0/1)")
+
+    graph = nx.MultiDiGraph(name="single-member aggregate stack")
+    graph.add_edge(juniper, phys)
+    graph.add_edge(juniper, ae0)
+    graph.add_edge(neighbor, nbr_port)
+    graph.add_edge(phys, nbr_port, "lldp")
+    graph.add_edge(nbr_port, phys, "lldp")
+    graph.add_edge(ae0, bystander, "cam")
+
+    stats = ReducerStats()
+    reducer = AdjacencyReducer(graph, aggregates=aggregates, stats=stats)
+    reducer.reduce()
+    return SimpleNamespace(
+        result=reducer.graph, stats=stats, ae0=ae0, phys=phys, bystander=bystander
+    )
+
+
+def _box(netbox_id, name):
+    box = Box(netbox_id)
+    box.name = name
+    return box
+
+
+def _port(netbox_id, interface_id, name):
+    port = Port((netbox_id, interface_id))
+    port.name = name
+    return port

--- a/tests/unittests/topology/reducer_stats_test.py
+++ b/tests/unittests/topology/reducer_stats_test.py
@@ -98,6 +98,7 @@ class TestSummaryLine:
         stats.cdp["pairs_matched"] = 47
         stats.cam["resolved_single_dataless"] = 12
         stats.cam["resolved_return_path"] = 71
+        stats.aggregates["removed"] = 9
         stats.save["rows_actually_updated"] = 14
         stats.save["cleared_nontouched"] = 3
         stats.save["cleared_mismatched_state"] = 0
@@ -113,6 +114,7 @@ class TestSummaryLine:
         assert "582 lldp" in line
         assert "47 cdp" in line
         assert "83 cam" in line  # 12 + 71 resolved via cam
+        assert "9 aggregates suppressed" in line
         assert "14 updated" in line
         assert "3 cleared (nontouched)" in line
         assert "0 cleared (mismatched-state)" in line

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ basepython = python3.11
 addopts = --failed-first
 markers =
     twisted: marks tests as needing twisted async to run
+    timeout: marks tests with a per-test timeout (pytest-timeout)
 
 [gh-actions]
 python =


### PR DESCRIPTION
## Scope and purpose

Fixes #4029. Dependent on #4067.

The bug and its root cause are described in #4029. In brief: aggregate (`ae`) interfaces whose members resolve a layer or two down the interface stack — Juniper especially — were never suppressed, so they picked up a wrong neighbour in the CAM phase. This makes aggregate suppression walk the aggregate/stack mapping transitively, so an aggregate is dropped as soon as *any* interface beneath it resolves, at any stack depth and regardless of which layer the vendor exposes the data on. The reducer is otherwise unchanged and no topology is added — the fix only stops storing a wrong neighbour.

Validated against a real production dataset: 51 aggregates suppressed (all `ae`, no physical ports), 36 single-homed LAGs and 15 MLAGs. MLAGs are left with no aggregate-level topology while their members keep their individual links, as #4029 specifies. Inheriting a common neighbour onto single-homed aggregates is intentionally out of scope ([rationale](https://github.com/Uninett/nav/issues/4029#issuecomment-4669447371)); the related details-page discoverability gap is split out as #4081.

### This pull request
* generalises aggregate suppression to walk the aggregate/stack mapping transitively
* names the resolved member that triggered each suppression in the `nav.topology` DEBUG log
* surfaces the suppressed-aggregate count in the `navtopology --l2` INFO summary line

### Verifying

1. Run `navtopology --l2` against data that includes Juniper-style stacked aggregates.
2. The INFO summary line gains an `N aggregates suppressed` field. With `nav.topology = DEBUG` in `logging.conf`, grep the log for `Ignoring aggregate` — every line should name an aggregate (`aeN`) interface and the member(s) that triggered its suppression; no physical/access ports should appear.
3. Confirm aggregates that previously carried a wrong neighbour are now cleared, while their physical members retain their resolved neighbours. For an MLAG aggregate, the aggregate has no topology and its members point at their distinct upstreams.
4. Run `navtopology --l2` a second time — it should report `0 cleared` (the correction is one-time, not flapping).

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: stacked on `feature/topology-reducer-instrumentation` (#4067) since it builds on that work; re-target to `master` once #4067 merges
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done — follow-up display work is #4081
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the boilerplate header to that file~~
