### PR TITLE
Add handling of ping probe failed traps to juniper syslog trap handler

### DIFF
--- a/changelog.d/4083.added.md
+++ b/changelog.d/4083.added.md
@@ -1,0 +1,1 @@
+Add handling of  traps to snmptrapd handler

--- a/python/nav/etc/alertmsg/pingProbe/pingProbeFailed-email.txt
+++ b/python/nav/etc/alertmsg/pingProbe/pingProbeFailed-email.txt
@@ -1,0 +1,2 @@
+Subject: Ping probe failed on {{ netbox.sysname }}
+{{ description }}

--- a/python/nav/etc/alertmsg/pingProbe/pingProbeFailed-sms.txt
+++ b/python/nav/etc/alertmsg/pingProbe/pingProbeFailed-sms.txt
@@ -1,1 +1,1 @@
-Ping probe failed on {{ netbox.sysname }}
+Ping probe failed on {{ netbox.sysname }}: {{ description }}

--- a/python/nav/etc/alertmsg/pingProbe/pingProbeFailed-sms.txt
+++ b/python/nav/etc/alertmsg/pingProbe/pingProbeFailed-sms.txt
@@ -1,0 +1,1 @@
+Ping probe failed on {{ netbox.sysname }}

--- a/python/nav/snmptrapd/handlers/sysloghandler.py
+++ b/python/nav/snmptrapd/handlers/sysloghandler.py
@@ -84,6 +84,9 @@ def handleTrap(trap, config=None):
     if event_name == "JSRPD_HA_SRG_STATE_CHANGE":
         return _handle_ha_srg_change_trap(netbox, trap_attributes, message)
 
+    if event_name == "PING_PROBE_FAILED":
+        return _handle_ping_probe_failed_trap(netbox, message)
+
     _logger.debug(
         "jnxSyslogTrap from %s ignored since it has for us irrelevant event name '%s'",
         netbox.sysname,
@@ -195,6 +198,28 @@ def _post_ha_srg_state_change_event(
         return True
 
 
+def _handle_ping_probe_failed_trap(netbox: AgentNetbox, message: str):
+    """Handles ping probe failed traps"""
+
+    event = Event(
+        source="snmptrapd",
+        target="eventEngine",
+        netboxid=netbox.netboxid,
+        eventtypeid="pingProbe",
+        state="s",
+    )
+    event["alerttype"] = "pingProbeFailed"
+    event["description"] = message or ""
+
+    try:
+        event.post()
+    except nav.errors.GeneralException:
+        _logger.exception("Unexpected exception while posting event")
+        return False
+    else:
+        return True
+
+
 def verify_event_type():
     """
     Safe way of verifying that the event- and alarmtypes exist in the
@@ -228,6 +253,19 @@ def verify_event_type():
     'High-availability services-redundancy-group state backup'
     WHERE NOT EXISTS (
     SELECT * FROM alerttype WHERE alerttype = 'haSrgStateBackup'));
+
+    INSERT INTO eventtype (
+    SELECT 'pingProbe',
+    'Tells us the result of a ping probe.','y'
+    WHERE NOT EXISTS (
+    SELECT * FROM eventtype WHERE eventtypeid = 'pingProbe'));
+
+    INSERT INTO alertType (
+    SELECT nextval('alerttype_alerttypeid_seq'), 'pingProbe',
+    'pingProbeFailed',
+    'Ping probe failed'
+    WHERE NOT EXISTS (
+    SELECT * FROM alerttype WHERE alerttype = 'pingProbeFailed'));
     """
 
     queries = sql.split(";")

--- a/tests/integration/snmptrapd/sysloghandler_test.py
+++ b/tests/integration/snmptrapd/sysloghandler_test.py
@@ -472,6 +472,32 @@ class TestHaSrgChangeHandler:
         assert event.varmap["new_state"] == "ACTIVE"
 
 
+class TestPingProbeHandler:
+    def test_handler_should_post_event_on_trap_indicating_ping_probe_failed(
+        db, localhost_using_legacy_db, mock_ping_probe_failed_trap
+    ):
+        sysloghandler.initialize()
+        accepted = sysloghandler.handleTrap(trap=mock_ping_probe_failed_trap)
+
+        assert accepted
+
+        event = EventQueue.objects.filter(
+            source_id="snmptrapd",
+            target_id="eventEngine",
+            netbox_id=localhost_using_legacy_db,
+            event_type_id="pingProbe",
+            state="s",
+        ).first()
+
+        assert event
+        assert event.varmap["alerttype"] == "pingProbeFailed"
+        assert (
+            event.varmap["description"]
+            == "PING_PROBE_FAILED: pingCtlOwnerIndex = PROACT-SWE, pingCtlTestName = "
+            + "PING-LO0"
+        )
+
+
 @pytest.fixture
 def mock_ineligible_trap(db, localhost_using_legacy_db):
     trap = SNMPTrap(
@@ -500,6 +526,35 @@ def mock_ineligible_trap(db, localhost_using_legacy_db):
             ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.2": "BACKUP",
             ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.3": "INELIGIBLE",
             ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.4": "Control plane down",
+        },
+    )
+    return trap
+
+
+@pytest.fixture
+def mock_ping_probe_failed_trap(db, localhost_using_legacy_db):
+    trap = SNMPTrap(
+        src="127.0.0.1",
+        agent="127.0.0.1",
+        type=None,
+        genericType=None,
+        snmpTrapOID="1.3.6.1.4.1.2636.4.12.0.1",
+        uptime=666,
+        community="ping",
+        version=2,
+        varbinds={
+            ".1.3.6.1.4.1.2636.3.35.1.1.1.2.15": "PING_PROBE_FAILED",
+            ".1.3.6.1.4.1.2636.3.35.1.1.1.3.15": "\x07\xe9\x06\x15\n)#\x00+\x00\x00",
+            ".1.3.6.1.4.1.2636.3.35.1.1.1.4.15": "7",
+            ".1.3.6.1.4.1.2636.3.35.1.1.1.5.15": "4",
+            ".1.3.6.1.4.1.2636.3.35.1.1.1.6.15": "14804",
+            ".1.3.6.1.4.1.2636.3.35.1.1.1.7.15": "rmopd",
+            ".1.3.6.1.4.1.2636.3.35.1.1.1.8.15": "test-trd-fw1",
+            ".1.3.6.1.4.1.2636.3.35.1.1.1.9.15": "PING_PROBE_FAILED: pingCtlOwnerIndex = PROACT-SWE, pingCtlTestName = PING-LO0",  # noqa: E501
+            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.52.1": "test-owner",
+            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.52.1": "PROACT-SWE",
+            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.52.2": "test-name",
+            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.52.2": "PING-LO0",
         },
     )
     return trap

--- a/tests/integration/snmptrapd/sysloghandler_test.py
+++ b/tests/integration/snmptrapd/sysloghandler_test.py
@@ -7,474 +7,469 @@ from nav.snmptrapd.handlers import sysloghandler
 from nav.snmptrapd.trap import SNMPTrap
 
 
-def test_module_should_be_importable():
-    assert sysloghandler is not None
+class TestGeneralSyslogHandler:
+    def test_module_should_be_importable(self):
+        assert sysloghandler is not None
 
-
-def test_event_and_alert_types_should_be_created_on_inializing(db):
-    sysloghandler.initialize()
-
-    assert EventType.objects.filter(id="haSrgStateChange").exists()
-    assert AlertType.objects.filter(name="haSrgStateIneligible").exists()
-
-
-def test_handler_should_log_trap(db, mock_ineligible_trap, caplog):
-    with caplog.at_level(logging.DEBUG, logger="nav.snmptrapd.sysloghandler"):
+    def test_event_and_alert_types_should_be_created_on_inializing(db):
         sysloghandler.initialize()
-        sysloghandler.handleTrap(trap=mock_ineligible_trap)
 
-    assert "Got jnxSyslogTrap from" in caplog.text
+        assert EventType.objects.filter(id="haSrgStateChange").exists()
+        assert AlertType.objects.filter(name="haSrgStateIneligible").exists()
 
+        assert EventType.objects.filter(id="pingProbe").exists()
+        assert AlertType.objects.filter(name="pingProbeFailed").exists()
 
-def test_handler_should_ignore_traps_of_irrelevant_type(db):
-    trap = SNMPTrap(
-        src="127.0.0.1",
-        agent="127.0.0.1",
-        type=None,
-        genericType=None,
-        snmpTrapOID="1.3.6.1.4.1.17373.3.32767.0.10205",
-        uptime=666,
-        community="weathergoose",
-        version=2,
-        varbinds={
-            ".1.3.6.1.4.1.17373.3.1.6.0": "2",
-            ".1.3.6.1.4.1.17373.3.4.1.5.1": "16",
-        },
-    )
+    def test_handler_should_log_trap(db, mock_ineligible_trap, caplog):
+        with caplog.at_level(logging.DEBUG, logger="nav.snmptrapd.sysloghandler"):
+            sysloghandler.initialize()
+            sysloghandler.handleTrap(trap=mock_ineligible_trap)
 
-    sysloghandler.initialize()
-    accepted = sysloghandler.handleTrap(trap=trap)
+        assert "Got jnxSyslogTrap from" in caplog.text
 
-    assert not accepted
+    def test_handler_should_ignore_traps_of_irrelevant_type(db):
+        trap = SNMPTrap(
+            src="127.0.0.1",
+            agent="127.0.0.1",
+            type=None,
+            genericType=None,
+            snmpTrapOID="1.3.6.1.4.1.17373.3.32767.0.   10205",
+            uptime=666,
+            community="weathergoose",
+            version=2,
+            varbinds={
+                ".1.3.6.1.4.1.17373.3.1.6.0": "2",
+                ".1.3.6.1.4.1.17373.3.4.1.5.1": "16",
+            },
+        )
 
-
-def test_handler_should_ignore_traps_from_unknown_netbox(db, caplog):
-    trap = SNMPTrap(
-        src="127.0.0.2",
-        agent="127.0.0.2",
-        type=None,
-        genericType=None,
-        snmpTrapOID="1.3.6.1.4.1.2636.4.12.0.1",
-        uptime=666,
-        community="srg",
-        version=2,
-        varbinds={
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.2.15": "JSRPD_HA_SRG_STATE_CHANGE",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.3.15": "\x07\xe9\x06\x15\n)#\x00+\x00\x00",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.4.15": "2",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.5.15": "4",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.6.15": "32881",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.7.15": "jsrpd",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.8.15": "test-trd-fw1",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.9.15": "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned [BACKUP -->INELIGIBLE] Reason: [Control plane down]",  # noqa: E501
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.1": "srg-id",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.2": "old-state",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.3": "new-state",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.4": "reason",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.1": "7",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.2": "BACKUP",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.3": "INELIGIBLE",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.4": "Control plane down",
-        },
-    )
-
-    with caplog.at_level(logging.DEBUG, logger="nav.snmptrapd.sysloghandler"):
         sysloghandler.initialize()
         accepted = sysloghandler.handleTrap(trap=trap)
 
-    assert not accepted
-    assert "Ignoring syslog trap from unknown netbox" in caplog.text
+        assert not accepted
 
+    def test_handler_should_ignore_traps_from_unknown_netbox(db, caplog):
+        trap = SNMPTrap(
+            src="127.0.0.2",
+            agent="127.0.0.2",
+            type=None,
+            genericType=None,
+            snmpTrapOID="1.3.6.1.4.1.2636.4.12.0.1",
+            uptime=666,
+            community="srg",
+            version=2,
+            varbinds={
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.2.15": "JSRPD_HA_SRG_STATE_CHANGE",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.3.15": "\x07\xe9\x06\x15\n)#\x00+\x00\x00",  # noqa: E501
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.4.15": "2",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.5.15": "4",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.6.15": "32881",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.7.15": "jsrpd",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.8.15": "test-trd-fw1",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.9.15": "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA  state transitioned [BACKUP -->INELIGIBLE]    Reason: [Control plane down]",  # noqa:    E501
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.1": "srg-id",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.2": "old-state",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.3": "new-state",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.4": "reason",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.1": "7",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.2": "BACKUP",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.3": "INELIGIBLE",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.4": "Control plane down",
+            },
+        )
 
-def test_map_trap_attributes_matches_correct_attributes_and_values(
-    db,
-    mock_ineligible_trap,
-):
-    sysloghandler.initialize()
-    trap_vars = sysloghandler._map_trap_variables(mock_ineligible_trap)
-    trap_attributes = sysloghandler._map_trap_attributes(trap_vars)
+        with caplog.at_level(logging.DEBUG, logger="nav.snmptrapd.sysloghandler"):
+            sysloghandler.initialize()
+            accepted = sysloghandler.handleTrap(trap=trap)
 
-    # Check that all key-value pairs are subsets of dict
-    assert trap_attributes == trap_attributes | {"srg-id": "7"}
-    assert trap_attributes == trap_attributes | {"old-state": "BACKUP"}
-    assert trap_attributes == trap_attributes | {"new-state": "INELIGIBLE"}
-    assert trap_attributes == trap_attributes | {"reason": "Control plane down"}
+        assert not accepted
+        assert "Ignoring syslog trap from unknown netbox" in caplog.text
 
-
-def test_handler_should_ignore_traps_of_irrelevant_event_name(
-    db, localhost_using_legacy_db, caplog
-):
-    trap = SNMPTrap(
-        src="127.0.0.1",
-        agent="127.0.0.1",
-        type=None,
-        genericType=None,
-        snmpTrapOID="1.3.6.1.4.1.2636.4.12.0.1",
-        uptime=666,
-        community="srg",
-        version=2,
-        varbinds={
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.2.2": "UI_DBASE_LOGIN_EVENT",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.3.2": "\x07\xe9\x06\x14\t4\x08\x00+\x00\x00",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.4.2": "6",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.5.2": "24",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.6.2": "49759",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.7.2": "mgd",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.8.2": "test-trd-fw1",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.9.2": "UI_DBASE_LOGIN_EVENT: User 'test' entering configuration mode",  # noqa: E501
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.2.1": "username",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.2.1": "test",
-            ".1.3.6.1.6.3.1.1.4.3.0": ".1.3.6.1.4.1.2636.1.1.1.2.142",
-        },
-    )
-
-    with caplog.at_level(logging.DEBUG, logger="nav.snmptrapd.sysloghandler"):
+    def test_map_trap_attributes_matches_correct_attributes_and_values(
+        db,
+        mock_ineligible_trap,
+    ):
         sysloghandler.initialize()
-        accepted = sysloghandler.handleTrap(trap=trap)
+        trap_vars = sysloghandler._map_trap_variables(mock_ineligible_trap)
+        trap_attributes = sysloghandler._map_trap_attributes(trap_vars)
 
-    assert not accepted
-    assert "irrelevant event name" in caplog.text
+        # Check that all key-value pairs are subsets of dict
+        assert trap_attributes == trap_attributes | {"srg-id": "7"}
+        assert trap_attributes == trap_attributes | {"old-state": "BACKUP"}
+        assert trap_attributes == trap_attributes | {"new-state": "INELIGIBLE"}
+        assert trap_attributes == trap_attributes | {"reason": "Control plane down"}
+
+    def test_handler_should_ignore_traps_of_irrelevant_event_name(
+        db, localhost_using_legacy_db, caplog
+    ):
+        trap = SNMPTrap(
+            src="127.0.0.1",
+            agent="127.0.0.1",
+            type=None,
+            genericType=None,
+            snmpTrapOID="1.3.6.1.4.1.2636.4.12.0.1",
+            uptime=666,
+            community="srg",
+            version=2,
+            varbinds={
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.2.2": "UI_DBASE_LOGIN_EVENT",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.3.2": "\x07\xe9\x06\x14\t4\x08\x00+\x00\x00",  # noqa: E501
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.4.2": "6",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.5.2": "24",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.6.2": "49759",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.7.2": "mgd",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.8.2": "test-trd-fw1",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.9.2": "UI_DBASE_LOGIN_EVENT: User 'test' entering configuration mode",  # noqa: E501
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.2.1": "username",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.2.1": "test",
+                ".1.3.6.1.6.3.1.1.4.3.0": ".1.3.6.1.4.1.2636.1.1.1.2.142",
+            },
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="nav.snmptrapd.sysloghandler"):
+            sysloghandler.initialize()
+            accepted = sysloghandler.handleTrap(trap=trap)
+
+        assert not accepted
+        assert "irrelevant event name" in caplog.text
 
 
-def test_handler_should_ignore_traps_indicating_state_change_to_other_than_ineligible_backup_or_active(  # noqa: E501
-    db, localhost_using_legacy_db, caplog
-):
-    trap = SNMPTrap(
-        src="127.0.0.1",
-        agent="127.0.0.1",
-        type=None,
-        genericType=None,
-        snmpTrapOID="1.3.6.1.4.1.2636.4.12.0.1",
-        uptime=666,
-        community="srg",
-        version=2,
-        varbinds={
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.2.15": "JSRPD_HA_SRG_STATE_CHANGE",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.3.15": "\x07\xe9\x06\x15\n)#\x00+\x00\x00",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.4.15": "2",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.5.15": "4",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.6.15": "32881",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.7.15": "jsrpd",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.8.15": "test-trd-fw1",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.9.15": "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned [BACKUP -->HOLD] Reason: [Split Brain Prevention logic result]",  # noqa: E501
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.1": "srg-id",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.2": "old-state",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.3": "new-state",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.4": "reason",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.1": "7",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.2": "BACKUP",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.3": "HOLD",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.4": "Split Brain Prevention logic result",  # noqa: E501
-        },
-    )
+class TestHaSrgChangeHandler:
+    def test_handler_should_ignore_traps_indicating_state_change_to_other_than_ineligible_backup_or_active(  # noqa: E501
+        db, localhost_using_legacy_db, caplog
+    ):
+        trap = SNMPTrap(
+            src="127.0.0.1",
+            agent="127.0.0.1",
+            type=None,
+            genericType=None,
+            snmpTrapOID="1.3.6.1.4.1.2636.4.12.0.1",
+            uptime=666,
+            community="srg",
+            version=2,
+            varbinds={
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.2.15": "JSRPD_HA_SRG_STATE_CHANGE",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.3.15": "\x07\xe9\x06\x15\n)#\x00+\x00\x00",  # noqa: E501
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.4.15": "2",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.5.15": "4",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.6.15": "32881",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.7.15": "jsrpd",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.8.15": "test-trd-fw1",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.9.15": "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned [BACKUP -->HOLD] Reason: [Split Brain Prevention logic result]",  # noqa: E501
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.1": "srg-id",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.2": "old-state",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.3": "new-state",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.4": "reason",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.1": "7",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.2": "BACKUP",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.3": "HOLD",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.4": "Split Brain Prevention logic result",  # noqa: E501
+            },
+        )
 
-    with caplog.at_level(logging.DEBUG, logger="nav.snmptrapd.sysloghandler"):
+        with caplog.at_level(logging.DEBUG, logger="nav.snmptrapd.sysloghandler"):
+            sysloghandler.initialize()
+            accepted = sysloghandler.handleTrap(trap=trap)
+
+        assert not accepted
+        assert (
+            "irrelevant change from old state 'BACKUP' to new state 'HOLD'"
+            in caplog.text
+        )
+
+    def test_handler_should_ignore_traps_indicating_state_change_to_backup_or_active_from_not_hold(  # noqa: E501
+        db, localhost_using_legacy_db, caplog
+    ):
+        trap = SNMPTrap(
+            src="127.0.0.1",
+            agent="127.0.0.1",
+            type=None,
+            genericType=None,
+            snmpTrapOID="1.3.6.1.4.1.2636.4.12.0.1",
+            uptime=666,
+            community="srg",
+            version=2,
+            varbinds={
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.2.15": "JSRPD_HA_SRG_STATE_CHANGE",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.3.15": "\x07\xe9\x06\x15\n)#\x00+\x00\x00",  # noqa: E501
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.4.15": "2",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.5.15": "4",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.6.15": "32881",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.7.15": "jsrpd",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.8.15": "test-trd-fw1",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.9.15": "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned   [BACKUP -->ACTIVE] Reason: [Split Brain Prevention logic result]",  # noqa: E501
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.1": "srg-id",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.2": "old-state",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.3": "new-state",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.4": "reason",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.1": "7",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.2": "BACKUP",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.3": "ACTIVE",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.4": "Split Brain Prevention logic result",  # noqa: E501
+            },
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="nav.snmptrapd.sysloghandler"):
+            sysloghandler.initialize()
+            accepted = sysloghandler.handleTrap(trap=trap)
+
+        assert not accepted
+        assert (
+            "irrelevant change from old state 'BACKUP' to new state 'ACTIVE'"
+            in caplog.text
+        )
+
+    def test_handler_should_post_event_on_trap_indicating_ineligible_state(
+        db, localhost_using_legacy_db, mock_ineligible_trap
+    ):
         sysloghandler.initialize()
-        accepted = sysloghandler.handleTrap(trap=trap)
+        accepted = sysloghandler.handleTrap(trap=mock_ineligible_trap)
 
-    assert not accepted
-    assert (
-        "irrelevant change from old state 'BACKUP' to new state 'HOLD'" in caplog.text
-    )
+        assert accepted
 
+        event = EventQueue.objects.filter(
+            source_id="snmptrapd",
+            target_id="eventEngine",
+            netbox_id=localhost_using_legacy_db,
+            subid="7",
+            event_type_id="haSrgStateChange",
+            state="s",
+        ).first()
 
-def test_handler_should_ignore_traps_indicating_state_change_to_backup_or_active_from_not_hold(  # noqa: E501
-    db, localhost_using_legacy_db, caplog
-):
-    trap = SNMPTrap(
-        src="127.0.0.1",
-        agent="127.0.0.1",
-        type=None,
-        genericType=None,
-        snmpTrapOID="1.3.6.1.4.1.2636.4.12.0.1",
-        uptime=666,
-        community="srg",
-        version=2,
-        varbinds={
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.2.15": "JSRPD_HA_SRG_STATE_CHANGE",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.3.15": "\x07\xe9\x06\x15\n)#\x00+\x00\x00",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.4.15": "2",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.5.15": "4",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.6.15": "32881",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.7.15": "jsrpd",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.8.15": "test-trd-fw1",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.9.15": "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned [BACKUP -->ACTIVE] Reason: [Split Brain Prevention logic result]",  # noqa: E501
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.1": "srg-id",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.2": "old-state",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.3": "new-state",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.4": "reason",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.1": "7",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.2": "BACKUP",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.3": "ACTIVE",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.4": "Split Brain Prevention logic result",  # noqa: E501
-        },
-    )
+        assert event
+        assert event.varmap["alerttype"] == "haSrgStateIneligible"
+        assert (
+            event.varmap["description"]
+            == "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned "
+            + "[BACKUP -->INELIGIBLE] Reason: [Control plane down]"
+        )
 
-    with caplog.at_level(logging.DEBUG, logger="nav.snmptrapd.sysloghandler"):
+    def test_handler_should_post_event_on_trap_indicating_state_change_from_hold_to_backup(  # noqa: E501
+        db,
+        localhost_using_legacy_db,
+    ):
+        backup_trap = SNMPTrap(
+            src="127.0.0.1",
+            agent="127.0.0.1",
+            type=None,
+            genericType=None,
+            snmpTrapOID="1.3.6.1.4.1.2636.4.12.0.1",
+            uptime=666,
+            community="srg",
+            version=2,
+            varbinds={
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.2.15": "JSRPD_HA_SRG_STATE_CHANGE",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.3.15": "\x07\xe9\x06\x15\n)#\x00+\x00\x00",  # noqa: E501
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.4.15": "2",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.5.15": "4",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.6.15": "32881",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.7.15": "jsrpd",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.8.15": "test-trd-fw1",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.9.15": "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned [HOLD -->BACKUP] Reason: [Peer state Active received]",  # noqa: E501
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.1": "srg-id",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.2": "old-state",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.3": "new-state",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.4": "reason",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.1": "7",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.2": "HOLD",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.3": "BACKUP",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.4": "Peer state Active received",
+            },
+        )
         sysloghandler.initialize()
-        accepted = sysloghandler.handleTrap(trap=trap)
+        accepted = sysloghandler.handleTrap(trap=backup_trap)
 
-    assert not accepted
-    assert (
-        "irrelevant change from old state 'BACKUP' to new state 'ACTIVE'" in caplog.text
-    )
+        assert accepted
 
+        event = EventQueue.objects.filter(
+            source_id="snmptrapd",
+            target_id="eventEngine",
+            netbox_id=localhost_using_legacy_db,
+            subid="7",
+            event_type_id="haSrgStateChange",
+            state="e",
+        ).first()
 
-def test_handler_should_post_event_on_trap_indicating_ineligible_state(
-    db, localhost_using_legacy_db, mock_ineligible_trap
-):
-    sysloghandler.initialize()
-    accepted = sysloghandler.handleTrap(trap=mock_ineligible_trap)
+        assert event
+        assert event.varmap["alerttype"] == "haSrgStateBackup"
+        assert (
+            event.varmap["description"]
+            == "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned "
+            + "[HOLD -->BACKUP] Reason: [Peer state Active received]"
+        )
+        assert event.varmap["old_state"] == "HOLD"
+        assert event.varmap["new_state"] == "BACKUP"
 
-    assert accepted
+    def test_handler_should_post_event_on_trap_indicating_state_change_from_hold_to_active(  # noqa: E501
+        db,
+        localhost_using_legacy_db,
+    ):
+        backup_trap = SNMPTrap(
+            src="127.0.0.1",
+            agent="127.0.0.1",
+            type=None,
+            genericType=None,
+            snmpTrapOID="1.3.6.1.4.1.2636.4.12.0.1",
+            uptime=666,
+            community="srg",
+            version=2,
+            varbinds={
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.2.15": "JSRPD_HA_SRG_STATE_CHANGE",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.3.15": "\x07\xe9\x06\x15\n)#\x00+\x00\x00",  # noqa: E501
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.4.15": "2",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.5.15": "4",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.6.15": "32881",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.7.15": "jsrpd",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.8.15": "test-trd-fw1",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.9.15": "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned [HOLD -->ACTIVE] Reason: [Peer state Active received]",  # noqa: E501
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.1": "srg-id",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.2": "old-state",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.3": "new-state",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.4": "reason",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.1": "7",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.2": "HOLD",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.3": "ACTIVE",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.4": "Peer state Active received",
+            },
+        )
 
-    event = EventQueue.objects.filter(
-        source_id="snmptrapd",
-        target_id="eventEngine",
-        netbox_id=localhost_using_legacy_db,
-        subid="7",
-        event_type_id="haSrgStateChange",
-        state="s",
-    ).first()
+        sysloghandler.initialize()
+        accepted = sysloghandler.handleTrap(trap=backup_trap)
 
-    assert event
-    assert event.varmap["alerttype"] == "haSrgStateIneligible"
-    assert (
-        event.varmap["description"]
-        == "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned "
-        + "[BACKUP -->INELIGIBLE] Reason: [Control plane down]"
-    )
+        assert accepted
 
+        event = EventQueue.objects.filter(
+            source_id="snmptrapd",
+            target_id="eventEngine",
+            netbox_id=localhost_using_legacy_db,
+            subid="7",
+            event_type_id="haSrgStateChange",
+            state="e",
+        ).first()
 
-def test_handler_should_post_event_on_trap_indicating_state_change_from_hold_to_backup(
-    db,
-    localhost_using_legacy_db,
-):
-    backup_trap = SNMPTrap(
-        src="127.0.0.1",
-        agent="127.0.0.1",
-        type=None,
-        genericType=None,
-        snmpTrapOID="1.3.6.1.4.1.2636.4.12.0.1",
-        uptime=666,
-        community="srg",
-        version=2,
-        varbinds={
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.2.15": "JSRPD_HA_SRG_STATE_CHANGE",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.3.15": "\x07\xe9\x06\x15\n)#\x00+\x00\x00",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.4.15": "2",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.5.15": "4",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.6.15": "32881",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.7.15": "jsrpd",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.8.15": "test-trd-fw1",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.9.15": "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned [HOLD -->BACKUP] Reason: [Peer state Active received]",  # noqa: E501
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.1": "srg-id",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.2": "old-state",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.3": "new-state",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.4": "reason",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.1": "7",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.2": "HOLD",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.3": "BACKUP",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.4": "Peer state Active received",
-        },
-    )
-    sysloghandler.initialize()
-    accepted = sysloghandler.handleTrap(trap=backup_trap)
+        assert event
+        assert event.varmap["alerttype"] == "haSrgStateActive"
+        assert (
+            event.varmap["description"]
+            == "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned "
+            + "[HOLD -->ACTIVE] Reason: [Peer state Active received]"
+        )
+        assert event.varmap["old_state"] == "HOLD"
+        assert event.varmap["new_state"] == "ACTIVE"
 
-    assert accepted
+    def test_handler_should_post_event_on_trap_indicating_state_change_from_ineligible_to_backup(  # noqa: E501
+        db,
+        localhost_using_legacy_db,
+    ):
+        backup_trap = SNMPTrap(
+            src="127.0.0.1",
+            agent="127.0.0.1",
+            type=None,
+            genericType=None,
+            snmpTrapOID="1.3.6.1.4.1.2636.4.12.0.1",
+            uptime=666,
+            community="srg",
+            version=2,
+            varbinds={
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.2.15": "JSRPD_HA_SRG_STATE_CHANGE",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.3.15": "\x07\xe9\x06\x15\n)#\x00+\x00\x00",  # noqa: E501
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.4.15": "2",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.5.15": "4",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.6.15": "32881",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.7.15": "jsrpd",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.8.15": "test-trd-fw1",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.9.15": "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned [INELIGIBLE -->BACKUP] Reason: [Peer state Active received]",  # noqa: E501
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.1": "srg-id",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.2": "old-state",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.3": "new-state",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.4": "reason",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.1": "7",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.2": "INELIGIBLE",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.3": "BACKUP",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.4": "Peer state Active received",
+            },
+        )
 
-    event = EventQueue.objects.filter(
-        source_id="snmptrapd",
-        target_id="eventEngine",
-        netbox_id=localhost_using_legacy_db,
-        subid="7",
-        event_type_id="haSrgStateChange",
-        state="e",
-    ).first()
+        sysloghandler.initialize()
+        accepted = sysloghandler.handleTrap(trap=backup_trap)
 
-    assert event
-    assert event.varmap["alerttype"] == "haSrgStateBackup"
-    assert (
-        event.varmap["description"]
-        == "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned [HOLD -->BACKUP] "
-        + "Reason: [Peer state Active received]"
-    )
-    assert event.varmap["old_state"] == "HOLD"
-    assert event.varmap["new_state"] == "BACKUP"
+        assert accepted
 
+        event = EventQueue.objects.filter(
+            source_id="snmptrapd",
+            target_id="eventEngine",
+            netbox_id=localhost_using_legacy_db,
+            subid="7",
+            event_type_id="haSrgStateChange",
+            state="e",
+        ).first()
 
-def test_handler_should_post_event_on_trap_indicating_state_change_from_hold_to_active(
-    db,
-    localhost_using_legacy_db,
-):
-    backup_trap = SNMPTrap(
-        src="127.0.0.1",
-        agent="127.0.0.1",
-        type=None,
-        genericType=None,
-        snmpTrapOID="1.3.6.1.4.1.2636.4.12.0.1",
-        uptime=666,
-        community="srg",
-        version=2,
-        varbinds={
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.2.15": "JSRPD_HA_SRG_STATE_CHANGE",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.3.15": "\x07\xe9\x06\x15\n)#\x00+\x00\x00",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.4.15": "2",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.5.15": "4",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.6.15": "32881",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.7.15": "jsrpd",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.8.15": "test-trd-fw1",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.9.15": "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned [HOLD -->ACTIVE] Reason: [Peer state Active received]",  # noqa: E501
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.1": "srg-id",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.2": "old-state",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.3": "new-state",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.4": "reason",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.1": "7",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.2": "HOLD",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.3": "ACTIVE",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.4": "Peer state Active received",
-        },
-    )
+        assert event
+        assert event.varmap["alerttype"] == "haSrgStateBackup"
+        assert (
+            event.varmap["description"]
+            == "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned "
+            + "[INELIGIBLE -->BACKUP] Reason: [Peer state Active received]"
+        )
+        assert event.varmap["old_state"] == "INELIGIBLE"
+        assert event.varmap["new_state"] == "BACKUP"
 
-    sysloghandler.initialize()
-    accepted = sysloghandler.handleTrap(trap=backup_trap)
+    def test_handler_should_post_event_on_trap_indicating_state_change_from_ineligible_to_active(  # noqa: E501
+        db,
+        localhost_using_legacy_db,
+    ):
+        backup_trap = SNMPTrap(
+            src="127.0.0.1",
+            agent="127.0.0.1",
+            type=None,
+            genericType=None,
+            snmpTrapOID="1.3.6.1.4.1.2636.4.12.0.1",
+            uptime=666,
+            community="srg",
+            version=2,
+            varbinds={
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.2.15": "JSRPD_HA_SRG_STATE_CHANGE",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.3.15": "\x07\xe9\x06\x15\n)#\x00+\x00\x00",  # noqa: E501
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.4.15": "2",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.5.15": "4",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.6.15": "32881",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.7.15": "jsrpd",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.8.15": "test-trd-fw1",
+                ".1.3.6.1.4.1.2636.3.35.1.1.1.9.15": "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned [INELIGIBLE -->ACTIVE] Reason: [Peer state Active received]",  # noqa: E501
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.1": "srg-id",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.2": "old-state",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.3": "new-state",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.4": "reason",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.1": "7",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.2": "INELIGIBLE",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.3": "ACTIVE",
+                ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.4": "Peer state Active received",
+            },
+        )
 
-    assert accepted
+        sysloghandler.initialize()
+        accepted = sysloghandler.handleTrap(trap=backup_trap)
 
-    event = EventQueue.objects.filter(
-        source_id="snmptrapd",
-        target_id="eventEngine",
-        netbox_id=localhost_using_legacy_db,
-        subid="7",
-        event_type_id="haSrgStateChange",
-        state="e",
-    ).first()
+        assert accepted
 
-    assert event
-    assert event.varmap["alerttype"] == "haSrgStateActive"
-    assert (
-        event.varmap["description"]
-        == "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned [HOLD -->ACTIVE] "
-        + "Reason: [Peer state Active received]"
-    )
-    assert event.varmap["old_state"] == "HOLD"
-    assert event.varmap["new_state"] == "ACTIVE"
+        event = EventQueue.objects.filter(
+            source_id="snmptrapd",
+            target_id="eventEngine",
+            netbox_id=localhost_using_legacy_db,
+            subid="7",
+            event_type_id="haSrgStateChange",
+            state="e",
+        ).first()
 
-
-def test_handler_should_post_event_on_trap_indicating_state_change_from_ineligible_to_backup(  # noqa: E501
-    db,
-    localhost_using_legacy_db,
-):
-    backup_trap = SNMPTrap(
-        src="127.0.0.1",
-        agent="127.0.0.1",
-        type=None,
-        genericType=None,
-        snmpTrapOID="1.3.6.1.4.1.2636.4.12.0.1",
-        uptime=666,
-        community="srg",
-        version=2,
-        varbinds={
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.2.15": "JSRPD_HA_SRG_STATE_CHANGE",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.3.15": "\x07\xe9\x06\x15\n)#\x00+\x00\x00",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.4.15": "2",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.5.15": "4",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.6.15": "32881",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.7.15": "jsrpd",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.8.15": "test-trd-fw1",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.9.15": "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned [INELIGIBLE -->BACKUP] Reason: [Peer state Active received]",  # noqa: E501
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.1": "srg-id",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.2": "old-state",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.3": "new-state",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.4": "reason",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.1": "7",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.2": "INELIGIBLE",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.3": "BACKUP",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.4": "Peer state Active received",
-        },
-    )
-
-    sysloghandler.initialize()
-    accepted = sysloghandler.handleTrap(trap=backup_trap)
-
-    assert accepted
-
-    event = EventQueue.objects.filter(
-        source_id="snmptrapd",
-        target_id="eventEngine",
-        netbox_id=localhost_using_legacy_db,
-        subid="7",
-        event_type_id="haSrgStateChange",
-        state="e",
-    ).first()
-
-    assert event
-    assert event.varmap["alerttype"] == "haSrgStateBackup"
-    assert (
-        event.varmap["description"]
-        == "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned "
-        + "[INELIGIBLE -->BACKUP] Reason: [Peer state Active received]"
-    )
-    assert event.varmap["old_state"] == "INELIGIBLE"
-    assert event.varmap["new_state"] == "BACKUP"
-
-
-def test_handler_should_post_event_on_trap_indicating_state_change_from_ineligible_to_active(  # noqa: E501
-    db,
-    localhost_using_legacy_db,
-):
-    backup_trap = SNMPTrap(
-        src="127.0.0.1",
-        agent="127.0.0.1",
-        type=None,
-        genericType=None,
-        snmpTrapOID="1.3.6.1.4.1.2636.4.12.0.1",
-        uptime=666,
-        community="srg",
-        version=2,
-        varbinds={
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.2.15": "JSRPD_HA_SRG_STATE_CHANGE",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.3.15": "\x07\xe9\x06\x15\n)#\x00+\x00\x00",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.4.15": "2",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.5.15": "4",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.6.15": "32881",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.7.15": "jsrpd",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.8.15": "test-trd-fw1",
-            ".1.3.6.1.4.1.2636.3.35.1.1.1.9.15": "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned [INELIGIBLE -->ACTIVE] Reason: [Peer state Active received]",  # noqa: E501
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.1": "srg-id",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.2": "old-state",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.3": "new-state",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.2.15.4": "reason",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.1": "7",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.2": "INELIGIBLE",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.3": "ACTIVE",
-            ".1.3.6.1.4.1.2636.3.35.1.2.1.3.15.4": "Peer state Active received",
-        },
-    )
-
-    sysloghandler.initialize()
-    accepted = sysloghandler.handleTrap(trap=backup_trap)
-
-    assert accepted
-
-    event = EventQueue.objects.filter(
-        source_id="snmptrapd",
-        target_id="eventEngine",
-        netbox_id=localhost_using_legacy_db,
-        subid="7",
-        event_type_id="haSrgStateChange",
-        state="e",
-    ).first()
-
-    assert event
-    assert event.varmap["alerttype"] == "haSrgStateActive"
-    assert (
-        event.varmap["description"]
-        == "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned "
-        + "[INELIGIBLE -->ACTIVE] Reason: [Peer state Active received]"
-    )
-    assert event.varmap["old_state"] == "INELIGIBLE"
-    assert event.varmap["new_state"] == "ACTIVE"
+        assert event
+        assert event.varmap["alerttype"] == "haSrgStateActive"
+        assert (
+            event.varmap["description"]
+            == "JSRPD_HA_SRG_STATE_CHANGE: SRG[7]:HA state transitioned "
+            + "[INELIGIBLE -->ACTIVE] Reason: [Peer state Active received]"
+        )
+        assert event.varmap["old_state"] == "INELIGIBLE"
+        assert event.varmap["new_state"] == "ACTIVE"
 
 
 @pytest.fixture

--- a/tests/integration/snmptrapd/sysloghandler_test.py
+++ b/tests/integration/snmptrapd/sysloghandler_test.py
@@ -11,7 +11,7 @@ class TestGeneralSyslogHandler:
     def test_module_should_be_importable(self):
         assert sysloghandler is not None
 
-    def test_event_and_alert_types_should_be_created_on_inializing(db):
+    def test_event_and_alert_types_should_be_created_on_inializing(self, db):
         sysloghandler.initialize()
 
         assert EventType.objects.filter(id="haSrgStateChange").exists()
@@ -20,14 +20,14 @@ class TestGeneralSyslogHandler:
         assert EventType.objects.filter(id="pingProbe").exists()
         assert AlertType.objects.filter(name="pingProbeFailed").exists()
 
-    def test_handler_should_log_trap(db, mock_ineligible_trap, caplog):
+    def test_handler_should_log_trap(self, db, mock_ineligible_trap, caplog):
         with caplog.at_level(logging.DEBUG, logger="nav.snmptrapd.sysloghandler"):
             sysloghandler.initialize()
             sysloghandler.handleTrap(trap=mock_ineligible_trap)
 
         assert "Got jnxSyslogTrap from" in caplog.text
 
-    def test_handler_should_ignore_traps_of_irrelevant_type(db):
+    def test_handler_should_ignore_traps_of_irrelevant_type(self, db):
         trap = SNMPTrap(
             src="127.0.0.1",
             agent="127.0.0.1",
@@ -48,7 +48,7 @@ class TestGeneralSyslogHandler:
 
         assert not accepted
 
-    def test_handler_should_ignore_traps_from_unknown_netbox(db, caplog):
+    def test_handler_should_ignore_traps_from_unknown_netbox(self, db, caplog):
         trap = SNMPTrap(
             src="127.0.0.2",
             agent="127.0.0.2",
@@ -86,6 +86,7 @@ class TestGeneralSyslogHandler:
         assert "Ignoring syslog trap from unknown netbox" in caplog.text
 
     def test_map_trap_attributes_matches_correct_attributes_and_values(
+        self,
         db,
         mock_ineligible_trap,
     ):
@@ -100,7 +101,7 @@ class TestGeneralSyslogHandler:
         assert trap_attributes == trap_attributes | {"reason": "Control plane down"}
 
     def test_handler_should_ignore_traps_of_irrelevant_event_name(
-        db, localhost_using_legacy_db, caplog
+        self, db, localhost_using_legacy_db, caplog
     ):
         trap = SNMPTrap(
             src="127.0.0.1",
@@ -136,7 +137,7 @@ class TestGeneralSyslogHandler:
 
 class TestHaSrgChangeHandler:
     def test_handler_should_ignore_traps_indicating_state_change_to_other_than_ineligible_backup_or_active(  # noqa: E501
-        db, localhost_using_legacy_db, caplog
+        self, db, localhost_using_legacy_db, caplog
     ):
         trap = SNMPTrap(
             src="127.0.0.1",
@@ -178,7 +179,7 @@ class TestHaSrgChangeHandler:
         )
 
     def test_handler_should_ignore_traps_indicating_state_change_to_backup_or_active_from_not_hold(  # noqa: E501
-        db, localhost_using_legacy_db, caplog
+        self, db, localhost_using_legacy_db, caplog
     ):
         trap = SNMPTrap(
             src="127.0.0.1",
@@ -220,7 +221,7 @@ class TestHaSrgChangeHandler:
         )
 
     def test_handler_should_post_event_on_trap_indicating_ineligible_state(
-        db, localhost_using_legacy_db, mock_ineligible_trap
+        self, db, localhost_using_legacy_db, mock_ineligible_trap
     ):
         sysloghandler.initialize()
         accepted = sysloghandler.handleTrap(trap=mock_ineligible_trap)
@@ -245,6 +246,7 @@ class TestHaSrgChangeHandler:
         )
 
     def test_handler_should_post_event_on_trap_indicating_state_change_from_hold_to_backup(  # noqa: E501
+        self,
         db,
         localhost_using_legacy_db,
     ):
@@ -301,6 +303,7 @@ class TestHaSrgChangeHandler:
         assert event.varmap["new_state"] == "BACKUP"
 
     def test_handler_should_post_event_on_trap_indicating_state_change_from_hold_to_active(  # noqa: E501
+        self,
         db,
         localhost_using_legacy_db,
     ):
@@ -358,6 +361,7 @@ class TestHaSrgChangeHandler:
         assert event.varmap["new_state"] == "ACTIVE"
 
     def test_handler_should_post_event_on_trap_indicating_state_change_from_ineligible_to_backup(  # noqa: E501
+        self,
         db,
         localhost_using_legacy_db,
     ):
@@ -415,6 +419,7 @@ class TestHaSrgChangeHandler:
         assert event.varmap["new_state"] == "BACKUP"
 
     def test_handler_should_post_event_on_trap_indicating_state_change_from_ineligible_to_active(  # noqa: E501
+        self,
         db,
         localhost_using_legacy_db,
     ):
@@ -474,7 +479,7 @@ class TestHaSrgChangeHandler:
 
 class TestPingProbeHandler:
     def test_handler_should_post_event_on_trap_indicating_ping_probe_failed(
-        db, localhost_using_legacy_db, mock_ping_probe_failed_trap
+        self, db, localhost_using_legacy_db, mock_ping_probe_failed_trap
     ):
         sysloghandler.initialize()
         accepted = sysloghandler.handleTrap(trap=mock_ping_probe_failed_trap)


### PR DESCRIPTION
## Scope and purpose

Dependent on #4080.

Reference: https://mibs.observium.org/mib/JUNIPER-SYSLOG-MIB/

This has been requested by the CNaaS engineering team. They want to get a notification when a ping probe fails, which happens when a juniper syslog trap with the event name `PING_PROBE_FAILED` is received. For now it is enough to open an event and the engineering team will close the event, because it is not clear yet what trap would have to be received to mark this event as closed again. 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [X] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
