### PR TITLE
Add machinetracker collapse-duplicates option

### DIFF
--- a/changelog.d/4098.added.md
+++ b/changelog.d/4098.added.md
@@ -1,0 +1,1 @@
+Add opt-in "Collapse duplicates" option to machinetracker IP search to merge the duplicate active-address rows that, by design, are recorded once per collecting router (e.g. with HSRP)

--- a/python/nav/web/machinetracker/forms.py
+++ b/python/nav/web/machinetracker/forms.py
@@ -74,6 +74,12 @@ class IpTrackerForm(MachineTrackerForm):
         help_text="Show which router the data is retrieved from",
     )
 
+    collapse = forms.BooleanField(
+        required=False,
+        initial=False,
+        help_text="Collapse duplicate rows from HSRP/redundant routers",
+    )
+
     def clean_ip_range(self):
         """Clean the ip_range field"""
         data = self.cleaned_data['ip_range']

--- a/python/nav/web/machinetracker/utils.py
+++ b/python/nav/web/machinetracker/utils.py
@@ -25,7 +25,7 @@ from IPy import IP
 from django.db import DatabaseError, transaction
 
 from nav import asyncdns
-from nav.models.manage import Prefix, Netbox, Interface
+from nav.models.manage import Arp, Prefix, Netbox, Interface
 
 _cached_hostname = {}
 _logger = logging.getLogger(__name__)
@@ -128,7 +128,7 @@ def ip_dict(rows):
     return result
 
 
-def collapse_overlapping(rows):
+def collapse_overlapping(rows: list[Arp]) -> list[Arp]:
     """Drops rows whose active period overlaps a newer kept row.
 
     `rows` is the list of Arp result rows for a single (ip, mac) pair, already

--- a/python/nav/web/machinetracker/utils.py
+++ b/python/nav/web/machinetracker/utils.py
@@ -128,6 +128,28 @@ def ip_dict(rows):
     return result
 
 
+def collapse_overlapping(rows):
+    """Drops rows whose active period overlaps a newer kept row.
+
+    `rows` is the list of Arp result rows for a single (ip, mac) pair, already
+    ordered newest-first (by -start_time). Rows with disjoint time windows
+    (genuine connect/disconnect history) are preserved, while rows that overlap
+    an already-kept row are dropped.
+
+    NAV records one Arp row per collecting router by design, so a single
+    address served by several routers (e.g. an HSRP pair) shows up as multiple
+    overlapping rows. This collapses those into one for callers that opt in.
+    """
+    kept = []
+    for row in rows:
+        overlaps = any(
+            row.start_time < k.end_time and k.start_time < row.end_time for k in kept
+        )
+        if not overlaps:
+            kept.append(row)
+    return kept
+
+
 def process_ip_row(row, dns):
     """Processes an IP search result row"""
     if row.end_time > datetime.now():

--- a/python/nav/web/machinetracker/views.py
+++ b/python/nav/web/machinetracker/views.py
@@ -33,6 +33,7 @@ from nav import asyncdns
 from nav.web.machinetracker import forms
 from nav.web.machinetracker.utils import ip_dict, UplinkTracker, InterfaceTracker
 from nav.web.machinetracker.utils import process_ip_row, track_mac
+from nav.web.machinetracker.utils import collapse_overlapping
 from nav.web.machinetracker.utils import (
     min_max_mac,
     ProcessInput,
@@ -115,7 +116,12 @@ def ip_do_search(request):
         )
         ip_range = create_ip_range(inactive, from_ip, to_ip, ip_result)
         tracker = create_tracker(
-            active, form.cleaned_data['dns'], inactive, ip_range, ip_result
+            active,
+            form.cleaned_data['dns'],
+            inactive,
+            ip_range,
+            ip_result,
+            form.cleaned_data['collapse'],
         )
         row_count = sum(len(mac_ip_pair) for mac_ip_pair in tracker.values())
 
@@ -181,7 +187,7 @@ def create_ip_range(inactive, from_ip, to_ip, ip_result):
     return ip_range
 
 
-def create_tracker(active, dns, inactive, ip_range, ip_result):
+def create_tracker(active, dns, inactive, ip_range, ip_result, collapse=False):
     """Creates a result tracker based on form data"""
     dns_lookups = None
     if dns:
@@ -196,16 +202,17 @@ def create_tracker(active, dns, inactive, ip_range, ip_result):
     tracker = OrderedDict()
     for ip_key in ip_range:
         if active and ip_key in ip_result:
-            create_active_row(tracker, dns, dns_lookups, ip_key, ip_result)
+            create_active_row(tracker, dns, dns_lookups, ip_key, ip_result, collapse)
         elif inactive and ip_key not in ip_result:
             create_inactive_row(tracker, dns, dns_lookups, ip_key)
     return tracker
 
 
-def create_active_row(tracker, dns, dns_lookups, ip_key, ip_result):
+def create_active_row(tracker, dns, dns_lookups, ip_key, ip_result, collapse=False):
     """Creates a tracker tuple where the result is active"""
     ip = str(ip_key)
     rows = ip_result[ip_key]
+    touched_keys = []
     for row in rows:
         row = process_ip_row(row, dns=False)
         if dns:
@@ -214,9 +221,14 @@ def create_active_row(tracker, dns, dns_lookups, ip_key, ip_result):
             else:
                 row.dns_lookup = dns_lookups[ip][0]
         row.ip_int_value = normalize_ip_to_string(row.ip)
-        if (row.ip, row.mac) not in tracker:
-            tracker[(row.ip, row.mac)] = []
-        tracker[(row.ip, row.mac)].append(row)
+        key = (row.ip, row.mac)
+        if key not in tracker:
+            tracker[key] = []
+            touched_keys.append(key)
+        tracker[key].append(row)
+    if collapse:
+        for key in touched_keys:
+            tracker[key] = collapse_overlapping(tracker[key])
 
 
 def create_inactive_row(tracker, dns, dns_lookups, ip_key):

--- a/python/nav/web/machinetracker/views.py
+++ b/python/nav/web/machinetracker/views.py
@@ -212,7 +212,7 @@ def create_active_row(tracker, dns, dns_lookups, ip_key, ip_result, collapse=Fal
     """Creates a tracker tuple where the result is active"""
     ip = str(ip_key)
     rows = ip_result[ip_key]
-    touched_keys = []
+    touched_keys = set()
     for row in rows:
         row = process_ip_row(row, dns=False)
         if dns:
@@ -222,10 +222,8 @@ def create_active_row(tracker, dns, dns_lookups, ip_key, ip_result, collapse=Fal
                 row.dns_lookup = dns_lookups[ip][0]
         row.ip_int_value = normalize_ip_to_string(row.ip)
         key = (row.ip, row.mac)
-        if key not in tracker:
-            tracker[key] = []
-            touched_keys.append(key)
-        tracker[key].append(row)
+        tracker.setdefault(key, []).append(row)
+        touched_keys.add(key)
     if collapse:
         for key in touched_keys:
             tracker[key] = collapse_overlapping(tracker[key])

--- a/python/nav/web/templates/machinetracker/ip_search.html
+++ b/python/nav/web/templates/machinetracker/ip_search.html
@@ -35,6 +35,15 @@
                 </div>
               {% endfor %}
             </div>
+            <div class="row machinetracker-filter">
+              <div class="small-12 column">
+                <label for="{{ form.collapse.auto_id }}"
+                       title="{{ form.collapse.help_text }}">
+                  {{ form.collapse }}
+                  {{ form.collapse.label }}
+                </label>
+              </div>
+            </div>
           </fieldset>
         </div>
 

--- a/tests/integration/web/machinetracker_test.py
+++ b/tests/integration/web/machinetracker_test.py
@@ -27,7 +27,9 @@ class TestCollapseOverlapping:
             _row(now - timedelta(hours=1), INFINITY, "router-a"),
             _row(now - timedelta(hours=2), INFINITY, "router-b"),
         ]
-        assert len(collapse_overlapping(rows)) == 1
+        kept = collapse_overlapping(rows)
+        assert len(kept) == 1
+        assert kept[0].sysname == "router-a"  # newer start_time wins
 
     def test_given_disjoint_history_rows_it_should_preserve_them(self):
         now = datetime.now()

--- a/tests/integration/web/machinetracker_test.py
+++ b/tests/integration/web/machinetracker_test.py
@@ -1,11 +1,72 @@
-from datetime import datetime
+from datetime import datetime, timedelta
+from types import SimpleNamespace
 
 from django.urls import reverse
 from django.utils.encoding import smart_str
 
 from nav.models.fields import INFINITY
 from nav.models.manage import Arp
+from nav.web.machinetracker.utils import collapse_overlapping
 from nav.web.machinetracker.views import VALID_HELP_TAB_NAMES, get_netbios_query
+
+
+def _row(start, end, sysname):
+    return SimpleNamespace(
+        ip="10.0.0.42",
+        mac="ca:fe:ba:be:f0:01",
+        start_time=start,
+        end_time=end,
+        sysname=sysname,
+    )
+
+
+class TestCollapseOverlapping:
+    def test_given_two_still_active_rows_it_should_collapse_to_one(self):
+        now = datetime.now()
+        rows = [
+            _row(now - timedelta(hours=1), INFINITY, "router-a"),
+            _row(now - timedelta(hours=2), INFINITY, "router-b"),
+        ]
+        assert len(collapse_overlapping(rows)) == 1
+
+    def test_given_disjoint_history_rows_it_should_preserve_them(self):
+        now = datetime.now()
+        rows = [
+            _row(now - timedelta(hours=1), now, "router-a"),
+            _row(now - timedelta(hours=4), now - timedelta(hours=3), "router-a"),
+        ]
+        assert len(collapse_overlapping(rows)) == 2
+
+    def test_given_overlapping_pair_plus_disjoint_it_should_keep_two(self):
+        now = datetime.now()
+        rows = [
+            _row(now - timedelta(hours=1), INFINITY, "router-a"),
+            _row(now - timedelta(hours=2), INFINITY, "router-b"),
+            _row(now - timedelta(hours=5), now - timedelta(hours=4), "router-a"),
+        ]
+        assert len(collapse_overlapping(rows)) == 2
+
+
+def test_given_collapse_option_it_should_merge_duplicate_active_rows(db, client):
+    mac = "ca:fe:ba:be:f0:02"
+    ip = "10.0.0.43"
+    for sysname in ("router-a", "router-b"):
+        Arp(
+            ip=ip,
+            mac=mac,
+            sysname=sysname,
+            start_time=datetime.now(),
+            end_time=INFINITY,
+        ).save()
+
+    url = reverse('machinetracker-ip')
+    params = {'ip_range': ip, 'period_filter': 'active', 'days': 7, 'source': 'on'}
+
+    without = client.get(url, dict(params))
+    assert without.context['ip_tracker_count'] == 2
+
+    with_collapse = client.get(url, dict(params, collapse='on'))
+    assert with_collapse.context['ip_tracker_count'] == 1
 
 
 def test_get_netbios_query_should_not_fail(db):


### PR DESCRIPTION
## Scope and purpose

Fixes #4098.

NAV records one `Arp` row per collecting router by design, so an address served by several routers (e.g. an HSRP pair) shows up as multiple overlapping rows in a machinetracker IP search for active addresses.

This adds an **opt-in** "Collapse duplicates" checkbox to the IP search form:

- Default **off** → existing behavior unchanged (raw rows preserved).
- When **on** → rows for the same `(ip, mac)` whose active time windows **overlap** are merged into one (newest kept).

Disjoint windows (genuine connect/disconnect history) are preserved — overlap test is `s1 < e2 and s2 < e1`. Still-active rows (`end_time = INFINITY`) always overlap, so they collapse to one.

### This pull request
* changes the UI (adds one checkbox to the machinetracker IP search form)

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation — not applicable; behavior is self-explanatory from the checkbox help text
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: new feature, based on `master`
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done — not applicable
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (see below)
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file — not applicable; no new source files

## How to observe

1. Have (or simulate) `arp` rows where the same `(ip, mac)` is collected by two routers — two rows, same ip/mac, both `end_time = infinity`, different `sysname`/`netbox`.
2. Go to Machinetracker → IP search, enter the prefix/address, filter = Active.
3. Without "Collapse duplicates": two rows per address. With it checked: one row.
4. Verify a genuine reconnect (same ip/mac, disjoint time windows) still shows both rows when collapse is on.

## Trade-off

With collapse on, the kept row is the newest, so the dropped router's name in the *Source* column is not shown. Acceptable since the option is opt-in. A future enhancement could annotate "seen by N routers".

## Screenshots
<img width="1638" height="1235" alt="70 days - collapsed" src="https://github.com/user-attachments/assets/d6be7228-ae13-41aa-a9fe-a579b96d7ce3" />
<img width="1638" height="1235" alt="70 days - not collapsed" src="https://github.com/user-attachments/assets/bee67950-7c79-41f5-843e-085c3bb8b1e1" />
<img width="1638" height="1235" alt="only active - collapsed" src="https://github.com/user-attachments/assets/3c9da838-4115-4230-85b4-bb6a508cc684" />
<img width="1638" height="1235" alt="only active - not collapsed" src="https://github.com/user-attachments/assets/260fed80-c315-4416-8134-609767a8bd8a" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)

