### PR TITLE
Ignore SNMP errors from alternate MIB instances

### DIFF
--- a/changelog.d/4101.fixed.md
+++ b/changelog.d/4101.fixed.md
@@ -1,0 +1,1 @@
+Stop ipdevpoll jobs from aborting when a device returns an SNMP error (such as `noAccess`) for a community- or context-indexed MIB instance

--- a/python/nav/mibs/mibretriever.py
+++ b/python/nav/mibs/mibretriever.py
@@ -36,6 +36,7 @@ import logging
 from typing import Awaitable, Iterator
 
 from pynetsnmp.netsnmp import SnmpTimeoutError
+from pynetsnmp.twistedsnmp import SnmpError
 from twisted.internet import defer, reactor
 from twisted.internet.error import TimeoutError
 from twisted.python.failure import Failure
@@ -656,17 +657,20 @@ class MultiMibMixIn(MibRetriever):
         return integrator(results)
 
     def __timeout_handler(self, failure, descr):
-        """Handles timeouts while processing alternate MIB instances.
+        """Handles errors while processing alternate MIB instances.
 
         Under the premise that we may have an incorrect community string for a
         MIB instance, we don't want to derail the entire process of collecting
-        from all instances, so we ignore timeouts for anything but the primary
-        (base) instance.
+        from all instances, so we ignore timeouts and access errors (such as a
+        device rejecting a community-indexed query with noAccess) for anything
+        but the primary (base) instance.
 
         """
         if self.agent_proxy is not self._base_agent:
-            failure.trap(TimeoutError, defer.TimeoutError)
-            self._logger.debug("ignoring timeout from %r", descr)
+            failure.trap(TimeoutError, defer.TimeoutError, SnmpError)
+            self._logger.debug(
+                "ignoring error from %r: %s", descr, failure.getErrorMessage()
+            )
             return None
         return failure
 

--- a/python/nav/mibs/mibretriever.py
+++ b/python/nav/mibs/mibretriever.py
@@ -644,7 +644,7 @@ class MultiMibMixIn(MibRetriever):
             self.agent_proxy = agent
             try:
                 one_result = yield method(*args, **kwargs).addErrback(
-                    self.__timeout_handler, descr
+                    self.__ignore_alternate_instance_error, descr
                 )
             finally:
                 if agent is not self._base_agent:
@@ -656,7 +656,7 @@ class MultiMibMixIn(MibRetriever):
             yield lambda thing: fire_eventually(thing)
         return integrator(results)
 
-    def __timeout_handler(self, failure, descr):
+    def __ignore_alternate_instance_error(self, failure, descr):
         """Handles errors while processing alternate MIB instances.
 
         Under the premise that we may have an incorrect community string for a
@@ -664,6 +664,13 @@ class MultiMibMixIn(MibRetriever):
         from all instances, so we ignore timeouts and access errors (such as a
         device rejecting a community-indexed query with noAccess) for anything
         but the primary (base) instance.
+
+        pynetsnmp raises noAccess, resourceUnavailable and authorizationError
+        only as the base SnmpError (distinguished by message string), so there
+        is no narrower class to trap here. Note that Snmpv3Error subclasses
+        SnmpError, so a v3 auth/context failure on an alternate instance is
+        swallowed too; this is a conscious choice, consistent with tolerating
+        timeouts on alternates, and only ever affects non-base instances.
 
         """
         if self.agent_proxy is not self._base_agent:

--- a/tests/unittests/mibs/mibretriever_test.py
+++ b/tests/unittests/mibs/mibretriever_test.py
@@ -15,9 +15,13 @@
 #
 """Tests for nav.mibs.mibretriever module"""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
+
+import pytest
+import pytest_twisted
 
 from pynetsnmp.twistedsnmp import SnmpError
+from twisted.internet import defer
 from twisted.internet.error import TimeoutError
 from twisted.python.failure import Failure
 
@@ -26,15 +30,10 @@ from nav.mibs.mibretriever import MultiMibMixIn
 from nav.mibs.types import LogicalMibInstance
 
 
-def _make_failure(exception):
-    """Wraps an exception in a Twisted Failure."""
-    return Failure(exception)
-
-
 class TestMultiMibMixInGetAlternateAgent:
     """Tests for MultiMibMixIn._get_alternate_agent()"""
 
-    def test_should_use_community_for_snmpv2(self):
+    def test_it_should_use_community_for_snmpv2(self):
         agent = Mock()
         agent.community = "public"
         agent.ip = "10.0.0.1"
@@ -51,7 +50,7 @@ class TestMultiMibMixInGetAlternateAgent:
         assert alt_agent.snmp_parameters.community == "public@100"
         assert alt_agent.snmp_parameters.context_name is None
 
-    def test_should_use_context_for_snmpv3(self):
+    def test_it_should_use_context_for_snmpv3(self):
         agent = Mock()
         agent.community = "public"
         agent.ip = "10.0.0.1"
@@ -105,7 +104,7 @@ class TestMultiMibMixInGetAlternateAgent:
 
         assert alt_agent.snmp_parameters.context_engine_id is None
 
-    def test_should_copy_protocol_from_base_agent(self):
+    def test_it_should_copy_protocol_from_base_agent(self):
         agent = Mock()
         agent.community = "public"
         agent.ip = "10.0.0.1"
@@ -121,8 +120,31 @@ class TestMultiMibMixInGetAlternateAgent:
         assert alt_agent.protocol is agent.protocol
 
 
-class TestMultiMibMixInTimeoutHandler:
-    """Tests for MultiMibMixIn.__timeout_handler()"""
+class TestMultiMibMixInIgnoreAlternateInstanceError:
+    """Tests for MultiMibMixIn.__ignore_alternate_instance_error()"""
+
+    def test_when_alternate_instance_returns_snmp_error_then_it_should_be_ignored(self):
+        mixin = self._make_mixin()
+        mixin.agent_proxy = Mock()  # any non-base agent
+        failure = Failure(SnmpError("Packet for 10.0.0.1 has error: Permission denied"))
+
+        assert self._handle(mixin, failure) is None
+
+    def test_when_alternate_instance_times_out_then_it_should_be_ignored(self):
+        mixin = self._make_mixin()
+        mixin.agent_proxy = Mock()  # any non-base agent
+        failure = Failure(TimeoutError("timed out"))
+
+        assert self._handle(mixin, failure) is None
+
+    def test_when_base_instance_returns_snmp_error_then_it_should_propagate(self):
+        mixin = self._make_mixin()
+        # agent_proxy is left as the base agent
+        failure = Failure(
+            SnmpError("Packet for 10.0.0.1 has error: Authorization error")
+        )
+
+        assert self._handle(mixin, failure, descr=None) is failure
 
     def _make_mixin(self):
         agent = Mock()
@@ -133,28 +155,38 @@ class TestMultiMibMixInTimeoutHandler:
         return MultiMibMixIn(agent, [])
 
     def _handle(self, mixin, failure, descr="vlan100"):
-        # __timeout_handler is name-mangled
-        return mixin._MultiMibMixIn__timeout_handler(failure, descr)
+        # __ignore_alternate_instance_error is name-mangled
+        return mixin._MultiMibMixIn__ignore_alternate_instance_error(failure, descr)
 
-    def test_when_alternate_instance_returns_snmp_error_then_it_should_be_ignored(self):
+
+class TestMultiMibMixInMultiquery:
+    """Tests that error handling is wired up correctly in _multiquery()"""
+
+    @pytest.mark.twisted
+    @pytest_twisted.inlineCallbacks
+    def test_when_alternate_instance_query_fails_then_multiquery_still_returns(self):
         mixin = self._make_mixin()
-        mixin.agent_proxy = Mock()  # any non-base agent
-        failure = _make_failure(
-            SnmpError("Packet for 10.0.0.1 has error: Permission denied")
-        )
+        base_agent = mixin._base_agent
+        alt_agent = Mock()
 
-        assert self._handle(mixin, failure) is None
+        def method():
+            if mixin.agent_proxy is base_agent:
+                return defer.succeed({"base": "ok"})
+            return defer.fail(
+                SnmpError("Packet for 10.0.0.1 has error: Permission denied")
+            )
 
-    def test_when_alternate_instance_times_out_then_it_should_be_ignored(self):
-        mixin = self._make_mixin()
-        mixin.agent_proxy = Mock()  # any non-base agent
-        failure = _make_failure(TimeoutError("timed out"))
+        agents = [(base_agent, None), (alt_agent, "vlan100")]
+        with patch.object(mixin, "_make_agents", return_value=agents):
+            result = yield mixin._multiquery(method)
 
-        assert self._handle(mixin, failure) is None
+        # The failing alternate instance did not abort the job; base survived
+        assert result == {"base": "ok"}
 
-    def test_when_base_instance_returns_snmp_error_then_it_should_propagate(self):
-        mixin = self._make_mixin()
-        # agent_proxy is left as the base agent
-        failure = _make_failure(SnmpError("Packet for 10.0.0.1 has error: genErr"))
-
-        assert self._handle(mixin, failure, descr=None) is failure
+    def _make_mixin(self):
+        agent = Mock()
+        agent.community = "public"
+        agent.ip = "10.0.0.1"
+        agent.port = 161
+        agent.snmp_parameters = SNMPParameters(version=2, community="public")
+        return MultiMibMixIn(agent, [])

--- a/tests/unittests/mibs/mibretriever_test.py
+++ b/tests/unittests/mibs/mibretriever_test.py
@@ -17,9 +17,18 @@
 
 from unittest.mock import Mock
 
+from pynetsnmp.twistedsnmp import SnmpError
+from twisted.internet.error import TimeoutError
+from twisted.python.failure import Failure
+
 from nav.ipdevpoll.snmp.common import SNMPParameters
 from nav.mibs.mibretriever import MultiMibMixIn
 from nav.mibs.types import LogicalMibInstance
+
+
+def _make_failure(exception):
+    """Wraps an exception in a Twisted Failure."""
+    return Failure(exception)
 
 
 class TestMultiMibMixInGetAlternateAgent:
@@ -110,3 +119,42 @@ class TestMultiMibMixInGetAlternateAgent:
         alt_agent = mixin._get_alternate_agent(instance)
 
         assert alt_agent.protocol is agent.protocol
+
+
+class TestMultiMibMixInTimeoutHandler:
+    """Tests for MultiMibMixIn.__timeout_handler()"""
+
+    def _make_mixin(self):
+        agent = Mock()
+        agent.community = "public"
+        agent.ip = "10.0.0.1"
+        agent.port = 161
+        agent.snmp_parameters = SNMPParameters(version=2, community="public")
+        return MultiMibMixIn(agent, [])
+
+    def _handle(self, mixin, failure, descr="vlan100"):
+        # __timeout_handler is name-mangled
+        return mixin._MultiMibMixIn__timeout_handler(failure, descr)
+
+    def test_when_alternate_instance_returns_snmp_error_then_it_should_be_ignored(self):
+        mixin = self._make_mixin()
+        mixin.agent_proxy = Mock()  # any non-base agent
+        failure = _make_failure(
+            SnmpError("Packet for 10.0.0.1 has error: Permission denied")
+        )
+
+        assert self._handle(mixin, failure) is None
+
+    def test_when_alternate_instance_times_out_then_it_should_be_ignored(self):
+        mixin = self._make_mixin()
+        mixin.agent_proxy = Mock()  # any non-base agent
+        failure = _make_failure(TimeoutError("timed out"))
+
+        assert self._handle(mixin, failure) is None
+
+    def test_when_base_instance_returns_snmp_error_then_it_should_propagate(self):
+        mixin = self._make_mixin()
+        # agent_proxy is left as the base agent
+        failure = _make_failure(SnmpError("Packet for 10.0.0.1 has error: genErr"))
+
+        assert self._handle(mixin, failure, descr=None) is failure


### PR DESCRIPTION
## Scope and purpose

Fixes #4101.

When ipdevpoll polls a device using community- or context-indexed BRIDGE-MIB
instances, and the device answers a query for one of those *alternate* instances
with an SNMP error such as `noAccess`, the entire job aborts.

pynetsnmp surfaces `noAccess` as an `SnmpError` reading
`Packet for <ip> has error: Permission denied`. `MultiMibMixIn.__timeout_handler`
only ignored `TimeoutError` for non-base (alternate) instances, so the `SnmpError`
propagated and aborted the plugin/job. This was observed against Cisco FirePower
(FTD) appliances, which return `noAccess` for community-indexed BRIDGE-MIB
queries, aborting every `topo` and `inventory` job for those devices each poll
cycle.

This extends `__timeout_handler` to also trap `SnmpError` for non-base instances,
matching the documented intent that errors for anything but the primary instance
should not derail collection. Errors on the base instance still propagate.

### How to observe

On an affected device (e.g. Cisco FirePower), a community-indexed query returns
`noAccess`:

```
snmpbulkget -v2c -c 'public@<instance>' <ip> 1.3.6.1.2.1.17.1.4.1.2
Error in packet.
Reason: noAccess
```

Before this change, `ipdevpoll.log` shows repeated `Job 'topo'/'inventory' ...
aborted: Job aborted due to plugin failure (cause=Packet for <ip> has error:
Permission denied)`. After, those jobs complete and the per-instance error is
ignored.

### This pull request
* changes SNMP error handling for alternate MIB instances

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation — n/a, internal error-handling change with no user-facing docs
* [x] Linted/formatted the code with ruff
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long
* [x] Based this pull request on the correct upstream branch (`5.18.x`, bugfix for the latest stable version)
* [x] If applicable: Created new issues if this PR does not fix the issue completely — see note below
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects (see "How to observe" above)
* [ ] If this results in changes in the UI: screenshots — n/a, no UI changes
* [ ] If this adds a new Python source code file: boilerplate header — n/a, no new source files

> Note: this stops the job aborts, but affected FirePower devices still expose a
> broken community-indexed BRIDGE-MIB, so NAV will not collect per-VLAN CAM data
> from them. That is a device-side limitation, not addressed here.
