### PR TITLE
Fix spurious 500 errors in room image management views

### DIFF
--- a/changelog.d/4103.fixed.md
+++ b/changelog.d/4103.fixed.md
@@ -1,0 +1,1 @@
+Stopped the room image views from returning spurious server errors (and emailing admins) when deleting already-deleted images or on malformed requests.

--- a/python/nav/web/info/images/views.py
+++ b/python/nav/web/info/images/views.py
@@ -73,10 +73,15 @@ def update_priority(request):
         for key, value in request.POST.items():
             _logger.debug('%s=%s', key, value)
             try:
-                image = Image.objects.get(pk=key)
+                imageid = int(key)
+                priority = int(value)
+            except ValueError:
+                return HttpResponse(status=400)
+            try:
+                image = Image.objects.get(pk=imageid)
             except Image.DoesNotExist:
                 return HttpResponse(status=404)
-            image.priority = value
+            image.priority = priority
             image.save()
 
     return HttpResponse(status=200)

--- a/python/nav/web/info/images/views.py
+++ b/python/nav/web/info/images/views.py
@@ -37,6 +37,7 @@ def delete_image(request):
             image = Image.objects.get(pk=imageid)
         except Image.DoesNotExist:
             # Already gone; deletion is idempotent, treat as success
+            messages.info(request, 'Image was already deleted')
             return HttpResponse(status=200)
         else:
             filepath = image.fullpath
@@ -48,10 +49,6 @@ def delete_image(request):
                 if error.errno != errno.ENOENT:
                     _logger.error('Could not delete image file %s: %s', filepath, error)
                     return HttpResponse(status=500)
-            else:
-                messages.success(
-                    request, 'Image &laquo;%s&raquo; deleted' % image.title
-                )
 
             try:
                 os.unlink(image.thumbpath)
@@ -61,6 +58,7 @@ def delete_image(request):
 
             # Fetch all image instances that uses this image and delete them
             Image.objects.filter(path=image.path, name=image.name).delete()
+            messages.success(request, 'Image &laquo;%s&raquo; deleted' % image.title)
 
     return HttpResponse(status=200)
 

--- a/python/nav/web/info/images/views.py
+++ b/python/nav/web/info/images/views.py
@@ -13,7 +13,9 @@ _logger = logging.getLogger('nav.web.info.image')
 def update_title(request):
     """Update the title for a room image"""
     if request.method == 'POST':
-        imageid = int(request.POST['id'])
+        imageid = _posted_image_id(request)
+        if imageid is None:
+            return HttpResponse(status=400)
         title = request.POST.get('title', '')
         try:
             image = Image.objects.get(pk=imageid)
@@ -29,7 +31,9 @@ def update_title(request):
 def delete_image(request):
     """Delete an image from a room"""
     if request.method == 'POST':
-        imageid = int(request.POST['id'])
+        imageid = _posted_image_id(request)
+        if imageid is None:
+            return HttpResponse(status=400)
 
         _logger.debug('Deleting image %s', imageid)
 
@@ -76,3 +80,11 @@ def update_priority(request):
             image.save()
 
     return HttpResponse(status=200)
+
+
+def _posted_image_id(request):
+    """Return the posted image id as an int, or None if missing or malformed"""
+    try:
+        return int(request.POST['id'])
+    except (KeyError, ValueError):
+        return None

--- a/python/nav/web/info/images/views.py
+++ b/python/nav/web/info/images/views.py
@@ -17,7 +17,7 @@ def update_title(request):
         try:
             image = Image.objects.get(pk=imageid)
         except Image.DoesNotExist:
-            return HttpResponse(status=500)
+            return HttpResponse(status=404)
         else:
             image.title = title
             image.save()
@@ -35,7 +35,8 @@ def delete_image(request):
         try:
             image = Image.objects.get(pk=imageid)
         except Image.DoesNotExist:
-            return HttpResponse(status=500)
+            # Already gone; deletion is idempotent, treat as success
+            return HttpResponse(status=200)
         else:
             filepath = image.fullpath
             try:
@@ -67,7 +68,10 @@ def update_priority(request):
     if request.method == 'POST':
         for key, value in request.POST.items():
             _logger.debug('%s=%s', key, value)
-            image = Image.objects.get(pk=key)
+            try:
+                image = Image.objects.get(pk=key)
+            except Image.DoesNotExist:
+                return HttpResponse(status=404)
             image.priority = value
             image.save()
 

--- a/python/nav/web/info/images/views.py
+++ b/python/nav/web/info/images/views.py
@@ -1,3 +1,4 @@
+import errno
 import logging
 import os
 
@@ -43,8 +44,9 @@ def delete_image(request):
                 _logger.debug('Deleting file %s', filepath)
                 os.unlink(filepath)
             except OSError as error:
-                # If the file is not found, then this is ok, otherwise not ok
-                if error.errno != 2:
+                # A missing file is fine; any other error is a real problem
+                if error.errno != errno.ENOENT:
+                    _logger.error('Could not delete image file %s: %s', filepath, error)
                     return HttpResponse(status=500)
             else:
                 messages.success(

--- a/tests/integration/web/info/images_test.py
+++ b/tests/integration/web/info/images_test.py
@@ -1,0 +1,122 @@
+"""Tests for the room/location image management views"""
+
+import errno
+
+import pytest
+from django.contrib.messages import get_messages
+from django.urls import reverse
+
+from nav.models.images import Image
+from nav.models.manage import Room
+from nav.models.profiles import Account
+
+NONEXISTENT_IMAGE_ID = 999999
+
+
+class TestDeleteImage:
+    def test_when_image_does_not_exist_then_delete_image_should_return_200(
+        self, client
+    ):
+        url = reverse('image-delete-image')
+        response = client.post(url, {'id': NONEXISTENT_IMAGE_ID})
+        assert response.status_code == 200
+
+    def test_when_image_already_deleted_then_delete_image_should_say_so(self, client):
+        url = reverse('image-delete-image')
+        response = client.post(url, {'id': NONEXISTENT_IMAGE_ID})
+        assert any('already deleted' in message for message in _messages(response))
+
+    def test_when_id_is_missing_then_delete_image_should_return_400(self, client):
+        url = reverse('image-delete-image')
+        response = client.post(url, {})
+        assert response.status_code == 400
+
+    def test_when_id_is_not_a_number_then_delete_image_should_return_400(self, client):
+        url = reverse('image-delete-image')
+        response = client.post(url, {'id': 'not-a-number'})
+        assert response.status_code == 400
+
+    def test_when_image_exists_then_delete_image_should_remove_the_row(
+        self, client, image
+    ):
+        url = reverse('image-delete-image')
+        response = client.post(url, {'id': image.id})
+        assert response.status_code == 200
+        assert not Image.objects.filter(pk=image.id).exists()
+
+    def test_when_file_already_gone_then_delete_image_should_report_success(
+        self, client, image
+    ):
+        # The fixture image has no backing file on disk, so this exercises the
+        # swallowed-ENOENT path; the success message must still be reported.
+        url = reverse('image-delete-image')
+        response = client.post(url, {'id': image.id})
+        assert response.status_code == 200
+        assert any('&raquo; deleted' in message for message in _messages(response))
+
+    def test_when_file_deletion_fails_then_delete_image_should_return_500(
+        self, client, image, monkeypatch, caplog
+    ):
+        def raise_permission_denied(*_args, **_kwargs):
+            raise OSError(errno.EACCES, "Permission denied")
+
+        monkeypatch.setattr(
+            "nav.web.info.images.views.os.unlink", raise_permission_denied
+        )
+        url = reverse('image-delete-image')
+        with caplog.at_level("ERROR", logger="nav.web.info.image"):
+            response = client.post(url, {'id': image.id})
+        assert response.status_code == 500
+        assert "Could not delete image file" in caplog.text
+
+
+class TestUpdateTitle:
+    def test_when_image_does_not_exist_then_update_title_should_return_404(
+        self, client
+    ):
+        url = reverse('image-update-title')
+        response = client.post(url, {'id': NONEXISTENT_IMAGE_ID, 'title': 'irrelevant'})
+        assert response.status_code == 404
+
+    def test_when_id_is_missing_then_update_title_should_return_400(self, client):
+        url = reverse('image-update-title')
+        response = client.post(url, {'title': 'irrelevant'})
+        assert response.status_code == 400
+
+
+class TestUpdatePriority:
+    def test_when_image_does_not_exist_then_update_priority_should_return_404(
+        self, client
+    ):
+        url = reverse('image-update-priority')
+        response = client.post(url, {str(NONEXISTENT_IMAGE_ID): '5'})
+        assert response.status_code == 404
+
+    def test_when_id_is_not_a_number_then_update_priority_should_return_400(
+        self, client
+    ):
+        url = reverse('image-update-priority')
+        response = client.post(url, {'not-a-number': '5'})
+        assert response.status_code == 400
+
+
+def _messages(response):
+    """Return the rendered text of all messages attached to a response"""
+    return [str(message) for message in get_messages(response.wsgi_request)]
+
+
+@pytest.fixture
+def image(db):
+    """An Image row pointing at a room, with no backing file on disk"""
+    room = Room.objects.get(pk='myroom')
+    admin = Account.objects.get(id=Account.ADMIN_ACCOUNT)
+    image = Image(
+        room=room,
+        uploader=admin,
+        title='Test image',
+        path='rooms/myroom',
+        name='nonexistent.jpg',
+        priority=0,
+    )
+    image.save()
+    return image


### PR DESCRIPTION
## Scope and purpose

NAV admins received a Django "Internal Server Error" email for `POST /search/image/delete` with no traceback attached. The room/location image management views (delete, title update, reorder) returned HTTP 500 for a range of benign or malformed conditions, and because Django's `AdminEmailHandler` mails admins on every 5xx response, each occurrence produced a spurious — and often tracebackless, therefore baffling — error mail.

Several distinct conditions were at fault. Deleting or retitling an image whose database row was already gone (a double-submit, or a sibling row removed by [`delete_image`'s bulk delete](https://github.com/Uninett/nav/blob/00bddb766a2a05c3e38da40ce561ab02bc32cf49/python/nav/web/info/images/views.py#L60-L61)) hit a deliberate `HttpResponse(status=500)`. Separately, a replayed or malformed request whose `id` was missing or non-numeric raised an *uncaught* exception — a genuine 500 with a full traceback — in all three views. None of these are server faults.

This PR gives each view a status that reflects what actually happened: an idempotent delete of an already-gone image returns 200, updates to a missing image return 404, and malformed input returns 400 — so admins stop receiving phantom mail for ordinary client behaviour. Genuine filesystem failures during deletion still return 500, but now log the underlying error so the resulting mail is actionable instead of empty. While here, the delete view's user feedback was made consistent: the success message now fires whenever the row is removed (previously it was skipped if the on-disk file was already gone), and a repeat delete reports "already deleted" rather than reloading silently.

## How to test

Automated: `pytest tests/integration/web/info/images_test.py` covers every status path (200 / 400 / 404 / 500) plus the message behaviour.

Manually, as a logged-in user, open a room's image upload page at `/search/room/<roomid>/upload/`, upload an image, then exercise:

- **Repeat delete** — delete the same image twice (or double-click the delete button). The second request returns 200 with an "Image was already deleted" notice instead of a 500. Tip: tick **Preserve log** in the browser devtools Network tab, otherwise the page reload after a successful delete clears the entry and the request looks like it died.
- **Malformed request** — replay the delete POST without its body (devtools "resend", or `curl` the endpoint with no `id`). It returns 400, not an uncaught 500. The same holds for a non-numeric `id`, and for non-numeric keys/values sent to the reorder endpoint.
- **Missing file, present row** — remove an image's file under `UPLOAD_DIR` while leaving its database row, then delete it via the UI. It still returns 200, removes the row, and reports success.

In every case above, confirm no admin error mail is generated — `AdminEmailHandler` only fires on 5xx, so the 200/400/404 responses are silent.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the boilerplate header~~
