### PR TITLE
Authenticate web tests via NAV's real allauth login flow

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,14 @@ def pytest_configure(config):
 
     setup_test_environment()
 
+    # The test suite logs in on nearly every web test, which would otherwise
+    # trip allauth's default "30/m/ip" login throttle and cause spurious
+    # failures. Disable only the login rate limits; allauth merges this over its
+    # defaults, so every other throttle keeps its real value.
+    from django.conf import settings
+
+    settings.ACCOUNT_RATE_LIMITS = {"login": None, "login_failed": None}
+
     if platform.system() == 'Linux':
         # Install custom reactor for Twisted tests
         from nav.ipdevpoll.epollreactor2 import install

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,5 +1,3 @@
-from nav.django.defaults import NAV_LOGIN_URL as LOGIN_URL
-
 import pytest
 from django.contrib.staticfiles.handlers import StaticFilesHandler
 from django.test.testcases import LiveServerThread
@@ -47,9 +45,14 @@ def live_server():
 @pytest.fixture
 def authenticated_page(page: Page, live_server, admin_username, admin_password):
     """Fixture providing a Playwright page logged in as admin"""
-    page.goto(f"{live_server}{LOGIN_URL}")
-    page.locator("#id_username").fill(admin_username)
+    # Imported lazily: importing nav.django.settings at conftest module level
+    # would lock in Django's settings before the DB fixtures configure it.
+    from django.conf import settings
+    from django.shortcuts import resolve_url
+
+    page.goto(f"{live_server}{resolve_url(settings.LOGIN_URL)}")
+    page.locator("#id_login").fill(admin_username)
     page.locator("#id_password").fill(admin_password)
-    page.locator("#submit-id-submit").click()
+    page.get_by_role("button", name="Log in").click()
     page.wait_for_url(f"{live_server}/")
     yield page, live_server

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -215,12 +215,32 @@ def localhost_using_legacy_db():
 def client(admin_username, admin_password):
     """Provides a Django test Client object already logged in to the web UI as
     an admin"""
-    from django.urls import reverse
-
     client_ = Client()
-    url = reverse('webfront-login')
-    client_.post(url, {'username': admin_username, 'password': admin_password})
+    log_in_client(client_, admin_username, admin_password)
     return client_
+
+
+@pytest.fixture
+def log_in():
+    """Provides a helper for logging a test client in via the real login flow"""
+    return log_in_client
+
+
+def log_in_client(client, username, password):
+    """Logs a Django test client in through NAV's real (allauth) login flow.
+
+    The login URL is resolved from ``settings.LOGIN_URL`` — the same setting the
+    rest of NAV uses to locate its login page — so these tests follow any future
+    change to the configured login path instead of silently exercising an
+    outdated one (which is how the dead legacy login view went untested).
+    """
+    from django.conf import settings
+    from django.shortcuts import resolve_url
+
+    return client.post(
+        resolve_url(settings.LOGIN_URL),
+        {'login': username, 'password': password},
+    )
 
 
 @pytest.fixture(scope='function')

--- a/tests/integration/web/crawler_test.py
+++ b/tests/integration/web/crawler_test.py
@@ -170,11 +170,10 @@ class WebCrawler(object):
     def login(self):
         login_url = urljoin(self.base_url, LOGIN_URL)
         opener = build_opener(HTTPCookieProcessor())
-        login_url = urljoin(self.base_url, "/index/login/")
         login_response = opener.open(login_url)
         login_html = lxml.html.parse(login_response)
-        login_form = login_html.find("//form[@method='post'][@action='/index/login/']")
-        login_form.fields["username"] = self.username
+        login_form = login_html.find(f".//form[@method='post'][@action='{LOGIN_URL}']")
+        login_form.fields["login"] = self.username
         login_form.fields["password"] = self.password
         login_data = urlencode(login_form.form_values()).encode("utf-8")
         opener.open(login_form.action, login_data, TIMEOUT)

--- a/tests/integration/web/info/room_test.py
+++ b/tests/integration/web/info/room_test.py
@@ -272,10 +272,9 @@ def test_sensor(db, localhost):
 
 
 @pytest.fixture(scope='function')
-def non_admin_client(client, non_admin_account):
+def non_admin_client(client, non_admin_account, log_in):
     client_ = Client()
-    url = reverse('webfront-login')
-    client_.post(url, {'username': non_admin_account.login, 'password': 'password'})
+    log_in(client_, non_admin_account.login, 'password')
     return client_
 
 

--- a/tests/integration/web/webfront_test.py
+++ b/tests/integration/web/webfront_test.py
@@ -220,15 +220,14 @@ class TestDeleteDashboardView:
 
 
 def test_when_logging_in_it_should_change_the_session_id(
-    db, client, admin_username, admin_password
+    db, client, admin_username, admin_password, log_in
 ):
-    login_url = reverse('webfront-login')
     logout_url = reverse('webfront-logout')
     # log out first to compare before and after being logged in
     client.post(logout_url)
     assert client.session.session_key, "the initial session lacks an ID"
     session_id_pre_login = client.session.session_key
-    client.post(login_url, {'username': admin_username, 'password': admin_password})
+    log_in(client, admin_username, admin_password)
     session_id_post_login = client.session.session_key
     assert session_id_post_login != session_id_pre_login
 
@@ -260,7 +259,7 @@ def test_shows_password_issue_banner_on_own_password_issues(db, client):
 
 
 def test_shows_password_issue_banner_to_admins_on_other_users_password_issues(
-    db, admin_account
+    db, admin_account, log_in
 ):
     """
     If other users have insecure or old passwords a banner should be shown to admins
@@ -282,8 +281,7 @@ def test_shows_password_issue_banner_to_admins_on_other_users_password_issues(
 
     # login with a password only used for this test
     client_ = Client()
-    url = reverse('webfront-login')
-    client_.post(url, {'username': admin_account.login, 'password': new_password})
+    log_in(client_, admin_account.login, new_password)
 
     # test
     index_url = reverse('webfront-index')


### PR DESCRIPTION
## Scope and purpose

Fixes #4108.

NAV's web login test fixtures authenticated by POSTing to the legacy `webfront-login` view (`do_login`), which has been unreachable in a running installation since 5.18.0, when the login flow moved to django-allauth at `/accounts/login/`. Because the tests drove the abandoned path, the real login flow had no automated coverage — the gap that let the login-logging regression in #4106 ship unnoticed.

This migrates every login helper in the test tree — the integration Django test-client fixtures, the urllib-based web crawler, and the Playwright functional fixture — to authenticate through the real allauth flow. The login URL is resolved from `settings.LOGIN_URL` (the same setting production reads to locate its login page), so the tests follow any future reconfiguration instead of silently drifting onto a stale path again. It also disables allauth's login rate limiting in the shared test bootstrap, since the suite logs in on nearly every web test and would otherwise trip the default `30/m/ip` throttle.

To observe the effect: run the integration web suite (e.g. `pytest tests/integration/web/webfront_test.py`) — the `client` fixture and the login tests now round-trip through `/accounts/login/`.

## Contributor Checklist

* [ ] ~~Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)~~ — test-only change, labelled `nonews`
* [ ] ~~Added/amended tests for new/changed code~~ — this PR *is* a test-infrastructure fix; no production code changed
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`)
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done — related follow-up is tracked in #4106 and #4107
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~
