### PR TITLE
Restore audit and application logging of user logins

### DIFF
--- a/changelog.d/4106.fixed.md
+++ b/changelog.d/4106.fixed.md
@@ -1,0 +1,1 @@
+Restored audit-log and application-log recording of user logins, which stopped when the login flow moved to django-allauth in 5.18.0.

--- a/python/nav/web/apps.py
+++ b/python/nav/web/apps.py
@@ -22,6 +22,9 @@ class NAVWebAppConfig(AppConfig):
     verbose_name = 'NAV Main web frontend application'
 
     def ready(self):
+        # Connect the login-logging signal receivers in every deployment mode.
+        from nav.web.auth import signals  # noqa: F401
+
         if 'runserver' not in sys.argv:
             return
 

--- a/python/nav/web/auth/signals.py
+++ b/python/nav/web/auth/signals.py
@@ -1,0 +1,50 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License version 3 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Authentication signal receivers that record logins in NAV's logs.
+
+Login logging is hung off Django's auth signals rather than a specific view, so
+it fires uniformly for every authentication path — the django-allauth login
+flow, REMOTE_USER, LDAP, and any future backend.
+"""
+
+import logging
+
+from django.contrib.auth.signals import user_logged_in, user_login_failed
+from django.dispatch import receiver
+
+from nav.auditlog.models import LogEntry
+
+_logger = logging.getLogger(__name__)
+
+
+@receiver(user_logged_in)
+def log_successful_login(sender, request, user, **kwargs):
+    """Records a successful login in the audit log and the application log"""
+    LogEntry.add_log_entry(user, 'log-in', '{actor} logged in', before=user)
+    _logger.info("%s successfully logged in", user.get_username())
+
+
+@receiver(user_login_failed)
+def log_failed_login(sender, credentials, request=None, **kwargs):
+    """Records a failed login attempt in the application log"""
+    # Auth backends name the identity credential differently: allauth uses
+    # "username", and NAVRemoteUserBackend uses "user".
+    username = (
+        credentials.get('username')
+        or credentials.get('login')
+        or credentials.get('user')
+    )
+    _logger.info("failed login: %r", username)

--- a/python/nav/web/webfront/views.py
+++ b/python/nav/web/webfront/views.py
@@ -404,17 +404,12 @@ def do_login(request: HttpRequest) -> HttpResponse:
 
         account = authenticate(request, username=username, password=password)
         if account is not None:
-            LogEntry.add_log_entry(
-                account, 'log-in', '{actor} logged in', before=account
-            )
             django_login(request, account)
             set_account(request, account)  # NAV legacy specific
-            _logger.info("%s successfully logged in", account.login)
             if not origin:
                 origin = reverse('webfront-index')
             return HttpResponseRedirect(origin)
         else:
-            _logger.info("failed login: %r", username)
             errors.append(
                 'Username or password is incorrect, or the account is locked.'
             )

--- a/tests/integration/web/auth/login_logging_test.py
+++ b/tests/integration/web/auth/login_logging_test.py
@@ -1,0 +1,70 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License version 3 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Tests that logins are recorded in the audit log and the application log.
+
+Logins go through django-allauth, so these exercise the real login flow (via the
+``log_in`` helper).
+"""
+
+import logging
+
+from django.test import Client
+
+from nav.auditlog.models import LogEntry
+
+
+class TestLoginLogging:
+    def test_when_a_user_logs_in_then_it_should_record_an_audit_log_entry(
+        self, db, non_admin_account, log_in
+    ):
+        entries = self._login_entries_for(non_admin_account)
+        count_before = entries.count()
+
+        log_in(Client(), non_admin_account.login, "password")
+
+        assert entries.count() == count_before + 1
+        assert non_admin_account.login in entries.order_by("-pk").first().summary
+
+    def test_when_a_user_logs_in_then_it_should_log_to_the_application_log(
+        self, db, non_admin_account, log_in, caplog
+    ):
+        with caplog.at_level(logging.INFO):
+            log_in(Client(), non_admin_account.login, "password")
+
+        assert f"{non_admin_account.login} successfully logged in" in caplog.text
+
+    def test_when_a_login_attempt_fails_then_it_should_log_to_the_application_log(
+        self, db, non_admin_account, log_in, caplog
+    ):
+        with caplog.at_level(logging.INFO):
+            log_in(Client(), non_admin_account.login, "wrong-password")
+
+        assert "failed login" in caplog.text
+
+    def test_when_a_login_attempt_fails_then_it_should_not_record_an_audit_log_entry(
+        self, db, non_admin_account, log_in
+    ):
+        entries = self._login_entries_for(non_admin_account)
+        count_before = entries.count()
+
+        log_in(Client(), non_admin_account.login, "wrong-password")
+
+        assert entries.count() == count_before
+
+    @staticmethod
+    def _login_entries_for(account):
+        """Returns the log-in audit-log entries whose actor is the given account"""
+        return LogEntry.objects.filter(verb="log-in", actor_pk=str(account.pk))


### PR DESCRIPTION
## Scope and purpose

Fixes #4106. Dependent on #4109.

Since NAV 5.18.0 the login flow goes through django-allauth, which bypasses the old `do_login` view — the only place that recorded a login. As a result NAV stopped writing the `log-in` audit-log entry (the more serious loss, since the audit log is the traceability record available to local administrators) and stopped writing the "successfully logged in" / "failed login" application-log lines.

This restores login logging by hanging it off Django's authentication signals (`user_logged_in` / `user_login_failed`) rather than a specific view, so it fires uniformly for the allauth flow, REMOTE_USER, LDAP, and any future backend. The now-redundant inline logging is removed from the unreachable `do_login` view, whose full removal is tracked in #4107. As a side effect, REMOTE_USER and LDAP logins are now recorded too — previously only the interactive login path was — which is a uniform-logging improvement.

To observe: log in through the web UI, then check the audit log (a `log-in` entry now appears) and NAV's application log (a "successfully logged in" line; a failed attempt logs "failed login").

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`)
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done — #4107 tracks removing the now-dead `do_login` view
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [x] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file
