### PR TITLE
Use Django connections in the geomap data view

### DIFF
--- a/changelog.d/+geomap-django-connection.changed.md
+++ b/changelog.d/+geomap-django-connection.changed.md
@@ -1,0 +1,1 @@
+The geomap data view now uses Django's thread-local, pooled database connection instead of the legacy `nav.db` connection cache, removing the last multithreaded web caller of that cache.

--- a/python/nav/web/geomap/views.py
+++ b/python/nav/web/geomap/views.py
@@ -21,6 +21,7 @@ from decimal import Decimal
 
 import psycopg2.extras
 
+from django.db import connection as db_connection
 from django.http import HttpResponse
 from django.http import HttpResponseForbidden
 from django.http import HttpResponseRedirect
@@ -28,7 +29,6 @@ from django.http import Http404
 from django.shortcuts import render
 from django.urls import reverse
 
-import nav.db
 from nav.web.auth.utils import get_account
 
 from nav.web.geomap.conf import get_configuration
@@ -132,10 +132,6 @@ def data(request, variant):
     variant must be a variant name defined in the configuration file.
 
     """
-    connection = nav.db.getConnection('geomapserver', 'manage')
-    connection.set_isolation_level(1)
-    db = connection.cursor(cursor_factory=psycopg2.extras.DictCursor)
-
     truthy = ['True', 'true', True]
     do_create_edges = request.GET.get('create_edges', True) in truthy
     do_fetch_data = request.GET.get('fetch_data', True) in truthy
@@ -166,17 +162,26 @@ def data(request, variant):
     else:
         time_interval = None
 
-    data = get_formatted_data(
-        variant,
-        db,
-        format_,
-        bounds,
-        viewport_size,
-        limit,
-        time_interval,
-        do_create_edges,
-        do_fetch_data,
-    )
+    # Use the Django-managed connection (thread-local and pooled via
+    # CONN_MAX_AGE) rather than the legacy nav.db cache. The geomap queries
+    # need a psycopg2 DictCursor, so reach through to the underlying psycopg2
+    # connection. Django owns that connection's lifecycle, so only the cursor
+    # is closed here, never the connection itself.
+    db_connection.ensure_connection()
+    with db_connection.connection.cursor(
+        cursor_factory=psycopg2.extras.DictCursor
+    ) as db:
+        data = get_formatted_data(
+            variant,
+            db,
+            format_,
+            bounds,
+            viewport_size,
+            limit,
+            time_interval,
+            do_create_edges,
+            do_fetch_data,
+        )
     response = HttpResponse(data)
     response['Content-Type'] = format_mime_type(format_)
     return response

--- a/tests/unittests/web/geomap/views_test.py
+++ b/tests/unittests/web/geomap/views_test.py
@@ -1,0 +1,67 @@
+#
+# Copyright (C) 2026 Uninett AS
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.  You should have received a copy of the GNU General Public
+# License along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Tests for the geomap data view's database access"""
+
+from unittest.mock import MagicMock, patch
+
+import psycopg2.extras
+from django.test import RequestFactory
+
+from nav.web.geomap import views
+
+
+QUERY = {
+    'format': 'geojson',
+    'limit': '30',
+    'viewportWidth': '800',
+    'viewportHeight': '600',
+    'create_edges': 'true',
+    'fetch_data': 'false',
+    'bbox': '10.0,63.0,10.5,63.5',
+}
+
+
+def test_when_serving_geomap_data_then_django_managed_connection_is_used():
+    """The view must fetch its DictCursor from the Django-managed connection
+    (not the legacy nav.db cache) and must never close that connection itself.
+    """
+    request = RequestFactory().get('/geomap/normal/data', QUERY)
+
+    cursor = MagicMock(name='cursor')
+    fake_connection = MagicMock(name='db_connection')
+    # cursor(...) is used as a context manager: `with ... as db`
+    fake_connection.connection.cursor.return_value.__enter__.return_value = cursor
+
+    with (
+        patch.object(views, 'db_connection', fake_connection),
+        patch.object(views, 'get_formatted_data', return_value='DATA') as get_data,
+        patch.object(views, 'format_mime_type', return_value='application/json'),
+    ):
+        response = views.data(request, 'normal')
+
+    assert response.status_code == 200
+    assert response.content == b'DATA'
+
+    # Django connection was established and a DictCursor requested from it
+    fake_connection.ensure_connection.assert_called_once()
+    fake_connection.connection.cursor.assert_called_once_with(
+        cursor_factory=psycopg2.extras.DictCursor
+    )
+    # The cursor from that connection is what gets handed to the query layer
+    assert get_data.call_args.args[1] is cursor
+    # We must not close the shared Django connection
+    fake_connection.connection.close.assert_not_called()
+    fake_connection.close.assert_not_called()


### PR DESCRIPTION
## Scope and purpose

Follow-up to #4111 (the #4104 connection-leak fix). That PR hardened the
legacy `nav.db` `ObjectCache` so it survives concurrent access. This PR
removes the **last multithreaded web caller** of that cache, which was the
actual path that triggered the race under mod_wsgi.

The geomap `data` view opened its cursor via `nav.db.getConnection()`,
sharing the process-wide `ObjectCache` across request threads. It now uses
Django's `django.db.connection`, which is thread-local and pooled via
`CONN_MAX_AGE` — the same pattern already used by the report system and 10+
other NAV modules.

Because the geomap queries need a `psycopg2` `DictCursor`, the view reaches
through to the underlying psycopg2 connection (`connection.connection`) and
closes only the cursor; Django owns the connection's lifecycle. The explicit
`set_isolation_level(1)` call is dropped — Django runs in autocommit and
READ COMMITTED is PostgreSQL's default.

The remaining `nav.db` callers are non-web scripts and daemons (snmptrapd,
smsd, logengine, cron bins) that run outside Django's request lifecycle, so
the legacy cache stays in place for them.

## This pull request

* migrates the geomap data view to Django's connection pooling
* removes the last multithreaded web dependency on the legacy `ObjectCache`

## Contributor Checklist

* [x] Added a changelog fragment for towncrier
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation — not applicable; internal implementation change
* [x] Linted/formatted the code with ruff
* [x] Wrote the commit message per the "If applied, this commit will ..." rule (<= 50 char subject)
* [x] Based this pull request on the correct upstream branch (`master`)
* [x] If it's not obvious from a linked issue, described how to observe the effect (geomap integration test `test_geomap_data_should_not_crash` exercises the view end-to-end)
* [ ] If this results in changes in the UI: screenshots — not applicable; no UI changes
* [x] If this adds a new Python source code file: boilerplate header — added to the new test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
