### PR TITLE
Migrate database driver from psycopg2 to psycopg3

### DIFF
--- a/changelog.d/3190.changed.md
+++ b/changelog.d/3190.changed.md
@@ -1,0 +1,1 @@
+Migrated the database driver from psycopg2 (maintenance mode) to psycopg3, using a Django backend that supports PostgreSQL `±infinity` timestamps.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,10 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "asciitree==0.3.3",
+    "psycopg>=3.2",
+    "django-psycopg-infinity",
+    # Transitional: kept until every legacy nav.db caller is migrated to
+    # psycopg3 / django.db; removed in the final migration commit.
     "psycopg2==2.9.10",
     "IPy==1.01",
     "pyaml",

--- a/python/nav/bin/mailin.py
+++ b/python/nav/bin/mailin.py
@@ -29,6 +29,8 @@ from nav.config import find_config_file
 
 bootstrap_django(__file__)
 
+from django.db import connection, transaction
+
 import nav
 import nav.mailin
 from nav import logs
@@ -126,13 +128,13 @@ def read_and_process_input(plugins, test=False):
 def add_mailin_subsystem():
     """Ensure that the 'mailin' subsystem exists in the db"""
 
-    conn = nav.db.getConnection('default', 'manage')
-    cursor = conn.cursor()
-
-    cursor.execute("select * from subsystem where name='mailin'")
-    if cursor.rowcount == 0:
-        cursor.execute("INSERT INTO subsystem (name, descr) VALUES ('mailin', '')")
-    conn.commit()
+    with transaction.atomic():
+        with connection.cursor() as cursor:
+            cursor.execute("select * from subsystem where name='mailin'")
+            if cursor.rowcount == 0:
+                cursor.execute(
+                    "INSERT INTO subsystem (name, descr) VALUES ('mailin', '')"
+                )
 
 
 def load_plugins(paths):

--- a/python/nav/bin/navclean.py
+++ b/python/nav/bin/navclean.py
@@ -46,6 +46,7 @@ def main():
         expiry = args.datetime
 
     cleaned = False
+    db_error = None
     with transaction.atomic():
         cleaners = get_selected_cleaners(args, connection)
         for cleaner in cleaners:
@@ -61,15 +62,22 @@ def main():
                 cleaned = True
 
             except DatabaseError as error:
-                print("The PostgreSQL backend produced an error", file=sys.stderr)
-                print(error, file=sys.stderr)
-                sys.exit(1)
+                # Roll back and bail out, but exit *after* leaving the atomic
+                # block so SystemExit doesn't unwind it on a broken transaction.
+                db_error = error
+                transaction.set_rollback(True)
+                break
 
         # Every run is a dry-run unless --force is given, so roll back all the
         # changes made above unless the user explicitly asked to keep them.
         if not args.force:
             transaction.set_rollback(True)
             cleaned = False
+
+    if db_error is not None:
+        print("The PostgreSQL backend produced an error", file=sys.stderr)
+        print(db_error, file=sys.stderr)
+        sys.exit(1)
 
     if not args.quiet:
         if cleaned:

--- a/python/nav/bin/navclean.py
+++ b/python/nav/bin/navclean.py
@@ -27,7 +27,7 @@ from nav.bootstrap import bootstrap_django
 
 bootstrap_django(__file__)
 
-import psycopg2
+from django.db import connection, transaction, DataError, DatabaseError
 from django.db.transaction import atomic
 from django.contrib.sessions.models import Session
 from django.utils import timezone
@@ -45,41 +45,37 @@ def main():
     elif args.datetime:
         expiry = args.datetime
 
-    connection = nav.db.getConnection('default', 'manage')
-    cleaners = get_selected_cleaners(args, connection)
-
     cleaned = False
-    for cleaner in cleaners:
-        try:
-            count = cleaner.clean(expiry, dry_run=not args.force)
-            if not args.quiet:
-                print(
-                    "Expired {expiry_type} records: {count}".format(
-                        expiry_type=cleaner.expiry_type,
-                        count=count if count is not None else "N/A",
+    with transaction.atomic():
+        cleaners = get_selected_cleaners(args, connection)
+        for cleaner in cleaners:
+            try:
+                count = cleaner.clean(expiry, dry_run=not args.force)
+                if not args.quiet:
+                    print(
+                        "Expired {expiry_type} records: {count}".format(
+                            expiry_type=cleaner.expiry_type,
+                            count=count if count is not None else "N/A",
+                        )
                     )
-                )
-            cleaned = True
+                cleaned = True
 
-        except psycopg2.Error as error:
-            print("The PostgreSQL backend produced an error", file=sys.stderr)
-            print(error, file=sys.stderr)
-            connection.rollback()
-            sys.exit(1)
+            except DatabaseError as error:
+                print("The PostgreSQL backend produced an error", file=sys.stderr)
+                print(error, file=sys.stderr)
+                sys.exit(1)
 
-    if not args.force:
-        connection.rollback()
-        cleaned = False
-    else:
-        connection.commit()
+        # Every run is a dry-run unless --force is given, so roll back all the
+        # changes made above unless the user explicitly asked to keep them.
+        if not args.force:
+            transaction.set_rollback(True)
+            cleaned = False
 
     if not args.quiet:
         if cleaned:
             print("Expired records were updated/deleted.")
         else:
             print("Nothing changed.")
-
-    connection.close()
 
 
 #
@@ -146,14 +142,12 @@ def make_argparser():
 
 def validate_sql(sql, args):
     """Validates than an SQL statement can run without errors"""
-    connection = nav.db.getConnection('default', 'manage')
-    cursor = connection.cursor()
     try:
-        cursor.execute(sql, args)
-    except psycopg2.DataError as error:
+        with transaction.atomic():
+            with connection.cursor() as cursor:
+                cursor.execute(sql, args)
+    except DataError as error:
         raise ValueError(error)
-    finally:
-        connection.rollback()
     return True
 
 

--- a/python/nav/bin/radiusparser.py
+++ b/python/nav/bin/radiusparser.py
@@ -29,7 +29,7 @@ server.  It has been written to not require any NAV libraries.
 It will require psycopg, a PostgreSQL driver for Python.
 """
 
-import psycopg2
+import psycopg
 import sys
 import os
 
@@ -62,16 +62,16 @@ def main(args=None):
 
     try:
         db_params = (dbhost, dbport, dbname, dbuser, dbpasswd)
-        connection = psycopg2.connect(
+        connection = psycopg.connect(
             "host=%s port=%s dbname=%s user=%s password=%s" % db_params
         )
-    except psycopg2.OperationalError as e:
+    except psycopg.OperationalError as e:
         print(
             "An error occured while connecting to the database:\n\n'%s'" % (str(e)[:-1])
         )
         sys.exit(1)
 
-    connection.set_isolation_level(0)
+    connection.autocommit = True
     database = connection.cursor()
 
     # Start "tail -f" on radius_logfile
@@ -158,7 +158,7 @@ def main(args=None):
                     )
                     try:
                         database.execute(sqlQuery, sqlParameters)
-                    except psycopg2.ProgrammingError as e:
+                    except psycopg.ProgrammingError as e:
                         # Write error to log
                         f.write("Query failed:\n")
                         f.write(str(e) + "\n\n\n")

--- a/python/nav/bin/snmptrapd.py
+++ b/python/nav/bin/snmptrapd.py
@@ -32,7 +32,7 @@ from nav.config import NAV_CONFIG, NAVConfigParser
 import nav.buildconf
 from nav.snmptrapd.plugin import load_handler_modules, ModuleLoadError
 from nav.util import is_valid_ip, address_to_string
-from nav.db import getConnection
+from django.db import connection, transaction
 from nav.bootstrap import bootstrap_django
 import nav.logs
 
@@ -127,10 +127,9 @@ def main():
         # Daemonized
         _logger.info('snmptrapd is now running in daemon mode')
 
-        # Reopen lost db connection
-        # This is a workaround for a double free bug in psycopg 2.0.7
-        # which is why we don't need to keep the return value
-        getConnection('default')
+        # We just forked; drop the database connection inherited from the
+        # parent so Django opens a fresh one in this process on next use.
+        connection.close()
 
         # Reopen log files on SIGHUP
         _logger.debug('Adding signal handler for reopening log files on SIGHUP.')
@@ -201,7 +200,6 @@ def trap_handler(trap):
 
     """
     _traplogger.debug("%s", trap)
-    connection = getConnection('default')
     handled_by = []
 
     for mod in handlermodules:
@@ -223,10 +221,6 @@ def trap_handler(trap):
                 mod.__name__,
                 why,
             )
-        # Assuming that the handler used the same connection as this
-        # function, we rollback any uncommitted changes.  This is to
-        # avoid idling in transactions.
-        connection.rollback()
 
     _log_trap_handle_result(handled_by, trap)
 
@@ -253,13 +247,11 @@ def _log_trap_handle_result(handled_by, trap):
 
 def verify_subsystem():
     """Verify that subsystem exists, if not insert it into database"""
-    db = getConnection('default')
-    c = db.cursor()
-
     sql = """INSERT INTO subsystem (SELECT 'snmptrapd', '' WHERE
     NOT EXISTS (SELECT * FROM subsystem WHERE name = 'snmptrapd'))"""
-    c.execute(sql)
-    db.commit()
+    with transaction.atomic():
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
 
 
 def signal_handler(signum, _):

--- a/python/nav/db/__init__.py
+++ b/python/nav/db/__init__.py
@@ -19,6 +19,7 @@ Provides common database functionality for NAV.
 """
 
 import atexit
+from collections import namedtuple
 from functools import wraps
 import logging
 import os
@@ -88,6 +89,41 @@ def escape(string):
     quoted = psycopg2.extensions.QuotedString(string)
     result = quoted.getquoted()
     return result if isinstance(result, str) else result.decode("utf-8")
+
+
+PGNotification = namedtuple("PGNotification", ["channel", "payload"])
+
+
+def get_pg_notifications(connection):
+    """Non-blocking drain of buffered PostgreSQL LISTEN/NOTIFY messages.
+
+    Consumes whatever input is waiting on the psycopg connection's socket and
+    returns the notifications that were buffered. Designed to be driven by a
+    select/reactor loop, mirroring psycopg2's ``poll()`` + ``notifies`` idiom
+    that psycopg3 no longer exposes on the connection object.
+
+    :param connection: A raw psycopg3 connection, e.g.
+                       ``django.db.connection.connection``.
+    :returns: A list of ``PGNotification(channel, payload)`` named tuples.
+    :raises psycopg.OperationalError: If the connection is broken (``consume_input``
+                                      raises on a dropped connection, just as
+                                      psycopg2's ``poll()`` used to).
+    """
+    pgconn = connection.pgconn
+    pgconn.consume_input()
+    notifications = []
+    while True:
+        notify = pgconn.notifies()
+        if notify is None:
+            break
+        channel = notify.relname
+        payload = notify.extra
+        if isinstance(channel, bytes):
+            channel = channel.decode("utf-8")
+        if isinstance(payload, bytes):
+            payload = payload.decode("utf-8")
+        notifications.append(PGNotification(channel, payload))
+    return notifications
 
 
 def get_connection_parameters(script_name='default', database='nav'):

--- a/python/nav/db/__init__.py
+++ b/python/nav/db/__init__.py
@@ -28,6 +28,7 @@ import time
 
 import psycopg2
 import psycopg2.extensions
+from psycopg import sql
 
 import nav
 from nav import config
@@ -81,14 +82,14 @@ class ConnectionObject(nav.CacheableObject):
 
 
 def escape(string):
-    """Escape a string for use in SQL statements.
+    """Escape and quote a string as an SQL literal.
 
-    ..warning:: You should be using parameterized queries if you can!
+    ..warning:: You should be using parameterized queries if you can!  This
+    helper only exists for the rare cases that must embed a literal directly in
+    generated SQL text, such as producing a standalone SQL script.
 
     """
-    quoted = psycopg2.extensions.QuotedString(string)
-    result = quoted.getquoted()
-    return result if isinstance(result, str) else result.decode("utf-8")
+    return sql.Literal(string).as_string()
 
 
 PGNotification = namedtuple("PGNotification", ["channel", "payload"])

--- a/python/nav/django/settings.py
+++ b/python/nav/django/settings.py
@@ -100,7 +100,7 @@ try:
     DATABASES = {
         'default': {
             'NAME': _name,
-            'ENGINE': 'django.db.backends.postgresql',
+            'ENGINE': 'django_psycopg_infinity.backends.postgresql',
             'HOST': _host,
             'PORT': _port,
             'USER': _user,

--- a/python/nav/event.py
+++ b/python/nav/event.py
@@ -16,9 +16,8 @@
 #
 """Simple API to interface with NAVs event queue."""
 
-from django.db import transaction
+from django.db import connection, transaction
 
-import nav.db
 from nav.errors import GeneralException
 
 from nav.models.event import EventType, AlertType
@@ -107,26 +106,20 @@ class Event(dict):
 
 
 class EventQ(object):
-    """Static class to manipulate the event queue"""
+    """Static class to manipulate the event queue.
 
-    @classmethod
-    def _get_connection(cls):
-        conn = nav.db.getConnection('default', 'manage')
-        # Make sure the connection doesn't autocommit: Posting an event
-        # consists of several SQL statements that should go into a single
-        # transaction.
-        conn.set_isolation_level(1)
-        return conn
+    Uses Django's thread-local database connection. Posting an event consists
+    of several SQL statements that must go into a single transaction, so
+    ``post_event`` wraps them in ``transaction.atomic()``.
+    """
 
     @classmethod
     def allocate_id(cls):
         sql = "SELECT NEXTVAL('eventq_eventqid_seq')"
-        conn = cls._get_connection()
-        cursor = conn.cursor()
-        cursor.execute(sql)
-        if cursor.rowcount > 0:
-            return cursor.fetchone()[0]
-        else:
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
+            if cursor.rowcount > 0:
+                return cursor.fetchone()[0]
             raise EventIdAllocationError
 
     @classmethod
@@ -160,23 +153,25 @@ class EventQ(object):
             "INSERT INTO eventq (eventqid, " + field_string + ") "
             "VALUES (%s" + placeholders + ")"
         )
-        eventqid = cls.allocate_id()
-        conn = cls._get_connection()
-        cursor = conn.cursor()
-        cursor.execute(eventsql, (eventqid,) + tuple(values))
 
-        # Prepare an SQL statement to post the variables, if any
-        if event:
-            varsql = "INSERT INTO eventqvar (eventqid, var, val)VALUES (%s, %s, %s)"
-            values = [(eventqid,) + i for i in event.items()]
-            cursor.executemany(varsql, values)
+        # Allocate the id and insert the event (plus its variables) atomically
+        with transaction.atomic():
+            eventqid = cls.allocate_id()
+            with connection.cursor() as cursor:
+                cursor.execute(eventsql, (eventqid,) + tuple(values))
 
-        # If we got this far, commit the transaction and update the event
-        # object with the allocated id
+                # Post the event variables, if any
+                if event:
+                    varsql = (
+                        "INSERT INTO eventqvar (eventqid, var, val)VALUES (%s, %s, %s)"
+                    )
+                    varvalues = [(eventqid,) + i for i in event.items()]
+                    cursor.executemany(varsql, varvalues)
 
-        conn.commit()
+                status = cursor.statusmessage
+
         event.eventqid = eventqid
-        return cursor.statusmessage
+        return status
 
     @classmethod
     def consume_events(cls, target):
@@ -188,39 +183,37 @@ class EventQ(object):
                              subid, time, eventtypeid, state, value, severity
                       FROM eventq
                       WHERE target = %s"""
-        conn = cls._get_connection()
-        conn.commit()
-        cursor = conn.cursor()
-
-        def load_vars(event):
-            varsql = "SELECT var, val FROM eventqvar WHERE eventqid=%s"
-            curs = conn.cursor()
-            curs.execute(varsql, (event.eventqid,))
-            if curs.rowcount > 0:
-                for var, val in curs.fetchmany():
-                    event[var] = val
+        with connection.cursor() as cursor:
+            cursor.execute(eventsql, (target,))
+            rows = cursor.fetchall()
 
         events = []
-        cursor.execute(eventsql, (target,))
-        if cursor.rowcount > 0:
-            for event_row in cursor.fetchall():
-                event = Event()
-                (
-                    event.eventqid,
-                    event.source,
-                    event.target,
-                    event.deviceid,
-                    event.netboxid,
-                    event.subid,
-                    event.time,
-                    event.eventtypeid,
-                    event.state,
-                    event.value,
-                    event.severity,
-                ) = event_row
-                load_vars(event)
-                events.append(event)
+        for event_row in rows:
+            event = Event()
+            (
+                event.eventqid,
+                event.source,
+                event.target,
+                event.deviceid,
+                event.netboxid,
+                event.subid,
+                event.time,
+                event.eventtypeid,
+                event.state,
+                event.value,
+                event.severity,
+            ) = event_row
+            cls._load_vars(event)
+            events.append(event)
         return events
+
+    @classmethod
+    def _load_vars(cls, event):
+        varsql = "SELECT var, val FROM eventqvar WHERE eventqid=%s"
+        with connection.cursor() as cursor:
+            cursor.execute(varsql, (event.eventqid,))
+            for var, val in cursor.fetchall():
+                event[var] = val
 
     @classmethod
     def delete_event(cls, eventqid):
@@ -230,11 +223,9 @@ class EventQ(object):
         processed by its target.
         """
         sql = "DELETE FROM eventq WHERE eventqid = %s"
-        conn = cls._get_connection()
-        cursor = conn.cursor()
-        cursor.execute(sql, (eventqid,))
-        conn.commit()
-        return cursor.statusmessage
+        with connection.cursor() as cursor:
+            cursor.execute(sql, (eventqid,))
+            return cursor.statusmessage
 
 
 class EventIdAllocationError(GeneralException):

--- a/python/nav/eventengine/engine.py
+++ b/python/nav/eventengine/engine.py
@@ -30,7 +30,7 @@ import time
 from functools import wraps
 import errno
 
-from psycopg2 import OperationalError
+from psycopg import OperationalError
 from django.db import connection, DatabaseError, transaction
 
 from nav.eventengine import export
@@ -119,15 +119,14 @@ class EventEngine(object):
                 if err.args[0] != errno.EINTR:
                     raise
             try:
-                conn.poll()
+                notifications = nav.db.get_pg_notifications(conn)
             except OperationalError:
                 connection.connection = None
                 self._listen()
                 return
-            if conn.notifies:
+            if notifications:
                 self._logger.debug("got event notification from database")
                 self._schedule_next_queuecheck()
-                del conn.notifies[:]
         else:
             self._logger.debug("regular sleep for %ss", delay)
             time.sleep(delay)

--- a/python/nav/ipdevpoll/db.py
+++ b/python/nav/ipdevpoll/db.py
@@ -28,8 +28,9 @@ import django.db
 from django.db import transaction
 from django.db.utils import OperationalError as DjangoOperationalError
 from django.db.utils import InterfaceError as DjangoInterfaceError
-from psycopg2 import InterfaceError, OperationalError
+from psycopg import InterfaceError, OperationalError
 
+from nav.db import get_pg_notifications
 from nav.models.event import EventQueue
 
 _logger = logging.getLogger(__name__)
@@ -294,16 +295,14 @@ class PostgresNotifyReader(abstract.FileDescriptor):
                 "check_for_notifications: polling for notifications from %r",
                 threading.current_thread(),
             )
-            connection.poll()
-            if connection.notifies:
-                _logger.debug("Found notifications: %r", connection.notifies)
-                if any(_is_a_new_ipdevpoll_event(c) for c in connection.notifies):
+            notifications = get_pg_notifications(connection)
+            if notifications:
+                _logger.debug("Found notifications: %r", notifications)
+                if any(_is_a_new_ipdevpoll_event(c) for c in notifications):
                     self.schedule_trigger()
-                del connection.notifies[:]
         else:
             _logger.debug(
-                "check_for_notifications: connection was empty in thread %r "
-                "(subscription is in %r)",
+                "check_for_notifications: connection was empty in thread %r",
                 threading.current_thread(),
             )
 

--- a/python/nav/logengine.py
+++ b/python/nav/logengine.py
@@ -52,9 +52,10 @@ from configparser import ConfigParser
 import datetime
 import optparse
 
+from django.db import connection, transaction, Error as DatabaseError
+
 import nav
 import nav.logs
-from nav import db
 from nav import daemon
 from nav.config import find_config_file
 
@@ -289,19 +290,16 @@ def delete_old_messages(config):
     """Delete old messages from db, according to config settings."""
     _logger.debug("Deleting old messages from db")
 
-    conn = db.getConnection('logger', 'logger')
-    cursor = conn.cursor()
-
-    for priority in range(0, 8):
-        if config.get("deletepriority", str(priority)):
-            days = config.getint("deletepriority", str(priority))
-            cursor.execute(
-                "DELETE FROM log_message WHERE newpriority=%s "
-                "AND time < now() - interval %s",
-                (priority, '%d days' % days),
-            )
-
-    conn.commit()
+    with transaction.atomic():
+        with connection.cursor() as cursor:
+            for priority in range(0, 8):
+                if config.get("deletepriority", str(priority)):
+                    days = config.getint("deletepriority", str(priority))
+                    cursor.execute(
+                        "DELETE FROM log_message WHERE newpriority=%s "
+                        "AND time < now() - interval %s",
+                        (priority, '%d days' % days),
+                    )
 
 
 def verify_singleton(quiet=False):
@@ -525,42 +523,39 @@ def add_type(facility, mnemonic, priorityid, types, database):
 def logengine(config, options):
     verify_singleton(options.quiet)
 
-    connection = db.getConnection('logger', 'logger')
-    database = connection.cursor()
-
-    # initial setup of dictionaries
-
-    categories = get_categories(database)
-    origins = get_origins(database)
-    types = get_types(database)
-
     # parse priorityexceptions
     (exceptionorigin, exceptiontype, exceptiontypeorigin) = get_exception_dicts(config)
 
-    # add new records
-    _logger.debug("Reading new log entries")
-    my_parse_and_insert = swallow_all_but_db_exceptions(parse_and_insert)
-    for line in read_log_lines(config):
-        my_parse_and_insert(
-            line,
-            database,
-            categories,
-            origins,
-            types,
-            exceptionorigin,
-            exceptiontype,
-            exceptiontypeorigin,
-        )
+    # All inserts happen in a single transaction that is committed on success
+    # (or rolled back if a database error propagates out of the block).
+    with transaction.atomic():
+        with connection.cursor() as database:
+            # initial setup of dictionaries
+            categories = get_categories(database)
+            origins = get_origins(database)
+            types = get_types(database)
 
-    # Make sure it all sticks
-    connection.commit()
+            # add new records
+            _logger.debug("Reading new log entries")
+            my_parse_and_insert = swallow_all_but_db_exceptions(parse_and_insert)
+            for line in read_log_lines(config):
+                my_parse_and_insert(
+                    line,
+                    database,
+                    categories,
+                    origins,
+                    types,
+                    exceptionorigin,
+                    exceptiontype,
+                    exceptiontypeorigin,
+                )
 
 
 def swallow_all_but_db_exceptions(func):
     def _swallow(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except db.driver.Error:
+        except DatabaseError:
             raise
         except Exception:  # noqa: BLE001
             _logger.exception("Unhandled exception occurred, ignoring.")

--- a/python/nav/pgsync.py
+++ b/python/nav/pgsync.py
@@ -24,7 +24,7 @@ import subprocess
 from textwrap import wrap
 from errno import ENOENT, EACCES
 from pathlib import Path
-import psycopg2
+import psycopg
 
 from nav.db import ConnectionParameters
 from nav.colors import colorize, print_color
@@ -48,7 +48,7 @@ def main():
     sync = Synchronizer('nav.models', options.apply_out_of_order_changes)
     try:
         sync.connect()
-    except psycopg2.OperationalError as err:
+    except psycopg.OperationalError as err:
         die(err)
 
     sync.synchronize()
@@ -294,9 +294,10 @@ class Synchronizer(object):
     def connect(self):
         """Connects the synchronizer to the NAV configured database."""
         dsn = str(self.connect_options)
-        self.connection = psycopg2.connect(dsn)
-        read_committed = 1
-        self.connection.set_isolation_level(read_committed)
+        # psycopg3 connections default to a non-autocommit, READ COMMITTED
+        # transaction, which is what this tool relies on (it commits its DDL
+        # explicitly), so no isolation level needs to be set here.
+        self.connection = psycopg.connect(dsn)
         self.cursor = self.connection.cursor()
 
     def synchronize(self):
@@ -538,7 +539,7 @@ class Synchronizer(object):
         print_color("%-20s " % (filename + ":"), COLOR_CYAN, newline=False)
         try:
             self.cursor.execute(sql)
-        except (psycopg2.DataError, psycopg2.ProgrammingError) as err:
+        except (psycopg.DataError, psycopg.ProgrammingError) as err:
             print_color(str(err) or type(err).__name__, COLOR_RED)
             sys.exit(2)
         else:

--- a/python/nav/smsd/navdbqueue.py
+++ b/python/nav/smsd/navdbqueue.py
@@ -25,8 +25,15 @@ Generally, a phone number is a user and vice versa.
 
 import logging
 import sys
+import time
 
-import nav.db
+from django.db import connection, transaction, ProgrammingError
+from django.db.utils import InterfaceError, OperationalError
+
+_logger = logging.getLogger("nav.smsd.queue")
+
+# Exceptions that suggest the database connection was lost and should be reset
+_DB_LOSS_ERRORS = (OperationalError, InterfaceError)
 
 
 class NAVDBQueue(object):
@@ -55,16 +62,15 @@ class NAVDBQueue(object):
         """
 
         dbconn = self._connect()
-        db = dbconn.cursor()
-
         data = dict(minage=str(minage))
 
         # Test minage
         if minage != '0':
             sql = "SELECT interval %(minage)s"
             try:
-                db.execute(sql, data)
-            except nav.db.driver.ProgrammingError:
+                with dbconn.cursor() as db:
+                    db.execute(sql, data)
+            except ProgrammingError:
                 self.logger.warning(
                     "'autocancel' value (%s) is not valid. "
                     + "Check config for errors.",
@@ -80,10 +86,10 @@ class NAVDBQueue(object):
         # Ignore messages
         sql = """UPDATE smsq SET sent = 'I'
             WHERE sent = 'N' AND time < now() - interval %(minage)s"""
-        db.execute(sql, data)
-        dbconn.commit()
-
-        return db.rowcount
+        with transaction.atomic():
+            with dbconn.cursor() as db:
+                db.execute(sql, data)
+                return db.rowcount
 
     def getusers(self, sent='N'):
         """
@@ -95,18 +101,15 @@ class NAVDBQueue(object):
 
         users = []
         dbconn = self._connect()
-        db = dbconn.cursor()
 
         data = dict(sent=sent)
         sql = """SELECT DISTINCT phone
             FROM smsq
             WHERE sent = %(sent)s
             ORDER BY phone"""
-        db.execute(sql, data)
-        result = db.fetchall()
-        # Rollback so we don't have old open transactions which foobars the
-        # usage of now() in setsentstatus()
-        dbconn.rollback()
+        with dbconn.cursor() as db:
+            db.execute(sql, data)
+            result = db.fetchall()
 
         # Create a simple list without the tuples
         for row in result:
@@ -123,18 +126,15 @@ class NAVDBQueue(object):
         """
 
         dbconn = self._connect()
-        db = dbconn.cursor()
 
         data = dict(phone=user, sent=sent)
         sql = """SELECT id, msg, severity
             FROM smsq
             WHERE phone = %(phone)s AND sent = %(sent)s
             ORDER BY severity ASC, time ASC"""
-        db.execute(sql, data)
-        result = db.fetchall()
-        # Rollback so we don't have old open transactions which foobars the
-        # usage of now() in setsentstatus()
-        dbconn.rollback()
+        with dbconn.cursor() as db:
+            db.execute(sql, data)
+            result = db.fetchall()
 
         return result
 
@@ -147,26 +147,26 @@ class NAVDBQueue(object):
         """
 
         dbconn = self._connect()
-        db = dbconn.cursor()
 
         data = dict(sent=sent)
         sql = """SELECT smsq.id as smsqid, name, msg, time
             FROM smsq
             JOIN account ON (account.id = smsq.accountid)
             WHERE sent = %(sent)s ORDER BY time ASC"""
-        db.execute(sql, data)
+        with dbconn.cursor() as db:
+            db.execute(sql, data)
+            rows = db.fetchall()
 
         result = []
-        for smsqid, name, msg, time in db.fetchall():
+        for smsqid, name, msg, msgtime in rows:
             result.append(
                 dict(
-                    id=smsqid, name=name, msg=msg, time=time.strftime("%Y-%m-%d %H:%M")
+                    id=smsqid,
+                    name=name,
+                    msg=msg,
+                    time=msgtime.strftime("%Y-%m-%d %H:%M"),
                 )
             )
-
-        # Rollback so we don't have old open transactions which foobars the
-        # usage of now() in setsentstatus()
-        dbconn.rollback()
 
         return result
 
@@ -178,7 +178,6 @@ class NAVDBQueue(object):
         """
 
         dbconn = self._connect()
-        db = dbconn.cursor()
 
         if sent == 'Y' or sent == 'I':
             sql = """UPDATE smsq
@@ -190,10 +189,10 @@ class NAVDBQueue(object):
                 WHERE id = %(id)s"""
 
         data = dict(sent=sent, smsid=smsid, id=identifier)
-        db.execute(sql, data)
-        dbconn.commit()
-
-        return db.rowcount
+        with transaction.atomic():
+            with dbconn.cursor() as db:
+                db.execute(sql, data)
+                return db.rowcount
 
     def inserttestmsgs(self, uid, phone, msg):
         """
@@ -203,18 +202,38 @@ class NAVDBQueue(object):
         """
 
         dbconn = self._connect()
-        db = dbconn.cursor()
 
         data = dict(uid=uid, phone=phone, msg=msg)
         sql = """INSERT INTO smsq (accountid, time, phone, msg) VALUES (
                  %(uid)s, now(), %(phone)s, %(msg)s)"""
 
-        db.execute(sql, data)
-        dbconn.commit()
-
-        return db.rowcount
+        with transaction.atomic():
+            with dbconn.cursor() as db:
+                db.execute(sql, data)
+                return db.rowcount
 
     @staticmethod
-    @nav.db.retry_on_db_loss(delay=5)
-    def _connect():
-        return nav.db.getConnection('smsd', 'navprofile')
+    def _connect(retries=3, delay=5):
+        """Return a healthy Django database connection.
+
+        Any connection left unusable by a previous error (e.g. the database
+        server was restarted) is dropped and re-established, retrying a few
+        times before giving up.  This preserves the reconnect behaviour smsd
+        previously got from the legacy nav.db connection cache.
+        """
+        for attempt in range(1, retries + 1):
+            connection.close_if_unusable_or_obsolete()
+            try:
+                connection.ensure_connection()
+                return connection
+            except _DB_LOSS_ERRORS:
+                _logger.error(
+                    "cannot establish db connection, attempt %d of %d",
+                    attempt,
+                    retries,
+                )
+                connection.close()
+                if attempt < retries:
+                    time.sleep(delay)
+                else:
+                    raise

--- a/python/nav/snmptrapd/handlers/handlertemplate.py
+++ b/python/nav/snmptrapd/handlers/handlertemplate.py
@@ -17,17 +17,12 @@
 
 import logging
 import nav.errors
-from nav.db import getConnection
+from django.db import connection, transaction
 from nav.event import Event
 
 
 # Create logger with modulename here
 _logger = logging.getLogger(__name__)
-
-
-# If you need to contact database.
-global db
-db = getConnection('default')
 
 
 def handleTrap(trap, config=None):
@@ -87,8 +82,6 @@ def verifyEventtype():
     database. Should be run when module is imported.
     """
 
-    c = db.cursor()
-
     # NB: Remember to replace the values with the one you need.
 
     sql = """
@@ -106,11 +99,11 @@ def verifyEventtype():
     """
 
     queries = sql.split(';')
-    for q in queries:
-        if len(q.rstrip()) > 0:
-            c.execute(q)
-
-    db.commit()
+    with transaction.atomic():
+        with connection.cursor() as c:
+            for q in queries:
+                if len(q.rstrip()) > 0:
+                    c.execute(q)
 
 
 def initialize():

--- a/python/nav/snmptrapd/handlers/linkupdown.py
+++ b/python/nav/snmptrapd/handlers/linkupdown.py
@@ -21,7 +21,7 @@ network equipment.
 import logging
 import nav.errors
 
-from nav.db import getConnection
+from django.db import connection, transaction, ProgrammingError
 from nav.event import Event
 
 _logger = logging.getLogger('nav.snmptrapd.linkupdown')
@@ -92,16 +92,16 @@ def get_interface_details(netboxid, ifindex):
                  LEFT JOIN module USING (moduleid)
                  WHERE netbox.netboxid=%s AND ifindex = %s"""
     _logger.debug(idquery)
-    cursor = getConnection('default').cursor()
-    try:
-        cursor.execute(idquery, (netboxid, ifindex))
-    except nav.db.driver.ProgrammingError:
-        _logger.exception("Unexpected error when querying database")
-    else:
-        if cursor.rowcount > 0:
-            return cursor.fetchone()
+    with connection.cursor() as cursor:
+        try:
+            cursor.execute(idquery, (netboxid, ifindex))
+        except ProgrammingError:
+            _logger.exception("Unexpected error when querying database")
         else:
-            _logger.debug('Could not find ifindex %s on %s', ifindex, netboxid)
+            if cursor.rowcount > 0:
+                return cursor.fetchone()
+            else:
+                _logger.debug('Could not find ifindex %s on %s', ifindex, netboxid)
 
     return (None, None, None, None, None)
 
@@ -138,9 +138,6 @@ def verify_event_type():
     Safe way of verifying that the event- and alarmtypes exist in the
     database. Should be run when module is imported.
     """
-    connection = getConnection('default')
-    cursor = connection.cursor()
-
     sql = """
     INSERT INTO eventtype (
     SELECT 'linkState','Tells us whether a link is up or down.','y'
@@ -161,11 +158,11 @@ def verify_event_type():
     """
 
     queries = sql.split(';')
-    for query in queries:
-        if query.rstrip():
-            cursor.execute(query)
-
-    connection.commit()
+    with transaction.atomic():
+        with connection.cursor() as cursor:
+            for query in queries:
+                if query.rstrip():
+                    cursor.execute(query)
 
 
 def initialize():

--- a/python/nav/snmptrapd/handlers/ups.py
+++ b/python/nav/snmptrapd/handlers/ups.py
@@ -23,7 +23,7 @@ off battery.
 """
 
 import logging
-from nav.db import getConnection
+from django.db import connection, transaction
 from nav.event import Event
 from nav.Snmp import Snmp
 
@@ -176,9 +176,6 @@ def verifyEventtype():
     database. Should be run when module is imported.
     """
 
-    db = getConnection('default')
-    c = db.cursor()
-
     # NB: Remember to replace the values with the one you need.
 
     sql = """
@@ -199,11 +196,11 @@ def verifyEventtype():
     """
 
     queries = sql.split(';')
-    for q in queries:
-        if q.rstrip():
-            c.execute(q)
-
-    db.commit()
+    with transaction.atomic():
+        with connection.cursor() as c:
+            for q in queries:
+                if q.rstrip():
+                    c.execute(q)
 
 
 def initialize():

--- a/python/nav/snmptrapd/trap.py
+++ b/python/nav/snmptrapd/trap.py
@@ -19,7 +19,7 @@ import string
 import logging
 from collections import namedtuple
 
-from nav.db import getConnection
+from django.db import connection
 
 _logger = logging.getLogger(__name__)
 
@@ -63,24 +63,24 @@ class SNMPTrap(object):
 
     def _lookup_agent(self):
         """Attempts to look up the corresponding netbox of this trap"""
-        conn = getConnection('snmptrapd')
-        cur = conn.cursor()
-        cur.execute(
-            "SELECT DISTINCT netboxid, sysname, roomid "
-            "FROM netbox "
-            "LEFT JOIN interface USING (netboxid) "
-            "LEFT JOIN gwportprefix USING (interfaceid) "
-            "WHERE %s IN (ip, gwip) ",
-            (self.agent,),
-        )
-
-        if cur.rowcount < 1:
-            _logger.warning(
-                "Unable to match trap agent %s to a NAV-monitored device", self.agent
+        with connection.cursor() as cur:
+            cur.execute(
+                "SELECT DISTINCT netboxid, sysname, roomid "
+                "FROM netbox "
+                "LEFT JOIN interface USING (netboxid) "
+                "LEFT JOIN gwportprefix USING (interfaceid) "
+                "WHERE %s IN (ip, gwip) ",
+                (self.agent,),
             )
-            return None
 
-        return AgentNetbox(*cur.fetchone())
+            if cur.rowcount < 1:
+                _logger.warning(
+                    "Unable to match trap agent %s to a NAV-monitored device",
+                    self.agent,
+                )
+                return None
+
+            return AgentNetbox(*cur.fetchone())
 
     @property
     def netbox(self):

--- a/python/nav/statemon/db.py
+++ b/python/nav/statemon/db.py
@@ -31,6 +31,7 @@ import threading
 
 import psycopg
 from psycopg.errors import InFailedSqlTransaction
+from psycopg.types.string import TextLoader
 
 from nav.db import get_connection_string
 from nav.util import synchronized
@@ -78,6 +79,11 @@ class _DB(threading.Thread):
         try:
             conn_str = get_connection_string(script_name='servicemon')
             self.db = psycopg.connect(conn_str)
+            # psycopg3 loads PostgreSQL inet/cidr columns as ipaddress objects
+            # by default, but statemon's callers (e.g. megaping) expect the
+            # plain strings that psycopg2 used to return.
+            self.db.adapters.register_loader("inet", TextLoader)
+            self.db.adapters.register_loader("cidr", TextLoader)
             atexit.register(self.close)
 
             _logger.info("Successfully (re)connected to NAVdb")

--- a/python/nav/statemon/db.py
+++ b/python/nav/statemon/db.py
@@ -122,6 +122,10 @@ class _DB(threading.Thread):
             except InFailedSqlTransaction:
                 _logger.critical("Rolling back aborted transaction...")
                 self.db.rollback()
+        # psycopg2 also inspected InternalError.pgcode here to re-raise unknown
+        # internal errors; psycopg3 splits SQLSTATEs into distinct exception
+        # classes, so any other error simply falls through to the reconnect
+        # path below, which is a safe recovery for genuine connection trouble.
         except Exception:  # noqa: BLE001
             if self.db is not None:
                 _logger.critical(
@@ -159,7 +163,7 @@ class _DB(threading.Thread):
         try:
             cursor = self.cursor()
             cursor.execute(statement, values)
-            _logger.debug("Executed: %s", statement)
+            _logger.debug("Executed: %s %s", statement, values)
             if commit:
                 self.db.commit()
             return cursor.fetchall()
@@ -187,7 +191,7 @@ class _DB(threading.Thread):
         try:
             cursor = self.cursor()
             cursor.execute(statement, values)
-            _logger.debug("Executed: %s", statement)
+            _logger.debug("Executed: %s %s", statement, values)
             if commit:
                 try:
                     self.db.commit()
@@ -197,7 +201,7 @@ class _DB(threading.Thread):
             _logger.critical(
                 "Database integrity error, throwing away update", exc_info=True
             )
-            _logger.debug("Tried to execute: %s", statement)
+            _logger.debug("Tried to execute: %s %s", statement, values)
             if commit:
                 self.db.rollback()
         except Exception:  # noqa: BLE001

--- a/python/nav/statemon/db.py
+++ b/python/nav/statemon/db.py
@@ -31,6 +31,7 @@ import threading
 
 import psycopg
 from psycopg.errors import InFailedSqlTransaction
+from psycopg.types.net import CidrBinaryLoader, InetBinaryLoader
 from psycopg.types.string import TextLoader
 
 from nav.db import get_connection_string
@@ -41,6 +42,25 @@ from .event import Event
 
 
 _logger = logging.getLogger(__name__)
+
+
+class _InetBinaryStrLoader(InetBinaryLoader):
+    """Loads inet columns as plain strings, even over the binary protocol.
+
+    psycopg3's default binary loader returns ipaddress objects; statemon's
+    callers (e.g. megaping) expect the plain strings psycopg2 used to return.
+    """
+
+    def load(self, data):
+        return str(super().load(data))
+
+
+class _CidrBinaryStrLoader(CidrBinaryLoader):
+    """Loads cidr columns as plain strings, even over the binary protocol."""
+
+    def load(self, data):
+        return str(super().load(data))
+
 
 # The event model requires a valid severity value, even though the event engine will
 # always override it when generating alerts. It therefore doesn't matter what value
@@ -81,9 +101,13 @@ class _DB(threading.Thread):
             self.db = psycopg.connect(conn_str)
             # psycopg3 loads PostgreSQL inet/cidr columns as ipaddress objects
             # by default, but statemon's callers (e.g. megaping) expect the
-            # plain strings that psycopg2 used to return.
+            # plain strings that psycopg2 used to return. Loaders are registered
+            # per wire format, so both the text and binary protocols must be
+            # overridden or the binary path leaks ipaddress objects.
             self.db.adapters.register_loader("inet", TextLoader)
             self.db.adapters.register_loader("cidr", TextLoader)
+            self.db.adapters.register_loader("inet", _InetBinaryStrLoader)
+            self.db.adapters.register_loader("cidr", _CidrBinaryStrLoader)
             atexit.register(self.close)
 
             _logger.info("Successfully (re)connected to NAVdb")

--- a/python/nav/statemon/db.py
+++ b/python/nav/statemon/db.py
@@ -29,9 +29,8 @@ import queue
 import time
 import threading
 
-import psycopg2
-from psycopg2.errorcodes import IN_FAILED_SQL_TRANSACTION
-from psycopg2.errorcodes import lookup as pg_err_lookup
+import psycopg
+from psycopg.errors import InFailedSqlTransaction
 
 from nav.db import get_connection_string
 from nav.util import synchronized
@@ -78,12 +77,10 @@ class _DB(threading.Thread):
         """Connects to the NAV database"""
         try:
             conn_str = get_connection_string(script_name='servicemon')
-            self.db = psycopg2.connect(conn_str)
+            self.db = psycopg.connect(conn_str)
             atexit.register(self.close)
 
             _logger.info("Successfully (re)connected to NAVdb")
-            # Set transaction isolation level to READ COMMITTED
-            self.db.set_isolation_level(1)
         except Exception:  # noqa: BLE001
             _logger.critical("Couldn't connect to db.", exc_info=True)
             self.db = None
@@ -93,14 +90,14 @@ class _DB(threading.Thread):
         try:
             if self.db:
                 self.db.close()
-        except psycopg2.InterfaceError:
+        except psycopg.InterfaceError:
             # ignore "already-closed" type errors
             pass
 
     def status(self):
         """Returns 0/1 connection status indicator"""
         try:
-            if self.db.status:
+            if self.db and not self.db.closed:
                 return 1
         except Exception:  # noqa: BLE001
             return 0
@@ -116,19 +113,9 @@ class _DB(threading.Thread):
             try:
                 cursor = self.db.cursor()
                 cursor.execute('SELECT 1')
-            except psycopg2.InternalError as err:
-                if err.pgcode == IN_FAILED_SQL_TRANSACTION:
-                    _logger.critical("Rolling back aborted transaction...")
-                    self.db.rollback()
-                else:
-                    _logger.critical(
-                        "PostgreSQL reported an internal error "
-                        "I don't know how to handle: %s "
-                        "(code=%s)",
-                        pg_err_lookup(err.pgcode),
-                        err.pgcode,
-                    )
-                    raise
+            except InFailedSqlTransaction:
+                _logger.critical("Rolling back aborted transaction...")
+                self.db.rollback()
         except Exception:  # noqa: BLE001
             if self.db is not None:
                 _logger.critical(
@@ -166,14 +153,14 @@ class _DB(threading.Thread):
         try:
             cursor = self.cursor()
             cursor.execute(statement, values)
-            _logger.debug("Executed: %s", cursor.query)
+            _logger.debug("Executed: %s", statement)
             if commit:
                 self.db.commit()
             return cursor.fetchall()
         except Exception:  # noqa: BLE001
             _logger.critical(
                 "Failed to execute query: %s",
-                cursor.query if cursor else statement,
+                statement,
                 exc_info=True,
             )
             if commit:
@@ -194,23 +181,23 @@ class _DB(threading.Thread):
         try:
             cursor = self.cursor()
             cursor.execute(statement, values)
-            _logger.debug("Executed: %s", cursor.query)
+            _logger.debug("Executed: %s", statement)
             if commit:
                 try:
                     self.db.commit()
                 except Exception:  # noqa: BLE001
                     _logger.critical("Failed to commit")
-        except psycopg2.IntegrityError:
+        except psycopg.IntegrityError:
             _logger.critical(
                 "Database integrity error, throwing away update", exc_info=True
             )
-            _logger.debug("Tried to execute: %s", cursor.query)
+            _logger.debug("Tried to execute: %s", statement)
             if commit:
                 self.db.rollback()
         except Exception:  # noqa: BLE001
             _logger.critical(
                 "Could not execute statement: %s",
-                cursor.query if cursor else statement,
+                statement,
                 exc_info=True,
             )
             if commit:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,9 @@
 # Dockerfile
 
 asciitree==0.3.3  # optional, for naventity
-psycopg2==2.9.10  # requires libpq to build
+psycopg>=3.2  # requires libpq to build if not using a wheel
+django-psycopg-infinity  # psycopg3 backend with ±infinity timestamp support
+psycopg2==2.9.10  # transitional, removed once all legacy callers are migrated
 IPy==1.01
 pyaml
 

--- a/tests/integration/statemondb_test.py
+++ b/tests/integration/statemondb_test.py
@@ -6,3 +6,18 @@ from nav.statemon import db
 def test_get_checkers_does_not_raise():
     conn = db.db()
     assert conn.get_checkers(True) is not None
+
+
+def test_when_reading_inet_columns_over_binary_protocol_then_returns_str():
+    """statemon callers expect the plain strings psycopg2 returned, regardless
+    of whether psycopg3 uses the text or the binary wire protocol.
+    """
+    conn = db.db()
+    conn.connect()
+    with conn.db.cursor(binary=True) as cursor:
+        cursor.execute("SELECT '10.0.0.1'::inet, '10.0.0.0/24'::cidr")
+        inet_value, cidr_value = cursor.fetchone()
+    assert inet_value == '10.0.0.1'
+    assert isinstance(inet_value, str)
+    assert cidr_value == '10.0.0.0/24'
+    assert isinstance(cidr_value, str)

--- a/tests/unittests/general/db_test.py
+++ b/tests/unittests/general/db_test.py
@@ -1,0 +1,14 @@
+"""Unit tests for nav.db helper functions."""
+
+from nav.db import escape
+
+
+class TestEscape:
+    def test_it_should_quote_a_plain_string_as_an_sql_literal(self):
+        assert escape("6 months") == "'6 months'"
+
+    def test_it_should_double_embedded_single_quotes(self):
+        assert escape("o'brien") == "'o''brien'"
+
+    def test_it_should_return_a_str(self):
+        assert isinstance(escape("foo"), str)

--- a/tests/unittests/general/logengine_test.py
+++ b/tests/unittests/general/logengine_test.py
@@ -87,13 +87,13 @@ def test_swallow_generic_exceptions():
 
 
 def test_raise_db_exception():
-    from nav.db import driver
+    from django.db import Error
 
     @logengine.swallow_all_but_db_exceptions
     def raiser():
-        raise driver.Error("This is an ex-database")
+        raise Error("This is an ex-database")
 
-    with pytest.raises(driver.Error):
+    with pytest.raises(Error):
         raiser()
 
 


### PR DESCRIPTION
Fixes #3190.

psycopg2 is in maintenance mode; this migrates NAV's database driver to
**psycopg3**. The `±infinity` timestamp blocker (NAV stores unresolved events as
`datetime.max` → `'infinity'`) is solved by the
[`django-psycopg-infinity`](https://pypi.org/project/django-psycopg-infinity/)
backend.

**Strategy (Django-first):** rather than port the legacy `nav.db` connection
cache to the psycopg3 API, migrate its raw callers onto `django.db.connection`
and let Django's psycopg3 backend handle isolation, autocommit, encoding, error
wrapping and pooling. Genuinely-standalone tools (run before/without the ORM)
keep a raw connection with minimal psycopg3 fixes.

## What this PR does

- **Backend:** add `psycopg>=3.2` + `django-psycopg-infinity`; switch the DB
  engine. `psycopg2` is retained **transitionally** (still used by the legacy
  cache callers below) and removed in the follow-up.
- **Django-first callers → `django.db.connection` + `transaction.atomic()`:**
  `event.py`, `logengine.py`, `bin/mailin.py`, `bin/navclean.py`, `snmptrapd`
  (+ handlers), `smsd/navdbqueue.py`.
- **LISTEN/NOTIFY readers** (`ipdevpoll/db.py`, `eventengine/engine.py`): ported
  to psycopg3's `pgconn.notifies()` via a shared `nav.db.get_pg_notifications`
  helper (psycopg3 dropped psycopg2's `poll()` + `.notifies`).
- **`escape()`** reimplemented on psycopg3 `sql.Literal(...).as_string()`.
- **Raw psycopg3 sites** (small fixes, no Django): `pgsync.py`,
  `bin/radiusparser.py`, `statemon/db.py`. statemon registers text loaders for
  `inet`/`cidr` — psycopg3 loads those as `ipaddress` objects by default, which
  broke megaping (it expects the strings psycopg2 returned).

## Deferred to follow-up PRs (avoids overlap)

- **Legacy cache removal** (`getConnection`/`ConnectionObject`/
  `_connection_cache`/`LegacyCleanupMiddleware`) + dropping transitional
  `psycopg2`: separate PR, after the callers still using it land.
- **report/\*** is migrated by #4111; **geomap** by #4113. This PR deliberately
  leaves those files untouched (verified zero conflict with both).

## Testing

- Full unit + integration suite green on py3.11 and py3.13.
- `ruff check` + `ruff format` clean.

Opened as **draft** — incremental; coordinates with #4111 and #4113.
