### PR TITLE
Make the VLAN topology detector LAG-aware

### DIFF
--- a/changelog.d/1687.fixed.md
+++ b/changelog.d/1687.fixed.md
@@ -1,0 +1,1 @@
+Fixed VLAN topology detection dropping detected VLANs from aggregated (LAG) uplinks, e.g. Juniper `ae` interfaces, where the layer-2 topology resolves on the physical member ports while the 802.1q configuration lives on the aggregate above them.

--- a/python/nav/topology/vlan.py
+++ b/python/nav/topology/vlan.py
@@ -50,7 +50,9 @@ class VlanGraphAnalyzer(object):
     def __init__(self):
         self.routed_vlans = self._build_vlan_router_dict()
         self.unrouted_vlans = self._build_unrouted_vlan_seed_dict()
-        self.layer2 = build_layer2_graph()
+        # Preload the allowed-VLAN set (a reverse one-to-one) so the per-edge
+        # trunk checks in the traversal don't each issue their own query.
+        self.layer2 = build_layer2_graph(related_extra=('swport_allowed_vlan',))
         annotate_vlan_bearers(self.layer2)
         self.stp_blocked = get_stp_blocked_ports()
         _logger.debug("blocked ports: %r", self.stp_blocked)

--- a/python/nav/topology/vlan.py
+++ b/python/nav/topology/vlan.py
@@ -30,6 +30,8 @@ from django.db import transaction
 from nav.models.manage import (
     GwPortPrefix,
     Interface,
+    InterfaceAggregate,
+    InterfaceStack,
     SwPortVlan,
     SwPortBlocked,
     Prefix,
@@ -49,6 +51,7 @@ class VlanGraphAnalyzer(object):
         self.routed_vlans = self._build_vlan_router_dict()
         self.unrouted_vlans = self._build_unrouted_vlan_seed_dict()
         self.layer2 = build_layer2_graph()
+        annotate_vlan_bearers(self.layer2)
         self.stp_blocked = get_stp_blocked_ports()
         _logger.debug("blocked ports: %r", self.stp_blocked)
         self.ifc_vlan_map = {}
@@ -226,10 +229,14 @@ class RoutedVlanTopologyAnalyzer(object):
                     self._log_block(next_edge)
 
         if vlan_is_active and ifc:
+            vlan_interface = _vlan_bearing_interface(ifc)
             _logger.debug(
-                "(%s) setting %s direction: %s", self.vlan.vlan, ifc, direction
+                "(%s) setting %s direction: %s",
+                self.vlan.vlan,
+                vlan_interface,
+                direction,
             )
-            self.ifc_directions[ifc] = direction
+            self.ifc_directions[vlan_interface] = direction
 
         return vlan_is_active
 
@@ -258,13 +265,19 @@ class RoutedVlanTopologyAnalyzer(object):
                 return dest, source, list(self.layer2[dest][source].keys())[0]
 
     def _interface_has_been_seen_before(self, ifc):
-        return ifc in self.ifc_directions
+        return _vlan_bearing_interface(ifc) in self.ifc_directions
 
     def _is_vlan_active_on_destination(self, dest, ifc):
         if not ifc:
             return False
 
-        if not ifc.trunk:
+        # The 802.1q configuration (trunk flag, allowed VLANs) is read from the
+        # VLAN-bearing interface -- which, where a vendor splits them across the
+        # LAG hierarchy (e.g. Juniper), can be the aggregate above the edge --
+        # while the topology (`to_interface`) stays on the physical member the
+        # edge is keyed by. Keep them separate: collapsing both onto `ifc` blinds
+        # the traversal to VLANs on such aggregated uplinks.
+        if not _vlan_bearing_interface(ifc).trunk:
             return self._ifc_has_vlan(ifc)
         else:
             non_trunks_on_vlan = dest.interfaces.filter(vlan=self.vlan.vlan).filter(
@@ -283,7 +296,10 @@ class RoutedVlanTopologyAnalyzer(object):
         )
 
     def _ifc_has_vlan(self, ifc):
-        return ifc.vlan == self.vlan.vlan or self._vlan_allowed_on_trunk(ifc)
+        vlan_interface = _vlan_bearing_interface(ifc)
+        return vlan_interface.vlan == self.vlan.vlan or self._vlan_allowed_on_trunk(
+            vlan_interface
+        )
 
     def _vlan_allowed_on_trunk(self, ifc):
         return (
@@ -302,7 +318,9 @@ class RoutedVlanTopologyAnalyzer(object):
     def _is_edge_blocked(self, edge):
         if edge:
             _source, _dest, ifc = edge
-            return self.vlan.vlan in self.stp_blocked.get(ifc.id, [])
+            return self.vlan.vlan in self.stp_blocked.get(
+                _vlan_bearing_interface(ifc).id, []
+            )
         return False
 
     def _log_descent(self, next_edge):
@@ -339,11 +357,11 @@ class RoutedVlanTopologyAnalyzer(object):
 
     def _mark_both_ends_as_blocked(self, edge):
         _source, _dest, source_ifc = edge
-        self.ifc_directions[source_ifc] = 'blocked'
+        self.ifc_directions[_vlan_bearing_interface(source_ifc)] = 'blocked'
         reverse_edge = self._find_reverse_edge(edge)
         if reverse_edge:
             _dest, _source, dest_ifc = reverse_edge
-            self.ifc_directions[dest_ifc] = 'blocked'
+            self.ifc_directions[_vlan_bearing_interface(dest_ifc)] = 'blocked'
 
 
 class UnroutedVlanTopologyAnalyzer(RoutedVlanTopologyAnalyzer):
@@ -478,6 +496,139 @@ def build_layer2_graph(related_extra=None):
         dest = link.to_interface.netbox if link.to_interface else link.to_netbox
         graph.add_edge(link.netbox, dest, key=link)
     return graph
+
+
+def annotate_vlan_bearers(graph: nx.MultiDiGraph) -> None:
+    """Annotates each layer-2 edge interface with its VLAN-bearing interface.
+
+    On some vendors' aggregated uplinks (e.g. Juniper) the resolved neighbor can
+    land on a physical member port while the 802.1q configuration sits on the
+    aggregate above it, so the edge interface itself looks VLAN-less to the
+    analyzer. For every edge interface this attaches a ``_vlan_bearer`` pointing
+    at the nearest interface up the aggregate/stack hierarchy that actually
+    carries VLAN configuration -- or the interface itself when it does.
+    :func:`_vlan_bearing_interface` reads the annotation back.
+
+    The hierarchy is loaded in bulk (two queries for the whole aggregate/stack
+    graph plus one for the ancestor interfaces) and walked in memory; resolving
+    it per interface would issue a query per stack hop and does not scale.
+    """
+    edge_interfaces = {key.pk: key for _u, _v, key in graph.edges(keys=True)}
+    if not edge_interfaces:
+        return
+
+    parents = _build_stack_parent_map()
+    ancestor_pks = set()
+    for pk in edge_interfaces:
+        ancestor_pks |= _ancestors(pk, parents)
+    ancestor_pks -= set(edge_interfaces)
+
+    # The edge interfaces are already loaded as the graph's edge keys; only their
+    # ancestors need fetching. Those are the interfaces a bundle's VLAN config
+    # lives on, so they are loaded with their allowed-VLAN set to spare the
+    # traversal a query per aggregate.
+    config = dict(edge_interfaces)
+    config.update(
+        (interface.pk, interface)
+        for interface in Interface.objects.filter(pk__in=ancestor_pks).select_related(
+            'swport_allowed_vlan'
+        )
+    )
+
+    for pk, interface in edge_interfaces.items():
+        interface._vlan_bearer = config.get(_find_bearer_pk(pk, parents, config))
+
+
+def _build_stack_parent_map() -> dict[int, set[int]]:
+    """Returns a ``{child_pk: {parent_pk, ...}}`` map of the aggregate/stack
+    hierarchy, combining both relations so a bearer can be found regardless of
+    which one a given vendor exposes each layer through.
+    """
+    parents = defaultdict(set)
+    for aggregator, member in InterfaceAggregate.objects.values_list(
+        'aggregator', 'interface'
+    ):
+        parents[member].add(aggregator)
+    for higher, lower in InterfaceStack.objects.values_list('higher', 'lower'):
+        parents[lower].add(higher)
+    return parents
+
+
+def _ancestors(pk: int, parents: dict[int, set[int]]) -> set[int]:
+    """Returns the transitive set of interface pks above ``pk`` in the
+    aggregate/stack hierarchy. The accumulated set doubles as the cycle guard.
+    """
+    seen = set()
+    frontier = set(parents.get(pk, ()))
+    while frontier:
+        seen |= frontier
+        nxt = set()
+        for parent in frontier:
+            nxt |= parents.get(parent, set()) - seen
+        frontier = nxt
+    return seen
+
+
+def _find_bearer_pk(
+    pk: int, parents: dict[int, set[int]], config: dict[int, Interface]
+) -> int:
+    """Returns the pk of the nearest interface at or above ``pk`` that carries
+    VLAN configuration, falling back to ``pk`` itself when none does.
+
+    Walks the hierarchy breadth-first so the layer closest to the edge wins. The
+    config-bearing filter is normally what discriminates -- a Juniper ``ae0``
+    and its logical ``ae0.0`` both bundle the same members, but only ``ae0``
+    holds the 802.1q configuration. The lowest-ifIndex tie-break only settles
+    the rare case where more than one candidate in the same layer carries
+    config; it mirrors the convention already used by
+    :meth:`Interface.get_aggregator`.
+    """
+    visited = set()
+    layer = {pk}
+    while layer:
+        config_bearers = [
+            candidate
+            for candidate in layer
+            if _carries_vlan_config(config.get(candidate))
+        ]
+        if config_bearers:
+            return min(
+                config_bearers,
+                key=lambda candidate: (config[candidate].ifindex, candidate),
+            )
+        visited |= layer
+        next_layer = set()
+        for child in layer:
+            next_layer |= parents.get(child, set()) - visited
+        layer = next_layer
+    return pk
+
+
+def _carries_vlan_config(interface: Interface | None) -> bool:
+    """Returns True if the interface carries VLAN configuration the traversal can
+    act on: a trunk flag or an access VLAN.
+
+    An allowed-VLAN set without the trunk flag is deliberately not counted --
+    :meth:`RoutedVlanTopologyAnalyzer._vlan_allowed_on_trunk` only consults the
+    allowed set on trunks, so such an interface exposes nothing usable and would
+    make a pointless bearer.
+    """
+    return bool(interface and (interface.trunk or interface.vlan is not None))
+
+
+def _vlan_bearing_interface(interface: Interface) -> Interface:
+    """Returns the interface that carries ``interface``'s 802.1q configuration.
+
+    On aggregated (LAG) uplinks the layer-2 topology and the VLAN configuration
+    can live on different layers of the interface hierarchy, depending on the
+    vendor: on Juniper, for instance, the resolved neighbor lands on the
+    physical member port(s) while the ``trunk``/``vlan``/allowed-VLAN data sits
+    on the aggregate above them. The two are bridged by the in-memory
+    ``_vlan_bearer`` annotation :func:`annotate_vlan_bearers` attaches to each
+    layer-2 edge interface. A plain, un-aggregated port carries its own
+    configuration and is its own bearer.
+    """
+    return getattr(interface, '_vlan_bearer', None) or interface
 
 
 def build_layer3_graph(related_extra=None):

--- a/tests/integration/topology/vlan_test.py
+++ b/tests/integration/topology/vlan_test.py
@@ -1,0 +1,85 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License version 3 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Integration tests for LAG-aware VLAN topology detection.
+
+The topology detector records a Juniper aggregate's layer-2 neighbor on the
+physical member ports, two stack layers below the ``ae`` interface, while the
+802.1q configuration lives on the aggregate itself. These tests exercise the
+whole VLAN pass (analyzer + database updater) to prove the two are bridged: the
+detected VLAN lands on the aggregate, never on its physical members.
+"""
+
+from nav.models.manage import SwPortAllowedVlan, SwPortVlan, Vlan
+from nav.topology import vlan as vlan_module
+from nav.topology.vlan import VlanGraphAnalyzer, VlanTopologyUpdater
+
+VLAN_NUMBER = 101
+
+
+def test_when_uplink_is_aggregated_then_the_vlan_should_land_on_the_aggregate(
+    juniper_aggregate_factory, interface_factory
+):
+    topo = _trunked_aggregate_topology(juniper_aggregate_factory, interface_factory)
+
+    _detect_vlan_topology()
+
+    assert SwPortVlan.objects.filter(interface=topo["ae0"]).exists()
+    for member in ("phys2", "phys3", "unit2", "unit3"):
+        assert not SwPortVlan.objects.filter(interface=topo[member]).exists(), (
+            f"{topo[member].ifname} is a LAG member and must carry no swportvlan"
+        )
+
+
+def test_when_bearer_annotation_is_absent_then_the_aggregate_vlan_should_be_lost(
+    juniper_aggregate_factory, interface_factory, monkeypatch
+):
+    """Without the aggregate/stack bridge the analyzer cannot see the VLAN on
+    the member-keyed edge, so the aggregate is dropped. Guards against the fix
+    being silently regressed."""
+    topo = _trunked_aggregate_topology(juniper_aggregate_factory, interface_factory)
+    monkeypatch.setattr(vlan_module, "annotate_vlan_bearers", lambda graph: None)
+
+    _detect_vlan_topology()
+
+    assert not SwPortVlan.objects.filter(interface=topo["ae0"]).exists()
+
+
+def _detect_vlan_topology():
+    analyzer = VlanGraphAnalyzer()
+    analyzer.analyze_all()
+    analyzer.add_access_port_vlans()
+    VlanTopologyUpdater(analyzer.ifc_vlan_map)()
+
+
+def _trunked_aggregate_topology(juniper_aggregate_factory, interface_factory):
+    """Builds the aggregated-uplink scenario: ``ae0`` is a trunk carrying
+    VLAN_NUMBER with its neighbor resolved on the physical members, and the far
+    end has an access port on that VLAN so the DFS sees it as active.
+    """
+    topo = juniper_aggregate_factory()
+
+    topo["ae0"].trunk = True
+    topo["ae0"].save()
+    allowed = SwPortAllowedVlan(interface=topo["ae0"])
+    allowed.set_allowed_vlans([VLAN_NUMBER])
+    allowed.save()
+
+    access_port = interface_factory(topo["dist_a"], "ge-0/0/5", 5)
+    access_port.vlan = VLAN_NUMBER
+    access_port.save()
+
+    Vlan(vlan=VLAN_NUMBER, net_type_id="lan", netbox=topo["sw"]).save()
+    return topo

--- a/tests/unittests/topology/vlan_test.py
+++ b/tests/unittests/topology/vlan_test.py
@@ -1,0 +1,127 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License version 3 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Unit tests for the aggregate/stack VLAN-bearer resolution in topology.vlan"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from nav.topology.vlan import (
+    _ancestors,
+    _carries_vlan_config,
+    _find_bearer_pk,
+)
+
+
+class TestCarriesVlanConfig:
+    def test_when_interface_is_none_then_it_should_return_false(self):
+        assert _carries_vlan_config(None) is False
+
+    def test_when_interface_is_a_trunk_then_it_should_return_true(self):
+        assert _carries_vlan_config(_fake_interface(trunk=True)) is True
+
+    def test_when_interface_has_an_access_vlan_then_it_should_return_true(self):
+        assert _carries_vlan_config(_fake_interface(vlan=42)) is True
+
+    def test_when_interface_has_allowed_vlans_but_no_trunk_then_it_should_return_false(
+        self,
+    ):
+        # An allowed-VLAN set is only usable on a trunk, so on its own it does
+        # not make an interface a VLAN bearer.
+        assert (
+            _carries_vlan_config(_fake_interface(swport_allowed_vlan=object())) is False
+        )
+
+    def test_when_interface_has_no_vlan_config_then_it_should_return_false(self):
+        assert _carries_vlan_config(_fake_interface()) is False
+
+
+class TestAncestors:
+    def test_when_chain_is_linear_then_it_should_return_every_layer_above(self):
+        parents = {1: {2}, 2: {3}}
+        assert _ancestors(1, parents) == {2, 3}
+
+    def test_when_interface_has_no_parents_then_it_should_return_empty_set(self):
+        assert _ancestors(1, {}) == set()
+
+    @pytest.mark.timeout(5)
+    def test_when_hierarchy_has_a_cycle_then_it_should_terminate(self):
+        # The timeout is the real assertion here: a lost cycle guard loops
+        # forever, so without it a regression would hang rather than fail. The
+        # returned set (which includes the seed, reached via the cycle) just
+        # confirms the guard still computes the full closure.
+        parents = {1: {2}, 2: {3}, 3: {1}}
+        assert _ancestors(1, parents) == {1, 2, 3}
+
+
+class TestFindBearerPk:
+    def test_when_port_carries_its_own_config_then_it_should_be_its_own_bearer(self):
+        config = {1: _fake_interface(trunk=True)}
+        assert _find_bearer_pk(1, {}, config) == 1
+
+    def test_when_no_layer_carries_config_then_it_should_fall_back_to_itself(self):
+        parents = {1: {2}, 2: {3}}
+        config = {1: _fake_interface(), 2: _fake_interface(), 3: _fake_interface()}
+        assert _find_bearer_pk(1, parents, config) == 1
+
+    def test_when_config_lives_two_layers_up_then_it_should_resolve_to_that_layer(self):
+        # The Juniper case: physical -> logical unit -> aggregate (trunk config)
+        parents = {1: {2}, 2: {3}}
+        config = {
+            1: _fake_interface(),
+            2: _fake_interface(),
+            3: _fake_interface(trunk=True, ifindex=865),
+        }
+        assert _find_bearer_pk(1, parents, config) == 3
+
+    def test_when_two_layers_carry_config_then_it_should_pick_the_nearer(self):
+        parents = {1: {2}, 2: {3}}
+        config = {
+            1: _fake_interface(),
+            2: _fake_interface(trunk=True),
+            3: _fake_interface(trunk=True),
+        }
+        assert _find_bearer_pk(1, parents, config) == 2
+
+    def test_when_two_ancestors_in_a_layer_carry_config_then_it_should_pick_lowest_ifindex(  # noqa: E501
+        self,
+    ):
+        # ae0 (ifindex 865) and its logical ae0.0 (876) both bundle the members;
+        # only the lower ifIndex actually holds the configuration.
+        parents = {1: {2}, 2: {3, 4}}
+        config = {
+            1: _fake_interface(),
+            2: _fake_interface(),
+            3: _fake_interface(trunk=True, ifindex=876),
+            4: _fake_interface(trunk=True, ifindex=865),
+        }
+        assert _find_bearer_pk(1, parents, config) == 4
+
+
+def _fake_interface(trunk=None, vlan=None, swport_allowed_vlan=None, ifindex=0):
+    """A stand-in Interface for the pure bearer helpers, which only read plain
+    attributes. A SimpleNamespace is chosen over a Mock on purpose: it holds
+    real values, so the ``x or y`` / ``is None`` checks behave as they would on
+    a real Interface, and it raises on any attribute the helper didn't expect
+    rather than silently satisfying the check with a truthy auto-created Mock
+    attribute.
+    """
+    return SimpleNamespace(
+        trunk=trunk,
+        vlan=vlan,
+        swport_allowed_vlan=swport_allowed_vlan,
+        ifindex=ifindex,
+    )


### PR DESCRIPTION
## Scope and purpose

Fixes #1687.

Restores VLAN topology detection across aggregated (LAG) uplinks on Juniper — and on any vendor that stores a link's 802.1q configuration on a different interface layer than where its L2 neighbour resolves. Since the #4029 L2 fix landed on `master`, a combined `navtopology --l2 --vlan` run wipes `swportvlan` data from every aggregate uplink and from every switch reachable only through one. This bridges the split by recording the VLAN on the interface that actually carries the 802.1q config (the aggregate, on Juniper) without writing any L2 topology onto it, so netmap is unaffected and MLAG bundles work (swportvlan is per-interface, not per-link).

See #1687 for the full background. One case is intentionally out of scope — aggregates whose SNMP data omits the `interface_aggregate` membership link (the issue's "Known limitation"); that needs device/SNMP-side investigation and is tracked separately.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] The residual orphaned-aggregate case is documented as a Known limitation in #1687; a follow-up will be filed once the SNMP-side behaviour is understood.
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions) — behaviour and reproduction are covered in #1687 and exercised by the new integration test.
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~ — restores VLAN data rather than changing UI chrome; no meaningful screenshot without a Juniper LAG environment.
* [x] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file
