### PR TITLE
Fix ipdevpoll startup segfault on hosts that forbid W+X memory

### DIFF
--- a/changelog.d/4066.fixed.md
+++ b/changelog.d/4066.fixed.md
@@ -1,0 +1,1 @@
+Fixed `ipdevpoll` crashing shortly after startup on systems that forbid writable-and-executable memory.

--- a/python/nav/daemon.py
+++ b/python/nav/daemon.py
@@ -340,9 +340,16 @@ def daemonize(pidfile, stdin=None, stdout=None, stderr=None):
     try:
         pid = os.fork()
         if pid > 0:
-            # We're the first parent. Exit!
+            # We're the first parent. Exit with os._exit() rather than
+            # sys.exit(): the parent must NOT run the Python interpreter's
+            # shutdown (module teardown and garbage collection). On hosts that
+            # forbid writable-and-executable memory, libffi/ctypes callback
+            # closures are allocated in memory shared across this fork();
+            # finalizing them during interpreter shutdown here would corrupt
+            # them for the surviving daemon, crashing it on the next C callback.
+            # See https://github.com/Uninett/nav/issues/4066
             _logger.debug("First parent exiting. Second has pid %d.", pid)
-            sys.exit(0)
+            os._exit(0)
     except OSError as error:
         _logger.debug("Fork #1 failed. (%s)", error)
         raise ForkError(1, error)
@@ -357,9 +364,10 @@ def daemonize(pidfile, stdin=None, stdout=None, stderr=None):
     try:
         pid = os.fork()
         if pid > 0:
-            # We're the second parent. Exit!
+            # We're the second parent. Exit with os._exit() rather than
+            # sys.exit(), for the same reason as the first fork above (#4066).
             _logger.debug("Second parent exiting. Daemon has pid %d.", pid)
-            sys.exit(0)
+            os._exit(0)
     except OSError as error:
         _logger.exception("Fork #2 failed. (%s)", error)
         raise ForkError(2, error)

--- a/tests/unittests/general/daemon_test.py
+++ b/tests/unittests/general/daemon_test.py
@@ -5,7 +5,7 @@ import errno
 import pytest
 from mock import patch
 
-from nav.daemon import daemonexit, PidFileWriteError
+from nav.daemon import daemonexit, daemonize, PidFileWriteError
 
 
 def test_daemonexit_should_pass_on_unexpected_exceptions():
@@ -30,7 +30,54 @@ def test_daemonexit_should_raise_pidfilewriteerror_on_other_os_errors():
             daemonexit(random_filename())
 
 
+class TestDaemonizeForkParentExit:
+    """The two intermediate fork parents in daemonize() must terminate with
+    os._exit(), never sys.exit(). Running the Python interpreter's shutdown
+    (module teardown and garbage collection) in a fork parent finalizes
+    libffi/ctypes callback closures that, on hosts forbidding
+    writable-and-executable memory, live in memory shared across the fork --
+    corrupting them for the surviving daemon and crashing it (issue #4066).
+    """
+
+    @pytest.mark.parametrize(
+        "fork_results",
+        [
+            pytest.param([111], id="first_parent"),
+            pytest.param([0, 222], id="second_parent"),
+        ],
+    )
+    def test_when_a_fork_parent_then_daemonize_should_exit_via_os_exit(
+        self, fork_results
+    ):
+        # fork_results drives os.fork(): [111] makes the first fork the parent;
+        # [0, 222] makes the first fork the child and the second fork the parent.
+        with (
+            patch('nav.daemon.pidfile_path', return_value='pidfile'),
+            patch('os.fork', side_effect=fork_results),
+            patch('os.chdir'),
+            patch('os.umask'),
+            patch('os.setsid'),
+            patch('sys.exit', side_effect=_SysExitReached) as sys_exit,
+            patch('os._exit', side_effect=_OsExitReached) as os_exit,
+        ):
+            with pytest.raises(_OsExitReached):
+                daemonize('pidfile')
+
+        os_exit.assert_called_once_with(0)
+        sys_exit.assert_not_called()
+
+
 # Helper functions
+
+
+class _OsExitReached(Exception):
+    """Raised by a mocked os._exit() to halt daemonize() at the intended
+    exit point (the real os._exit() never returns)."""
+
+
+class _SysExitReached(Exception):
+    """Raised by a mocked sys.exit(); reaching it means the buggy
+    interpreter-shutdown exit path was taken instead of os._exit()."""
 
 
 def random_filename():


### PR DESCRIPTION
## Scope and purpose

Closes #4066.

On hosts that forbid writable-and-executable memory, `ipdevpolld` segfaults a few seconds after starting, while the exact same binary run in the foreground (`ipdevpolld -f`) runs indefinitely. The core dump shows the crash is a corrupted `libffi`/`ctypes` callback trampoline: net-snmp invokes pynetsnmp's Python callback and jumps into a trampoline whose backing memory has been freed underneath it.

The trigger is the double fork in `daemonize()`. Its two intermediate parent processes exited via `sys.exit(0)`, which raises `SystemExit` and runs the full Python interpreter shutdown, finalizing the `ctypes` closures (`ffi_closure_free()`). Under a W^X memory policy, `libffi` allocates those closures in memory shared across the fork, so freeing them in an exiting parent corrupts the very pages the surviving daemon still relies on — and the next callback from C jumps through a wrecked trampoline. Exiting the fork parents with `os._exit(0)` skips interpreter shutdown, leaves the closures intact for the daemon, and is the canonical double-fork idiom anyway ([daemon.py#L343-L352](https://github.com/Uninett/nav/blob/b5b2298c52c5be40485abf7ec0cc71cd11b2b999/python/nav/daemon.py#L343-L352)).

Only `ipdevpoll` has been observed to hit this, because of its net-snmp integration via pynetsnmp, which sets up `ctypes` callback closures at import time (before the fork). The only other NAV daemon with that same integration is `snmptrapd` (when configured with its pynetsnmp trap-agent backend), which could in principle be affected under the same conditions. The fix is in the shared `daemonize()` helper, so it covers any daemon that holds such closures.

Reproduced in a Debian 13 container (matching `libffi8` 3.4.8 / Python 3.13) under a seccomp policy that denies writable+executable mappings: with `sys.exit(0)` a forked child dies the instant C code calls the closure; with `os._exit(0)` it survives. The added unit test asserts the invariant directly — both fork parents must terminate via `os._exit()`, never `sys.exit()` — and fails on the pre-fix code.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: no further `5.18.x` release is planned, so this bugfix targets `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the boilerplate header to that file~~
