### PR TITLE
Pin junos-eznc to unbreak IPv6-homed Juniper devices

### DIFF
--- a/changelog.d/4119.fixed.md
+++ b/changelog.d/4119.fixed.md
@@ -1,0 +1,1 @@
+Pinned `junos-eznc` below 2.8.1 to keep PortAdmin and SeedDB working for IPv6-addressed Juniper devices, until napalm brackets IPv6 hosts.

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,9 @@
 # Bound the transitive paramiko range so pip-compile's backtracking resolver
 # doesn't enumerate versions across napalm/junos-eznc/ncclient/netmiko.
 paramiko>=4,<5
+
+# junos-eznc 2.8.1 added hostname validation that rejects bare IPv6 literals,
+# but napalm's junos driver hands them the device IP unbracketed. This breaks
+# PortAdmin and SeedDB for IPv6-addressed Juniper devices. Pin below the
+# offending release until napalm's junos driver brackets IPv6 hosts. See #4119.
+junos-eznc<2.8.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,3 +222,7 @@ showcontent = true
 exclude-newer = "1 week"
 # pynetsnmp-2 is our own package
 exclude-newer-package = { pynetsnmp-2 = false }
+# uv sync/lock ignore constraints.txt (only the pip interface reads it), so the
+# junos-eznc pin from constraints.txt is repeated here to protect uv-based dev
+# environments too. Keep the two in sync. See #4119.
+constraint-dependencies = ["junos-eznc<2.8.1"]

--- a/tests/unittests/napalm_test.py
+++ b/tests/unittests/napalm_test.py
@@ -17,6 +17,8 @@
 import pytest
 from unittest.mock import Mock
 
+import napalm
+
 from nav.models import manage
 from nav.napalm import connect, NapalmError
 
@@ -64,3 +66,20 @@ class TestNapalm:
         profile_mock.configuration = {}
         with pytest.raises(NapalmError):
             connect(host=netbox_mock, profile=profile_mock)
+
+
+def test_when_hostname_is_a_bare_ipv6_address_then_the_junos_driver_should_accept_it():
+    """Regression test for #4119.
+
+    junos-eznc 2.8.1 started rejecting unbracketed IPv6 literals as the host
+    value, while napalm's junos driver hands them the device IP verbatim. NAV
+    always hands bare IP addresses to the Napalm driver, so constructing the junos
+    driver with one must not raise. Construction is where the driver builds the
+    jnpr.junos.Device and PyEZ validates the host; no network I/O happens until
+    open(), so this stays a pure unit test.
+    """
+    junos_driver = napalm.get_network_driver("junos")
+
+    device = junos_driver(hostname="2001:db8::1", username="admin", password="x")
+
+    assert device.hostname == "2001:db8::1"


### PR DESCRIPTION
## Scope and purpose

Fixes #4119.

`junos-eznc` 2.8.1 started rejecting unbracketed IPv6 literals as the host value, while napalm's junos driver still passes them through unbracketed — breaking PortAdmin and the SeedDB connectivity check for IPv6-homed Juniper devices. This pins `junos-eznc<2.8.1` until napalm's junos driver is fixed upstream.

The pin is repeated in two places because they feed different resolvers: `constraints.txt` covers the pip interface (and the Debian build), while the `[tool.uv] constraint-dependencies` entry covers `uv sync`/`uv lock`, which ignore `constraints.txt`.

### This pull request
* changes a dependency

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~
