### PR TITLE
Fix invalid shipped OIDC authentication.toml example

### DIFF
--- a/changelog.d/4121.fixed.md
+++ b/changelog.d/4121.fixed.md
@@ -1,0 +1,1 @@
+Fixed the shipped OIDC authentication.toml example, which was rejected by config validation; OIDC providers now accept an entry-level `scope` setting like social providers do.

--- a/doc/reference/social-account.rst
+++ b/doc/reference/social-account.rst
@@ -119,6 +119,7 @@ Overview of settings:
    client_id = "your.service.id" # Get from idp
    secret = "your.service.secret" # Get from idp
    server_url = "https://my.server.example.com"
+   # scope = ["openid", "profile", "email"]  # optional; these are the defaults
 
    # [oidc.idps.some-unique-id.settings]  # optional settings
    # Optional PKCE defaults False, but may be required by
@@ -136,8 +137,6 @@ Overview of settings:
    # If omitted, a method from the the server's
    # token auth methods list is used
    # token_auth_method = client_secret_basic
-   #
-   # scope = [],
    #
    # The field to be used as the account ID. Might depend on scope
    # uid_field = "sub"
@@ -177,11 +176,11 @@ Using Feide OIDC (aka. dataporten) as an example
    client_id = "your.service.id"  # Get from your Feide admin
    secret = "your.service.secret"  # Get from your Feide admin
    server_url = "https://auth.dataporten.no/"
+   scope = ["userid-feide"]  # Feide does not support the standard OIDC scopes
 
    # optional settings but needed for Feide OIDC
    [oidc.idps.dataporten-oidc.settings]
    uid_field = "https://n.feide.no/claims/eduPersonPrincipalName"
-   scope = ["userid-feide"]
 
 Just like when using a provider app you get the client id and secret from
 `Feide Kundeportal <https://kunde.feide.no>`_, and you need to add the redirect

--- a/python/nav/etc/webfront/authentication.toml
+++ b/python/nav/etc/webfront/authentication.toml
@@ -41,8 +41,7 @@ enabled = false
 # client_id = "not.optional"
 # secret = "not.optional"
 # server_url = "https://auth.dataporten.no/"  # NEVER optional
-# Feide OIDC does not support the standard OIDC scopes/claims
-# scope = ["userid-feide"]
+# scope = ["userid-feide"]  # Feide does not support the standard OIDC scopes
 
-# [oidc.dataporten-oidc.settings]
+# [oidc.idps.dataporten-oidc.settings]
 # uid_field = "https://n.feide.no/claims/eduPersonPrincipalName"

--- a/python/nav/web/auth/allauth/__init__.py
+++ b/python/nav/web/auth/allauth/__init__.py
@@ -200,7 +200,7 @@ class OIDCConfigParser(SocialProviderHelper, TOMLConfigParser):
     Feide OIDC does not support the standard OIDC scopes/claims
     scope = ["userid-feide"]  # Other idps have "profile" for this
 
-    [oidc.dataporten-oidc.settings]
+    [oidc.idps.dataporten-oidc.settings]
     uid_field = "https://n.feide.no/claims/eduPersonPrincipalName"
     """
 

--- a/python/nav/web/auth/allauth/models.py
+++ b/python/nav/web/auth/allauth/models.py
@@ -166,6 +166,7 @@ class OIDCProviderEntry(BaseModel):
     client_id: str
     secret: str
     server_url: str
+    scope: list[str] = []
     settings: OIDCProviderSettings = OIDCProviderSettings()
 
 
@@ -188,6 +189,10 @@ class OIDCConfig(BaseModel):
             }
             # Pass through any extra provider-specific settings
             settings.update(entry.settings.model_extra)
+            # Entry-level scope (the documented spelling) wins over any scope
+            # smuggled in through the settings passthrough above.
+            if entry.scope:
+                settings["scope"] = entry.scope
 
             app: dict[str, Any] = {
                 "provider_id": provider_id,

--- a/python/nav/web/auth/allauth/models.py
+++ b/python/nav/web/auth/allauth/models.py
@@ -166,6 +166,7 @@ class OIDCProviderEntry(BaseModel):
     client_id: str
     secret: str
     server_url: str
+    scope: list[str] = []
     settings: OIDCProviderSettings = OIDCProviderSettings()
 
 
@@ -188,6 +189,10 @@ class OIDCConfig(BaseModel):
             }
             # Pass through any extra provider-specific settings
             settings.update(entry.settings.model_extra)
+            # Entry-level scope (the documented level) wins over any scope
+            # smuggled in through the settings passthrough above.
+            if entry.scope:
+                settings["scope"] = entry.scope
 
             app: dict[str, Any] = {
                 "provider_id": provider_id,

--- a/tests/unittests/web/auth/allauth_models_test.py
+++ b/tests/unittests/web/auth/allauth_models_test.py
@@ -1,6 +1,8 @@
 """Tests for Pydantic-based authentication config models."""
 
+import re
 import tomllib
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -272,6 +274,40 @@ foo = 1
         settings = result["openid_connect"]["APPS"][0]["settings"]
         assert settings["scope"] == ["openid", "email"]
 
+    def test_when_entry_level_scope_set_then_generate_should_route_it_into_settings(
+        self,
+    ):
+        config_string = """
+[idps.dataporten-oidc]
+name = "Feide OIDC"
+client_id = "id"
+secret = "sec"
+server_url = "https://auth.dataporten.no/"
+scope = ["userid-feide"]
+"""
+        raw = tomllib.loads(config_string)
+        oc = OIDCConfig.model_validate(raw)
+        result = oc.generate_SOCIALACCOUNT_PROVIDERS()
+        settings = result["openid_connect"]["APPS"][0]["settings"]
+        assert settings["scope"] == ["userid-feide"]
+
+    def test_when_scope_set_both_places_then_generate_should_prefer_entry_level(self):
+        oc = OIDCConfig(
+            idps={
+                "test": OIDCProviderEntry(
+                    name="Test",
+                    client_id="id",
+                    secret="sec",
+                    server_url="https://example.com",
+                    scope=["userid-feide"],
+                    settings=OIDCProviderSettings(scope=["openid", "email"]),
+                ),
+            },
+        )
+        result = oc.generate_SOCIALACCOUNT_PROVIDERS()
+        settings = result["openid_connect"]["APPS"][0]["settings"]
+        assert settings["scope"] == ["userid-feide"]
+
 
 class TestAuthenticationConfig:
     def test_when_defaults_then_all_sections_should_have_defaults(self):
@@ -344,3 +380,46 @@ bogus-key = true
         ):
             with pytest.raises(ValidationError):
                 read_authentication_config()
+
+
+class TestShippedExampleConfig:
+    """Regression tests for the bundled ``etc/webfront/authentication.toml``.
+
+    The core demand of issue #4121 is that the shipped example must validate as
+    written; these guard against it drifting back into a form the config models
+    reject.
+    """
+
+    def test_when_examples_enabled_then_shipped_config_should_validate(self):
+        raw = tomllib.loads(_enable_shipped_examples())
+        config = AuthenticationConfig.model_validate(raw)
+
+        oidc_app = config.oidc.generate_SOCIALACCOUNT_PROVIDERS()["openid_connect"][
+            "APPS"
+        ][0]
+        assert oidc_app["settings"]["scope"] == ["userid-feide"]
+
+        github = config.social.generate_SOCIALACCOUNT_PROVIDERS()["github"]
+        assert github["SCOPE"] == ["user:email"]
+
+
+def _enable_shipped_examples() -> str:
+    """Return the bundled ``authentication.toml`` with its examples enabled.
+
+    The shipped file interleaves prose comments with commented-out TOML. This
+    strips one leading ``#`` from every line and keeps only the lines that then
+    read as TOML — table headers or ``key = value`` assignments — reconstructing
+    a fully-enabled config to validate.
+    """
+    import nav
+
+    path = Path(nav.__file__).parent / "etc" / "webfront" / "authentication.toml"
+    is_toml = re.compile(r"^(\[.*\]|[A-Za-z0-9_.-]+\s*=)")
+    lines = []
+    for line in path.read_text().splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            stripped = stripped[1:].lstrip()
+        if is_toml.match(stripped):
+            lines.append(stripped)
+    return "\n".join(lines)


### PR DESCRIPTION
## Scope and purpose

Fixes #4121.

The OIDC example shipped in `webfront/authentication.toml` no longer validated against the Pydantic config models introduced in #4025, so a user who copied it hit a `ValidationError` and NAV refused to start. Two things were wrong: `scope` was documented at the IdP entry level, which `OIDCProviderEntry` rejected (`extra="forbid"`), and the settings section was mis-spelled `[oidc.dataporten-oidc.settings]`, missing the `.idps.` segment.

Rather than force `scope` into the `[...settings]` sub-table, this restores it as a first-class entry-level field on OIDC providers — matching how social providers already expose [`scope`](https://github.com/Uninett/nav/blob/6545ed38bf68400086f3d4b024ae1597b1d9e580/python/nav/web/auth/allauth/models.py#L110) — and [routes it](https://github.com/Uninett/nav/blob/6545ed38bf68400086f3d4b024ae1597b1d9e580/python/nav/web/auth/allauth/models.py#L193-L195) into allauth's per-APP `settings`, where the openid_connect provider reads it. Entry-level scope takes precedence over any value passed through the settings passthrough. The shipped example and the reference docs are corrected to match, and a regression test now enables the bundled example and asserts the whole file validates.

A reviewer can observe the effect by uncommenting the OIDC example block in `python/nav/etc/webfront/authentication.toml` and starting NAV: before this change it raises a `ValidationError` at startup, after it loads cleanly.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~
