### PR TITLE
Survive database reboot in legacy DB cleanup

### DIFF
--- a/changelog.d/4128.fixed.md
+++ b/changelog.d/4128.fixed.md
@@ -1,0 +1,1 @@
+Legacy connection cleanup no longer raises an HTTP 500 when a cached database connection was killed out-of-band, e.g. by a database server reboot.

--- a/python/nav/django/legacy.py
+++ b/python/nav/django/legacy.py
@@ -15,6 +15,8 @@
 #
 """Various functionality to bridge legacy NAV code with Django"""
 
+import psycopg2
+
 from django.utils.deprecation import MiddlewareMixin
 
 from nav import db
@@ -33,6 +35,16 @@ class LegacyCleanupMiddleware(MiddlewareMixin):
         """
         connections = (v.object for v in db._connection_cache.values())
         for conn in connections:
-            conn.rollback()
+            try:
+                conn.rollback()
+            except psycopg2.Error:
+                # The cached connection may have died out-of-band during the
+                # request (database reboot, server-side termination, network
+                # drop) after getConnection() last validated it. psycopg2 does
+                # not flag such a connection as closed until the failing I/O, so
+                # the rollback here is what raises. Swallow it so cleanup does
+                # not turn into an HTTP 500; getConnection() validates and
+                # replaces the dead connection on the next request.
+                pass
 
         return response

--- a/tests/integration/legacy_reboot_test.py
+++ b/tests/integration/legacy_reboot_test.py
@@ -1,0 +1,82 @@
+#
+# Copyright (C) 2026 Uninett AS
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.  You should have received a copy of the GNU General Public
+# License along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Integration tests for legacy DB cleanup surviving a PostgreSQL reboot.
+
+Rebooting the database server (which happens in production from time to time)
+terminates every backend, so any legacy connection cached in
+``nav.db._connection_cache`` becomes dead. ``LegacyCleanupMiddleware`` rolls
+back every cached connection on each response; rolling back a dead connection
+must not turn request cleanup into an HTTP 500.
+"""
+
+import psycopg2
+import pytest
+
+import nav.db
+from nav.db import (
+    get_connection_parameters,
+    get_connection_string,
+    getConnection,
+)
+from nav.django.legacy import LegacyCleanupMiddleware
+
+
+@pytest.fixture
+def admin_connection():
+    """A separate connection used to terminate the cached backend."""
+    conn = psycopg2.connect(get_connection_string(get_connection_parameters('default')))
+    conn.autocommit = True
+    yield conn
+    conn.close()
+
+
+def _kill_backend(admin_conn, pid):
+    """Terminate the given backend, as a server reboot would."""
+    with admin_conn.cursor() as cur:
+        cur.execute("SELECT pg_terminate_backend(%s)", (pid,))
+
+
+class TestLegacyCleanupAfterDatabaseReboot:
+    def test_when_reboot_kills_backend_then_connection_is_not_yet_marked_closed(
+        self, db, admin_connection
+    ):
+        """psycopg2 does not flag a connection closed until the next I/O.
+
+        This documents why a plain ``if conn.closed`` guard in the middleware is
+        not enough: right after the reboot the dead connection still looks open.
+        """
+        conn = getConnection('default')
+        with conn.cursor() as cur:
+            cur.execute("SELECT 1")
+
+        _kill_backend(admin_connection, conn.get_backend_pid())
+
+        assert conn.closed == 0
+
+    def test_cleanup_should_not_raise_when_cached_connection_died_in_reboot(
+        self, db, admin_connection
+    ):
+        conn = getConnection('default')
+        with conn.cursor() as cur:
+            cur.execute("SELECT 1")
+        assert conn in [obj.object for obj in nav.db._connection_cache.values()]
+
+        _kill_backend(admin_connection, conn.get_backend_pid())
+
+        middleware = LegacyCleanupMiddleware(get_response=lambda request: request)
+        response = object()
+        # Must not raise even though the cached connection is now dead
+        assert middleware.process_response(None, response) is response

--- a/tests/unittests/general/legacy_cleanup_test.py
+++ b/tests/unittests/general/legacy_cleanup_test.py
@@ -1,0 +1,63 @@
+#
+# Copyright (C) 2026 Uninett AS
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.  You should have received a copy of the GNU General Public
+# License along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Tests for legacy database connection cleanup"""
+
+from unittest.mock import MagicMock, patch
+
+import psycopg2
+
+from nav import db
+from nav.db import ConnectionObject
+from nav.django.legacy import LegacyCleanupMiddleware
+
+
+def _cache_with(*connections):
+    """Builds an ObjectCache-like dict of ConnectionObjects wrapping the given
+    mock connections.
+    """
+    cache = {}
+    for i, conn in enumerate(connections):
+        cache[i] = ConnectionObject(conn, key=i)
+    return cache
+
+
+class TestLegacyCleanupMiddleware:
+    def test_when_rollback_fails_on_dead_connection_then_cleanup_should_not_raise(
+        self,
+    ):
+        # A connection killed out-of-band (e.g. a database reboot) raises on
+        # rollback rather than being flagged as closed beforehand.
+        dead = MagicMock()
+        dead.rollback.side_effect = psycopg2.OperationalError(
+            "server closed the connection unexpectedly"
+        )
+
+        with patch.object(db, '_connection_cache', _cache_with(dead)):
+            middleware = LegacyCleanupMiddleware(get_response=MagicMock())
+            response = MagicMock()
+            # Must not raise even though rollback() fails
+            assert middleware.process_response(None, response) is response
+
+        dead.rollback.assert_called_once()
+
+    def test_when_cached_connection_is_healthy_then_it_should_be_rolled_back(self):
+        healthy = MagicMock()
+
+        with patch.object(db, '_connection_cache', _cache_with(healthy)):
+            middleware = LegacyCleanupMiddleware(get_response=MagicMock())
+            middleware.process_response(None, MagicMock())
+
+        healthy.rollback.assert_called_once()


### PR DESCRIPTION
## Scope and purpose

Fixes #4128.

`LegacyCleanupMiddleware` rolls back every cached legacy connection at the end of
each request. When the PostgreSQL server reboots (or a backend is otherwise
terminated out-of-band) mid-request, the cached connection dies after
`getConnection()` last validated it. psycopg2 does not flag such a connection as
closed until the next I/O, so the `rollback()` in cleanup is what fails, raising
`psycopg2.OperationalError` and turning request cleanup into an HTTP 500.

This PR wraps the rollback in a `try/except psycopg2.Error`, so a dead cached
connection no longer breaks the response; `getConnection()` validates and
replaces it on the next request.

Split out from #4111 (issue #4104) as a separable fix, per review feedback.

### How to observe

Terminate the cached connection's backend after it has been used, then trigger a
response so the middleware runs. The included integration test does exactly this
via `pg_terminate_backend`, reproducing the pre-fix HTTP 500.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation — not applicable, internal bugfix
* [x] Linted/formatted the code with ruff
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ..."
* [x] Based this pull request on the correct upstream branch (`5.19.x`, a bugfix affecting the latest stable version)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely — not applicable, fully fixed
* [x] If it's not obvious from a linked issue, described how to interact with NAV to observe the effects (see above)
* [ ] If this results in changes in the UI: Added screenshots — not applicable, no UI change
* [x] If this adds a new Python source code file: Added the boilerplate header (both new test files have it)
