### PR TITLE
Move report queries onto Django's DB connection

### DIFF
--- a/changelog.d/4130.fixed.md
+++ b/changelog.d/4130.fixed.md
@@ -1,0 +1,1 @@
+The report subsystem now reads through Django's thread-local database connection instead of the non-thread-safe legacy connection cache, avoiding connection leaks and intermittent HTTP 500s under mod_wsgi's multithreaded workers.

--- a/python/nav/report/IPtree.py
+++ b/python/nav/report/IPtree.py
@@ -17,7 +17,9 @@
 """Builds and represents IP nets in a tree structure."""
 
 from copy import deepcopy
-from nav import db
+
+from django.db import connection
+
 from nav.ip import IP
 from nav.report.IPtools import getMask, sort_nets_by_prefixlength, andIpMask
 
@@ -101,9 +103,9 @@ def get_subnets(network, min_length=None):
           AND masklen(netaddr) < %s
     """
     args = (network.version(), str(network), min_length, max_length)
-    db_cursor = db.getConnection('default').cursor()
-    db_cursor.execute(sql.strip(), args)
-    db_result = db_cursor.fetchall()
+    with connection.cursor() as cursor:
+        cursor.execute(sql.strip(), args)
+        db_result = cursor.fetchall()
     return [IP(i[0]) for i in db_result]
 
 

--- a/python/nav/report/dbresult.py
+++ b/python/nav/report/dbresult.py
@@ -15,9 +15,8 @@
 #
 """Represents the meta information and result from a database query."""
 
-import psycopg2
-
-from nav import db
+from django.db import connection
+from django.db.utils import DataError, ProgrammingError
 
 
 class DatabaseResult(object):
@@ -37,32 +36,30 @@ class DatabaseResult(object):
         self.error = ""
         self.hidden = []
 
-        connection = db.getConnection('default')
-        cursor = connection.cursor()
-
         self.sql, self.parameters = report_config.make_sql()
 
         # Make a dictionary of which columns to summarize
         self.sums = {sum_key: '' for sum_key in report_config.sum}
 
         try:
-            cursor.execute(self.sql, self.parameters or None)
-            self.result = cursor.fetchall()
+            with connection.cursor() as cursor:
+                cursor.execute(self.sql, self.parameters or None)
+                self.result = cursor.fetchall()
 
-            # A list of the column headers.
-            report_config.sql_select = [col.name for col in cursor.description]
+                # A list of the column headers.
+                report_config.sql_select = [col.name for col in cursor.description]
 
-            # Total count of the rows returned.
-            self.rowcount = len(self.result)
+                # Total count of the rows returned.
+                self.rowcount = len(self.result)
 
-        except psycopg2.ProgrammingError as error:
+        except ProgrammingError as error:
             self.error = (
                 "There was an unhandled SQL error! There may be "
                 "something wrong with the definition of the '{}' "
                 "report: {}".format(report_config.title, error)
             )
 
-        except psycopg2.DataError as error:
+        except DataError as error:
             self.error = (
                 "Data error! Some of your input data is of an invalid type: {}".format(
                     error

--- a/python/nav/report/metaIP.py
+++ b/python/nav/report/metaIP.py
@@ -16,8 +16,10 @@
 """Holds meta information on one IPy.IP address."""
 
 import re
+
+from django.db import connection
+
 from IPy import IP
-from nav import db
 
 
 class MetaIP:
@@ -77,9 +79,9 @@ class MetaIP:
                  WHERE family(netaddr) = %s"""
             % family
         )
-        cursor = db.getConnection('default', 'manage').cursor()
-        cursor.execute(sql)
-        rows = cursor.fetchall()
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
+            rows = cursor.fetchall()
         result = {}
         for row in rows:
             result[IP(row[2])] = {

--- a/tests/integration/report/dbresult_test.py
+++ b/tests/integration/report/dbresult_test.py
@@ -1,0 +1,65 @@
+#
+# Copyright (C) 2026 Uninett AS
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.  You should have received a copy of the GNU General Public
+# License along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Integration tests for DatabaseResult running on Django's DB connection.
+
+These exercise the real ``django.db.connection`` code path, including the error
+handling: after the migration off the legacy connection, DB-API errors surface
+as ``django.db.utils.*`` exceptions rather than ``psycopg2.*`` ones, so a
+malformed report definition must still be caught and reported instead of
+producing an HTTP 500.
+"""
+
+from nav.report.dbresult import DatabaseResult
+from nav.report.generator import ReportConfig
+
+
+def _config(sql, title="test report"):
+    config = ReportConfig()
+    config.sql = sql
+    config.title = title
+    return config
+
+
+class TestDatabaseResult:
+    def test_when_sql_is_valid_then_result_and_headers_are_populated(self, db):
+        result = DatabaseResult(_config("SELECT 1 AS n"))
+
+        assert not result.error
+        assert result.result == [(1,)]
+        assert result.rowcount == 1
+
+    def test_when_sql_is_valid_then_column_headers_are_recorded(self, db):
+        config = _config("SELECT 1 AS the_answer")
+
+        DatabaseResult(config)
+
+        assert config.sql_select == ["the_answer"]
+
+    def test_when_report_sql_is_malformed_then_error_is_set_without_raising(self, db):
+        # A malformed report definition must not turn into an HTTP 500. Before
+        # catching Django's wrapped exception this raised uncaught.
+        result = DatabaseResult(
+            _config("SELECT * FROM does_not_exist_xyz", title="broken report")
+        )
+
+        assert result.error
+        assert "broken report" in result.error
+
+    def test_when_report_input_type_is_invalid_then_data_error_is_set(self, db):
+        result = DatabaseResult(_config("SELECT 'not-an-int'::integer AS n"))
+
+        assert result.error
+        assert "Data error" in result.error

--- a/tests/integration/report/legacy_query_test.py
+++ b/tests/integration/report/legacy_query_test.py
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2026 Uninett AS
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.  You should have received a copy of the GNU General Public
+# License along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Integration tests for report queries migrated onto Django's DB connection.
+
+get_subnets() (IPtree) and MetaIP._createMetaMap() (metaIP) now run their raw
+SQL through django.db.connection. These tests exercise that real cursor path.
+"""
+
+from IPy import IP as IPyIP
+
+from nav.ip import IP
+from nav.report.IPtree import get_subnets
+from nav.report.metaIP import MetaIP
+
+
+class TestGetSubnets:
+    def test_when_queried_then_it_should_return_ip_objects_from_db(self, db):
+        result = get_subnets(IP("10.0.0.0/8"))
+
+        # Exercises the migrated django.db.connection cursor path; the result
+        # depends on seeded data, so assert on shape rather than exact contents.
+        assert isinstance(result, list)
+        assert all(isinstance(net, IP) for net in result)
+        assert all(net in IP("10.0.0.0/8") for net in result)
+
+
+class TestMetaIP:
+    def test_when_no_prefixes_exist_then_tree_net_should_still_render(self, db):
+        MetaIP.invalidateCache()
+
+        meta = MetaIP(IPyIP("10.0.0.0/24"))
+
+        # No prefix data seeded, so no metadata is attached, but the migrated
+        # query must run and getTreeNet() must produce the tree label.
+        assert meta.prefixid is None
+        assert meta.getTreeNet() == "10.0.0"


### PR DESCRIPTION
## Scope and purpose

Fixes #4130.

The report subsystem read from the database through the legacy
`nav.db.getConnection()` cache (`nav.ObjectCache`), which is not thread-safe and
misbehaves under mod_wsgi's multithreaded workers — the same root cause as #4104.
This moves `DatabaseResult`, `IPtree.get_subnets` and `MetaIP._createMetaMap`
onto Django's `django.db.connection`, whose connections are thread-local, taking
reports off the fragile legacy cache.

`metaIP` dropped its legacy `'manage'` database alias, which already resolved to
the same `nav` database (no `db_manage` in db.conf), so that is behaviourally a
no-op.

DB-API errors now surface as `django.db.utils.*` exceptions rather than
`psycopg2.*`. `dbresult.py` is updated to catch `ProgrammingError` / `DataError`
from `django.db.utils`; without this a malformed report SQL definition would
raise uncaught and produce an HTTP 500 — the regression flagged in the review of
#4111.

Split out from #4111 (issue #4104) as a separable change, per review feedback.

### How to observe

The new integration tests exercise the real `django.db.connection` path,
including the error handling:

```
pytest tests/integration/report/dbresult_test.py \
       tests/integration/report/legacy_query_test.py
```

`test_when_report_sql_is_malformed_then_error_is_set_without_raising` and
`test_when_report_input_type_is_invalid_then_data_error_is_set` fail against the
old `psycopg2` handlers (uncaught `django.db.utils.*` → HTTP 500) and pass with
the Django-wrapped handlers.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation — not applicable, internal change
* [x] Linted/formatted the code with ruff
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ..."
* [x] Based this pull request on the correct upstream branch (`5.19.x`, a bugfix affecting the latest stable version)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely — not applicable, fully fixed
* [x] If it's not obvious from a linked issue, described how to interact with NAV to observe the effects (see above)
* [ ] If this results in changes in the UI: Added screenshots — not applicable, no UI change
* [x] If this adds a new Python source code file: Added the boilerplate header (both new test files have it)
