### PR TITLE
Read config files as UTF-8 regardless of locale

### DIFF
--- a/changelog.d/4132.fixed.md
+++ b/changelog.d/4132.fixed.md
@@ -1,0 +1,1 @@
+Fixed a `UnicodeDecodeError` that could prevent ipdevpoll from loading `ipdevpoll.conf` under a non-UTF-8 locale such as `LANG=C`. Configuration files read by ipdevpoll and several other subsystems are now decoded as UTF-8 regardless of the system locale.

--- a/python/nav/config/__init__.py
+++ b/python/nav/config/__init__.py
@@ -182,7 +182,7 @@ class NAVConfigParser(configparser.ConfigParser):
             if f
         ]
         filenames.extend(os.path.join('.', name) for name in self.DEFAULT_CONFIG_FILES)
-        files_read = self.read(filenames)
+        files_read = self.read(filenames, encoding='utf-8')
 
         if files_read:
             _logger.debug("Read config files %r", files_read)

--- a/python/nav/etc/ipdevpoll.conf
+++ b/python/nav/etc/ipdevpoll.conf
@@ -237,7 +237,7 @@ filter = topology
 
 [cam]
 # When NAV detects a monitored MAC address on a switch port, it classifies the
-# port as a "link port" and only creates adjacency candidates — no CAM records
+# port as a "link port" and only creates adjacency candidates - no CAM records
 # are logged for that port.  If the neighbor device has no management profiles,
 # however, it cannot be polled, so Machine Tracker has no way to locate end
 # hosts behind it.

--- a/tests/unittests/config_test.py
+++ b/tests/unittests/config_test.py
@@ -1,5 +1,10 @@
+import os
+import subprocess
+import sys
 from pathlib import Path
 from unittest import TestCase
+
+import pytest
 
 from nav.config import _config_resource_walk, find_config_file, get_config_locations
 
@@ -113,3 +118,60 @@ class TestNavConfigDir:
 
         found_path = find_config_file("nonexistent.conf")
         assert found_path is None
+
+
+class TestConfigFileEncoding:
+    """#4132: config files must be read as UTF-8 regardless of the locale's
+    preferred encoding.
+    """
+
+    def test_when_locale_encoding_is_not_utf8_then_navconfigparser_should_still_read_utf8_files(  # noqa: E501
+        self, tmp_path
+    ):
+        config_file = tmp_path / "utf8.conf"
+        config_file.write_text("[section]\nkey = a—b\n", encoding="utf-8")
+
+        result = _run_in_ascii_locale(_READ_UTF8_CONFIG_SCRIPT, config_dir=tmp_path)
+
+        if result.returncode == _COULD_NOT_FORCE_ASCII:
+            pytest.skip("interpreter could not be forced to a non-UTF-8 locale")
+        assert result.returncode == 0, result.stderr
+
+
+# The regression is only observable when the interpreter's default encoding is
+# not UTF-8, and that cannot be changed once the process has started. So we read
+# the config file in a child interpreter whose locale is forced to plain ASCII.
+
+_COULD_NOT_FORCE_ASCII = 99
+
+_READ_UTF8_CONFIG_SCRIPT = f"""
+import locale
+import sys
+
+from nav.config import NAVConfigParser
+
+if "utf" in locale.getpreferredencoding(False).lower().replace("-", ""):
+    sys.exit({_COULD_NOT_FORCE_ASCII})
+
+parser = NAVConfigParser(default_config="", default_config_files=("utf8.conf",))
+expected = "a" + chr(0x2014) + "b"
+assert parser.get("section", "key") == expected, parser.get("section", "key")
+"""
+
+
+def _run_in_ascii_locale(script, config_dir):
+    env = {
+        **os.environ,
+        "LC_ALL": "C",
+        "LANG": "C",
+        "PYTHONUTF8": "0",
+        "PYTHONCOERCECLOCALE": "0",
+        "NAV_CONFIG_DIR": str(config_dir),
+    }
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    )


### PR DESCRIPTION
## Scope and purpose

Fixes #4132.

NAV 5.19.0 shipped `ipdevpoll.conf` with a UTF-8 en-dash in a comment. When [`NAVConfigParser`](https://github.com/Uninett/nav/blob/fe82e94b7bbfa9c89567820528f32e61cecaf291/python/nav/config/__init__.py#L185) reads a config file it relied on the locale's preferred encoding, so on a host whose locale resolves to ASCII (for example `LANG=C`/`LC_ALL=C` without Python's C-locale-to-UTF-8 coercion) ipdevpoll crashed at startup with `UnicodeDecodeError`. Configuration files may legitimately contain UTF-8, so the parser should not depend on the locale — it now decodes config files as UTF-8 regardless, matching what [`open_configfile()`](https://github.com/Uninett/nav/blob/fe82e94b7bbfa9c89567820528f32e61cecaf291/python/nav/config/__init__.py#L239) has always done. The stray en-dash is also reverted to a plain hyphen so the shipped example loads even on installs that have not yet received the parser fix.

This resolves the reported crash. Several other config readers (`arnold`, `logengine`, `logs`, `mailin`, the syslogger web view) share the same locale-dependent pattern and will be hardened in a follow-up PR based on `master`.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done — the reported crash is fully fixed here; follow-up hardening of NAV's other config readers is planned as a separate `master` PR, not yet filed as an issue.
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [ ] ~~If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file~~
