### PR TITLE
Read remaining config files as UTF-8 regardless of locale

### DIFF
--- a/changelog.d/4134.fixed.md
+++ b/changelog.d/4134.fixed.md
@@ -1,0 +1,1 @@
+Made NAV always read configuration files as UTF-8 in its arnold, logengine, logging, mailin and syslogger config readers, so a UTF-8 character in a config file no longer crashes them with `UnicodeDecodeError` under a non-UTF-8 locale (such as `LANG=C`).

--- a/python/nav/arnold.py
+++ b/python/nav/arnold.py
@@ -595,7 +595,7 @@ def parse_nonblock_file(filename):
 
     # Open nonblocklist, parse it.
     try:
-        handle = open(filename)
+        handle = open(filename, encoding="utf-8")
     except IOError as why:
         raise FileError(why)
 
@@ -622,7 +622,7 @@ def parse_nonblock_file(filename):
 def get_config(configfile):
     """Get config from file"""
     config = configparser.ConfigParser()
-    config.read(configfile)
+    config.read(configfile, encoding="utf-8")
     return config
 
 

--- a/python/nav/bin/mailin.py
+++ b/python/nav/bin/mailin.py
@@ -50,7 +50,7 @@ def main():
 
     # Todo: fail if config file is not found
     conf = configparser.ConfigParser()
-    conf.read(find_config_file(CONFIG_FILE))
+    conf.read(find_config_file(CONFIG_FILE), encoding='utf-8')
 
     # Must do this after config, so logfile can be configurable
     if args.test:

--- a/python/nav/logengine.py
+++ b/python/nav/logengine.py
@@ -597,7 +597,7 @@ def main():
     # Process setup
 
     config = ConfigParser()
-    config.read(find_config_file('logger.conf'))
+    config.read(find_config_file('logger.conf'), encoding='utf-8')
 
     nav.logs.init_stderr_logging()
 

--- a/python/nav/logs.py
+++ b/python/nav/logs.py
@@ -124,14 +124,14 @@ def _get_logging_conf():
     """
     filename = os.environ.get(LOGGING_CONF_VAR, LOGGING_CONF_FILE_DEFAULT)
     config = configparser.ConfigParser()
-    read = config.read(filename)
+    read = config.read(filename, encoding="utf-8")
     if filename not in read and LOGGING_CONF_VAR in os.environ:
         _logger.error(
             "cannot read logging config from %s, trying default %s",
             filename,
             LOGGING_CONF_FILE_DEFAULT,
         )
-        config.read(LOGGING_CONF_FILE_DEFAULT)
+        config.read(LOGGING_CONF_FILE_DEFAULT, encoding="utf-8")
     return config
 
 

--- a/python/nav/web/syslogger/views.py
+++ b/python/nav/web/syslogger/views.py
@@ -220,7 +220,7 @@ def exceptions_response(request):
     if not account:
         return HttpResponseRedirect('/')
     config = ConfigParser()
-    config.read(find_config_file('logger.conf'))
+    config.read(find_config_file('logger.conf'), encoding='utf-8')
     options = config.options("priorityexceptions")
     excepts = []
     context = {}

--- a/tests/unittests/ascii_locale.py
+++ b/tests/unittests/ascii_locale.py
@@ -1,0 +1,76 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License version 3 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Helper for testing behaviour that only manifests outside a UTF-8 locale.
+
+Encoding regressions like #4132 are only observable when the interpreter's
+preferred encoding is not UTF-8, and that cannot be changed once the process has
+started. Tests therefore hand a snippet to a child interpreter whose locale is
+forced to plain ASCII.
+
+Note that the child's command line is itself decoded using the ASCII locale, so
+snippets must be pure ASCII. Build any non-ASCII expectation inside the snippet,
+e.g. with ``chr(0x2014)`` rather than a literal em dash.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+_COULD_NOT_FORCE_ASCII = 99
+
+# Prepended to every snippet, so a UTF-8-insisting interpreter bails out before
+# the snippet's own imports run.
+_SKIP_UNLESS_ASCII = """
+import locale
+import sys
+
+if "utf" in locale.getpreferredencoding(False).lower().replace("-", ""):
+    sys.exit({sentinel})
+""".format(sentinel=_COULD_NOT_FORCE_ASCII)
+
+
+def assert_runs_in_ascii_locale(script, **extra_env):
+    """Run script in a child interpreter forced to a non-UTF-8 locale.
+
+    Skips the calling test if the interpreter cannot be talked out of UTF-8, and
+    fails it if the script exits non-zero, reporting the child's stderr.
+
+    Any keyword arguments are added to the child's environment.
+    """
+    result = _run_in_ascii_locale(_SKIP_UNLESS_ASCII + script, extra_env)
+    if result.returncode == _COULD_NOT_FORCE_ASCII:
+        pytest.skip("interpreter could not be forced to a non-UTF-8 locale")
+    assert result.returncode == 0, result.stderr
+
+
+def _run_in_ascii_locale(script, extra_env):
+    env = {
+        **os.environ,
+        "LC_ALL": "C",
+        "LANG": "C",
+        "PYTHONUTF8": "0",
+        "PYTHONCOERCECLOCALE": "0",
+        **extra_env,
+    }
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    )

--- a/tests/unittests/config_files_test.py
+++ b/tests/unittests/config_files_test.py
@@ -1,0 +1,164 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License version 3 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Tests for NAV's configuration file handling (#4132).
+
+NAV reads configuration files as UTF-8 regardless of locale, so the shipped
+examples must be valid UTF-8 and the INI/TOML ones must parse cleanly through
+NAV's own readers, and the readers themselves must decode as UTF-8 even when the
+locale's preferred encoding is not.
+"""
+
+import os
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+import nav
+from nav.config import getconfig
+
+_ETC_DIR = Path(nav.__file__).resolve().parent / "etc"
+
+# Shipped INI-style configuration files, i.e. the ones NAV parses with a
+# configparser-based reader. getconfig() reads them exactly as NAV does in
+# production (via open_configfile(), which decodes as UTF-8).
+_INI_CONFIG_FILES = [
+    "alertengine.conf",
+    "alertprofiles/five_periods.conf",
+    "alertprofiles/one_period.conf",
+    "alertprofiles/three_periods.conf",
+    "arnold/arnold.conf",
+    "dhcpstats.conf",
+    "eventengine.conf",
+    "graphite.conf",
+    "ipdevpoll.conf",
+    "logger.conf",
+    "logging.conf",
+    "mailin.conf",
+    "navstats.conf",
+    "netbiostracker.conf",
+    "portadmin/portadmin.conf",
+    "smsd.conf",
+    "snmptrapd.conf",
+    "sortedstats.conf",
+    "webfront/jwt.conf",
+    "webfront/webfront.conf",
+]
+
+# Shipped TOML configuration files.
+_TOML_CONFIG_FILES = [
+    "webfront/authentication.toml",
+]
+
+
+class TestShippedConfigFiles:
+    def test_when_walking_shipped_etc_then_every_file_should_be_valid_utf8(self):
+        undecodable = []
+        for path in _shipped_config_files():
+            try:
+                path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                undecodable.append(str(path.relative_to(_ETC_DIR)))
+        assert not undecodable, f"shipped files are not valid UTF-8: {undecodable}"
+
+    @pytest.mark.parametrize("relative_path", _INI_CONFIG_FILES)
+    def test_when_reading_a_shipped_ini_config_then_it_should_parse(
+        self, relative_path
+    ):
+        # Must not raise; an all-comments example legitimately yields no sections.
+        getconfig(str(_ETC_DIR / relative_path))
+
+    @pytest.mark.parametrize("relative_path", _TOML_CONFIG_FILES)
+    def test_when_reading_a_shipped_toml_config_then_it_should_parse(
+        self, relative_path
+    ):
+        # Must not raise; tomllib mandates UTF-8, so decoding is locale-independent.
+        with open(_ETC_DIR / relative_path, "rb") as handle:
+            tomllib.load(handle)
+
+
+class TestRawIniReaderEncoding:
+    """Raw configparser-based readers must decode config files as UTF-8
+    regardless of the locale's preferred encoding (#4132).
+    """
+
+    def test_when_locale_encoding_is_not_utf8_then_logging_conf_reader_should_read_utf8(  # noqa: E501
+        self, tmp_path
+    ):
+        config_file = tmp_path / "logging.conf"
+        # The non-ASCII byte lives in a full-line comment, mirroring the stray
+        # dash character that triggered #4132 in a shipped config's comment.
+        config_file.write_text("[levels]\nroot = INFO\n# a—b\n", encoding="utf-8")
+
+        result = _run_python_in_ascii_locale(
+            _READ_LOGGING_CONF_SCRIPT, {"NAV_LOGGING_CONF": str(config_file)}
+        )
+
+        if result.returncode == _COULD_NOT_FORCE_ASCII:
+            pytest.skip("interpreter could not be forced to a non-UTF-8 locale")
+        assert result.returncode == 0, result.stderr
+
+
+def _shipped_config_files():
+    """Yield every shipped file under etc/, minus backups and hidden files."""
+    for path in sorted(_ETC_DIR.rglob("*")):
+        if not path.is_file():
+            continue
+        if "__pycache__" in path.parts:
+            continue
+        if path.name.startswith(".") or path.name.endswith("~"):
+            continue
+        yield path
+
+
+# The regression is only observable when the interpreter's default encoding is
+# not UTF-8, and that cannot be changed once the process has started. So we read
+# the config file in a child interpreter whose locale is forced to plain ASCII.
+
+_COULD_NOT_FORCE_ASCII = 99
+
+_READ_LOGGING_CONF_SCRIPT = """
+import locale
+import sys
+
+if "utf" in locale.getpreferredencoding(False).lower().replace("-", ""):
+    sys.exit({skip})
+
+from nav.logs import _get_logging_conf
+
+config = _get_logging_conf()
+assert config.get("levels", "root") == "INFO", dict(config["levels"])
+""".format(skip=_COULD_NOT_FORCE_ASCII)
+
+
+def _run_python_in_ascii_locale(script, extra_env):
+    env = {
+        **os.environ,
+        "LC_ALL": "C",
+        "LANG": "C",
+        "PYTHONUTF8": "0",
+        "PYTHONCOERCECLOCALE": "0",
+        **extra_env,
+    }
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    )

--- a/tests/unittests/config_files_test.py
+++ b/tests/unittests/config_files_test.py
@@ -21,9 +21,6 @@ NAV's own readers, and the readers themselves must decode as UTF-8 even when the
 locale's preferred encoding is not.
 """
 
-import os
-import subprocess
-import sys
 import tomllib
 from pathlib import Path
 
@@ -31,6 +28,8 @@ import pytest
 
 import nav
 from nav.config import getconfig
+
+from .ascii_locale import assert_runs_in_ascii_locale
 
 _ETC_DIR = Path(nav.__file__).resolve().parent / "etc"
 
@@ -64,6 +63,13 @@ _INI_CONFIG_FILES = [
 _TOML_CONFIG_FILES = [
     "webfront/authentication.toml",
 ]
+
+_READ_LOGGING_CONF_SCRIPT = """
+from nav.logs import _get_logging_conf
+
+config = _get_logging_conf()
+assert config.get("levels", "root") == "INFO", dict(config["levels"])
+"""
 
 
 class TestShippedConfigFiles:
@@ -105,13 +111,9 @@ class TestRawIniReaderEncoding:
         # dash character that triggered #4132 in a shipped config's comment.
         config_file.write_text("[levels]\nroot = INFO\n# a—b\n", encoding="utf-8")
 
-        result = _run_python_in_ascii_locale(
-            _READ_LOGGING_CONF_SCRIPT, {"NAV_LOGGING_CONF": str(config_file)}
+        assert_runs_in_ascii_locale(
+            _READ_LOGGING_CONF_SCRIPT, NAV_LOGGING_CONF=str(config_file)
         )
-
-        if result.returncode == _COULD_NOT_FORCE_ASCII:
-            pytest.skip("interpreter could not be forced to a non-UTF-8 locale")
-        assert result.returncode == 0, result.stderr
 
 
 def _shipped_config_files():
@@ -124,41 +126,3 @@ def _shipped_config_files():
         if path.name.startswith(".") or path.name.endswith("~"):
             continue
         yield path
-
-
-# The regression is only observable when the interpreter's default encoding is
-# not UTF-8, and that cannot be changed once the process has started. So we read
-# the config file in a child interpreter whose locale is forced to plain ASCII.
-
-_COULD_NOT_FORCE_ASCII = 99
-
-_READ_LOGGING_CONF_SCRIPT = """
-import locale
-import sys
-
-if "utf" in locale.getpreferredencoding(False).lower().replace("-", ""):
-    sys.exit({skip})
-
-from nav.logs import _get_logging_conf
-
-config = _get_logging_conf()
-assert config.get("levels", "root") == "INFO", dict(config["levels"])
-""".format(skip=_COULD_NOT_FORCE_ASCII)
-
-
-def _run_python_in_ascii_locale(script, extra_env):
-    env = {
-        **os.environ,
-        "LC_ALL": "C",
-        "LANG": "C",
-        "PYTHONUTF8": "0",
-        "PYTHONCOERCECLOCALE": "0",
-        **extra_env,
-    }
-    return subprocess.run(
-        [sys.executable, "-c", script],
-        env=env,
-        capture_output=True,
-        encoding="utf-8",
-        errors="replace",
-    )

--- a/tests/unittests/config_test.py
+++ b/tests/unittests/config_test.py
@@ -1,12 +1,17 @@
-import os
-import subprocess
-import sys
 from pathlib import Path
 from unittest import TestCase
 
-import pytest
-
 from nav.config import _config_resource_walk, find_config_file, get_config_locations
+
+from .ascii_locale import assert_runs_in_ascii_locale
+
+_READ_UTF8_CONFIG_SCRIPT = """
+from nav.config import NAVConfigParser
+
+parser = NAVConfigParser(default_config="", default_config_files=("utf8.conf",))
+expected = "a" + chr(0x2014) + "b"
+assert parser.get("section", "key") == expected, parser.get("section", "key")
+"""
 
 
 class TestConfigResourceWalk(TestCase):
@@ -131,47 +136,6 @@ class TestConfigFileEncoding:
         config_file = tmp_path / "utf8.conf"
         config_file.write_text("[section]\nkey = a—b\n", encoding="utf-8")
 
-        result = _run_in_ascii_locale(_READ_UTF8_CONFIG_SCRIPT, config_dir=tmp_path)
-
-        if result.returncode == _COULD_NOT_FORCE_ASCII:
-            pytest.skip("interpreter could not be forced to a non-UTF-8 locale")
-        assert result.returncode == 0, result.stderr
-
-
-# The regression is only observable when the interpreter's default encoding is
-# not UTF-8, and that cannot be changed once the process has started. So we read
-# the config file in a child interpreter whose locale is forced to plain ASCII.
-
-_COULD_NOT_FORCE_ASCII = 99
-
-_READ_UTF8_CONFIG_SCRIPT = f"""
-import locale
-import sys
-
-from nav.config import NAVConfigParser
-
-if "utf" in locale.getpreferredencoding(False).lower().replace("-", ""):
-    sys.exit({_COULD_NOT_FORCE_ASCII})
-
-parser = NAVConfigParser(default_config="", default_config_files=("utf8.conf",))
-expected = "a" + chr(0x2014) + "b"
-assert parser.get("section", "key") == expected, parser.get("section", "key")
-"""
-
-
-def _run_in_ascii_locale(script, config_dir):
-    env = {
-        **os.environ,
-        "LC_ALL": "C",
-        "LANG": "C",
-        "PYTHONUTF8": "0",
-        "PYTHONCOERCECLOCALE": "0",
-        "NAV_CONFIG_DIR": str(config_dir),
-    }
-    return subprocess.run(
-        [sys.executable, "-c", script],
-        env=env,
-        capture_output=True,
-        encoding="utf-8",
-        errors="replace",
-    )
+        assert_runs_in_ascii_locale(
+            _READ_UTF8_CONFIG_SCRIPT, NAV_CONFIG_DIR=str(tmp_path)
+        )


### PR DESCRIPTION
## Scope and purpose

Follow-up to #4132, which #4133 fixed for `ipdevpoll.conf` on the `5.19.x` branch. That crash — a `UnicodeDecodeError` raised when a config file containing UTF-8 is read under a non-UTF-8 locale such as `LANG=C` — was never unique to ipdevpoll: several other readers decode config files using the locale's preferred encoding rather than UTF-8, so the same failure can strike any of them. This hardens the remaining readers (`arnold`, `logengine`, `logs`, `mailin`, and the syslogger web view — plus [`arnold.parse_nonblock_file`](https://github.com/Uninett/nav/blob/767586c44352c17838525d6583dacc2c315ae5e2/python/nav/arnold.py#L598), which reads its file with a bare `open()`) to always decode as UTF-8, matching what `open_configfile()` already does.

It also adds a test module that walks the shipped `etc/` tree asserting every example file is valid UTF-8 and that the INI and TOML examples parse through NAV's own readers, plus a locale-forced regression test proving a configparser-based reader still decodes UTF-8 when the interpreter's preferred encoding is ASCII.

The `NAVConfigParser` fix and the shipped-config character revert from #4133 reach `master` via the normal `5.19.x` merge-forward and are intentionally not duplicated here.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: based on `master`, as this hardens latent behaviour present across all versions rather than fixing the specific 5.19 regression (#4133 handles that on `5.19.x`).
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [x] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file
