### PR TITLE
Roll back after database connection ping

### DIFF
--- a/changelog.d/4135.fixed.md
+++ b/changelog.d/4135.fixed.md
@@ -1,0 +1,1 @@
+Database connection validation (`SELECT 1` ping) no longer leaves connections stuck "idle in transaction", which previously pinned the transaction horizon and blocked VACUUM.

--- a/python/nav/db/__init__.py
+++ b/python/nav/db/__init__.py
@@ -73,8 +73,14 @@ class ConnectionObject(nav.CacheableObject):
         Executes a simple query, like SELECT 1.  If no exceptions are
         raised, the database connection should still be up.
         """
-        cursor = self.object.cursor()
-        cursor.execute('SELECT 1')
+        with self.object.cursor() as cursor:
+            cursor.execute('SELECT 1')
+        # The connection uses READ COMMITTED (not autocommit), so the ping
+        # query opened a transaction. Roll it back so the connection is not
+        # left "idle in transaction", which would pin the xmin horizon and
+        # block VACUUM. This also clears any uncommitted read left on the
+        # connection by an earlier caller.
+        self.object.rollback()
         # If we got this far withouth exceptions, we did OK
         return 1
 

--- a/tests/unittests/general/db_ping_test.py
+++ b/tests/unittests/general/db_ping_test.py
@@ -1,0 +1,37 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.  You should have received a copy of the GNU General Public License
+# along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+from unittest.mock import MagicMock
+
+from nav.db import ConnectionObject
+
+
+class TestConnectionObjectPing:
+    def test_when_pinging_then_it_should_execute_select_1(self):
+        connection = MagicMock()
+        conn_object = ConnectionObject(connection, key=('nav', 'nav'))
+
+        conn_object.ping()
+
+        cursor = connection.cursor.return_value.__enter__.return_value
+        cursor.execute.assert_called_once_with('SELECT 1')
+
+    def test_when_pinging_then_it_should_roll_back_to_avoid_idle_in_transaction(self):
+        connection = MagicMock()
+        conn_object = ConnectionObject(connection, key=('nav', 'nav'))
+
+        conn_object.ping()
+
+        connection.rollback.assert_called_once()


### PR DESCRIPTION
## Scope and purpose

Fixes #4135.

`ConnectionObject.ping()` runs `SELECT 1` to validate cached database connections but never commits or rolls back. Connections use isolation level READ COMMITTED (not autocommit), so each ping opens a transaction that is never closed.

`getConnection()` pings every cached connection on each call, so long-lived daemons that go quiet between queries leave their connection stuck "idle in transaction" indefinitely. That pins the transaction horizon (`xmin`), blocking VACUUM and bloating tables, and holds a backend slot.

This PR rolls back after the ping so the connection returns to a clean `idle` state.

### How to observe

Run a long-lived NAV daemon (e.g. snmptrapd), let it go idle after a DB lookup, and inspect `pg_stat_activity`. Before this change the backend sits in `state = idle in transaction` with last query `SELECT 1`, growing for hours; after, it settles at `idle`.

### This pull request
* fixes a database connection leak (idle-in-transaction)

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation — not applicable; internal implementation fix
* [x] Linted/formatted the code with ruff
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long
* [x] Based this pull request on the correct upstream branch (`master`)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely — not applicable; fully resolves #4135
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects (see above)
* [ ] If this results in changes in the UI: screenshots — not applicable; no UI changes
* [x] If this adds a new Python source code file: boilerplate header — added to the new test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)