### PR TITLE
Serve browsable API Bootstrap CSS locally

### DIFF
--- a/changelog.d/4089.fixed.md
+++ b/changelog.d/4089.fixed.md
@@ -1,0 +1,1 @@
+The browsable REST API no longer loads Bootstrap CSS from an external CDN, so it renders correctly on air-gapped/offline clients.

--- a/python/nav/web/templates/rest_framework/api.html
+++ b/python/nav/web/templates/rest_framework/api.html
@@ -1,10 +1,7 @@
 {% extends "rest_framework/base.html" %}
 
 {% block style %}
-  <link rel="stylesheet"
-        href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"
-        integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7"
-        crossorigin="anonymous">
+  {{ block.super }}
   <style>
     .page-header { margin: 0 0 20px; padding: 0; }
     .navbar { margin-bottom: 0; }


### PR DESCRIPTION
## Scope and purpose

Fixes #4089.

The DRF browsable API root (`/api/1`) is the only NAV page loading a stylesheet from a public CDN: its template overrides DRF's entire `style` block and pulls Bootstrap from `maxcdn.bootstrapcdn.com` instead of the copy DRF already bundles as a local static file. Air-gapped admin stations can't reach the CDN, so the page renders unstyled or stalls on the blocked request until the browser times out.

The template only ever overrode `style` to add three small NAV-specific tweaks. Calling `{{ block.super }}` restores DRF's locally-bundled Bootstrap (3.4.1, a patch-level bump over the old 3.3.6 pin) and keeps those tweaks, so nothing now leaves the NAV host to render the API browser.

To observe: open `/api/1`. Bootstrap now loads from `/static/rest_framework/css/bootstrap.min.css` with no request to `maxcdn.bootstrapcdn.com`. Styling is functionally equivalent, with one minor, benign layout difference: the endpoint list now renders below the introductory text rather than floating to its right (a side effect of restoring DRF's `bootstrap-tweaks.css`, which the old override had dropped).

### This pull request
* ~~adds/changes/removes a dependency~~
* ~~changes the database~~
* ~~changes the API~~

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] ~~Added/amended tests for new/changed code~~ — template-inheritance change; verified by rendering the template (no `maxcdn` reference, Bootstrap resolves to the local static path)
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
* [x] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~ — only a minor layout reflow (endpoint list moves below the intro text instead of right of it); no functional UI change
* [ ] ~~If this adds a new Python source code file: Added the boilerplate header to that file~~
