### PR TITLE
Add HTTP(S) proxy support for OUI file download

### DIFF
--- a/changelog.d/4141.added.md
+++ b/changelog.d/4141.added.md
@@ -1,0 +1,1 @@
+Added support for downloading the IEEE OUI file through an HTTP(S) proxy, configurable via `update_ouis.conf`, for NAV installations behind a firewall

--- a/doc/reference/backend-processes.rst
+++ b/doc/reference/backend-processes.rst
@@ -225,12 +225,16 @@ and their corresponding vendors. This enables NAV to display the vendor name
 of a device based on its MAC address, helping to identify whether a device is,
 for example, from Juniper or Cisco.
 
+The OUI file is downloaded from the IEEE over HTTP(S). Installations behind a
+firewall with no direct outbound access can route the download through an
+HTTP(S) proxy by setting the ``proxy`` option in :file:`update_ouis.conf`.
+
 :Dependencies:
   None
 :Run mode:
   cron
 :Configuration:
-  None
+  :file:`update_ouis.conf`
 :Logs:
   Logs to STDERR.
 

--- a/python/nav/bin/update_ouis.py
+++ b/python/nav/bin/update_ouis.py
@@ -31,6 +31,7 @@ bootstrap_django(__file__)
 
 import django.db
 
+from nav.config import NAVConfigParser
 from nav.macaddress import MacPrefix
 from nav.logs import init_stderr_logging
 
@@ -40,6 +41,20 @@ FILE_URL = "https://standards-oui.ieee.org/oui/oui.txt"
 USER_AGENT = "Mozilla/5.0 (X11; Linux i686; rv:135.0) Gecko/20100101 Firefox/135.0"
 
 MAX_ERRORS = 100
+
+
+class OuiConfig(NAVConfigParser):
+    """update_ouis config parser"""
+
+    DEFAULT_CONFIG_FILES = ("update_ouis.conf",)
+    DEFAULT_CONFIG = """
+[oui]
+proxy =
+"""
+
+    def get_proxy(self) -> str:
+        """Returns the configured HTTP(S) proxy URL, or an empty string"""
+        return self.get("oui", "proxy", fallback="").strip()
 
 
 def main():
@@ -66,7 +81,11 @@ def _download_oui_file(url: str) -> str:
     headers = {
         'User-Agent': USER_AGENT,
     }
-    response = requests.get(url, headers=headers)
+    proxy = OuiConfig().get_proxy()
+    proxies = {"http": proxy, "https": proxy} if proxy else None
+    if proxy:
+        _logger.debug("Using proxy %s for OUI download", proxy)
+    response = requests.get(url, headers=headers, proxies=proxies)
     response.raise_for_status()
     return response.text
 

--- a/python/nav/etc/update_ouis.conf
+++ b/python/nav/etc/update_ouis.conf
@@ -1,0 +1,10 @@
+# Configuration for the navoui command, which updates the database with OUIs
+# (MAC address vendor prefixes) downloaded from the IEEE.
+
+[oui]
+# HTTP(S) proxy to use when downloading the OUI file. Useful when NAV runs
+# behind a firewall with no direct outbound access to the IEEE web site.
+# Leave empty to connect directly. Example:
+#
+# proxy = http://proxy.example.org:3128
+proxy =

--- a/python/nav/etc/update_ouis.conf
+++ b/python/nav/etc/update_ouis.conf
@@ -7,4 +7,3 @@
 # Leave empty to connect directly. Example:
 #
 # proxy = http://proxy.example.org:3128
-proxy =

--- a/tests/unittests/update_ouis_test.py
+++ b/tests/unittests/update_ouis_test.py
@@ -1,0 +1,41 @@
+"""Unit tests for nav/bin/update_ouis.py proxy configuration"""
+
+from unittest.mock import patch
+
+from nav.bin import update_ouis
+from nav.bin.update_ouis import OuiConfig
+
+
+def test_given_configured_proxy_then_get_proxy_returns_it():
+    conf = OuiConfig()
+    conf.set("oui", "proxy", "http://proxy.example.org:3128")
+    assert conf.get_proxy() == "http://proxy.example.org:3128"
+
+
+def test_given_whitespace_proxy_then_get_proxy_strips_it():
+    conf = OuiConfig()
+    conf.set("oui", "proxy", "  http://proxy.example.org:3128  ")
+    assert conf.get_proxy() == "http://proxy.example.org:3128"
+
+
+def test_given_no_proxy_then_get_proxy_returns_empty_string():
+    conf = OuiConfig()
+    conf.set("oui", "proxy", "")
+    assert conf.get_proxy() == ""
+
+
+def test_when_proxy_configured_then_download_passes_proxies():
+    proxy = "http://proxy.example.org:3128"
+    with patch.object(OuiConfig, "get_proxy", return_value=proxy):
+        with patch.object(update_ouis, "requests") as mock_requests:
+            update_ouis._download_oui_file(update_ouis.FILE_URL)
+    _, kwargs = mock_requests.get.call_args
+    assert kwargs["proxies"] == {"http": proxy, "https": proxy}
+
+
+def test_when_no_proxy_configured_then_download_passes_no_proxies():
+    with patch.object(OuiConfig, "get_proxy", return_value=""):
+        with patch.object(update_ouis, "requests") as mock_requests:
+            update_ouis._download_oui_file(update_ouis.FILE_URL)
+    _, kwargs = mock_requests.get.call_args
+    assert kwargs["proxies"] is None

--- a/tests/unittests/update_ouis_test.py
+++ b/tests/unittests/update_ouis_test.py
@@ -24,6 +24,18 @@ def test_given_no_proxy_then_get_proxy_returns_empty_string():
     assert conf.get_proxy() == ""
 
 
+def test_given_commented_out_proxy_in_file_then_get_proxy_returns_empty_string():
+    conf = OuiConfig()
+    conf.read_string("[oui]\n# proxy =\n")
+    assert conf.get_proxy() == ""
+
+
+def test_given_proxy_set_in_file_then_get_proxy_returns_it():
+    conf = OuiConfig()
+    conf.read_string("[oui]\nproxy = http://proxy.example.com:3128\n")
+    assert conf.get_proxy() == "http://proxy.example.com:3128"
+
+
 def test_when_proxy_configured_then_download_passes_proxies():
     proxy = "http://proxy.example.org:3128"
     with patch.object(OuiConfig, "get_proxy", return_value=proxy):


### PR DESCRIPTION
## Scope and purpose

Fixes #4141.

NAV installations behind a firewall with no direct outbound internet access could not download the IEEE OUI file, causing `navoui` to fail with `[Errno 113] No route to host`.

This PR adds an `OuiConfig` parser reading a new `update_ouis.conf`. When its `[oui] proxy` option is set, `navoui` routes the download through that HTTP(S) proxy. The option is empty by default, so direct connections are unaffected. The config file lives in NAV's config directory and survives upgrades, unlike proxy settings placed in the regenerated `navoui` cron entry.

### This pull request
* changes the database — no
* changes the API — no
* adds/changes/removes a dependency — no

To try it, set in `/etc/nav/update_ouis.conf`:

    [oui]
    proxy = http://proxy.example.org:3128

then run `navoui`; the download goes through the proxy.

## Contributor Checklist

* [x] Added a changelog fragment for towncrier
* [x] Added/amended tests for new/changed code
* [x] Added/changed documentation — updated the navoui section in backend-processes.rst to reference update_ouis.conf and describe proxy configuration
* [x] Linted/formatted the code with ruff
* [x] Wrote the commit message per https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch (`master`, new feature)
* [ ] Created new issues if this PR does not fix the issue completely — N/A, fully fixes
* [x] Described how to interact with NAV to observe the effects
* [ ] Screenshots — N/A, no UI changes
* [ ] Boilerplate header on new Python file — N/A, test module follows existing test convention (docstring only)
