### PR TITLE
Suppress power supply alerts for units never observed working

### DIFF
--- a/changelog.d/4148.fixed.md
+++ b/changelog.d/4148.fixed.md
@@ -1,0 +1,1 @@
+Stop raising false power supply alerts for units that were never observed in a working state, such as empty (uninstalled) PSU bays reported by Cisco

--- a/python/nav/ipdevpoll/plugins/psuwatch.py
+++ b/python/nav/ipdevpoll/plugins/psuwatch.py
@@ -63,7 +63,7 @@ class PowerSupplyOrFanStateWatcher(Plugin):
             new_state = yield self._retrieve_current_unit_state(unit)
             state_map[unit] = new_state
             if old_state != new_state:
-                yield self._handle_state_change(unit, new_state)
+                yield self._handle_state_change(unit, old_state, new_state)
 
         return True
 
@@ -87,12 +87,12 @@ class PowerSupplyOrFanStateWatcher(Plugin):
         return STATE_UNKNOWN
 
     @defer.inlineCallbacks
-    def _handle_state_change(self, unit, new_state):
+    def _handle_state_change(self, unit, old_state, new_state):
         self._logger.info(
-            "%s state changed from %s to %s", unit.name, unit.up, new_state
+            "%s state changed from %s to %s", unit.name, old_state, new_state
         )
         yield db.run_in_thread(self._update_internal_state, unit, new_state)
-        yield db.run_in_thread(self._post_event, unit, new_state)
+        yield db.run_in_thread(self._post_event, unit, old_state, new_state)
 
     #
     # Synchronous database access methods
@@ -117,11 +117,22 @@ class PowerSupplyOrFanStateWatcher(Plugin):
             up=new_state, downsince=unit.downsince
         )
 
-    def _post_event(self, unit, new_state):
+    def _post_event(self, unit, old_state, new_state):
         factory = EVENT_MAP.get(unit.physical_class)
         assert factory is not None
 
         if new_state in (STATE_DOWN, STATE_WARNING):
+            # A unit transitioning straight from UNKNOWN to a non-working state
+            # was never observed working in the first place. This is typically an
+            # empty (uninstalled) PSU bay, which Cisco lists in entPhysicalTable
+            # and reports as offEnvOther; there is no genuine failure to alert on.
+            # Only raise an alert once a unit that was actually seen working goes
+            # down.
+            if old_state == STATE_UNKNOWN:
+                self._logger.debug(
+                    "not alerting on %s: never observed in a working state", unit.name
+                )
+                return
             construct = factory.start
         else:
             construct = factory.end

--- a/tests/unittests/ipdevpoll/plugins_psuwatch_test.py
+++ b/tests/unittests/ipdevpoll/plugins_psuwatch_test.py
@@ -1,0 +1,65 @@
+from contextlib import nullcontext
+from unittest.mock import Mock
+
+import pytest
+
+from nav.ipdevpoll.plugins import psuwatch
+from nav.ipdevpoll.plugins.psuwatch import (
+    PowerSupplyOrFanStateWatcher,
+    STATE_DOWN,
+    STATE_UNKNOWN,
+    STATE_UP,
+    STATE_WARNING,
+)
+
+
+@pytest.fixture
+def factory():
+    """A stand-in event factory whose start/end produce mock events."""
+    fake = Mock()
+    fake.start.return_value = Mock(name="start_event")
+    fake.end.return_value = Mock(name="end_event")
+    return fake
+
+
+@pytest.fixture
+def watcher(monkeypatch, factory):
+    """A watcher wired up to post events through the fake factory only."""
+    monkeypatch.setattr(psuwatch, "EVENT_MAP", {"powerSupply": factory})
+    monkeypatch.setattr(psuwatch.transaction, "atomic", lambda: nullcontext())
+
+    return object.__new__(PowerSupplyOrFanStateWatcher)
+
+
+def _unit():
+    return Mock(
+        physical_class="powerSupply",
+        name="Power Supply B",
+        id=1,
+        device_id=None,
+        netbox=Mock(sysname="switch.example.org"),
+    )
+
+
+class TestPostEvent:
+    def test_should_not_alert_when_never_observed_working(self, watcher, factory):
+        """An empty bay goes straight from UNKNOWN to DOWN and must not alert."""
+        watcher._post_event(_unit(), STATE_UNKNOWN, STATE_DOWN)
+        factory.start.assert_not_called()
+        factory.end.assert_not_called()
+
+    def test_should_alert_when_working_unit_goes_down(self, watcher, factory):
+        """A real PSU that was UP and fails must raise a start (psuNotOK) event."""
+        watcher._post_event(_unit(), STATE_UP, STATE_DOWN)
+        factory.start.assert_called_once()
+        factory.start.return_value.save.assert_called_once()
+
+    def test_should_alert_when_working_unit_warns(self, watcher, factory):
+        watcher._post_event(_unit(), STATE_UP, STATE_WARNING)
+        factory.start.assert_called_once()
+
+    def test_should_resolve_when_unit_comes_back_up(self, watcher, factory):
+        """A recovery must raise an end (psuOK) event regardless of prior state."""
+        watcher._post_event(_unit(), STATE_DOWN, STATE_UP)
+        factory.end.assert_called_once()
+        factory.end.return_value.save.assert_called_once()


### PR DESCRIPTION
## Scope and purpose

Fixes #4148.

Switches with an optional secondary PSU bay that was never populated raise false `psuNotOK` alerts. Cisco lists the empty bay in `ENTITY-MIB::entPhysicalTable` and reports `cefcFRUPowerOperStatus = offEnvOther(1)`, which NAV maps to `STATE_DOWN`. A newly discovered unit starts at `STATE_UNKNOWN`, so the first poll is an UNKNOWN→DOWN transition and `psuwatch` raises an alert for a power supply that was never installed.

### Why not filter empty bays at discovery

An earlier approach filtered PSU entities with no serial/`Device`. Testing against real hardware showed this is unsafe: on Catalyst 9300 stacks, `entPhysicalSerialNum` **and** `entPhysicalModelName` come back blank over SNMP even for present, powered supplies (`cefcFRUPowerOperStatus = on(2)`), while the CLI reports both bays populated with real serials. Filtering on serial or model would silently drop live power supplies from monitoring. There is no reliable inventory-based discriminator for an empty bay on Cisco.

### The fix

Only alert when a unit that was actually observed in a working state goes down. A unit transitioning straight from `STATE_UNKNOWN` to DOWN/WARNING was never seen working — typically an empty bay — and has no genuine failure to report, so `psuwatch` now suppresses the event. A real supply that fails was previously `on`, so the UP→DOWN transition still raises an alert.

This is vendor-neutral and needs no inventory heuristics.

### This pull request
* (none of dependency/database/API changes apply)

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation — not applicable
* [x] Linted/formatted the code with ruff
* [x] Wrote the commit message per https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch (\`master\`)
* [ ] If applicable: Created new issues — not applicable
* [x] Described how to observe the effects first-hand (see below)
* [ ] Screenshots — no UI changes

## How to observe

On a Cisco switch with an empty optional PSU bay (reports \`cefcFRUPowerOperStatus = offEnvOther\`, and \`entPhysicalSerialNum\`/\`entPhysicalModelName\` may be blank):

- Before: the first \`psuwatch\` poll takes the unit UNKNOWN→DOWN and raises \`psuNotOK\` for a PSU that was never installed.
- After: a unit that was never observed working does not raise \`psuNotOK\`. An installed PSU that was \`on\` and later fails still transitions UP→DOWN and alerts as before.