### PR TITLE
Restrict portadmin

### DIFF
--- a/changelog.d/3298.added.md
+++ b/changelog.d/3298.added.md
@@ -1,0 +1,1 @@
+Added per-attribute privileges for PortAdmin

--- a/doc/reference/portadmin.rst
+++ b/doc/reference/portadmin.rst
@@ -123,8 +123,11 @@ To activate the voice VLAN, click the checkbox and click "Save".
 I cannot edit an interface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Two things can lead to an interface not being editable (no fields or dropdowns appear):
+Several things can lead to an interface not being editable (no fields or dropdowns appear):
 
+* Your user group has not been granted the PortAdmin privilege for the attribute
+  you are trying to change on this device. A NAV administrator must grant it, see
+  :ref:`portadmin-privileges`.
 * The NAV admin has turned on VLAN authorization. This means you can only
   edit interfaces that have a VLAN that you are organizationally connected to.
 * Something called a *read-write community* has not been set on the device. The
@@ -138,6 +141,66 @@ Some parts of the interface is disabled/greyed out
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 See above.
+
+
+.. _portadmin-privileges:
+
+Authorizing changes
+===================
+
+PortAdmin has two independent layers of authorization:
+
+1. **Which interfaces** a user may edit at all. This is governed by the
+   ``vlan_auth`` config option described below, based on the relationship between
+   the user's organizations and the VLAN of the interface.
+2. **What the user may change** on those interfaces. This is governed by the
+   per-attribute privileges described here.
+
+The second layer is off by default. Set ``require_privileges`` to ``on`` in the
+``[authorization]`` section of :file:`portadmin.conf` to enforce it. While it is
+off, any user allowed to edit an interface may change every attribute on it.
+
+Each editable interface attribute has its own privilege:
+
+==============================  ==========================================
+Privilege                       Permits changing
+==============================  ==========================================
+``portadmin_description``       The port description (ifalias)
+``portadmin_vlan``              The access/native VLAN of a port
+``portadmin_admin_status``      Enabling and disabling a port
+``portadmin_poe``               The PoE state of a port
+``portadmin_voice_vlan``        The voice VLAN setting of a port
+``portadmin_trunk``             Trunk configuration
+==============================  ==========================================
+
+.. important:: Once ``require_privileges`` is on, the default is to deny. A user who
+   is not a NAV administrator cannot change anything in PortAdmin until at least one
+   of these privileges has been granted to one of their user groups. NAV
+   administrators always have full access.
+
+Privileges are granted per user group in the Useradmin tool, under
+:guilabel:`Groups`. Each grant has a *target* that scopes it to a set of IP
+devices. The target is a regular expression, matched against the names of the
+*device groups* defined in SeedDB, in the same way the targets of ``web_access``
+privileges are regular expressions. The privilege applies to an IP device if the
+expression matches at least one of the device groups it belongs to:
+
+``^SDN$``
+    The privilege applies only to IP devices in the device group ``SDN``.
+
+``^LEGACY-.*``
+    The privilege applies to IP devices in any device group whose name starts with
+    ``LEGACY-``.
+
+``.*``
+    The privilege applies to every IP device that is in a device group.
+
+Remember to anchor a target with ``^`` and ``$`` when you mean an exact group name.
+An unanchored target such as ``SDN`` also matches a group named ``SDN-EDGE``.
+
+.. note:: Since a target only ever matches device group names, an IP device that
+   belongs to no device group at all is matched by no target, not even ``.*``. Put
+   an IP device in at least one device group before granting anyone access to it.
 
 
 The Config File
@@ -179,6 +242,12 @@ the example config file. Some of the options that can be set in this file are:
     If you want to limit what users can do in PortAdmin you activate
     this option. What this does is limit the choice of VLANs to the
     ones connected to the users organization.
+
+**require_privileges**
+    When set to ``true``, each interface attribute can only be changed by users
+    whose group has been granted the corresponding PortAdmin privilege. The default
+    is ``false``, which lets any user who may edit an interface change every
+    attribute on it. See :ref:`portadmin-privileges`.
 
 **vlan and netident**
     Some network admins want to use a separate VLAN to indicate that

--- a/python/nav/etc/portadmin/portadmin.conf
+++ b/python/nav/etc/portadmin/portadmin.conf
@@ -59,6 +59,27 @@
 
 #vlan_auth = off
 
+# require_privileges controls whether the per-attribute PortAdmin privileges are
+# enforced. These decide *what* a user may change on an interface they are allowed
+# to edit: there is a separate privilege for the port description, the vlan,
+# enabling/disabling, the PoE state, the voice vlan and trunk editing. Privileges
+# are granted per user group in the Useradmin tool. Each grant is scoped by its
+# target, a regular expression matched against the names of the device groups an
+# IP device belongs to: '^SDN$' for the devices in the SDN device group, or '.*'
+# for every device that is in a device group at all. A device that is in no device
+# group is matched by no target.
+#
+# When this is off (the default), any user allowed to edit an interface may change
+# every attribute on it. When it is on, the default is to deny: a non-admin user
+# cannot change anything until a privilege has been granted to one of their groups.
+# NAV administrators are always allowed everything.
+#
+# This is independent of vlan_auth above, which decides *which* interfaces a user
+# may edit at all.
+# Possible values are: 1, yes, on, true, 0, no, off, false
+
+#require_privileges = off
+
 [defaultvlan]
 #
 # Default vlan is the vlan that is not necessary defined on the switch

--- a/python/nav/models/sql/changes/sc.05.19.0004.sql
+++ b/python/nav/models/sql/changes/sc.05.19.0004.sql
@@ -1,0 +1,6 @@
+INSERT INTO Privilege (privilegename) VALUES ('portadmin_vlan');
+INSERT INTO Privilege (privilegename) VALUES ('portadmin_description');
+INSERT INTO Privilege (privilegename) VALUES ('portadmin_admin_status');
+INSERT INTO Privilege (privilegename) VALUES ('portadmin_poe');
+INSERT INTO Privilege (privilegename) VALUES ('portadmin_voice_vlan');
+INSERT INTO Privilege (privilegename) VALUES ('portadmin_trunk');

--- a/python/nav/portadmin/config.py
+++ b/python/nav/portadmin/config.py
@@ -38,6 +38,7 @@ link_edit = true
 
 [authorization]
 vlan_auth = off
+require_privileges = off
 
 [defaultvlan]
 [ifaliasformat]
@@ -49,6 +50,15 @@ enabled = false
     def is_vlan_authorization_enabled(self):
         """Check config to see if authorization is to be done"""
         return self.getboolean("authorization", "vlan_auth")
+
+    def is_privilege_authorization_enabled(self):
+        """Checks if per-attribute privileges are required to change an interface
+
+        When this is off, any user who is allowed to edit an interface may change
+        every attribute on it, which is how PortAdmin behaved before per-attribute
+        privileges were introduced. Default is off.
+        """
+        return self.getboolean("authorization", "require_privileges", fallback=False)
 
     def is_commit_enabled(self):
         """Checks if configuration commit is turned on or off. Default is on"""

--- a/python/nav/portadmin/privileges.py
+++ b/python/nav/portadmin/privileges.py
@@ -21,6 +21,7 @@ from enum import StrEnum
 
 from nav.models.manage import Netbox
 from nav.models.profiles import Account
+from nav.portadmin.config import CONFIG
 
 _logger = logging.getLogger(__name__)
 
@@ -53,6 +54,12 @@ class PortadminPermissions:
     Since a target only ever matches group names, a netbox that belongs to no device
     group matches no target, and no privilege applies to it.
 
+    Enforcement is controlled by the ``require_privileges`` option in the
+    ``[authorization]`` section of :file:`portadmin.conf`, and is off by default. While
+    it is off, any user allowed to edit an interface may change every attribute on it,
+    which is how PortAdmin behaved before these privileges existed. This is independent
+    of the ``vlan_auth`` option, which governs *which* interfaces a user may edit.
+
     Instances are cheap to pass around and evaluate the account's privileges only
     once, so a single instance can be reused for every interface on a netbox.
     """
@@ -61,9 +68,10 @@ class PortadminPermissions:
         self.account = account
         self.netbox = netbox
         self._is_admin = account.is_admin()
+        self._enforced = CONFIG.is_privilege_authorization_enabled()
         self._allowed = (
             set(PortadminPrivilege)
-            if self._is_admin
+            if self._is_admin or not self._enforced
             else self._resolve_allowed_privileges()
         )
 

--- a/python/nav/portadmin/privileges.py
+++ b/python/nav/portadmin/privileges.py
@@ -1,0 +1,153 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.  You should have received a copy of the GNU General Public License
+# along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Defines granular privileges for PortAdmin."""
+
+import logging
+import re
+from enum import StrEnum
+
+from nav.models.manage import Netbox
+from nav.models.profiles import Account
+
+_logger = logging.getLogger(__name__)
+
+
+class PortadminPrivilege(StrEnum):
+    """The PortAdmin privilege type names
+
+    These correspond to rows in the `privilege` database table, and to the
+    individually editable attributes exposed by PortAdmin. The members compare equal
+    to their string values, so they can be used directly in database queries.
+    """
+
+    VLAN = "portadmin_vlan"
+    DESCRIPTION = "portadmin_description"
+    ADMIN_STATUS = "portadmin_admin_status"
+    POE = "portadmin_poe"
+    VOICE_VLAN = "portadmin_voice_vlan"
+    TRUNK = "portadmin_trunk"
+
+
+class PortadminPermissions:
+    """The set of PortAdmin attributes an account may edit on a given netbox.
+
+    Each privilege is scoped by its ``target``, a regular expression matched against
+    the names of the device groups the netbox belongs to, in the same way the targets
+    of ``web_access`` privileges are regular expressions. The privilege applies if the
+    expression matches at least one of the groups, so `^SDN$` covers the netboxes in
+    the `SDN` device group, while `.*` covers every netbox that is in a group at all.
+
+    Since a target only ever matches group names, a netbox that belongs to no device
+    group matches no target, and no privilege applies to it.
+
+    Instances are cheap to pass around and evaluate the account's privileges only
+    once, so a single instance can be reused for every interface on a netbox.
+    """
+
+    def __init__(self, account: Account, netbox: Netbox):
+        self.account = account
+        self.netbox = netbox
+        self._is_admin = account.is_admin()
+        self._allowed = (
+            set(PortadminPrivilege)
+            if self._is_admin
+            else self._resolve_allowed_privileges()
+        )
+
+    def _resolve_allowed_privileges(self) -> set[str]:
+        """Finds the privileges granted to this account that apply to this netbox"""
+        group_ids = self._get_netbox_group_ids()
+        privileges = self.account.get_privileges().filter(
+            type__name__in=list(PortadminPrivilege)
+        )
+        return {
+            privilege.type.name
+            for privilege in privileges
+            if self._target_matches_groups(privilege.target, group_ids)
+        }
+
+    def _get_netbox_group_ids(self) -> set[str]:
+        """Returns the set of device group names the netbox belongs to"""
+        return set(self.netbox.groups.values_list("id", flat=True))
+
+    @staticmethod
+    def _target_matches_groups(target: str, group_ids: set[str]) -> bool:
+        """Decides whether a privilege target matches a set of device groups
+
+        The target is a regular expression, matched against each device group name.
+        It matches if at least one of them matches. A netbox that belongs to no
+        device group therefore matches no target at all.
+
+        :param target: The ``target`` value of a privilege.
+        :param group_ids: The device group names
+        """
+        if not target:
+            return False
+        try:
+            pattern = re.compile(target)
+        except re.error:
+            _logger.error("Invalid regexp in PortAdmin privilege target: %r", target)
+            return False
+        return any(pattern.search(group_id) for group_id in group_ids)
+
+    def can(self, privilege: str) -> bool:
+        """Returns True if the account may change the given attribute
+
+        :raises ValueError: If the privilege is not a PortAdmin privilege.
+        """
+        return PortadminPrivilege(privilege) in self._allowed
+
+    @property
+    def can_edit_something(self) -> bool:
+        """Returns True if the account may change at least one attribute"""
+        return bool(self._allowed)
+
+    @property
+    def allowed(self) -> frozenset[str]:
+        """Returns the set of privilege names granted on this netbox"""
+        return frozenset(self._allowed)
+
+    # Convenience accessors, primarily for use from Django templates
+
+    @property
+    def vlan(self) -> bool:
+        """Returns True if the account may change the VLAN"""
+        return self.can(PortadminPrivilege.VLAN)
+
+    @property
+    def description(self) -> bool:
+        """Returns True if the account may change the port description"""
+        return self.can(PortadminPrivilege.DESCRIPTION)
+
+    @property
+    def admin_status(self) -> bool:
+        """Returns True if the account may enable/disable the interface"""
+        return self.can(PortadminPrivilege.ADMIN_STATUS)
+
+    @property
+    def poe(self) -> bool:
+        """Returns True if the account may change the PoE state"""
+        return self.can(PortadminPrivilege.POE)
+
+    @property
+    def voice_vlan(self) -> bool:
+        """Returns True if the account may change the voice VLAN"""
+        return self.can(PortadminPrivilege.VOICE_VLAN)
+
+    @property
+    def trunk(self) -> bool:
+        """Returns True if the account may edit trunks"""
+        return self.can(PortadminPrivilege.TRUNK)

--- a/python/nav/web/portadmin/utils.py
+++ b/python/nav/web/portadmin/utils.py
@@ -27,6 +27,7 @@ from nav.models.profiles import Account
 from nav.portadmin.config import CONFIG
 from nav.portadmin.management import ManagementFactory
 from nav.portadmin.handlers import ManagementHandler
+from nav.portadmin.privileges import PortadminPermissions
 from nav.portadmin.vlan import FantasyVlan
 from nav.enterprise.ids import VENDOR_ID_CISCOSYSTEMS
 
@@ -73,10 +74,13 @@ def find_and_populate_allowed_vlans(
     netbox: manage.Netbox,
     interfaces: Sequence[manage.Interface],
     handler: ManagementHandler,
+    permissions: Optional[PortadminPermissions] = None,
 ):
     """Finds allowed vlans and indicate which interfaces can be edited"""
     allowed_vlans = find_allowed_vlans_for_user_on_netbox(account, netbox, handler)
-    set_editable_flag_on_interfaces(interfaces, allowed_vlans, account)
+    set_editable_flag_on_interfaces(
+        interfaces, allowed_vlans, account, permissions=permissions
+    )
     return allowed_vlans
 
 
@@ -129,6 +133,7 @@ def set_editable_flag_on_interfaces(
     interfaces: Sequence[manage.Interface],
     vlans: Sequence[FantasyVlan],
     user: Optional[Account] = None,
+    permissions: Optional[PortadminPermissions] = None,
 ):
     """Sets the pseudo-attribute `iseditable` on each interface in the interfaces
     list, indicating whether the PortAdmin UI should allow edits to it or not.
@@ -136,11 +141,20 @@ def set_editable_flag_on_interfaces(
     An interface will be considered "editable" only if its native vlan matches one of
     the vlan tags from `vlans`. An interface may be considered non-editable if it is
     an uplink, depending on how portadmin is configured.
+
+    If `permissions` is given, no interface is editable unless the user has been
+    granted at least one per-attribute PortAdmin privilege on the netbox. Which
+    individual attributes may be changed is decided per attribute, elsewhere.
     """
     vlan_tags = {vlan.vlan for vlan in vlans}
     allow_everything = not should_check_access_rights(account=user) if user else False
+    may_edit_something = permissions.can_edit_something if permissions else True
 
     for interface in interfaces:
+        if not may_edit_something:
+            interface.iseditable = False
+            continue
+
         if allow_everything:
             interface.iseditable = True
             continue

--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -268,11 +268,12 @@ def populate_infodict(request, netbox, interfaces):
     voice_vlan = None
     supports_poe = False
     poe_options = []
+    permissions = PortadminPermissions(get_account(request), netbox)
 
     if not has_error:
         account = get_account(request)
         allowed_vlans = find_and_populate_allowed_vlans(
-            account, netbox, interfaces, handler
+            account, netbox, interfaces, handler, permissions=permissions
         )
         voice_vlan = _setup_voice_vlan(request, netbox, interfaces, handler)
         mark_detained_interfaces(interfaces)
@@ -295,10 +296,11 @@ def populate_infodict(request, netbox, interfaces):
         'allowed_vlans': allowed_vlans,
         'readonly': has_error,
         'aliastemplate': _get_alias_template(),
-        'trunk_edit': CONFIG.get_trunk_edit(),
+        'trunk_edit': CONFIG.get_trunk_edit() and permissions.trunk,
         'auditlog_api_parameters': json.dumps(auditlog_api_parameters),
         'supports_poe': supports_poe,
         'poe_options': poe_options,
+        'permissions': permissions,
     }
 
     if handler:
@@ -858,6 +860,7 @@ def render_trunk_edit(request, interfaceid):
             'allowed_vlans': allowed_vlans,
             'trunk_edit': CONFIG.get_trunk_edit() and permissions.trunk,
             'readonly': not handler.is_configurable() or not permissions.trunk,
+            'permissions': permissions,
         }
     )
 

--- a/python/nav/web/portadmin/views.py
+++ b/python/nav/web/portadmin/views.py
@@ -51,6 +51,7 @@ from nav.web.portadmin.utils import (
     add_poe_info,
 )
 from nav.portadmin.config import CONFIG
+from nav.portadmin.privileges import PortadminPermissions, PortadminPrivilege
 from nav.portadmin.snmp.base import SNMPHandler
 from nav.portadmin.management import ManagementFactory
 from nav.portadmin.handlers import (
@@ -500,19 +501,34 @@ def set_interface_values(account, interface, request):
     handler = get_management_handler(interface.netbox)
 
     if handler:
+        permissions = PortadminPermissions(account, interface.netbox)
         # Order is important here, set_voice need to be before set_vlan
-        set_voice_vlan(handler, interface, request)
-        set_ifalias(account, handler, interface, request)
-        set_vlan(account, handler, interface, request)
-        set_admin_status(handler, interface, request)
-        set_poe_state(handler, interface, request)
+        set_voice_vlan(handler, interface, request, permissions)
+        set_ifalias(account, handler, interface, request, permissions)
+        set_vlan(account, handler, interface, request, permissions)
+        set_admin_status(handler, interface, request, permissions)
+        set_poe_state(handler, interface, request, permissions)
         save_to_database([interface])
     else:
         messages.info(request, 'Could not connect to netbox')
 
 
-def set_poe_state(handler, interface, request):
+def set_poe_state(handler, interface, request, permissions: PortadminPermissions):
+    """Set the PoE state on the interface if it is requested
+
+    :raises ValueError: If the requested state is not one of the states the device
+                        reports as supported.
+    """
     if 'poe_state' in request.POST:
+        if not permissions.poe:
+            _logger.debug(
+                "%s: denied PoE state change on %s - missing %s privilege",
+                permissions.account.login,
+                interface,
+                PortadminPrivilege.POE,
+            )
+            messages.error(request, "Not allowed to change PoE state on this IP device")
+            return
         poe_state_name = request.POST.get('poe_state')
         for option in handler.get_poe_state_options():
             if option.name == poe_state_name:
@@ -536,9 +552,26 @@ def build_ajax_messages(request):
     return ajax_messages
 
 
-def set_ifalias(account, handler: ManagementHandler, interface, request):
+def set_ifalias(
+    account,
+    handler: ManagementHandler,
+    interface,
+    request,
+    permissions: PortadminPermissions,
+):
     """Set ifalias on netbox if it is requested"""
     if 'ifalias' in request.POST:
+        if not permissions.description:
+            _logger.debug(
+                "%s: denied port description change on %s - missing %s privilege",
+                account.login,
+                interface,
+                PortadminPrivilege.DESCRIPTION,
+            )
+            messages.error(
+                request, "Not allowed to change port description on this IP device"
+            )
+            return
         ifalias = request.POST.get('ifalias')
         if check_format_on_ifalias(ifalias):
             try:
@@ -565,9 +598,24 @@ def set_ifalias(account, handler: ManagementHandler, interface, request):
             messages.error(request, "Wrong format on port description")
 
 
-def set_vlan(account, handler: ManagementHandler, interface, request):
+def set_vlan(
+    account,
+    handler: ManagementHandler,
+    interface,
+    request,
+    permissions: PortadminPermissions,
+):
     """Set vlan on netbox if it is requested"""
     if 'vlan' in request.POST:
+        if not permissions.vlan:
+            _logger.debug(
+                "%s: denied vlan change on %s - missing %s privilege",
+                account.login,
+                interface,
+                PortadminPrivilege.VLAN,
+            )
+            messages.error(request, "Not allowed to change vlan on this IP device")
+            return
         try:
             vlan = int(request.POST.get('vlan'))
         except ValueError:
@@ -609,7 +657,9 @@ def set_vlan(account, handler: ManagementHandler, interface, request):
             messages.error(request, "Error setting vlan: %s" % error)
 
 
-def set_voice_vlan(handler: ManagementHandler, interface, request):
+def set_voice_vlan(
+    handler: ManagementHandler, interface, request, permissions: PortadminPermissions
+):
     """Set voicevlan on interface
 
     A voice vlan is a normal vlan that is defined by the user of NAV as
@@ -620,6 +670,17 @@ def set_voice_vlan(handler: ManagementHandler, interface, request):
 
     """
     if 'voicevlan' in request.POST:
+        if not permissions.voice_vlan:
+            _logger.debug(
+                "%s: denied voice vlan change on %s - missing %s privilege",
+                permissions.account.login,
+                interface,
+                PortadminPrivilege.VOICE_VLAN,
+            )
+            messages.error(
+                request, "Not allowed to change voice vlan on this IP device"
+            )
+            return
         cdp_changed = False
         voice_vlan = fetch_voice_vlan_for_netbox(request, handler)
         use_cisco_voice_vlan = CONFIG.is_cisco_voice_enabled() and is_cisco(
@@ -667,13 +728,29 @@ def set_voice_vlan(handler: ManagementHandler, interface, request):
             messages.error(request, "Error setting voicevlan: %s" % error)
 
 
-def set_admin_status(handler: ManagementHandler, interface, request: HttpRequest):
+def set_admin_status(
+    handler: ManagementHandler,
+    interface,
+    request: HttpRequest,
+    permissions: PortadminPermissions,
+):
     """Set admin status for the interface"""
     status_up = '1'
     status_down = '2'
     account = get_account(request)
 
     if 'ifadminstatus' in request.POST:
+        if not permissions.admin_status:
+            _logger.debug(
+                "%s: denied enable/disable on %s - missing %s privilege",
+                account.login,
+                interface,
+                PortadminPrivilege.ADMIN_STATUS,
+            )
+            messages.error(
+                request, "Not allowed to enable or disable ports on this IP device"
+            )
+            return
         adminstatus = request.POST['ifadminstatus']
         try:
             if adminstatus == status_up:
@@ -727,15 +804,26 @@ def render_trunk_edit(request, interfaceid):
 
     interface = Interface.objects.get(pk=interfaceid)
     handler = get_management_handler(interface.netbox)
-    if request.method == 'POST':
-        try:
-            handle_trunk_edit(request, handler, interface)
-        except ManagementError as error:
-            messages.error(request, 'Error editing trunk: %s' % error)
-        else:
-            messages.success(request, 'Trunk edit successful')
-
     account = get_account(request)
+    permissions = PortadminPermissions(account, interface.netbox)
+
+    if request.method == 'POST':
+        if not permissions.trunk:
+            messages.error(request, 'Not allowed to edit trunks on this IP device')
+            _logger.debug(
+                "%s: denied trunk edit on %s - missing %s privilege",
+                account.login,
+                interface,
+                PortadminPrivilege.TRUNK,
+            )
+        else:
+            try:
+                handle_trunk_edit(request, handler, interface)
+            except ManagementError as error:
+                messages.error(request, 'Error editing trunk: %s' % error)
+            else:
+                messages.success(request, 'Trunk edit successful')
+
     netbox = interface.netbox
     add_readonly_reason(request, handler)
     try:
@@ -768,8 +856,8 @@ def render_trunk_edit(request, interfaceid):
             'native_vlan': native_vlan,
             'trunked_vlans': trunked_vlans,
             'allowed_vlans': allowed_vlans,
-            'trunk_edit': CONFIG.get_trunk_edit(),
-            'readonly': not handler.is_configurable(),
+            'trunk_edit': CONFIG.get_trunk_edit() and permissions.trunk,
+            'readonly': not handler.is_configurable() or not permissions.trunk,
         }
     )
 
@@ -837,6 +925,19 @@ def restart_interfaces(request):
         )
     netbox = list(netboxes)[0]
 
+    # Restarting an interface is an admin status change, but is also done implicitly
+    # after a vlan change, so either privilege permits it
+    permissions = PortadminPermissions(get_account(request), netbox)
+    if not (permissions.admin_status or permissions.vlan):
+        _logger.debug(
+            "%s: denied interface restart on %s - insufficient privileges",
+            permissions.account.login,
+            netbox.sysname,
+        )
+        return HttpResponse(
+            status=403, content=b"Not allowed to restart interfaces on this IP device"
+        )
+
     handler = get_management_handler(netbox)
     if handler:
         try:
@@ -858,6 +959,19 @@ def commit_configuration(request):
         return HttpResponse("Configuration commit is configured to not be done")
 
     interface = get_object_or_404(Interface, pk=request.POST.get('interfaceid'))
+
+    # Committing only persists changes already made, so any edit privilege permits it
+    permissions = PortadminPermissions(get_account(request), interface.netbox)
+    if not permissions.can_edit_something:
+        _logger.debug(
+            "%s: denied configuration commit on %s - no edit privileges",
+            permissions.account.login,
+            interface.netbox.sysname,
+        )
+        return HttpResponse(
+            status=403,
+            content=b"Not allowed to commit configuration on this IP device",
+        )
 
     handler = get_management_handler(interface.netbox)
     if handler:

--- a/python/nav/web/templates/portadmin/portlist.html
+++ b/python/nav/web/templates/portadmin/portlist.html
@@ -7,6 +7,13 @@
 {% include 'portadmin/_messages.html' with hx_swap_oob=True %}
 {% endif %}
 
+{% if not loading and not readonly and not permissions.can_edit_something %}
+  <div class="alert-box info">
+    You do not have permission to change anything on this IP device. Ask a NAV
+    administrator to grant your user group the relevant PortAdmin privileges.
+  </div>
+{% endif %}
+
 <div id="portadmin-wrapper" class="faketable{% if loading %} loading{% endif %}">
   <div class="caption">
     <a href="{{ netbox.get_absolute_url }}"
@@ -55,7 +62,7 @@
         PoE State
       </div>
     {% endif %}
-    {% if not readonly %}
+    {% if not readonly and permissions.can_edit_something %}
       <div class="column {% if voice_vlan %}medium-1{% else %}medium-2{% endif %} text-right">
         <input type="button" class="saveall_button button tiny" value="Save all"/>
       </div>
@@ -83,7 +90,7 @@
         {% else %}
           <input type="checkbox" class="ifadminstatus" data-orig="{{ interface.ifadminstatus }}"
                  {% if interface.ifadminstatus == 1 %}checked{% endif %}
-                 {% if not interface.iseditable %}disabled{% endif %}
+                 {% if not interface.iseditable or not permissions.admin_status %}disabled{% endif %}
           >
         {% endif %}
       </div>
@@ -96,7 +103,7 @@
 
       {# Port Description - input field #}
       <div class="{% if readonly or supports_poe %}medium-3{% else %}medium-4{% endif %} column">
-        {% if interface.iseditable and not readonly %}
+        {% if interface.iseditable and not readonly and permissions.description %}
           <input class="ifalias" type="text"
                  value="{{ interface.ifalias|default_if_none:'' }}"
                  data-orig="{{ interface.ifalias|default_if_none:'' }}"/>
@@ -123,7 +130,7 @@
               Trunk
             {% endif %}
           {% else %}
-            {% if interface.iseditable and not readonly %}
+            {% if interface.iseditable and not readonly and permissions.vlan %}
               {% if interface.detained %}
                 {{ interface.vlan|default_if_none:'' }}
                 <a href="{% url 'arnold-detainedports' %}">
@@ -178,7 +185,7 @@
                      name="voice_vlan"
                      data-orig="{{ interface.voice_activated|default:'false' }}"
                      {% if interface.voice_activated %}checked{% endif %}
-                     {% if readonly or not interface.iseditable %}disabled="disabled"{% endif %}>
+                     {% if readonly or not interface.iseditable or not permissions.voice_vlan %}disabled="disabled"{% endif %}>
             </span>
           {% else %}
             &nbsp;
@@ -190,22 +197,26 @@
       {% if supports_poe %}
         <div class="medium-1 small-4 column">
           {% if interface.supports_poe %}
-            <form class="custom">
-              {% csrf_token %}
-              <select class="poelist" name="{{ interface.ifname }}">
-                {% for poe_option in poe_options %}
-                  <option value="{{ poe_option.name }}" label="{{ poe_option.name }}"
-                          {% if interface.poe_state.name == poe_option.name %}selected="selected"
-                          data-orig="{{ poe_option.name }}"{% endif %}>
-                {% endfor %}
-              </select>
-            </form>
+            {% if permissions.poe and not readonly %}
+              <form class="custom">
+                {% csrf_token %}
+                <select class="poelist" name="{{ interface.ifname }}">
+                  {% for poe_option in poe_options %}
+                    <option value="{{ poe_option.name }}" label="{{ poe_option.name }}"
+                            {% if interface.poe_state.name == poe_option.name %}selected="selected"
+                            data-orig="{{ poe_option.name }}"{% endif %}>
+                  {% endfor %}
+                </select>
+              </form>
+            {% else %}
+              {{ interface.poe_state.name|default:'&nbsp;' }}
+            {% endif %}
           {% endif %}
         </div>
       {% endif %}
 
       {# Button for saving #}
-      {% if interface.iseditable and not readonly %}
+      {% if interface.iseditable and not readonly and permissions.can_edit_something %}
           <div class="{% if voice_vlan %}medium-1 small-4{% else %}medium-2 small-8{% endif %}  column text-right">
               <button class="tiny portadmin-save secondary">Save</button>
           </div>

--- a/python/nav/web/templates/portadmin/trunk_edit.html
+++ b/python/nav/web/templates/portadmin/trunk_edit.html
@@ -96,7 +96,13 @@
 
   {% else %}
     {% if not trunk_edit %}
-      <div class="alert-box info">Trunk editing is disabled</div>
+      {% if interface and not permissions.trunk %}
+        <div class="alert-box info">
+          You do not have permission to edit trunks on this IP device.
+        </div>
+      {% else %}
+        <div class="alert-box info">Trunk editing is disabled</div>
+      {% endif %}
     {% else %}
       <p class="error">This interface does not exist</p>
     {% endif %}

--- a/tests/integration/portadmin/privileges_test.py
+++ b/tests/integration/portadmin/privileges_test.py
@@ -1,0 +1,160 @@
+"""Tests for per-attribute PortAdmin authorization, against real database objects"""
+
+import pytest
+
+from nav.models.manage import NetboxGroup
+from nav.models.profiles import AccountGroup, PrivilegeType
+from nav.portadmin.privileges import PortadminPermissions, PortadminPrivilege
+
+
+def _grant(account_group, privilege, target):
+    """Grants a PortAdmin privilege to an account group, scoped to a target"""
+    return account_group.privileges.create(
+        type=PrivilegeType.objects.get(name=privilege), target=target
+    )
+
+
+@pytest.fixture()
+def account_group(db, non_admin_account):
+    """An account group holding the account whose privileges are under test"""
+    group = AccountGroup.objects.create(name="portadmin privilege test group")
+    non_admin_account.groups.add(group)
+    return group
+
+
+@pytest.fixture()
+def sdn_group(db):
+    group = NetboxGroup.objects.create(id="SDN", description="SDN switches")
+    return group
+
+
+@pytest.fixture()
+def legacy_group(db):
+    group = NetboxGroup.objects.create(id="LEGACY", description="Legacy switches")
+    return group
+
+
+@pytest.fixture()
+def sdn_netbox(localhost, sdn_group):
+    localhost.groups.add(sdn_group)
+    return localhost
+
+
+@pytest.fixture()
+def legacy_netbox(localhost, legacy_group):
+    localhost.groups.add(legacy_group)
+    return localhost
+
+
+class TestPortadminPermissions:
+    def test_when_user_is_admin_it_should_allow_everything(
+        self, admin_account, sdn_netbox
+    ):
+        permissions = PortadminPermissions(admin_account, sdn_netbox)
+        for privilege in PortadminPrivilege:
+            assert permissions.can(privilege)
+
+    def test_when_user_has_no_privileges_it_should_allow_nothing(
+        self, non_admin_account, sdn_netbox
+    ):
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+        for privilege in PortadminPrivilege:
+            assert not permissions.can(privilege)
+
+    def test_when_a_privilege_is_granted_then_can_edit_something_should_be_true(
+        self, non_admin_account, account_group, sdn_netbox
+    ):
+        _grant(account_group, PortadminPrivilege.DESCRIPTION, "SDN")
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+        assert permissions.can_edit_something
+
+    def test_when_no_privileges_are_granted_then_can_edit_something_should_be_false(
+        self, non_admin_account, sdn_netbox
+    ):
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+        assert not permissions.can_edit_something
+
+    def test_when_netbox_is_outside_the_privilege_target_it_should_not_be_allowed(
+        self, non_admin_account, account_group, sdn_netbox
+    ):
+        _grant(account_group, PortadminPrivilege.VLAN, "^LEGACY$")
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+        assert not permissions.vlan
+
+    def test_when_target_names_a_group_it_should_match_that_group(
+        self, non_admin_account, legacy_netbox, account_group
+    ):
+        _grant(account_group, PortadminPrivilege.VLAN, "^LEGACY$")
+        permissions = PortadminPermissions(non_admin_account, legacy_netbox)
+        assert permissions.vlan
+
+    def test_when_target_matches_everything_it_should_match_any_group(
+        self, non_admin_account, sdn_netbox, account_group
+    ):
+        _grant(account_group, PortadminPrivilege.VLAN, ".*")
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+        assert permissions.vlan
+
+    def test_when_netbox_is_in_no_group_it_should_not_match_any_target(
+        self, non_admin_account, localhost, account_group
+    ):
+        """A target only matches group names, so a netbox without any matches none"""
+        _grant(account_group, PortadminPrivilege.VLAN, ".*")
+        permissions = PortadminPermissions(non_admin_account, localhost)
+        assert not permissions.vlan
+
+    def test_when_target_is_unanchored_it_should_match_substrings(
+        self, non_admin_account, localhost, account_group
+    ):
+        """Anchor a target with ^ and $ to match a group name exactly"""
+        edge = NetboxGroup.objects.create(id="SDN-EDGE", description="Edge switches")
+        localhost.groups.add(edge)
+        _grant(account_group, PortadminPrivilege.VLAN, "SDN")
+        permissions = PortadminPermissions(non_admin_account, localhost)
+        assert permissions.vlan
+
+    def test_when_target_is_an_invalid_regexp_it_should_not_match(
+        self, non_admin_account, sdn_netbox, account_group
+    ):
+        """A malformed target must be denied rather than raise"""
+        _grant(account_group, PortadminPrivilege.VLAN, "*")
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+        assert not permissions.vlan
+
+    def test_when_privilege_name_is_unknown_it_should_raise_error(
+        self, non_admin_account, sdn_netbox
+    ):
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+
+        with pytest.raises(ValueError):
+            permissions.can("some_other_privilege")
+
+    def test_when_netbox_is_in_several_groups_it_should_match_any_of_them(
+        self, non_admin_account, localhost, sdn_group, legacy_group, account_group
+    ):
+        localhost.groups.add(sdn_group, legacy_group)
+        _grant(account_group, PortadminPrivilege.VLAN, "LEGACY")
+        permissions = PortadminPermissions(non_admin_account, localhost)
+        assert permissions.vlan
+
+    @pytest.mark.parametrize(
+        "privilege,accessor",
+        [
+            (PortadminPrivilege.VLAN, "vlan"),
+            (PortadminPrivilege.DESCRIPTION, "description"),
+            (PortadminPrivilege.ADMIN_STATUS, "admin_status"),
+            (PortadminPrivilege.POE, "poe"),
+            (PortadminPrivilege.VOICE_VLAN, "voice_vlan"),
+            (PortadminPrivilege.TRUNK, "trunk"),
+        ],
+    )
+    def test_when_a_privilege_is_granted_its_accessor_should_be_true(
+        self, non_admin_account, sdn_netbox, account_group, privilege, accessor
+    ):
+        """Each privilege must map to the accessor that reports it"""
+        _grant(account_group, privilege, ".*")
+
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+
+        assert getattr(permissions, accessor)
+        assert permissions.allowed == frozenset([privilege])

--- a/tests/integration/portadmin/privileges_test.py
+++ b/tests/integration/portadmin/privileges_test.py
@@ -1,10 +1,26 @@
 """Tests for per-attribute PortAdmin authorization, against real database objects"""
 
+from unittest.mock import patch
+
 import pytest
 
 from nav.models.manage import NetboxGroup
 from nav.models.profiles import AccountGroup, PrivilegeType
 from nav.portadmin.privileges import PortadminPermissions, PortadminPrivilege
+
+
+@pytest.fixture
+def privileges_enforced():
+    """Switches on enforcement of the per-attribute privileges
+
+    Enforcement is off by default, in which case every attribute is editable and
+    there would be nothing to assert.
+    """
+    with patch(
+        "nav.portadmin.privileges.CONFIG.is_privilege_authorization_enabled",
+        return_value=True,
+    ):
+        yield
 
 
 def _grant(account_group, privilege, target):
@@ -46,6 +62,7 @@ def legacy_netbox(localhost, legacy_group):
     return localhost
 
 
+@pytest.mark.usefixtures("privileges_enforced")
 class TestPortadminPermissions:
     def test_when_user_is_admin_it_should_allow_everything(
         self, admin_account, sdn_netbox
@@ -158,3 +175,32 @@ class TestPortadminPermissions:
 
         assert getattr(permissions, accessor)
         assert permissions.allowed == frozenset([privilege])
+
+
+class TestPrivilegeEnforcementSwitch:
+    """The require_privileges option decides whether privileges are enforced at all"""
+
+    def test_when_enforcement_is_off_it_should_allow_everything(
+        self, non_admin_account, sdn_netbox
+    ):
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+
+        assert permissions.can_edit_something
+        assert permissions.allowed == frozenset(PortadminPrivilege)
+
+    def test_when_enforcement_is_off_it_should_ignore_the_target(
+        self, non_admin_account, sdn_netbox, account_group
+    ):
+        """A grant scoped away from this netbox must not restrict anything"""
+        _grant(account_group, PortadminPrivilege.VLAN, "^LEGACY$")
+
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+
+        assert permissions.vlan
+
+    def test_when_enforcement_is_on_it_should_deny_by_default(
+        self, non_admin_account, sdn_netbox, privileges_enforced
+    ):
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+
+        assert not permissions.can_edit_something

--- a/tests/integration/web/portadmin_test.py
+++ b/tests/integration/web/portadmin_test.py
@@ -7,7 +7,7 @@ from django.test.client import RequestFactory
 from django.urls import reverse
 from django.utils.encoding import smart_str
 from jnpr.junos.exception import ConnectRefusedError
-from mock import patch, Mock
+from mock import ANY, patch, Mock
 
 from nav.models.manage import Interface, Netbox, NetboxGroup, NetboxProfile
 from nav.models.profiles import AccountGroup, PrivilegeType
@@ -239,7 +239,7 @@ class TestPortadminDataLoading:
         result = populate_infodict(mock_request, netbox, interfaces)
 
         mock_find_vlans.assert_called_once_with(
-            mock_request.account, netbox, interfaces, mock_handler
+            mock_request.account, netbox, interfaces, mock_handler, permissions=ANY
         )
         mock_setup_voice.assert_called_once_with(
             mock_request, netbox, interfaces, mock_handler

--- a/tests/integration/web/portadmin_test.py
+++ b/tests/integration/web/portadmin_test.py
@@ -1,6 +1,7 @@
 import uuid
 
 import pytest
+from django.contrib.messages.storage.fallback import FallbackStorage
 from django.http import HttpResponse
 from django.test.client import RequestFactory
 from django.urls import reverse
@@ -8,9 +9,20 @@ from django.utils.encoding import smart_str
 from jnpr.junos.exception import ConnectRefusedError
 from mock import patch, Mock
 
-from nav.models.manage import Interface, Netbox, NetboxProfile
+from nav.models.manage import Interface, Netbox, NetboxGroup, NetboxProfile
+from nav.models.profiles import AccountGroup, PrivilegeType
 from nav.portadmin.handlers import ManagementHandler
-from nav.web.portadmin.views import populate_infodict, load_portadmin_data_by_kwargs
+from nav.portadmin.privileges import PortadminPermissions, PortadminPrivilege
+from nav.web.portadmin.views import (
+    commit_configuration,
+    load_portadmin_data_by_kwargs,
+    populate_infodict,
+    set_admin_status,
+    set_ifalias,
+    set_poe_state,
+    set_vlan,
+    set_voice_vlan,
+)
 
 
 class TestPortadminSearchViews:
@@ -405,3 +417,243 @@ def create_interface(netbox, **kwargs):
     )
     interface.save()
     return interface
+
+
+# --- PortAdmin per-attribute privileges ---------------------------------------
+
+
+@pytest.fixture
+def privileges_enforced():
+    """Enforces per-attribute privileges
+
+    Enforcement is off by default, in which case every attribute is editable and
+    there would be nothing to assert.
+    """
+    with patch(
+        "nav.portadmin.privileges.CONFIG.is_privilege_authorization_enabled",
+        return_value=True,
+    ) as mock_enabled:
+        yield mock_enabled
+
+
+@pytest.fixture
+def privileged_netbox(interface, privileges_enforced):
+    """The netbox of the test interface, placed in a device group"""
+    group = NetboxGroup.objects.create(id="SDN", description="SDN switches")
+    interface.netbox.groups.add(group)
+    yield interface.netbox
+    group.delete()
+
+
+@pytest.fixture
+def account_group(db, non_admin_account):
+    """An account group holding the account whose privileges are under test"""
+    group = AccountGroup.objects.create(name="portadmin view test group")
+    non_admin_account.groups.add(group)
+    return group
+
+
+def grant_privilege(account_group, privilege, target=".*"):
+    """Grants a PortAdmin privilege to an account group, scoped to a target"""
+    return account_group.privileges.create(
+        type=PrivilegeType.objects.get(name=privilege), target=target
+    )
+
+
+def request_with_messages(**post_data):
+    """Builds a POST request the messages framework can add messages to
+
+    The setters report refused changes with messages.error(), which needs message
+    storage on the request.
+    """
+    request = RequestFactory().post("/portadmin/save", post_data)
+    request.session = {}
+    request._messages = FallbackStorage(request)
+    return request
+
+
+class TestSetterPrivilegeGuards:
+    """Each setter must refuse its change when the privilege is missing
+
+    The management handler is mocked, since these tests are about authorization and
+    must not attempt to talk to a real device.
+    """
+
+    def test_when_description_privilege_is_missing_it_should_not_set_ifalias(
+        self, non_admin_account, privileged_netbox, interface
+    ):
+        request = request_with_messages(interfaceid="1", ifalias="new description")
+        handler = Mock()
+
+        set_ifalias(
+            non_admin_account,
+            handler,
+            interface,
+            request,
+            PortadminPermissions(non_admin_account, privileged_netbox),
+        )
+
+        handler.set_interface_description.assert_not_called()
+
+    def test_when_description_privilege_is_granted_it_should_set_ifalias(
+        self, non_admin_account, privileged_netbox, interface, account_group
+    ):
+        grant_privilege(account_group, PortadminPrivilege.DESCRIPTION)
+        request = request_with_messages(interfaceid="1", ifalias="new description")
+        handler = Mock()
+
+        set_ifalias(
+            non_admin_account,
+            handler,
+            interface,
+            request,
+            PortadminPermissions(non_admin_account, privileged_netbox),
+        )
+
+        handler.set_interface_description.assert_called_once()
+
+    def test_when_vlan_privilege_is_missing_it_should_not_set_vlan(
+        self, non_admin_account, privileged_netbox, interface
+    ):
+        request = request_with_messages(interfaceid="1", vlan="42")
+        handler = Mock()
+
+        set_vlan(
+            non_admin_account,
+            handler,
+            interface,
+            request,
+            PortadminPermissions(non_admin_account, privileged_netbox),
+        )
+
+        handler.set_vlan.assert_not_called()
+        handler.set_native_vlan.assert_not_called()
+
+    def test_when_admin_status_privilege_is_missing_it_should_not_change_status(
+        self, non_admin_account, privileged_netbox, interface
+    ):
+        request = request_with_messages(interfaceid="1", ifadminstatus="2")
+        handler = Mock()
+
+        with patch(
+            "nav.web.portadmin.views.get_account", return_value=non_admin_account
+        ):
+            set_admin_status(
+                handler,
+                interface,
+                request,
+                PortadminPermissions(non_admin_account, privileged_netbox),
+            )
+
+        handler.set_interface_down.assert_not_called()
+        handler.set_interface_up.assert_not_called()
+
+    def test_when_poe_privilege_is_missing_it_should_not_set_poe_state(
+        self, non_admin_account, privileged_netbox, interface
+    ):
+        request = request_with_messages(interfaceid="1", poe_state="auto")
+        handler = Mock()
+
+        set_poe_state(
+            handler,
+            interface,
+            request,
+            PortadminPermissions(non_admin_account, privileged_netbox),
+        )
+
+        handler.set_poe_state.assert_not_called()
+
+    def test_when_voice_vlan_privilege_is_missing_it_should_not_set_voice_vlan(
+        self, non_admin_account, privileged_netbox, interface
+    ):
+        request = request_with_messages(interfaceid="1", voicevlan="true")
+        handler = Mock()
+
+        set_voice_vlan(
+            handler,
+            interface,
+            request,
+            PortadminPermissions(non_admin_account, privileged_netbox),
+        )
+
+        handler.set_interface_voice_vlan.assert_not_called()
+        handler.set_cisco_voice_vlan.assert_not_called()
+
+    def test_when_a_privilege_is_missing_it_should_not_block_the_others(
+        self, non_admin_account, privileged_netbox, interface, account_group
+    ):
+        """A refused attribute must not prevent permitted ones from being applied"""
+        grant_privilege(account_group, PortadminPrivilege.DESCRIPTION)
+        request = request_with_messages(
+            interfaceid="1", ifalias="new description", vlan="42"
+        )
+        handler = Mock()
+        permissions = PortadminPermissions(non_admin_account, privileged_netbox)
+
+        set_ifalias(non_admin_account, handler, interface, request, permissions)
+        set_vlan(non_admin_account, handler, interface, request, permissions)
+
+        handler.set_interface_description.assert_called_once()
+        handler.set_vlan.assert_not_called()
+
+    def test_when_netbox_is_outside_the_privilege_target_it_should_not_set_vlan(
+        self, non_admin_account, privileged_netbox, interface, account_group
+    ):
+        """A grant scoped to other device groups must not apply here"""
+        grant_privilege(account_group, PortadminPrivilege.VLAN, "^LEGACY$")
+        request = request_with_messages(interfaceid="1", vlan="42")
+        handler = Mock()
+
+        set_vlan(
+            non_admin_account,
+            handler,
+            interface,
+            request,
+            PortadminPermissions(non_admin_account, privileged_netbox),
+        )
+
+        handler.set_vlan.assert_not_called()
+
+
+class TestCommitConfigurationPrivileges:
+    """Committing requires at least one edit privilege on the device"""
+
+    def test_when_user_has_no_privileges_it_should_return_403(
+        self, non_admin_account, privileged_netbox, interface
+    ):
+        request = RequestFactory().post(
+            "/portadmin/commit", {"interfaceid": str(interface.id)}
+        )
+
+        with (
+            patch(
+                "nav.web.portadmin.views.get_account", return_value=non_admin_account
+            ),
+            patch("nav.web.portadmin.views.get_management_handler") as get_handler,
+        ):
+            response = commit_configuration(request)
+
+        assert response.status_code == 403
+        get_handler.assert_not_called()
+
+    def test_when_user_has_an_edit_privilege_it_should_commit(
+        self, non_admin_account, privileged_netbox, interface, account_group
+    ):
+        grant_privilege(account_group, PortadminPrivilege.DESCRIPTION)
+        request = RequestFactory().post(
+            "/portadmin/commit", {"interfaceid": str(interface.id)}
+        )
+        handler = Mock()
+
+        with (
+            patch(
+                "nav.web.portadmin.views.get_account", return_value=non_admin_account
+            ),
+            patch(
+                "nav.web.portadmin.views.get_management_handler", return_value=handler
+            ),
+        ):
+            response = commit_configuration(request)
+
+        assert response.status_code == 200
+        handler.commit_configuration.assert_called_once()

--- a/tests/unittests/portadmin/config_test.py
+++ b/tests/unittests/portadmin/config_test.py
@@ -1,0 +1,24 @@
+"""Tests for the PortAdmin configuration file options"""
+
+import pytest
+
+from nav.portadmin.config import PortAdminConfig
+
+
+class TestRequirePrivilegesOption:
+    def test_when_option_is_absent_it_should_default_to_off(self):
+        """Upgrading without touching portadmin.conf must not restrict anyone"""
+        config = PortAdminConfig()
+        config.remove_option("authorization", "require_privileges")
+
+        assert not config.is_privilege_authorization_enabled()
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [("on", True), ("true", True), ("1", True), ("off", False), ("no", False)],
+    )
+    def test_when_option_is_set_it_should_be_honoured(self, value, expected):
+        config = PortAdminConfig()
+        config.set("authorization", "require_privileges", value)
+
+        assert config.is_privilege_authorization_enabled() == expected

--- a/tests/unittests/web/portadmin/utils_test.py
+++ b/tests/unittests/web/portadmin/utils_test.py
@@ -37,3 +37,31 @@ class TestSetEditableFlagOnInterfaces:
                 for ifc in mock_interfaces
                 if ifc is not editable_interface
             )
+
+    def test_when_user_may_not_edit_anything_no_interface_should_be_editable(self):
+        permissions = Mock(can_edit_something=False)
+        interfaces = [Mock(vlan=1, iseditable=True) for _ in range(3)]
+
+        with patch(
+            "nav.web.portadmin.utils.should_check_access_rights", return_value=False
+        ):
+            set_editable_flag_on_interfaces(
+                interfaces, [Mock(vlan=1)], Mock(), permissions=permissions
+            )
+
+        assert not any(ifc.iseditable for ifc in interfaces)
+
+    def test_when_user_may_edit_something_it_should_still_apply_the_vlan_rules(self):
+        permissions = Mock(can_edit_something=True)
+        editable = Mock(vlan=666, iseditable=False, to_netbox=None)
+        interfaces = [Mock(vlan=99, iseditable=False, to_netbox=None), editable]
+
+        with patch(
+            "nav.web.portadmin.utils.should_check_access_rights", return_value=True
+        ):
+            set_editable_flag_on_interfaces(
+                interfaces, [Mock(vlan=666)], Mock(), permissions=permissions
+            )
+
+        assert editable.iseditable
+        assert not interfaces[0].iseditable

--- a/tests/unittests/web/portadmin/views_test.py
+++ b/tests/unittests/web/portadmin/views_test.py
@@ -1,9 +1,32 @@
 from unittest.mock import Mock, patch
 
+import pytest
 from django.test import RequestFactory
 
 from nav.portadmin.handlers import ManagementError
+from nav.portadmin.privileges import PortadminPrivilege
 from nav.web.portadmin.views import commit_configuration
+
+
+@pytest.fixture(autouse=True)
+def all_privileges_granted():
+    """Grants every PortAdmin privilege, so these tests exercise handler behavior
+    rather than authorization.
+
+    `get_account` is patched as well, since resolving the account of a request
+    without a session would otherwise require database access.
+    """
+    with (
+        patch("nav.web.portadmin.views.get_account", return_value=Mock(login="tester")),
+        patch("nav.web.portadmin.views.PortadminPermissions") as mock_permissions,
+    ):
+        mock_permissions.return_value = Mock(
+            account=Mock(login="tester"),
+            can_edit_something=True,
+            allowed=frozenset(PortadminPrivilege),
+            can=lambda privilege: True,
+        )
+        yield mock_permissions
 
 
 class TestCommitConfiguration:


### PR DESCRIPTION
## Scope and purpose

Fixes #3298. 

Adds granularity for PortAdmin permissions via group permissions based on #4159 

These granular permissions can be toggled on and off via `portadmin.conf` via the new `require_privileges` setting under `[authorization]`. With this on, no non-admin user will be able to edit anything in portadmin until they get given access via group permissions. Defaults to being off so existing NAV instances do not change behavior before whoever own the instance wants it to be enabled.

You also do not have access to the `save` button unless you have a permission to edit any field, and thus can make use of the button.

`restart` requires either VLAN or enable/disable privileges. Claude added this because VLAN changes require restarts, and disabling and then enabling is practically the same as restarting, but I see a world where someone should be allowed to restart but not be able to just disable a port. Maybe a separate restart permission should be added? Not entirely sure about this one, so please comment on that.

Best reviewed commit-by-commit since it's a decently sized PR. Wanted to split it up into multiple PRs, but these commits cant really exist without the others


## before and after

Before, access to all fields:
<img width="2019" height="625" alt="image" src="https://github.com/user-attachments/assets/6c5595df-d7ca-401e-aaba-cefdfdb9ccb5" />


after, with only permissions for port description:
<img width="2119" height="670" alt="image" src="https://github.com/user-attachments/assets/275d3010-8fcb-412e-ba4e-4ac7bd6d3e0b" />

## how to test

You'll need a device with some sort of write permissions that works with Portadmin, like netconf. Then you create a user group, and a non-admin user to that group, and add permissions there and use that account to see how it affects your access in portadmin. Add the device to at least one device group, and check that permissions are given correctly when using the targeting syntax

I have tested that the frontend disables the elements that you do not have rights to edit, but I have not tried to update an actual switch since the switch I've managed to tunnel to is not a lab switch or anything so I don't want to mess things up 

<!-- remove things that do not apply -->
### This pull request
* adds/changes/removes a dependency
* changes the database
* changes the API


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [x] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
