### PR TITLE
Only read `web_access` privileges when checking if someone should have web access

### DIFF
--- a/changelog.d/4154.fixed.md
+++ b/changelog.d/4154.fixed.md
@@ -1,0 +1,1 @@
+Fix web_access reading all privileges (not just web_access) when checking if user should have access to a page

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -197,12 +197,14 @@ class Account(AbstractBaseUser):
         elif privileges.count() == 0:
             return False
         elif action == 'web_access':
-            for privilege in privileges:
+            # There are multiple types of privileges, only `web_access`
+            # should be used in this context
+            for privilege in privileges.filter(type__name='web_access'):
                 try:
                     regexp = re.compile(privilege.target)
                 except re.error:
                     logging.getLogger('nav.models.profiles').error(
-                        "Invalid regexp in privilege target for group %s: %r",
+                        "Invalid regexp in web_access privilege for group %s: %r",
                         privilege.group_id,
                         privilege.target,
                     )

--- a/tests/integration/models/account_test.py
+++ b/tests/integration/models/account_test.py
@@ -58,3 +58,30 @@ class TestHasPermWebAccess:
         self._grant(group, "web_access", r"^/(portadmin)/?")
 
         assert account.has_perm("web_access", "/portadmin/") is True
+
+    def test_when_another_privilege_target_matches_everything_it_should_not_give_access(
+        self, account_in_group
+    ):
+        """
+        A non-web_access target must never be able to grant web access.
+        This is tested because there was a bug where all privileges
+        could give web access.
+        """
+        account, group = account_in_group
+        self._grant(group, "alert_by", ".*")
+
+        assert account.has_perm("web_access", "/useradmin/") is False
+
+    def test_when_web_access_matches_it_should_give_access(self, account_in_group):
+        account, group = account_in_group
+        self._grant(group, "web_access", r"^/status/")
+
+        assert account.has_perm("web_access", "/status/") is True
+
+    def test_when_web_access_does_not_match_it_should_not_give_access(
+        self, account_in_group
+    ):
+        account, group = account_in_group
+        self._grant(group, "web_access", r"^/status/")
+
+        assert account.has_perm("web_access", "/useradmin/") is False


### PR DESCRIPTION
Fixes #4154, based on #4156
This PR makes it so we only check `web_access` privileges when determining if someone should have web access, instead of all privileges.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [ ] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
