### PR TITLE
Add portadmin privileges class

### DIFF
--- a/python/nav/models/sql/changes/sc.05.19.0004.sql
+++ b/python/nav/models/sql/changes/sc.05.19.0004.sql
@@ -1,0 +1,6 @@
+INSERT INTO Privilege (privilegename) VALUES ('portadmin_vlan');
+INSERT INTO Privilege (privilegename) VALUES ('portadmin_description');
+INSERT INTO Privilege (privilegename) VALUES ('portadmin_admin_status');
+INSERT INTO Privilege (privilegename) VALUES ('portadmin_poe');
+INSERT INTO Privilege (privilegename) VALUES ('portadmin_voice_vlan');
+INSERT INTO Privilege (privilegename) VALUES ('portadmin_trunk');

--- a/python/nav/portadmin/privileges.py
+++ b/python/nav/portadmin/privileges.py
@@ -1,0 +1,153 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.  You should have received a copy of the GNU General Public License
+# along with NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Defines granular privileges for PortAdmin."""
+
+import logging
+import re
+from enum import StrEnum
+
+from nav.models.manage import Netbox
+from nav.models.profiles import Account
+
+_logger = logging.getLogger(__name__)
+
+
+class PortadminPrivilege(StrEnum):
+    """The PortAdmin privilege type names
+
+    These correspond to rows in the `privilege` database table, and to the
+    individually editable attributes exposed by PortAdmin. The members compare equal
+    to their string values, so they can be used directly in database queries.
+    """
+
+    VLAN = "portadmin_vlan"
+    DESCRIPTION = "portadmin_description"
+    ADMIN_STATUS = "portadmin_admin_status"
+    POE = "portadmin_poe"
+    VOICE_VLAN = "portadmin_voice_vlan"
+    TRUNK = "portadmin_trunk"
+
+
+class PortadminPermissions:
+    """The set of PortAdmin attributes an account may edit on a given netbox.
+
+    Each privilege is scoped by its ``target``, a regular expression matched against
+    the names of the device groups the netbox belongs to, in the same way the targets
+    of ``web_access`` privileges are regular expressions. The privilege applies if the
+    expression matches at least one of the groups, so `^SDN$` covers the netboxes in
+    the `SDN` device group, while `.*` covers every netbox that is in a group at all.
+
+    Since a target only ever matches group names, a netbox that belongs to no device
+    group matches no target, and no privilege applies to it.
+
+    Instances are cheap to pass around and evaluate the account's privileges only
+    once, so a single instance can be reused for every interface on a netbox.
+    """
+
+    def __init__(self, account: Account, netbox: Netbox):
+        self.account = account
+        self.netbox = netbox
+        self._is_admin = account.is_admin()
+        self._allowed = (
+            set(PortadminPrivilege)
+            if self._is_admin
+            else self._resolve_allowed_privileges()
+        )
+
+    def _resolve_allowed_privileges(self) -> set[str]:
+        """Finds the privileges granted to this account that apply to this netbox"""
+        group_ids = self._get_netbox_group_ids()
+        privileges = self.account.get_privileges().filter(
+            type__name__in=list(PortadminPrivilege)
+        )
+        return {
+            privilege.type.name
+            for privilege in privileges
+            if self._target_matches_groups(privilege.target, group_ids)
+        }
+
+    def _get_netbox_group_ids(self) -> set[str]:
+        """Returns the set of device group names the netbox belongs to"""
+        return set(self.netbox.groups.values_list("id", flat=True))
+
+    @staticmethod
+    def _target_matches_groups(target: str, group_ids: set[str]) -> bool:
+        """Decides whether a privilege target matches a set of device groups
+
+        The target is a regular expression, matched against each device group name.
+        It matches if at least one of them matches. A netbox that belongs to no
+        device group therefore matches no target at all.
+
+        :param target: The ``target`` value of a privilege.
+        :param group_ids: The device group names
+        """
+        if not target:
+            return False
+        try:
+            pattern = re.compile(target)
+        except re.error:
+            _logger.error("Invalid regexp in PortAdmin privilege target: %r", target)
+            return False
+        return any(pattern.search(group_id) for group_id in group_ids)
+
+    def can(self, privilege: str) -> bool:
+        """Returns True if the account may change the given attribute
+
+        :raises ValueError: If the privilege is not a PortAdmin privilege.
+        """
+        return PortadminPrivilege(privilege) in self._allowed
+
+    @property
+    def can_edit_something(self) -> bool:
+        """Returns True if the account may change at least one attribute"""
+        return bool(self._allowed)
+
+    @property
+    def allowed(self) -> frozenset[str]:
+        """Returns the set of privilege names granted on this netbox"""
+        return frozenset(self._allowed)
+
+    # Convenience accessors, primarily for use from Django templates
+
+    @property
+    def vlan(self) -> bool:
+        """Returns True if the account may change the VLAN"""
+        return self.can(PortadminPrivilege.VLAN)
+
+    @property
+    def description(self) -> bool:
+        """Returns True if the account may change the port description"""
+        return self.can(PortadminPrivilege.DESCRIPTION)
+
+    @property
+    def admin_status(self) -> bool:
+        """Returns True if the account may enable/disable the interface"""
+        return self.can(PortadminPrivilege.ADMIN_STATUS)
+
+    @property
+    def poe(self) -> bool:
+        """Returns True if the account may change the PoE state"""
+        return self.can(PortadminPrivilege.POE)
+
+    @property
+    def voice_vlan(self) -> bool:
+        """Returns True if the account may change the voice VLAN"""
+        return self.can(PortadminPrivilege.VOICE_VLAN)
+
+    @property
+    def trunk(self) -> bool:
+        """Returns True if the account may edit trunks"""
+        return self.can(PortadminPrivilege.TRUNK)

--- a/tests/integration/portadmin/privileges_test.py
+++ b/tests/integration/portadmin/privileges_test.py
@@ -1,0 +1,160 @@
+"""Tests for per-attribute PortAdmin authorization, against real database objects"""
+
+import pytest
+
+from nav.models.manage import NetboxGroup
+from nav.models.profiles import AccountGroup, PrivilegeType
+from nav.portadmin.privileges import PortadminPermissions, PortadminPrivilege
+
+
+def _grant(account_group, privilege, target):
+    """Grants a PortAdmin privilege to an account group, scoped to a target"""
+    return account_group.privileges.create(
+        type=PrivilegeType.objects.get(name=privilege), target=target
+    )
+
+
+@pytest.fixture()
+def account_group(db, non_admin_account):
+    """An account group holding the account whose privileges are under test"""
+    group = AccountGroup.objects.create(name="portadmin privilege test group")
+    non_admin_account.groups.add(group)
+    return group
+
+
+@pytest.fixture()
+def sdn_group(db):
+    group = NetboxGroup.objects.create(id="SDN", description="SDN switches")
+    return group
+
+
+@pytest.fixture()
+def legacy_group(db):
+    group = NetboxGroup.objects.create(id="LEGACY", description="Legacy switches")
+    return group
+
+
+@pytest.fixture()
+def sdn_netbox(localhost, sdn_group):
+    localhost.groups.add(sdn_group)
+    return localhost
+
+
+@pytest.fixture()
+def legacy_netbox(localhost, legacy_group):
+    localhost.groups.add(legacy_group)
+    return localhost
+
+
+class TestPortadminPermissions:
+    def test_when_user_is_admin_it_should_allow_everything(
+        self, admin_account, sdn_netbox
+    ):
+        permissions = PortadminPermissions(admin_account, sdn_netbox)
+        for privilege in PortadminPrivilege:
+            assert permissions.can(privilege)
+
+    def test_when_user_has_no_privileges_it_should_allow_nothing(
+        self, non_admin_account, sdn_netbox
+    ):
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+        for privilege in PortadminPrivilege:
+            assert not permissions.can(privilege)
+
+    def test_when_a_privilege_is_granted_then_can_edit_something_should_be_true(
+        self, non_admin_account, account_group, sdn_netbox
+    ):
+        _grant(account_group, PortadminPrivilege.DESCRIPTION, "SDN")
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+        assert permissions.can_edit_something
+
+    def test_when_no_privileges_are_granted_then_can_edit_something_should_be_false(
+        self, non_admin_account, sdn_netbox
+    ):
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+        assert not permissions.can_edit_something
+
+    def test_when_netbox_is_outside_the_privilege_target_it_should_not_be_allowed(
+        self, non_admin_account, account_group, sdn_netbox
+    ):
+        _grant(account_group, PortadminPrivilege.VLAN, "^LEGACY$")
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+        assert not permissions.vlan
+
+    def test_when_target_names_a_group_it_should_match_that_group(
+        self, non_admin_account, legacy_netbox, account_group
+    ):
+        _grant(account_group, PortadminPrivilege.VLAN, "^LEGACY$")
+        permissions = PortadminPermissions(non_admin_account, legacy_netbox)
+        assert permissions.vlan
+
+    def test_when_target_matches_everything_it_should_match_any_group(
+        self, non_admin_account, sdn_netbox, account_group
+    ):
+        _grant(account_group, PortadminPrivilege.VLAN, ".*")
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+        assert permissions.vlan
+
+    def test_when_netbox_is_in_no_group_it_should_not_match_any_target(
+        self, non_admin_account, localhost, account_group
+    ):
+        """A target only matches group names, so a netbox without any matches none"""
+        _grant(account_group, PortadminPrivilege.VLAN, ".*")
+        permissions = PortadminPermissions(non_admin_account, localhost)
+        assert not permissions.vlan
+
+    def test_when_target_is_unanchored_it_should_match_substrings(
+        self, non_admin_account, localhost, account_group
+    ):
+        """Anchor a target with ^ and $ to match a group name exactly"""
+        edge = NetboxGroup.objects.create(id="SDN-EDGE", description="Edge switches")
+        localhost.groups.add(edge)
+        _grant(account_group, PortadminPrivilege.VLAN, "SDN")
+        permissions = PortadminPermissions(non_admin_account, localhost)
+        assert permissions.vlan
+
+    def test_when_target_is_an_invalid_regexp_it_should_not_match(
+        self, non_admin_account, sdn_netbox, account_group
+    ):
+        """A malformed target must be denied rather than raise"""
+        _grant(account_group, PortadminPrivilege.VLAN, "*")
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+        assert not permissions.vlan
+
+    def test_when_privilege_name_is_unknown_it_should_raise_error(
+        self, non_admin_account, sdn_netbox
+    ):
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+
+        with pytest.raises(ValueError):
+            permissions.can("some_other_privilege")
+
+    def test_when_netbox_is_in_several_groups_it_should_match_any_of_them(
+        self, non_admin_account, localhost, sdn_group, legacy_group, account_group
+    ):
+        localhost.groups.add(sdn_group, legacy_group)
+        _grant(account_group, PortadminPrivilege.VLAN, "LEGACY")
+        permissions = PortadminPermissions(non_admin_account, localhost)
+        assert permissions.vlan
+
+    @pytest.mark.parametrize(
+        "privilege,accessor",
+        [
+            (PortadminPrivilege.VLAN, "vlan"),
+            (PortadminPrivilege.DESCRIPTION, "description"),
+            (PortadminPrivilege.ADMIN_STATUS, "admin_status"),
+            (PortadminPrivilege.POE, "poe"),
+            (PortadminPrivilege.VOICE_VLAN, "voice_vlan"),
+            (PortadminPrivilege.TRUNK, "trunk"),
+        ],
+    )
+    def test_when_a_privilege_is_granted_its_accessor_should_be_true(
+        self, non_admin_account, sdn_netbox, account_group, privilege, accessor
+    ):
+        """Each privilege must map to the accessor that reports it"""
+        _grant(account_group, privilege, ".*")
+
+        permissions = PortadminPermissions(non_admin_account, sdn_netbox)
+
+        assert getattr(permissions, accessor)
+        assert permissions.allowed == frozenset([privilege])


### PR DESCRIPTION
## Scope and purpose

Part of #3298. Lays groundwork for granular permissions in PortAdmin and defines the syntax for setting privileges in user groups. This is inert code that can be merged without affecting anything, but future PRs will make use of it for the proper implementation.

The targeting syntax is regex that matches against Device groups. A device must therefore be in a device group for it to be possible to give permissions for that device. i.e. if you want to give description edit rights to all devices, then you should make a group that contain all devices and match against that in the target.

I'm fully open to changing this syntax. Figured this is a big topic of discussion, which is largely why I put this part in its own PR.

<!-- Add a description of what this PR does and why it is needed. If a linked ticket(s)
fully cover it, you can omit this. -->

<!-- remove things that do not apply -->
### This pull request
* adds/changes/removes a dependency
* changes the database
* changes the API


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [ ] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [x] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
