### PR TITLE
Add test dependencies `pysmi` and `cryptography`

### DIFF
--- a/changelog.d/4162.fixed.md
+++ b/changelog.d/4162.fixed.md
@@ -1,0 +1,1 @@
+Add test dependency cryptography - snmpsim uses pysnmp which uses cryptography, but only declares it as dev dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,8 @@ dev = [
 ]
 test = [
     "coverage>=7.0.0",
+    "cryptography>=44.0.1", # snmpsim uses pysnmp which uses cryptography, but only declares it as dev dependency
+    "pysmi>=2.0.0,<3.0.0", # imported by snmpsim.utils, not pulled in by pysnmp
     "mock==2.0.0",
     "pytest>=8.3.3",
     "pytest-metadata==3.1.1",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -353,13 +353,17 @@ def _build_snmpsim_command(workspace):
     ]
 
     if which('uvx') and _uv_has_python('3.11'):
-        snmpsim_pkg = _get_installed_snmpsim_spec()
-        return [
-            'uvx',
-            '--python=3.11',
-            f'--from={snmpsim_pkg}',
-            'snmpsim-command-responder',
-        ] + snmpsim_args
+        return (
+            [
+                'uvx',
+                '--python=3.11',
+                f'--with={_get_installed_spec("cryptography")}',  # snmpsim uses pysnmp which uses cryptography, but only declares it as dev dependency # noqa: E501
+                f'--with={_get_installed_spec("pysmi")}',  # imported by snmpsim.utils, not pulled in by pysnmp # noqa: E501
+                f'--from={_get_installed_spec("snmpsim")}',
+                'snmpsim-command-responder',
+            ]
+            + snmpsim_args
+        )
 
     snmpsimd = which('snmpsim-command-responder')
     if not snmpsimd:
@@ -391,16 +395,16 @@ def _uv_has_python(version):
     return result.returncode == 0
 
 
-def _get_installed_snmpsim_spec():
-    """Returns a pip specifier for the locally installed snmpsim version.
+def _get_installed_spec(package_name: str):
+    """Returns a pip specifier for the locally installed version.
 
-    Falls back to an unpinned 'snmpsim' if the package is not installed.
+    Falls back to an unpinned version if the package is not installed.
     """
     try:
-        version = importlib.metadata.version('snmpsim')
-        return f'snmpsim=={version}'
+        version = importlib.metadata.version(package_name)
+        return f'{package_name}=={version}'
     except importlib.metadata.PackageNotFoundError:
-        return 'snmpsim'
+        return package_name
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Scope and purpose

We use snmpsim, which uses pysnmp. And pysnmp added code in the most recent release (v7.1.28) that uses cryptography, but cryptography is only declared as a dev dependency in pysnmp. 

Ref to pysnmp only having cryptography as dev dependency: https://github.com/lextudio/pysnmp/blob/13e732372d1c56f49a0f03485f013b636f53ef1d/pyproject.toml#L59
Example: https://github.com/Uninett/nav/actions/runs/32002738313/job/95306094981

See https://github.com/lextudio/snmpsim/pull/16 for further details. (When that is merged we can revert these changes.)

Due to the changes in #4009 snmpsim is run in an isolated environment via uvx, so those need to be explicitly requested there as well. 

<!-- remove things that do not apply -->
### This pull request
* adds a test dependency


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [ ] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
