### PR TITLE
Fix status widget breaking if default admin account is locked

### DIFF
--- a/changelog.d/4165.fixed.md
+++ b/changelog.d/4165.fixed.md
@@ -1,0 +1,1 @@
+Fixed status widget not containing alerts when the default admin user was locked

--- a/changelog.d/4165.fixed.md
+++ b/changelog.d/4165.fixed.md
@@ -1,1 +1,1 @@
-Fixed status widget not containing alerts when the default admin user was locked
+Fixed status widget showing blank when the default admin user was locked/deactivated

--- a/python/nav/web/navlets/locationstatus.py
+++ b/python/nav/web/navlets/locationstatus.py
@@ -38,9 +38,6 @@ class LocationStatus(RoomStatus):
     def get_context_data_view(self, context):
         context = super(LocationStatus, self).get_context_data_view(context)
 
-        if context.get("error"):
-            return context
-
         assert 'results' in context
 
         result_ids = [r.get('id') for r in context['results']]

--- a/python/nav/web/navlets/locationstatus.py
+++ b/python/nav/web/navlets/locationstatus.py
@@ -37,6 +37,10 @@ class LocationStatus(RoomStatus):
 
     def get_context_data_view(self, context):
         context = super(LocationStatus, self).get_context_data_view(context)
+
+        if context.get("error"):
+            return context
+
         assert 'results' in context
 
         result_ids = [r.get('id') for r in context['results']]
@@ -53,7 +57,7 @@ class LocationStatus(RoomStatus):
             locations.append(location)
 
         context['items'] = locations
-        context['last_update'] = datetime.now()
+        context['last_updated'] = datetime.now()
         context['name'] = 'room'
         context['name_plural'] = 'rooms'
         context['history_route'] = 'devicehistory-view-location'

--- a/python/nav/web/navlets/roomstatus.py
+++ b/python/nav/web/navlets/roomstatus.py
@@ -39,6 +39,9 @@ class RoomStatus(Status2Widget):
 
     def get_context_data_view(self, context):
         context = super(RoomStatus, self).get_context_data_view(context)
+        if context.get("error"):
+            return context
+
         assert 'results' in context
 
         result_ids = [r.get('id') for r in context['results']]
@@ -55,7 +58,7 @@ class RoomStatus(Status2Widget):
             rooms.append(room)
 
         context['items'] = rooms
-        context['last_update'] = datetime.now()
+        context['last_updated'] = datetime.now()
         context['name'] = 'room'
         context['name_plural'] = 'rooms'
         context['history_route'] = 'devicehistory-view-room'

--- a/python/nav/web/navlets/roomstatus.py
+++ b/python/nav/web/navlets/roomstatus.py
@@ -39,8 +39,6 @@ class RoomStatus(Status2Widget):
 
     def get_context_data_view(self, context):
         context = super(RoomStatus, self).get_context_data_view(context)
-        if context.get("error"):
-            return context
 
         assert 'results' in context
 

--- a/python/nav/web/navlets/status2.py
+++ b/python/nav/web/navlets/status2.py
@@ -23,10 +23,11 @@ from django.test.client import RequestFactory
 from django.utils.datastructures import MultiValueDictKeyError
 from django.utils.dateparse import parse_datetime
 
-from nav.models.profiles import Account
 from nav.models.manage import Netbox
-from nav.web.status2.forms import StatusWidgetForm
+from nav.models.profiles import Account
 from nav.web.api.v1.views import AlertHistoryViewSet
+from nav.web.auth.utils import get_account
+from nav.web.status2.forms import StatusWidgetForm
 from . import Navlet
 
 
@@ -45,7 +46,9 @@ class Status2Widget(Navlet):
     def get_context_data_view(self, context):
         self.title = self.preferences.get('title', self.title)
         status_filter = self.preferences.get('status_filter')
-        results = self.do_query(status_filter)
+        results = self.do_query(
+            status_filter, account=get_account(context["view"].request)
+        )
         self.add_formatted_time(results)
         self.add_netbox(results)
         context['extra_columns'] = self.find_extra_columns(status_filter)
@@ -63,15 +66,11 @@ class Status2Widget(Navlet):
         context['interval'] = self.preferences['refresh_interval'] / 1000
         return context
 
-    def do_query(self, query_string):
+    def do_query(self, query_string, account: Account):
         """Queries for alerts given a query string"""
         factory = RequestFactory()
         view = AlertHistoryViewSet.as_view({'get': 'list'})
         request = factory.get("?%s" % query_string)
-        account = Account.objects.get(pk=Account.ADMIN_ACCOUNT)
-        # Fake request! This is safe
-        # We cannot know whether the user is sudo'ed...
-        # but since we operate as admin it is irrelevant
         request.account = request.user = account
         response = view(request)
         return response.data.get('results')

--- a/python/nav/web/navlets/status2.py
+++ b/python/nav/web/navlets/status2.py
@@ -15,6 +15,7 @@
 #
 """Status2 widget"""
 
+import logging
 from datetime import datetime
 from operator import itemgetter
 
@@ -22,6 +23,7 @@ from django.http import QueryDict
 from django.test.client import RequestFactory
 from django.utils.datastructures import MultiValueDictKeyError
 from django.utils.dateparse import parse_datetime
+from rest_framework import status
 
 from nav.models.manage import Netbox
 from nav.models.profiles import Account
@@ -29,6 +31,12 @@ from nav.web.api.v1.views import AlertHistoryViewSet
 from nav.web.auth.utils import get_account
 from nav.web.status2.forms import StatusWidgetForm
 from . import Navlet
+
+_logger = logging.getLogger(__name__)
+
+
+class QueryError(Exception):
+    """The requested data could not be queried"""
 
 
 class Status2Widget(Navlet):
@@ -46,9 +54,17 @@ class Status2Widget(Navlet):
     def get_context_data_view(self, context):
         self.title = self.preferences.get('title', self.title)
         status_filter = self.preferences.get('status_filter')
-        results = self.do_query(
-            status_filter, account=get_account(context["view"].request)
-        )
+        try:
+            results = self.do_query(
+                status_filter, account=get_account(context["view"].request)
+            )
+        # Catch error here and display it
+        except QueryError:
+            context["results"] = None
+            context["error"] = "NAV was not able to get the alerts."
+            context['last_updated'] = datetime.now()
+            return context
+
         self.add_formatted_time(results)
         self.add_netbox(results)
         context['extra_columns'] = self.find_extra_columns(status_filter)
@@ -73,6 +89,9 @@ class Status2Widget(Navlet):
         request = factory.get("?%s" % query_string)
         request.account = request.user = account
         response = view(request)
+        if response.status_code != status.HTTP_200_OK:
+            _logger.error("Error when querying alerts: %s", response.data.get("detail"))
+            raise QueryError
         return response.data.get('results')
 
     def add_formatted_time(self, results):

--- a/python/nav/web/navlets/status2.py
+++ b/python/nav/web/navlets/status2.py
@@ -61,7 +61,7 @@ class Status2Widget(Navlet):
         # Catch error here and display it
         except QueryError:
             context["results"] = None
-            context["error"] = "NAV was not able to get the alerts."
+            context["error"] = "NAV was not able to get the alerts"
             context['last_updated'] = datetime.now()
             return context
 

--- a/python/nav/web/navlets/status2.py
+++ b/python/nav/web/navlets/status2.py
@@ -54,10 +54,13 @@ class Status2Widget(Navlet):
     def get_context_data_view(self, context):
         self.title = self.preferences.get('title', self.title)
         status_filter = self.preferences.get('status_filter')
+        account = get_account(context["view"].request)
+        # This is a hack to get the status widget to work when the user is not logged in
+        # (aka the default account, which is locked, leading the query to fail)
+        if account.is_default_account():
+            account = Account.objects.get(id=Account.ADMIN_ACCOUNT)
         try:
-            results = self.do_query(
-                status_filter, account=get_account(context["view"].request)
-            )
+            results = self.do_query(query_string=status_filter, account=account)
         except QueryError:
             context["results"] = []
             context["error_message"] = "NAV was not able to get the alerts"

--- a/python/nav/web/navlets/status2.py
+++ b/python/nav/web/navlets/status2.py
@@ -60,7 +60,7 @@ class Status2Widget(Navlet):
             )
         # Catch error here and display it
         except QueryError:
-            context["results"] = None
+            context["results"] = []
             context["error"] = "NAV was not able to get the alerts"
             context['last_updated'] = datetime.now()
             return context

--- a/python/nav/web/navlets/status2.py
+++ b/python/nav/web/navlets/status2.py
@@ -89,8 +89,12 @@ class Status2Widget(Navlet):
         request.account = request.user = account
         response = view(request)
         if response.status_code != status.HTTP_200_OK:
-            _logger.error("Error when querying alerts: %s", response.data.get("detail"))
-            raise QueryError
+            _logger.warning(
+                "Error when querying alerts: %s - %s",
+                response.status_code,
+                response.data.get("detail"),
+            )
+            raise QueryError(response.data.get("detail"))
         return response.data.get('results')
 
     def add_formatted_time(self, results):

--- a/python/nav/web/navlets/status2.py
+++ b/python/nav/web/navlets/status2.py
@@ -60,7 +60,7 @@ class Status2Widget(Navlet):
             )
         except QueryError:
             context["results"] = []
-            context["error"] = "NAV was not able to get the alerts"
+            context["error_message"] = "NAV was not able to get the alerts"
             context['last_updated'] = datetime.now()
             return context
 

--- a/python/nav/web/navlets/status2.py
+++ b/python/nav/web/navlets/status2.py
@@ -81,7 +81,7 @@ class Status2Widget(Navlet):
         context['interval'] = self.preferences['refresh_interval'] / 1000
         return context
 
-    def do_query(self, query_string, account: Account):
+    def do_query(self, query_string: str, account: Account) -> list[dict]:
         """Queries for alerts given a query string"""
         factory = RequestFactory()
         view = AlertHistoryViewSet.as_view({'get': 'list'})

--- a/python/nav/web/navlets/status2.py
+++ b/python/nav/web/navlets/status2.py
@@ -58,7 +58,6 @@ class Status2Widget(Navlet):
             results = self.do_query(
                 status_filter, account=get_account(context["view"].request)
             )
-        # Catch error here and display it
         except QueryError:
             context["results"] = []
             context["error"] = "NAV was not able to get the alerts"

--- a/python/nav/web/templates/navlets/room_location_status_view.html
+++ b/python/nav/web/templates/navlets/room_location_status_view.html
@@ -69,16 +69,8 @@
     </script>
 
 
-  {% else %}
-    {% if error %}
-      <div class="alert-box error">
-        {{ error }}
-      </div>
-
-    {% else %}
-      <div class="alert-box success with-icon">No alerts in any {{name_plural}}</div>
-    {% endif %}
-
+  {% elif not error_message %}
+    <div class="alert-box success with-icon">No alerts in any {{name_plural}}</div>
   {% endif %}
 
   <small class="right">

--- a/python/nav/web/templates/navlets/room_location_status_view.html
+++ b/python/nav/web/templates/navlets/room_location_status_view.html
@@ -70,11 +70,19 @@
 
 
   {% else %}
-    <div class="alert-box success with-icon">No alerts in any {{name_plural}}</div>
+    {% if error %}
+      <div class="alert-box error">
+        {{ error }}
+      </div>
+
+    {% else %}
+      <div class="alert-box success with-icon">No alerts in any {{name_plural}}</div>
+    {% endif %}
+
   {% endif %}
 
   <small class="right">
-    Last update: <span class="last-update">{{ last_update }}</span>
+    Last updated: <span class="last-updated">{{ last_updated }}</span>
   </small>
 
 {% endblock %}

--- a/python/nav/web/templates/navlets/status2_view.html
+++ b/python/nav/web/templates/navlets/status2_view.html
@@ -85,21 +85,17 @@
         {{ error }}
       </div>
 
-      <div class="status2-widget-footer">
-        <a href="{% url 'status2-index' %}" title="Go to the status page">Go to the status page</a>
-        <small class="last-updated">Last updated: {{ last_updated }}</small>
-      </div>
-
     {% else %}
       <div class="alert-box success">
         According to your criteria, everything seems ok
       </div>
 
-      <div class="status2-widget-footer">
-        <a href="{% url 'status2-index' %}" title="Go to the status page">Go to the status page</a>
-        <small class="last-updated">Last updated: {{ last_updated }}</small>
-      </div>
     {% endif %}
+
+    <div class="status2-widget-footer">
+      <a href="{% url 'status2-index' %}" title="Go to the status page">Go to the status page</a>
+      <small class="last-updated">Last updated: {{ last_updated }}</small>
+    </div>
 
   {% endif %}
 

--- a/python/nav/web/templates/navlets/status2_view.html
+++ b/python/nav/web/templates/navlets/status2_view.html
@@ -79,18 +79,10 @@
 
     </table>
 
-  {% else %}
-    {% if error %}
-      <div class="alert-box error">
-        {{ error }}
-      </div>
-
-    {% else %}
-      <div class="alert-box success">
-        According to your criteria, everything seems ok
-      </div>
-
-    {% endif %}
+  {% elif not error_message %}
+    <div class="alert-box success">
+      According to your criteria, everything seems ok
+    </div>
 
     <div class="status2-widget-footer">
       <a href="{% url 'status2-index' %}" title="Go to the status page">Go to the status page</a>

--- a/python/nav/web/templates/navlets/status2_view.html
+++ b/python/nav/web/templates/navlets/status2_view.html
@@ -80,14 +80,26 @@
     </table>
 
   {% else %}
-    <div class="alert-box success">
-      According to your criteria, everything seems ok
-    </div>
+    {% if error %}
+      <div class="alert-box error">
+        {{ error }}
+      </div>
 
-    <div class="status2-widget-footer">
-      <a href="{% url 'status2-index' %}" title="Go to the status page">Go to the status page</a>
-      <small class="last-updated">Last updated: {{ last_updated }}</small>
-    </div>
+      <div class="status2-widget-footer">
+        <a href="{% url 'status2-index' %}" title="Go to the status page">Go to the status page</a>
+        <small class="last-updated">Last updated: {{ last_updated }}</small>
+      </div>
+
+    {% else %}
+      <div class="alert-box success">
+        According to your criteria, everything seems ok
+      </div>
+
+      <div class="status2-widget-footer">
+        <a href="{% url 'status2-index' %}" title="Go to the status page">Go to the status page</a>
+        <small class="last-updated">Last updated: {{ last_updated }}</small>
+      </div>
+    {% endif %}
 
   {% endif %}
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -474,6 +474,16 @@ def default_account(db):
 
 
 @pytest.fixture()
+def locked_account(db):
+    from nav.models.profiles import Account
+
+    account = Account(login="locked_user", is_active=False)
+    account.save()
+    yield account
+    account.delete()
+
+
+@pytest.fixture()
 def netbox_factory(db):
     """Returns a factory for minimal Netboxes.
 

--- a/tests/integration/web/auth/conftest.py
+++ b/tests/integration/web/auth/conftest.py
@@ -15,13 +15,3 @@ def session_request(db):
     middleware.process_request(session_request)
     session_request.session.save()
     return session_request
-
-
-@pytest.fixture()
-def locked_account(db):
-    from nav.models.profiles import Account
-
-    account = Account(login="locked_user", is_active=False)
-    account.save()
-    yield account
-    account.delete()

--- a/tests/integration/widget_test.py
+++ b/tests/integration/widget_test.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 from django.urls import reverse
 
 from nav.web.navlets.feedreader import FeedReaderNavlet
+from nav.web.navlets.locationstatus import LocationStatus
 from nav.web.navlets.roomstatus import RoomStatus
 from nav.web.navlets.status2 import Status2Widget, QueryError
 from nav.models.event import AlertHistory, AlertHistoryMessage
@@ -17,9 +18,9 @@ def test_roomstatus_should_not_fail_on_multiple_messages(
     alerthist_with_two_messages, admin_account
 ):
     widget = RoomStatus()
-    request = Mock()
-    request.account = admin_account
-    result = widget.get_context_data_view({"view": request})
+    request = Mock(user=admin_account)
+    view = Mock(request=request)
+    result = widget.get_context_data_view({"view": view})
     print(result)
     assert 'results' in result
 
@@ -32,12 +33,32 @@ def test_roomstatus_should_not_fail_on_multiple_messages(
     assert matching[0]['netbox_object'] == alerthist_with_two_messages.netbox
 
 
+def test_room_status_should_show_error_on_failed_query(admin_account):
+    widget = RoomStatus()
+    widget.do_query = Mock(side_effect=QueryError)
+    request = Mock(user=admin_account)
+    view = Mock(request=request)
+    result = widget.get_context_data_view({"view": view})
+    assert not result["results"]
+    assert "NAV was not able to get the alerts." in result["error"]
+
+
+def test_location_status_should_show_error_on_failed_query(admin_account):
+    widget = LocationStatus()
+    widget.do_query = Mock(side_effect=QueryError)
+    request = Mock(user=admin_account)
+    view = Mock(request=request)
+    result = widget.get_context_data_view({"view": view})
+    assert not result["results"]
+    assert "NAV was not able to get the alerts." in result["error"]
+
+
 def test_status_should_show_error_on_failed_query(admin_account):
     widget = Status2Widget()
     widget.do_query = Mock(side_effect=QueryError)
-    request = Mock()
-    request.account = admin_account
-    result = widget.get_context_data_view({"view": request})
+    request = Mock(user=admin_account)
+    view = Mock(request=request)
+    result = widget.get_context_data_view({"view": view})
     assert not result["results"]
     assert "NAV was not able to get the alerts." in result["error"]
 

--- a/tests/integration/widget_test.py
+++ b/tests/integration/widget_test.py
@@ -1,12 +1,13 @@
 from datetime import datetime, timedelta
 from unittest.mock import Mock
 
+from django.test import Client
 from django.urls import reverse
 
 from nav.web.navlets.feedreader import FeedReaderNavlet
 from nav.web.navlets.locationstatus import LocationStatus
 from nav.web.navlets.roomstatus import RoomStatus
-from nav.web.navlets.status2 import Status2Widget, QueryError
+from nav.web.navlets.status2 import Status2Widget
 from nav.models.event import AlertHistory, AlertHistoryMessage
 from nav.models.profiles import AccountDashboard, AccountNavlet
 from nav.models.fields import INFINITY
@@ -33,34 +34,43 @@ def test_roomstatus_should_not_fail_on_multiple_messages(
     assert matching[0]['netbox_object'] == alerthist_with_two_messages.netbox
 
 
-def test_room_status_should_show_error_on_failed_query(admin_account):
-    widget = RoomStatus()
-    widget.do_query = Mock(side_effect=QueryError)
-    request = Mock(user=admin_account)
+@pytest.mark.parametrize("widget", [RoomStatus, LocationStatus, Status2Widget])
+def test_status_widget_should_show_error_on_failed_query(widget, default_account):
+    widget = widget()
+    request = Mock(user=default_account)
     view = Mock(request=request)
     result = widget.get_context_data_view({"view": view})
     assert not result["results"]
-    assert "NAV was not able to get the alerts" in result["error"]
+    assert "NAV was not able to get the alerts" in result["error_message"]
 
 
-def test_location_status_should_show_error_on_failed_query(admin_account):
-    widget = LocationStatus()
-    widget.do_query = Mock(side_effect=QueryError)
-    request = Mock(user=admin_account)
-    view = Mock(request=request)
-    result = widget.get_context_data_view({"view": view})
-    assert not result["results"]
-    assert "NAV was not able to get the alerts" in result["error"]
+def test_when_admin_account_is_inactive_then_status_widget_should_still_list_alerts(
+    log_in, admin_account, non_admin_account, alerthist_with_two_messages
+):
+    """Regression test for https://github.com/Uninett/nav/issues/4163"""
+    admin_account.is_active = False
+    admin_account.save()
 
+    dashboard = AccountDashboard.objects.create(
+        account=non_admin_account, name="Dashboard"
+    )
+    navlet = AccountNavlet.objects.create(
+        navlet="nav.web.navlets.status2.Status2Widget",
+        account=non_admin_account,
+        dashboard=dashboard,
+        preferences={
+            "status_filter": "event_type=boxState&stateless_threshold=24",
+            "refresh_interval": 60000,
+        },
+    )
+    client = Client()
+    log_in(client, "other_user", "password")
 
-def test_status_should_show_error_on_failed_query(admin_account):
-    widget = Status2Widget()
-    widget.do_query = Mock(side_effect=QueryError)
-    request = Mock(user=admin_account)
-    view = Mock(request=request)
-    result = widget.get_context_data_view({"view": view})
-    assert not result["results"]
-    assert "NAV was not able to get the alerts" in result["error"]
+    response = client.get(reverse("get-user-navlet", kwargs={"navlet_id": navlet.id}))
+
+    assert response.status_code == 200
+    assert not response.context.get("error_message")
+    assert response.context["results"]
 
 
 def test_feedreader_widget_should_get_nav_blog_posts():

--- a/tests/integration/widget_test.py
+++ b/tests/integration/widget_test.py
@@ -3,8 +3,9 @@ from unittest.mock import Mock
 
 from django.urls import reverse
 
-from nav.web.navlets.roomstatus import RoomStatus
 from nav.web.navlets.feedreader import FeedReaderNavlet
+from nav.web.navlets.roomstatus import RoomStatus
+from nav.web.navlets.status2 import Status2Widget, QueryError
 from nav.models.event import AlertHistory, AlertHistoryMessage
 from nav.models.profiles import AccountDashboard, AccountNavlet
 from nav.models.fields import INFINITY
@@ -29,6 +30,16 @@ def test_roomstatus_should_not_fail_on_multiple_messages(
     ]
     assert len(matching) == 1
     assert matching[0]['netbox_object'] == alerthist_with_two_messages.netbox
+
+
+def test_status_should_show_error_on_failed_query(admin_account):
+    widget = Status2Widget()
+    widget.do_query = Mock(side_effect=QueryError)
+    request = Mock()
+    request.account = admin_account
+    result = widget.get_context_data_view({"view": request})
+    assert not result["results"]
+    assert "NAV was not able to get the alerts." in result["error"]
 
 
 def test_feedreader_widget_should_get_nav_blog_posts():

--- a/tests/integration/widget_test.py
+++ b/tests/integration/widget_test.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from unittest.mock import Mock
 
 from django.urls import reverse
 
@@ -11,9 +12,13 @@ from nav.models.fields import INFINITY
 import pytest
 
 
-def test_roomstatus_should_not_fail_on_multiple_messages(alerthist_with_two_messages):
+def test_roomstatus_should_not_fail_on_multiple_messages(
+    alerthist_with_two_messages, admin_account
+):
     widget = RoomStatus()
-    result = widget.get_context_data_view({})
+    request = Mock()
+    request.account = admin_account
+    result = widget.get_context_data_view({"view": request})
     print(result)
     assert 'results' in result
 

--- a/tests/integration/widget_test.py
+++ b/tests/integration/widget_test.py
@@ -40,7 +40,7 @@ def test_room_status_should_show_error_on_failed_query(admin_account):
     view = Mock(request=request)
     result = widget.get_context_data_view({"view": view})
     assert not result["results"]
-    assert "NAV was not able to get the alerts." in result["error"]
+    assert "NAV was not able to get the alerts" in result["error"]
 
 
 def test_location_status_should_show_error_on_failed_query(admin_account):
@@ -50,7 +50,7 @@ def test_location_status_should_show_error_on_failed_query(admin_account):
     view = Mock(request=request)
     result = widget.get_context_data_view({"view": view})
     assert not result["results"]
-    assert "NAV was not able to get the alerts." in result["error"]
+    assert "NAV was not able to get the alerts" in result["error"]
 
 
 def test_status_should_show_error_on_failed_query(admin_account):
@@ -60,7 +60,7 @@ def test_status_should_show_error_on_failed_query(admin_account):
     view = Mock(request=request)
     result = widget.get_context_data_view({"view": view})
     assert not result["results"]
-    assert "NAV was not able to get the alerts." in result["error"]
+    assert "NAV was not able to get the alerts" in result["error"]
 
 
 def test_feedreader_widget_should_get_nav_blog_posts():

--- a/tests/integration/widget_test.py
+++ b/tests/integration/widget_test.py
@@ -35,9 +35,9 @@ def test_roomstatus_should_not_fail_on_multiple_messages(
 
 
 @pytest.mark.parametrize("widget", [RoomStatus, LocationStatus, Status2Widget])
-def test_status_widget_should_show_error_on_failed_query(widget, default_account):
+def test_status_widget_should_show_error_on_failed_query(widget, locked_account):
     widget = widget()
-    request = Mock(user=default_account)
+    request = Mock(user=locked_account)
     view = Mock(request=request)
     result = widget.get_context_data_view({"view": view})
     assert not result["results"]


### PR DESCRIPTION
## Scope and purpose

Fixes #4163. 

I decided to keep the call to `AlertHistoryViewSet` since [`AlertHistoryFilterBackend.filter_queryset()`](https://github.com/Uninett/nav/blob/5b71398892378d0b228134ff9685a5cdab357fb1/python/nav/web/api/v1/filter_backends.py#L122-L160) wants a view as well and I did not want to start faking it. 
So I decided to simply pass the user that is requesting the status widget on to the `AlertHistoryViewSet`. 

And the widget will now show an error if the response has a status code different than `200`:

<img width="1067" height="237" alt="image" src="https://github.com/user-attachments/assets/8c33d7c2-7cf8-4c4c-bc0c-514d28f4aa5a" />

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [X] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
