### PR TITLE
Fix REMOTE_USER/SSO authentication regression

### DIFF
--- a/changelog.d/4168.fixed.md
+++ b/changelog.d/4168.fixed.md
@@ -1,0 +1,1 @@
+REMOTE_USER/SSO authentication works again. Since NAV 5.17.0 the configured variable was ignored entirely, and every visitor was silently treated as the anonymous default account.

--- a/doc/reference/remote_user.rst
+++ b/doc/reference/remote_user.rst
@@ -10,8 +10,7 @@ The feature is enabled by setting ``enabled=yes`` in this section (A missing
 section or value, or the value ``off`` is interpreted as the support being
 off). When enabled, NAV will check for the HTTP header in ``varname`` (set to
 ``REMOTE_USER`` by default), on every page load. If there is a string there, NAV
-will attempt to use it as a username to log in with. An account will be created
-if one does not already exist for that username.
+will attempt to use it as a username to log in with.
 
 ``REMOTE_USER`` (or another header) can be set by the web server hosting NAV,
 and is a simple way of supporting federated logins via eg. Kerberors or SAML,

--- a/python/nav/web/auth/backends.py
+++ b/python/nav/web/auth/backends.py
@@ -23,7 +23,7 @@ from django.http import HttpRequest
 
 from nav.auditlog.models import LogEntry
 from nav.models.profiles import Account
-from nav.web.auth import remote_user
+from nav.web.auth.remote_user import CONFIG as REMOTE_USER_CONFIG
 
 
 _logger = logging.getLogger(__name__)
@@ -33,32 +33,34 @@ class NAVRemoteUserBackend(RemoteUserBackend):
     "An adaptation of Django's RemoteUserBackend that is configurable the NAV way"
 
     def __init__(self):
-        self.create_unknown_user = remote_user.CONFIG.will_autocreate_user()
+        self.create_unknown_user = REMOTE_USER_CONFIG.will_autocreate_user()
 
     def authenticate(
-        self, request: Optional[HttpRequest], user: str
+        self, request: Optional[HttpRequest], remote_user: str
     ) -> Optional[Account]:
         """Authenticates the username supplied by the web server.
 
         Returns the matching account, or None if REMOTE_USER authentication is
         disabled in NAV's configuration, or the username matches no account
         that is allowed to log in.
+
+        The `remote_user` parameter name is dictated by Django's
+        `RemoteUserMiddleware`.
         """
-        if not remote_user.CONFIG.is_remote_user_enabled():
+        if not REMOTE_USER_CONFIG.is_remote_user_enabled():
             return None
 
-        user = super().authenticate(request, user)
-        return user
+        return super().authenticate(request, remote_user)
 
     def clean_username(self, username):
-        return remote_user.CONFIG.clean_username(username)
+        return REMOTE_USER_CONFIG.clean_username(username)
 
     def configure_user(self, request, user, created=True):
         if created:
             user.ext_sync = 'REMOTE_USER'
             user.save()
 
-            remote_user_varname = remote_user.CONFIG.get_remote_user_varname()
+            remote_user_varname = REMOTE_USER_CONFIG.get_remote_user_varname()
             _logger.info(
                 "Created user %s from header %s",
                 user.get_username(),

--- a/python/nav/web/auth/backends.py
+++ b/python/nav/web/auth/backends.py
@@ -1,8 +1,28 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License version 3 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Authentication backends for NAV's web interface."""
+
 import logging
+from typing import Optional
 
 from django.contrib.auth.backends import RemoteUserBackend
+from django.http import HttpRequest
 
 from nav.auditlog.models import LogEntry
+from nav.models.profiles import Account
 from nav.web.auth import remote_user
 
 
@@ -15,7 +35,15 @@ class NAVRemoteUserBackend(RemoteUserBackend):
     def __init__(self):
         self.create_unknown_user = remote_user.CONFIG.will_autocreate_user()
 
-    def authenticate(self, request, user):
+    def authenticate(
+        self, request: Optional[HttpRequest], user: str
+    ) -> Optional[Account]:
+        """Authenticates the username supplied by the web server.
+
+        Returns the matching account, or None if REMOTE_USER authentication is
+        disabled in NAV's configuration, or the username matches no account
+        that is allowed to log in.
+        """
         if not remote_user.CONFIG.is_remote_user_enabled():
             return None
 

--- a/python/nav/web/auth/middleware.py
+++ b/python/nav/web/auth/middleware.py
@@ -101,13 +101,15 @@ class NAVRemoteUserMiddleware(RemoteUserMiddleware):
         )
 
         self._logger.debug(
-            'request.META["REMOTE_USER"]: "%s"',
-            request.META.get("REMOTE_USER", "NOT SET"),
+            'request.META["%s"]: "%s"',
+            self.header,
+            request.META.get(self.header, "NOT SET"),
         )
         next = super().process_request(request)
         remote_userobj = get_account(request)
         self._logger.debug(
-            'REMOTE_USER: "%s" from "%s"',
+            '%s resolved to account "%s" from "%s"',
+            self.header,
             remote_userobj.get_username(),
             path,
         )

--- a/python/nav/web/auth/signals.py
+++ b/python/nav/web/auth/signals.py
@@ -41,10 +41,11 @@ def log_successful_login(sender, request, user, **kwargs):
 def log_failed_login(sender, credentials, request=None, **kwargs):
     """Records a failed login attempt in the application log"""
     # Auth backends name the identity credential differently: allauth uses
-    # "username", and NAVRemoteUserBackend uses "user".
+    # "username" or "login", while Django's RemoteUserMiddleware passes the
+    # identity along as "remote_user".
     username = (
         credentials.get('username')
         or credentials.get('login')
-        or credentials.get('user')
+        or credentials.get('remote_user')
     )
     _logger.info("failed login: %r", username)

--- a/tests/integration/web/auth/conftest.py
+++ b/tests/integration/web/auth/conftest.py
@@ -1,7 +1,48 @@
+from contextlib import contextmanager
+from unittest.mock import patch
+
 import pytest
 
-from django.test import RequestFactory
+from django.test import Client, RequestFactory
 from django.contrib.sessions.middleware import SessionMiddleware
+
+
+@pytest.fixture()
+def anonymous_client():
+    """Provides a logged-out Django test client.
+
+    Deliberately not named ``client``: the project-wide fixture of that name in
+    ``tests/integration/conftest.py`` is already logged in as admin, and naming
+    this one the same would shadow it for every test in this directory.
+    """
+    return Client()
+
+
+@pytest.fixture()
+def remote_user_auth():
+    """Provides a context manager for configuring REMOTE_USER authentication.
+
+    Both flags patched here are re-read on every request, so the patches must
+    stay active while the request is being made, not merely while the test is
+    set up. `varname` is deliberately not among them: the middleware reads that
+    one only once, when the middleware chain is built.
+    """
+
+    @contextmanager
+    def _remote_user_auth(enabled=True, autocreate=False):
+        with (
+            patch(
+                "nav.web.auth.remote_user.CONFIG.is_remote_user_enabled",
+                return_value=enabled,
+            ),
+            patch(
+                "nav.web.auth.remote_user.CONFIG.will_autocreate_user",
+                return_value=autocreate,
+            ),
+        ):
+            yield
+
+    return _remote_user_auth
 
 
 @pytest.fixture()

--- a/tests/integration/web/auth/login_logging_test.py
+++ b/tests/integration/web/auth/login_logging_test.py
@@ -15,8 +15,10 @@
 #
 """Tests that logins are recorded in the audit log and the application log.
 
-Logins go through django-allauth, so these exercise the real login flow (via the
-``log_in`` helper).
+Ordinary logins go through django-allauth, so these exercise the real login flow
+(via the ``log_in`` helper). REMOTE_USER logins reach the same signal receiver by
+a different route, and name their credential differently, so they are covered
+here too.
 """
 
 import logging
@@ -46,13 +48,21 @@ class TestLoginLogging:
 
         assert f"{non_admin_account.login} successfully logged in" in caplog.text
 
-    def test_when_a_login_attempt_fails_then_it_should_log_to_the_application_log(
+    def test_when_a_login_attempt_fails_then_it_should_log_the_rejected_username(
         self, db, non_admin_account, log_in, caplog
     ):
         with caplog.at_level(logging.INFO):
             log_in(Client(), non_admin_account.login, "wrong-password")
 
-        assert "failed login" in caplog.text
+        assert f"failed login: '{non_admin_account.login}'" in caplog.text
+
+    def test_when_a_remote_user_login_fails_then_it_should_log_the_rejected_username(
+        self, db, anonymous_client, remote_user_auth, caplog
+    ):
+        with remote_user_auth(), caplog.at_level(logging.INFO):
+            anonymous_client.get("/", REMOTE_USER="nosuchuser")
+
+        assert "failed login: 'nosuchuser'" in caplog.text
 
     def test_when_a_login_attempt_fails_then_it_should_not_record_an_audit_log_entry(
         self, db, non_admin_account, log_in

--- a/tests/integration/web/auth/remote_user_test.py
+++ b/tests/integration/web/auth/remote_user_test.py
@@ -23,6 +23,9 @@ parameters are named wrong is skipped without ever being called. A test that
 invokes the backend directly cannot observe that.
 """
 
+import logging
+from unittest.mock import patch
+
 from django.contrib.auth import SESSION_KEY
 
 from nav.models.profiles import Account
@@ -65,3 +68,27 @@ class TestRemoteUserLogin:
             anonymous_client.get("/", REMOTE_USER=non_admin_account.login)
 
         assert anonymous_client.session.get(SESSION_KEY) == str(Account.DEFAULT_ACCOUNT)
+
+
+class TestRemoteUserDebugLogging:
+    def test_when_varname_is_customised_then_the_log_should_name_that_variable(
+        self, db, non_admin_account, anonymous_client, remote_user_auth, caplog
+    ):
+        varname = "HTTP_X_REMOTE_USER"
+
+        # The patch must be active before this client's first request: the
+        # middleware reads `self.header` once, when the chain is built.
+
+        with (
+            remote_user_auth(),
+            patch(
+                "nav.web.auth.remote_user.CONFIG.get_remote_user_varname",
+                return_value=varname,
+            ),
+            caplog.at_level(logging.DEBUG, logger="nav.web.auth.middleware"),
+        ):
+            anonymous_client.get(
+                "/", headers={"x-remote-user": non_admin_account.login}
+            )
+
+        assert f'request.META["{varname}"]: "{non_admin_account.login}"' in caplog.text

--- a/tests/integration/web/auth/remote_user_test.py
+++ b/tests/integration/web/auth/remote_user_test.py
@@ -1,0 +1,67 @@
+#
+# Copyright (C) 2026 Sikt
+#
+# This file is part of Network Administration Visualized (NAV).
+#
+# NAV is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License version 3 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# NAV. If not, see <http://www.gnu.org/licenses/>.
+#
+"""Tests that REMOTE_USER logins work through the full middleware stack.
+
+These drive a Django test client rather than calling
+``NAVRemoteUserBackend.authenticate()`` directly, because the bug they guard
+against lives in the dispatch *between* the two: Django matches credentials to
+backends by binding them against each backend's signature, so a backend whose
+parameters are named wrong is skipped without ever being called. A test that
+invokes the backend directly cannot observe that.
+"""
+
+from django.contrib.auth import SESSION_KEY
+
+from nav.models.profiles import Account
+
+
+class TestRemoteUserLogin:
+    def test_when_remote_user_is_set_then_it_should_log_that_account_in(
+        self, db, non_admin_account, anonymous_client, remote_user_auth
+    ):
+        with remote_user_auth():
+            anonymous_client.get("/", REMOTE_USER=non_admin_account.login)
+
+        assert anonymous_client.session.get(SESSION_KEY) == str(non_admin_account.pk)
+
+    def test_when_remote_user_is_set_again_then_it_should_stay_logged_in_without_cycling_the_session(  # noqa: E501
+        self, db, non_admin_account, anonymous_client, remote_user_auth
+    ):
+        with remote_user_auth():
+            anonymous_client.get("/", REMOTE_USER=non_admin_account.login)
+            session_key_after_login = anonymous_client.session.session_key
+            anonymous_client.get("/", REMOTE_USER=non_admin_account.login)
+
+        assert anonymous_client.session.get(SESSION_KEY) == str(non_admin_account.pk)
+        assert anonymous_client.session.session_key == session_key_after_login
+
+    def test_when_remote_user_is_unknown_and_autocreate_is_on_then_it_should_create_and_log_in_the_account(  # noqa: E501
+        self, db, anonymous_client, remote_user_auth
+    ):
+        with remote_user_auth(autocreate=True):
+            anonymous_client.get("/", REMOTE_USER="newcomer")
+
+        account = Account.objects.get(login="newcomer")
+        assert account.ext_sync == "REMOTE_USER"
+        assert anonymous_client.session.get(SESSION_KEY) == str(account.pk)
+
+    def test_when_remote_user_is_disabled_then_the_session_should_stay_anonymous(
+        self, db, non_admin_account, anonymous_client, remote_user_auth
+    ):
+        with remote_user_auth(enabled=False):
+            anonymous_client.get("/", REMOTE_USER=non_admin_account.login)
+
+        assert anonymous_client.session.get(SESSION_KEY) == str(Account.DEFAULT_ACCOUNT)

--- a/tests/unittests/web/auth/backends_test.py
+++ b/tests/unittests/web/auth/backends_test.py
@@ -9,7 +9,7 @@ class TestNAVRemoteUserBackend:
     def test_init_sets_create_unknown_user(self):
         expected = 6
         with patch(
-            'nav.web.auth.backends.remote_user.CONFIG.will_autocreate_user',
+            'nav.web.auth.remote_user.CONFIG.will_autocreate_user',
             return_value=expected,
         ):
             backend = NAVRemoteUserBackend()
@@ -18,24 +18,11 @@ class TestNAVRemoteUserBackend:
     def test_authenticate_returns_None_if_backend_not_enabled(self):
         backend = NAVRemoteUserBackend()
         with patch(
-            'nav.web.auth.backends.remote_user.CONFIG.is_remote_user_enabled',
+            'nav.web.auth.remote_user.CONFIG.is_remote_user_enabled',
             return_value=False,
         ):
-            result = backend.authenticate(None, None)
+            result = backend.authenticate(None, remote_user=None)
             assert result is None
-
-    def test_authenticate_returns_user_if_backend_is_enabled(self):
-        expected = 7
-        backend = NAVRemoteUserBackend()
-        mock_backend = Mock()
-        mock_backend.authenticate.return_value = expected
-        with patch(
-            'nav.web.auth.backends.remote_user.CONFIG.is_remote_user_enabled',
-            return_value=True,
-        ):
-            with patch('builtins.super', return_value=mock_backend):
-                result = backend.authenticate(None, expected)
-                assert result == expected
 
     def test_clean_username_golden_path(self):
         # no need to test how clean_username works here‥


### PR DESCRIPTION
## Scope and purpose

Fixes #4168.

Renames the credential parameter of `NAVRemoteUserBackend.authenticate()` to the one Django's `RemoteUserMiddleware` actually passes, which is all it takes to put the backend back into service. Two adjacent defects in the same path get their own commits: the failed-login log line now names the rejected identity rather than `None`, and the middleware's debug line names the configured `varname` rather than a hardcoded `REMOTE_USER`.

The rest is scaffolding: integration tests that drive a real request through the middleware stack — the existing unit tests called the backend directly and so could not see the dispatch at all — plus a licence header and type hints on the touched module, and the removal of a self-contradicting paragraph from the remote user reference docs.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [x] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done — the `aprocess_request` deprecation noted in #4168 still needs its own issue
* [ ] ~~If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)~~ — #4168 carries a reproduction recipe needing no SSO infrastructure
* [ ] ~~If this results in changes in the UI: Added screenshots of the before and after~~
* [x] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file
