### PR TITLE
Remove insecure password banner on remote user accounts

### DIFF
--- a/changelog.d/4172.fixed.md
+++ b/changelog.d/4172.fixed.md
@@ -1,0 +1,1 @@
+Fixed showing insecure password banner on accounts from REMOTE USER when password is empty

--- a/python/nav/models/profiles.py
+++ b/python/nav/models/profiles.py
@@ -309,6 +309,8 @@ class Account(AbstractBaseUser):
 
     def has_plaintext_password(self):
         """Returns True if this account appears to contain a plain-text password"""
+        if not self.password:
+            return False
         if not self.has_old_style_password_hash():
             try:
                 self.password_hash
@@ -320,7 +322,9 @@ class Account(AbstractBaseUser):
         """Returns True if this account's password is salted hash, but using a
         deprecated hashing method.
         """
-        if not (self.has_plaintext_password() or self.has_old_style_password_hash()):
+        if self.password and not (
+            self.has_plaintext_password() or self.has_old_style_password_hash()
+        ):
             return self.password_hash.method != nav.pwhash.DEFAULT_METHOD
         return False
 

--- a/tests/integration/web/webfront_test.py
+++ b/tests/integration/web/webfront_test.py
@@ -4,7 +4,7 @@ from urllib.parse import quote
 
 import pytest
 from django.http import Http404
-from django.test import Client
+from django.test import Client, RequestFactory
 from django.urls import reverse
 from django.utils.encoding import smart_str
 from mock import Mock, patch
@@ -17,6 +17,7 @@ from nav.models.profiles import (
 )
 from nav.web.webfront import find_dashboard, get_dashboards_for_account
 from nav.web.webfront.utils import tool_list
+from nav.web.webfront.views import index
 
 
 def test_tools_should_be_readable():
@@ -255,6 +256,25 @@ def test_shows_password_issue_banner_on_own_password_issues(db, client):
     assert (
         "Your account has an insecure or old password. It should be reset."
         in smart_str(response.content)
+    )
+
+
+def test_do_not_show_password_issue_banner_on_empty_password(db):
+    """
+    Remote user login sets the password to empty which lead to showing the password
+    issues banner, even though there are no issues
+    """
+
+    factory = RequestFactory()
+
+    request = factory.get(reverse('webfront-index'))
+    request.user = Account.objects.create(login="emptypassword", password="")
+
+    response = index(request)
+
+    assert (
+        "Your account has an insecure or old password. It should be reset."
+        not in smart_str(response.content)
     )
 
 


### PR DESCRIPTION
## Scope and purpose

These account are saved with an empty string as password (since creating remote users with Django and not NAV itself (#3621), which leads to it being counted as plaintext (see https://github.com/Uninett/nav/blob/7cfa5f681ae6c175d8d80252c6c8a74f26812cc0/python/nav/models/profiles.py#L310-L317), which will then show the insecure/outdated password banner.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to NAV can be found in the
[Hacker's guide to NAV](https://nav.readthedocs.io/en/latest/hacking/hacking.html#hacker-s-guide-to-nav).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each or remove the line if not applicable. -->

* [X] Added a changelog fragment for [towncrier](https://nav.readthedocs.io/en/latest/hacking/hacking.html#adding-a-changelog-entry)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://nav.readthedocs.io/en/latest/hacking/hacking.html#pre-commit-hooks-and-ruff)
* [X] Wrote the commit message so that the first line continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] Based this pull request on the correct upstream branch: For a patch/bugfix affecting the latest stable version, it should be based on that version's branch (`<major>.<minor>.x`). For a new feature or other additions, it should be based on `master`.
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If it's not obvious from a linked issue, described how to interact with NAV in order for a reviewer to observe the effects of this change first-hand (commands, URLs, UI interactions)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this adds a new Python source code file: Added the [boilerplate header](https://nav.readthedocs.io/en/latest/hacking/hacking.html#python-boilerplate-headers) to that file

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
